### PR TITLE
Implement VOC-to-execution MVP scaffold

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,9 @@ AUTH_MODE=mock
 PORT=3000
 DATABASE_URL=postgres://feedbackops:feedbackops@localhost:5432/feedbackops
 VITE_API_BASE_URL=http://localhost:3000
+POSTGRES_DB=feedbackops
+POSTGRES_USER=feedbackops
+POSTGRES_PASSWORD=feedbackops
 
 # Local Docker run:
 # docker compose up --build
@@ -9,6 +12,8 @@ VITE_API_BASE_URL=http://localhost:3000
 # Fixed URLs:
 # frontend: http://localhost:5180
 # backend health: http://localhost:3000/api/health
+# Docker internal DATABASE_URL:
+# postgres://feedbackops:feedbackops@postgres:5432/feedbackops
 #
 # Local non-Docker database setup, when a local Postgres is available:
 # pnpm --filter @feedbackops/backend db:migrate

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+AUTH_MODE=mock
+PORT=3000
+DATABASE_URL=postgres://feedbackops:feedbackops@localhost:5432/feedbackops
+VITE_API_BASE_URL=http://localhost:3000
+
+# Local Docker run:
+# docker compose up --build
+#
+# Fixed URLs:
+# frontend: http://localhost:5180
+# backend health: http://localhost:3000/api/health
+#
+# Local non-Docker database setup, when a local Postgres is available:
+# pnpm --filter @feedbackops/backend db:migrate
+# pnpm --filter @feedbackops/backend db:seed

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+dist
+coverage
+.DS_Store
+.vite
+*.log
+*.tsbuildinfo

--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:22-alpine
+
+WORKDIR /app
+RUN corepack enable
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json ./
+COPY apps/backend/package.json apps/backend/package.json
+COPY apps/frontend/package.json apps/frontend/package.json
+COPY packages/shared/package.json packages/shared/package.json
+COPY packages/ui/package.json packages/ui/package.json
+RUN pnpm install --frozen-lockfile
+
+COPY apps/backend apps/backend
+COPY packages/shared packages/shared
+
+EXPOSE 3000
+CMD ["pnpm", "--filter", "@feedbackops/backend", "start"]

--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine
+FROM node:20-alpine
 
 WORKDIR /app
 RUN corepack enable

--- a/apps/backend/db/migrate.ts
+++ b/apps/backend/db/migrate.ts
@@ -1,0 +1,38 @@
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import pg from "pg";
+
+const { Pool } = pg;
+
+const databaseUrl = process.env.DATABASE_URL;
+
+if (!databaseUrl) {
+  throw new Error("DATABASE_URL is required to run migrations.");
+}
+
+const pool = new Pool({ connectionString: databaseUrl });
+const migrationsDirectory = new URL("./migrations", import.meta.url);
+
+try {
+  await pool.query("create table if not exists schema_migrations (filename text primary key, applied_at timestamptz not null default now())");
+  const files = (await readdir(migrationsDirectory)).filter((file) => file.endsWith(".sql")).sort();
+
+  for (const file of files) {
+    const alreadyApplied = await pool.query("select 1 from schema_migrations where filename = $1", [file]);
+    if (alreadyApplied.rowCount) continue;
+
+    const sql = await readFile(join(migrationsDirectory.pathname, file), "utf8");
+    await pool.query("begin");
+    try {
+      await pool.query(sql);
+      await pool.query("insert into schema_migrations (filename) values ($1)", [file]);
+      await pool.query("commit");
+      console.log(`applied ${file}`);
+    } catch (error) {
+      await pool.query("rollback");
+      throw error;
+    }
+  }
+} finally {
+  await pool.end();
+}

--- a/apps/backend/db/migrate.ts
+++ b/apps/backend/db/migrate.ts
@@ -1,4 +1,5 @@
 import { readdir, readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
 import { join } from "node:path";
 import pg from "pg";
 
@@ -11,7 +12,7 @@ if (!databaseUrl) {
 }
 
 const pool = new Pool({ connectionString: databaseUrl });
-const migrationsDirectory = new URL("./migrations", import.meta.url);
+const migrationsDirectory = fileURLToPath(new URL("./migrations", import.meta.url));
 
 try {
   await pool.query("create table if not exists schema_migrations (filename text primary key, applied_at timestamptz not null default now())");
@@ -21,7 +22,7 @@ try {
     const alreadyApplied = await pool.query("select 1 from schema_migrations where filename = $1", [file]);
     if (alreadyApplied.rowCount) continue;
 
-    const sql = await readFile(join(migrationsDirectory.pathname, file), "utf8");
+    const sql = await readFile(join(migrationsDirectory, file), "utf8");
     await pool.query("begin");
     try {
       await pool.query(sql);

--- a/apps/backend/db/migrations/202605140100_mvp_foundation.sql
+++ b/apps/backend/db/migrations/202605140100_mvp_foundation.sql
@@ -1,0 +1,151 @@
+create schema if not exists core;
+create schema if not exists permission;
+create schema if not exists voc;
+create schema if not exists finding;
+create schema if not exists task;
+
+create table if not exists core.actors (
+  id text primary key,
+  workspace_id text not null,
+  name text not null,
+  role_level text not null check (role_level in ('Admin', 'Developer', 'User')),
+  created_at timestamptz not null default now()
+);
+
+create table if not exists core.managed_systems (
+  id text primary key,
+  workspace_id text not null,
+  name text not null,
+  archived boolean not null default false,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists core.analytics_areas (
+  id text primary key,
+  workspace_id text not null,
+  managed_system_id text not null references core.managed_systems(id),
+  name text not null,
+  archived boolean not null default false,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists permission.permission_grants (
+  id text primary key,
+  workspace_id text not null,
+  actor_id text not null references core.actors(id),
+  managed_system_id text not null references core.managed_systems(id),
+  capability text,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists permission.permission_denies (
+  id text primary key,
+  workspace_id text not null,
+  actor_id text not null references core.actors(id),
+  managed_system_id text not null references core.managed_systems(id),
+  reason text,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists permission.permission_requests (
+  id text primary key,
+  workspace_id text not null,
+  managed_system_id text not null references core.managed_systems(id),
+  requester_id text not null references core.actors(id),
+  reason text not null,
+  status text not null check (status in ('pending', 'approved', 'rejected', 'revoked')),
+  created_at timestamptz not null default now()
+);
+
+create table if not exists core.audit_logs (
+  id text primary key,
+  workspace_id text not null,
+  actor_id text references core.actors(id),
+  event_type text not null,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists core.app_state (
+  id text primary key,
+  payload jsonb not null,
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists voc.vocs (
+  id text primary key,
+  workspace_id text not null,
+  managed_system_id text not null references core.managed_systems(id),
+  analytics_area_id text references core.analytics_areas(id),
+  reporter_id text not null references core.actors(id),
+  title text not null,
+  description text not null,
+  source_context text,
+  severity text,
+  triage_state text not null,
+  reporter_facing_status text not null,
+  owner_id text references core.actors(id),
+  created_at timestamptz not null default now()
+);
+
+create table if not exists voc.voc_conversation_entries (
+  id text primary key,
+  workspace_id text not null,
+  voc_id text not null references voc.vocs(id),
+  author_id text not null references core.actors(id),
+  entry_type text not null check (entry_type in ('public_update', 'reporter_reply', 'internal_comment')),
+  body text not null,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists finding.findings (
+  id text primary key,
+  workspace_id text not null,
+  managed_system_id text not null references core.managed_systems(id),
+  title text not null,
+  summary text not null,
+  status text not null,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists task.task_requests (
+  id text primary key,
+  workspace_id text not null,
+  managed_system_id text not null references core.managed_systems(id),
+  title text not null,
+  status text not null,
+  source_type text not null,
+  source_id text not null,
+  requested_by_id text not null references core.actors(id),
+  created_at timestamptz not null default now()
+);
+
+create table if not exists task.tasks (
+  id text primary key,
+  workspace_id text not null,
+  managed_system_id text not null references core.managed_systems(id),
+  title text not null,
+  status text not null,
+  assignee_id text references core.actors(id),
+  priority text,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists core.entity_links (
+  id text primary key,
+  workspace_id text not null,
+  source_type text not null,
+  source_id text not null,
+  target_type text not null,
+  target_id text not null,
+  relation_type text not null check (relation_type <> 'generated_voc'),
+  visibility text not null,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists vocs_workspace_status_idx on voc.vocs (workspace_id, triage_state);
+create index if not exists task_requests_workspace_status_idx on task.task_requests (workspace_id, status);
+create index if not exists entity_links_source_idx on core.entity_links (workspace_id, source_type, source_id);
+create index if not exists entity_links_target_idx on core.entity_links (workspace_id, target_type, target_id);
+create index if not exists entity_links_relation_idx on core.entity_links (workspace_id, relation_type);
+create index if not exists audit_logs_workspace_event_idx on core.audit_logs (workspace_id, actor_id, event_type, created_at);

--- a/apps/backend/db/migrations/202605140100_mvp_foundation.sql
+++ b/apps/backend/db/migrations/202605140100_mvp_foundation.sql
@@ -66,12 +66,6 @@ create table if not exists core.audit_logs (
   created_at timestamptz not null default now()
 );
 
-create table if not exists core.app_state (
-  id text primary key,
-  payload jsonb not null,
-  updated_at timestamptz not null default now()
-);
-
 create table if not exists voc.vocs (
   id text primary key,
   workspace_id text not null,

--- a/apps/backend/db/migrations/202605140130_create_app_state.sql
+++ b/apps/backend/db/migrations/202605140130_create_app_state.sql
@@ -1,5 +1,0 @@
-create table if not exists core.app_state (
-  id text primary key,
-  payload jsonb not null,
-  updated_at timestamptz not null default now()
-);

--- a/apps/backend/db/migrations/202605140130_create_app_state.sql
+++ b/apps/backend/db/migrations/202605140130_create_app_state.sql
@@ -1,0 +1,5 @@
+create table if not exists core.app_state (
+  id text primary key,
+  payload jsonb not null,
+  updated_at timestamptz not null default now()
+);

--- a/apps/backend/db/seed.sql
+++ b/apps/backend/db/seed.sql
@@ -1,0 +1,53 @@
+insert into core.actors (id, workspace_id, name, role_level) values
+  ('admin', 'ws-main', 'Admin', 'Admin'),
+  ('admin-denied-looker', 'ws-main', 'Denied Admin', 'Admin'),
+  ('dev-tableau', 'ws-main', 'Tableau Developer', 'Developer'),
+  ('user-tableau', 'ws-main', 'Reporter', 'User')
+on conflict (id) do update set name = excluded.name, role_level = excluded.role_level;
+
+insert into core.managed_systems (id, workspace_id, name) values
+  ('ms-tableau', 'ws-main', 'Tableau'),
+  ('ms-powerbi', 'ws-main', 'Power BI'),
+  ('ms-looker', 'ws-main', 'Looker')
+on conflict (id) do update set name = excluded.name;
+
+insert into core.analytics_areas (id, workspace_id, managed_system_id, name) values
+  ('aa-tableau-exec', 'ws-main', 'ms-tableau', 'Executive Reporting'),
+  ('aa-powerbi-ops', 'ws-main', 'ms-powerbi', 'Operations Analytics'),
+  ('aa-looker-revenue', 'ws-main', 'ms-looker', 'Revenue Analytics')
+on conflict (id) do update set name = excluded.name, managed_system_id = excluded.managed_system_id;
+
+insert into permission.permission_grants (id, workspace_id, actor_id, managed_system_id, capability) values
+  ('grant-dev-tableau', 'ws-main', 'dev-tableau', 'ms-tableau', null),
+  ('grant-user-tableau', 'ws-main', 'user-tableau', 'ms-tableau', null)
+on conflict (id) do update set capability = excluded.capability;
+
+insert into permission.permission_denies (id, workspace_id, actor_id, managed_system_id, reason) values
+  ('deny-admin-looker', 'ws-main', 'admin-denied-looker', 'ms-looker', 'Explicit deny precedence fixture')
+on conflict (id) do update set reason = excluded.reason;
+
+insert into voc.vocs (
+  id, workspace_id, managed_system_id, analytics_area_id, reporter_id, title, description,
+  severity, triage_state, reporter_facing_status, owner_id
+) values
+  ('voc-seeded-tableau', 'ws-main', 'ms-tableau', 'aa-tableau-exec', 'user-tableau', 'Seeded Tableau VOC', 'Dashboard is intermittently slow.', 'medium', 'triaging', '검토 중', 'dev-tableau'),
+  ('voc-high-unlinked', 'ws-main', 'ms-tableau', null, 'user-tableau', 'High severity unlinked VOC', 'Month-end finance dashboard is down.', 'high', 'triaged', '검토 중', 'dev-tableau')
+on conflict (id) do update set
+  title = excluded.title,
+  description = excluded.description,
+  severity = excluded.severity,
+  triage_state = excluded.triage_state,
+  reporter_facing_status = excluded.reporter_facing_status,
+  owner_id = excluded.owner_id;
+
+insert into finding.findings (id, workspace_id, managed_system_id, title, summary, status) values
+  ('finding-seeded-tableau', 'ws-main', 'ms-tableau', 'Seeded Tableau performance finding', 'Repeated VOCs indicate cache misses.', 'active')
+on conflict (id) do update set title = excluded.title, summary = excluded.summary, status = excluded.status;
+
+insert into task.task_requests (id, workspace_id, managed_system_id, title, status, source_type, source_id, requested_by_id) values
+  ('task-request-seeded', 'ws-main', 'ms-tableau', 'Investigate Tableau cache regression', 'pending_review', 'finding', 'finding-seeded-tableau', 'admin')
+on conflict (id) do update set title = excluded.title, status = excluded.status;
+
+insert into core.entity_links (id, workspace_id, source_type, source_id, target_type, target_id, relation_type, visibility) values
+  ('link-finding-task-request-seeded', 'ws-main', 'finding', 'finding-seeded-tableau', 'task_request', 'task-request-seeded', 'requested_task', 'summary_visible')
+on conflict (id) do update set visibility = excluded.visibility;

--- a/apps/backend/db/seed.sql
+++ b/apps/backend/db/seed.sql
@@ -2,6 +2,7 @@ insert into core.actors (id, workspace_id, name, role_level) values
   ('admin', 'ws-main', 'Admin', 'Admin'),
   ('admin-denied-looker', 'ws-main', 'Denied Admin', 'Admin'),
   ('dev-tableau', 'ws-main', 'Tableau Developer', 'Developer'),
+  ('dev-tableau-self-approve', 'ws-main', 'Privileged Tableau Developer', 'Developer'),
   ('user-tableau', 'ws-main', 'Reporter', 'User')
 on conflict (id) do update set name = excluded.name, role_level = excluded.role_level;
 
@@ -19,6 +20,8 @@ on conflict (id) do update set name = excluded.name, managed_system_id = exclude
 
 insert into permission.permission_grants (id, workspace_id, actor_id, managed_system_id, capability) values
   ('grant-dev-tableau', 'ws-main', 'dev-tableau', 'ms-tableau', null),
+  ('grant-dev-tableau-self-approve', 'ws-main', 'dev-tableau-self-approve', 'ms-tableau', null),
+  ('grant-dev-tableau-self-approve-capability', 'ws-main', 'dev-tableau-self-approve', 'ms-tableau', 'task_request_self_approval'),
   ('grant-user-tableau', 'ws-main', 'user-tableau', 'ms-tableau', null)
 on conflict (id) do update set capability = excluded.capability;
 

--- a/apps/backend/db/seed.ts
+++ b/apps/backend/db/seed.ts
@@ -1,0 +1,20 @@
+import { readFile } from "node:fs/promises";
+import pg from "pg";
+
+const { Pool } = pg;
+
+const databaseUrl = process.env.DATABASE_URL;
+
+if (!databaseUrl) {
+  throw new Error("DATABASE_URL is required to seed the database.");
+}
+
+const pool = new Pool({ connectionString: databaseUrl });
+const seedFile = new URL("./seed.sql", import.meta.url);
+
+try {
+  await pool.query(await readFile(seedFile, "utf8"));
+  console.log("seeded FeedbackOps MVP data");
+} finally {
+  await pool.end();
+}

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@feedbackops/backend",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "test": "vitest run",
+    "build": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@feedbackops/shared": "workspace:*",
+    "cors": "^2.8.5",
+    "express": "^5.1.0"
+  },
+  "devDependencies": {
+    "@types/cors": "^2.8.18",
+    "@types/express": "^5.0.2",
+    "@types/supertest": "^6.0.3",
+    "supertest": "^7.1.1",
+    "tsx": "^4.19.4",
+    "vitest": "^3.1.3"
+  }
+}

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -5,17 +5,22 @@
   "type": "module",
   "scripts": {
     "dev": "tsx watch src/index.ts",
+    "start": "tsx src/index.ts",
+    "db:migrate": "tsx db/migrate.ts",
+    "db:seed": "tsx db/seed.ts",
     "test": "vitest run",
     "build": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
     "@feedbackops/shared": "workspace:*",
     "cors": "^2.8.5",
-    "express": "^5.1.0"
+    "express": "^5.1.0",
+    "pg": "^8.20.0"
   },
   "devDependencies": {
     "@types/cors": "^2.8.18",
     "@types/express": "^5.0.2",
+    "@types/pg": "^8.20.0",
     "@types/supertest": "^6.0.3",
     "supertest": "^7.1.1",
     "tsx": "^4.19.4",

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -11,11 +11,17 @@ export function createApp(store: AppStore = createStoreFromEnv(process.env)): Ex
     try {
       await store.ready;
       if (request.method !== "GET" && store.persist) {
-        response.on("finish", () => {
+        const json = response.json.bind(response);
+        response.json = ((body: unknown) => {
           if (response.statusCode < 400) {
-            void store.persist?.();
+            void store.persist?.().then(
+              () => json(body),
+              (error: unknown) => next(error)
+            );
+            return response;
           }
-        });
+          return json(body);
+        }) as Response["json"];
       }
       next();
     } catch (error) {
@@ -127,7 +133,8 @@ export function createApp(store: AppStore = createStoreFromEnv(process.env)): Ex
 
   app.post("/voc-clusters", (request, response, next) => {
     try {
-      response.status(201).json(toApi(store.createCluster(actor(request), request.body)));
+      actor(request);
+      response.status(410).json({ error: { code: "not_found", message: "VOC Cluster endpoints are not available in the minimum MVP slice." } });
     } catch (error) {
       next(error);
     }
@@ -135,7 +142,8 @@ export function createApp(store: AppStore = createStoreFromEnv(process.env)): Ex
 
   app.post("/voc-clusters/:id/create-finding", (request, response, next) => {
     try {
-      response.status(201).json(toApi(store.createFindingFromCluster(actor(request), request.params.id, request.body)));
+      actor(request);
+      response.status(410).json({ error: { code: "not_found", message: "VOC Cluster endpoints are not available in the minimum MVP slice." } });
     } catch (error) {
       next(error);
     }
@@ -176,6 +184,22 @@ export function createApp(store: AppStore = createStoreFromEnv(process.env)): Ex
   app.get("/task-requests", (request, response, next) => {
     try {
       response.json(toApi(store.listTaskRequests(actor(request), request.query.managed_system_id?.toString())));
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  app.post("/task-requests", (request, response, next) => {
+    try {
+      response.status(201).json(toApi(store.createTaskRequest(actor(request), request.body)));
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  app.get("/task-requests/:id", (request, response, next) => {
+    try {
+      response.json(toApi(store.getTaskRequest(actor(request), request.params.id)));
     } catch (error) {
       next(error);
     }
@@ -224,6 +248,22 @@ export function createApp(store: AppStore = createStoreFromEnv(process.env)): Ex
   app.get("/tasks", (request, response, next) => {
     try {
       response.json(toApi(store.listTasks(actor(request), request.query.managed_system_id?.toString())));
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  app.post("/tasks", (request, response, next) => {
+    try {
+      response.status(201).json(toApi(store.createTask(actor(request), request.body)));
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  app.get("/tasks/:id", (request, response, next) => {
+    try {
+      response.json(toApi(store.getTask(actor(request), request.params.id)));
     } catch (error) {
       next(error);
     }

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -1,11 +1,27 @@
 import cors from "cors";
 import express, { type Express, type NextFunction, type Request, type Response } from "express";
-import { ApiError, MvpStore, toApi } from "./mvp";
+import { ApiError, toApi } from "./mvp";
+import { createStoreFromEnv, type AppStore } from "./persistence";
 
-export function createApp(store = new MvpStore()): Express {
+export function createApp(store: AppStore = createStoreFromEnv(process.env)): Express {
   const app = express();
   app.use(cors());
   app.use(express.json());
+  app.use(async (request, response, next) => {
+    try {
+      await store.ready;
+      if (request.method !== "GET" && store.persist) {
+        response.on("finish", () => {
+          if (response.statusCode < 400) {
+            void store.persist?.();
+          }
+        });
+      }
+      next();
+    } catch (error) {
+      next(error);
+    }
+  });
 
   const actor = (request: Request) => store.actor(request.header("x-actor-id"));
 
@@ -168,6 +184,22 @@ export function createApp(store = new MvpStore()): Express {
   app.post("/task-requests/:id/approve", (request, response, next) => {
     try {
       response.json(toApi(store.approveTaskRequest(actor(request), request.params.id, request.body)));
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  app.post("/task-requests/:id/reject", (request, response, next) => {
+    try {
+      response.json(toApi(store.rejectTaskRequest(actor(request), request.params.id, request.body)));
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  app.post("/task-requests/:id/request-more-evidence", (request, response, next) => {
+    try {
+      response.json(toApi(store.requestMoreEvidenceForTaskRequest(actor(request), request.params.id, request.body)));
     } catch (error) {
       next(error);
     }

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -13,6 +13,22 @@ export function createApp(store = new MvpStore()): Express {
     response.json({ ok: true });
   });
 
+  app.get("/managed-systems", (request, response, next) => {
+    try {
+      response.json(toApi(store.listManagedSystems(actor(request))));
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  app.get("/analytics-areas", (request, response, next) => {
+    try {
+      response.json(toApi(store.listAnalyticsAreas(actor(request), request.query.managed_system_id?.toString())));
+    } catch (error) {
+      next(error);
+    }
+  });
+
   app.post("/vocs", (request, response, next) => {
     try {
       response.status(201).json(toApi(store.createVoc(actor(request), request.body)));
@@ -48,6 +64,14 @@ export function createApp(store = new MvpStore()): Express {
   app.post("/vocs/:id/request-task", (request, response, next) => {
     try {
       response.status(201).json(toApi(store.requestTaskFromVoc(actor(request), request.params.id, request.body)));
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  app.post("/vocs/:id/create-finding", (request, response, next) => {
+    try {
+      response.status(201).json(toApi(store.createFindingFromVoc(actor(request), request.params.id, request.body)));
     } catch (error) {
       next(error);
     }
@@ -109,6 +133,38 @@ export function createApp(store = new MvpStore()): Express {
     }
   });
 
+  app.get("/findings", (request, response, next) => {
+    try {
+      response.json(toApi(store.listFindings(actor(request), request.query.managed_system_id?.toString())));
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  app.get("/findings/:id", (request, response, next) => {
+    try {
+      response.json(toApi(store.getFinding(actor(request), request.params.id)));
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  app.post("/findings", (request, response, next) => {
+    try {
+      response.status(201).json(toApi(store.createFinding(actor(request), request.body)));
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  app.get("/task-requests", (request, response, next) => {
+    try {
+      response.json(toApi(store.listTaskRequests(actor(request), request.query.managed_system_id?.toString())));
+    } catch (error) {
+      next(error);
+    }
+  });
+
   app.post("/task-requests/:id/approve", (request, response, next) => {
     try {
       response.json(toApi(store.approveTaskRequest(actor(request), request.params.id, request.body)));
@@ -128,6 +184,38 @@ export function createApp(store = new MvpStore()): Express {
   app.patch("/tasks/:id", (request, response, next) => {
     try {
       response.json(toApi(store.patchTask(actor(request), request.params.id, request.body)));
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  app.get("/tasks", (request, response, next) => {
+    try {
+      response.json(toApi(store.listTasks(actor(request), request.query.managed_system_id?.toString())));
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  app.post("/permission-requests", (request, response, next) => {
+    try {
+      response.status(201).json(toApi(store.createPermissionRequest(actor(request), request.body)));
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  app.get("/permission-requests", (request, response, next) => {
+    try {
+      response.json(toApi(store.listPermissionRequests(actor(request))));
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  app.post("/permission-requests/:id/approve", (request, response, next) => {
+    try {
+      response.json(toApi(store.approvePermissionRequest(actor(request), request.params.id)));
     } catch (error) {
       next(error);
     }

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -1,0 +1,173 @@
+import cors from "cors";
+import express, { type Express, type NextFunction, type Request, type Response } from "express";
+import { ApiError, MvpStore, toApi } from "./mvp";
+
+export function createApp(store = new MvpStore()): Express {
+  const app = express();
+  app.use(cors());
+  app.use(express.json());
+
+  const actor = (request: Request) => store.actor(request.header("x-actor-id"));
+
+  app.get("/api/health", (_request, response) => {
+    response.json({ ok: true });
+  });
+
+  app.post("/vocs", (request, response, next) => {
+    try {
+      response.status(201).json(toApi(store.createVoc(actor(request), request.body)));
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  app.get("/vocs", (request, response, next) => {
+    try {
+      response.json(toApi(store.listVocs(actor(request), request.query.managed_system_id?.toString())));
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  app.get("/vocs/:id", (request, response, next) => {
+    try {
+      response.json(toApi(store.getVoc(actor(request), request.params.id)));
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  app.patch("/vocs/:id", (request, response, next) => {
+    try {
+      response.json(toApi(store.patchVoc(actor(request), request.params.id, request.body)));
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  app.post("/vocs/:id/request-task", (request, response, next) => {
+    try {
+      response.status(201).json(toApi(store.requestTaskFromVoc(actor(request), request.params.id, request.body)));
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  app.post("/vocs/:id/public-updates", (request, response, next) => {
+    try {
+      response.status(201).json(toApi(store.createConversation(actor(request), request.params.id, "public_update", request.body)));
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  app.post("/vocs/:id/reporter-replies", (request, response, next) => {
+    try {
+      response.status(201).json(toApi(store.createConversation(actor(request), request.params.id, "reporter_reply", request.body)));
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  app.post("/vocs/:id/internal-comments", (request, response, next) => {
+    try {
+      response.status(201).json(toApi(store.createConversation(actor(request), request.params.id, "internal_comment", request.body)));
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  app.get("/vocs/:id/reporter-summary", (request, response, next) => {
+    try {
+      response.json(store.reporterSummary(actor(request), request.params.id));
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  app.post("/voc-clusters", (request, response, next) => {
+    try {
+      response.status(201).json(toApi(store.createCluster(actor(request), request.body)));
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  app.post("/voc-clusters/:id/create-finding", (request, response, next) => {
+    try {
+      response.status(201).json(toApi(store.createFindingFromCluster(actor(request), request.params.id, request.body)));
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  app.post("/findings/:id/request-task", (request, response, next) => {
+    try {
+      response.status(201).json(toApi(store.requestTaskFromFinding(actor(request), request.params.id, request.body)));
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  app.post("/task-requests/:id/approve", (request, response, next) => {
+    try {
+      response.json(toApi(store.approveTaskRequest(actor(request), request.params.id, request.body)));
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  app.post("/task-requests/:id/convert-to-task", (request, response, next) => {
+    try {
+      response.status(201).json(toApi(store.convertTaskRequest(actor(request), request.params.id)));
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  app.patch("/tasks/:id", (request, response, next) => {
+    try {
+      response.json(toApi(store.patchTask(actor(request), request.params.id, request.body)));
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  app.get("/entity-links", (request, response, next) => {
+    try {
+      response.json(toApi(store.listEntityLinks(actor(request))));
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  app.post("/entity-links", (request, response, next) => {
+    try {
+      response.status(201).json(toApi(store.createEntityLink(actor(request), request.body)));
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  app.get("/dashboard/action-queues", (request, response, next) => {
+    try {
+      response.json(store.dashboardQueues(actor(request)));
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  app.post("/survey-responses/:id/create-voc", (_request, response) => {
+    response.status(404).json({ error: { code: "not_found", message: "Survey Response to VOC conversion is not available." } });
+  });
+
+  app.use((error: unknown, _request: Request, response: Response, _next: NextFunction) => {
+    if (error instanceof ApiError) {
+      response.status(error.status).json({ error: { code: error.code, message: error.message } });
+      return;
+    }
+    response.status(500).json({ error: { code: "internal_error", message: error instanceof Error ? error.message : "Unknown error" } });
+  });
+
+  return app;
+}

--- a/apps/backend/src/domain.test.ts
+++ b/apps/backend/src/domain.test.ts
@@ -1,6 +1,7 @@
 import request from "supertest";
 import { describe, expect, it } from "vitest";
 import { createApp } from "./app";
+import { createStoreFromEnv } from "./persistence";
 
 const app = createApp();
 
@@ -153,6 +154,58 @@ describe("FeedbackOps backend MVP invariants", () => {
       .set("x-actor-id", "admin")
       .send({})
       .expect(404);
+  });
+
+  it("rejects and requests more evidence for Task Requests without creating Tasks", async () => {
+    const rejectedRequest = await request(app)
+      .post("/vocs/voc-seeded-tableau/request-task")
+      .set("x-actor-id", "admin")
+      .send({ title: "Reject this execution candidate" })
+      .expect(201);
+
+    const rejected = await request(app)
+      .post(`/task-requests/${rejectedRequest.body.id}/reject`)
+      .set("x-actor-id", "admin")
+      .send({ reason: "The evidence does not justify execution yet." })
+      .expect(200);
+
+    expect(rejected.body.status).toBe("rejected");
+
+    const rejectedConversion = await request(app)
+      .post(`/task-requests/${rejectedRequest.body.id}/convert-to-task`)
+      .set("x-actor-id", "admin")
+      .send({});
+
+    expect(rejectedConversion.status).toBe(409);
+    expect(rejectedConversion.body.error.code).toBe("invalid_transition");
+
+    const evidenceRequest = await request(app)
+      .post("/vocs/voc-seeded-tableau/request-task")
+      .set("x-actor-id", "admin")
+      .send({ title: "Needs better source context" })
+      .expect(201);
+
+    const needsMoreEvidence = await request(app)
+      .post(`/task-requests/${evidenceRequest.body.id}/request-more-evidence`)
+      .set("x-actor-id", "admin")
+      .send({ reason: "Attach source dashboards and recent failure examples." })
+      .expect(200);
+
+    expect(needsMoreEvidence.body.status).toBe("needs_more_evidence");
+
+    const evidenceConversion = await request(app)
+      .post(`/task-requests/${evidenceRequest.body.id}/convert-to-task`)
+      .set("x-actor-id", "admin")
+      .send({});
+
+    expect(evidenceConversion.status).toBe(409);
+    expect(evidenceConversion.body.error.code).toBe("invalid_transition");
+  });
+
+  it("selects Postgres-backed persistence when DATABASE_URL is configured", () => {
+    const store = createStoreFromEnv({ DATABASE_URL: "postgres://feedbackops:feedbackops@localhost:5432/feedbackops" });
+
+    expect(store.persistence).toBe("postgres");
   });
 });
 

--- a/apps/backend/src/domain.test.ts
+++ b/apps/backend/src/domain.test.ts
@@ -1,0 +1,262 @@
+import request from "supertest";
+import { describe, expect, it } from "vitest";
+import { createApp } from "./app";
+
+const app = createApp();
+
+describe("FeedbackOps backend MVP invariants", () => {
+  it("requires managed_system_id when creating VOC", async () => {
+    const response = await request(app)
+      .post("/vocs")
+      .set("x-actor-id", "user-tableau")
+      .send({ title: "Slow dashboard", description: "The executive view times out." });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error.code).toBe("validation_failed");
+  });
+
+  it("rejects reporter-submitted severity on VOC create", async () => {
+    const response = await request(app)
+      .post("/vocs")
+      .set("x-actor-id", "user-tableau")
+      .send({
+        managed_system_id: "ms-tableau",
+        title: "Slow dashboard",
+        description: "The executive view times out.",
+        severity: "high"
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error.code).toBe("validation_failed");
+  });
+
+  it("validates analytics area belongs to the selected Managed System", async () => {
+    const response = await request(app)
+      .post("/vocs")
+      .set("x-actor-id", "user-tableau")
+      .send({
+        managed_system_id: "ms-tableau",
+        analytics_area_id: "aa-looker-revenue",
+        title: "Wrong area",
+        description: "The selected area belongs to another system."
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error.code).toBe("validation_failed");
+  });
+
+  it("blocks sibling Managed System access for scoped actors", async () => {
+    const response = await request(app)
+      .get("/vocs?managed_system_id=ms-looker")
+      .set("x-actor-id", "dev-tableau");
+
+    expect(response.status).toBe(403);
+    expect(response.body.error.code).toBe("permission_denied");
+  });
+
+  it("lets explicit deny override Admin-level allow", async () => {
+    const response = await request(app)
+      .get("/vocs?managed_system_id=ms-looker")
+      .set("x-actor-id", "admin-denied-looker");
+
+    expect(response.status).toBe(403);
+    expect(response.body.error.code).toBe("permission_denied");
+  });
+
+  it("prevents reporter editing core VOC fields after triage begins", async () => {
+    const created = await request(app)
+      .post("/vocs")
+      .set("x-actor-id", "user-tableau")
+      .send({
+        managed_system_id: "ms-tableau",
+        title: "Missing filters",
+        description: "The operational view needs region filters."
+      });
+
+    await request(app)
+      .patch(`/vocs/${created.body.id}`)
+      .set("x-actor-id", "admin")
+      .send({ triage_state: "triaging", severity: "high" })
+      .expect(200);
+
+    const response = await request(app)
+      .patch(`/vocs/${created.body.id}`)
+      .set("x-actor-id", "user-tableau")
+      .send({ title: "Edited after triage" });
+
+    expect(response.status).toBe(409);
+    expect(response.body.error.code).toBe("invalid_transition");
+  });
+
+  it("rejects generated_voc relation type and cross-workspace links", async () => {
+    const forbiddenRelation = await request(app)
+      .post("/entity-links")
+      .set("x-actor-id", "admin")
+      .send({
+        source_type: "survey_response",
+        source_id: "sr-1",
+        target_type: "voc",
+        target_id: "voc-1",
+        relation_type: "generated_voc",
+        visibility: "summary_visible"
+      });
+
+    expect(forbiddenRelation.status).toBe(400);
+    expect(forbiddenRelation.body.error.code).toBe("validation_failed");
+
+    const crossWorkspace = await request(app)
+      .post("/entity-links")
+      .set("x-actor-id", "admin")
+      .send({
+        source_type: "voc",
+        source_id: "voc-seeded-tableau",
+        target_type: "finding",
+        target_id: "finding-other-workspace",
+        relation_type: "created_finding",
+        visibility: "summary_visible"
+      });
+
+    expect(crossWorkspace.status).toBe(400);
+    expect(crossWorkspace.body.error.code).toBe("workspace_mismatch");
+  });
+
+  it("does not auto-resolve reporter-facing VOC status when tasks are done or released", async () => {
+    const flow = await request(app)
+      .post("/vocs/voc-seeded-tableau/request-task")
+      .set("x-actor-id", "admin")
+      .send({ title: "Repair dashboard cache" })
+      .expect(201);
+
+    const converted = await request(app)
+      .post(`/task-requests/${flow.body.id}/convert-to-task`)
+      .set("x-actor-id", "admin")
+      .send({})
+      .expect(201);
+
+    await request(app)
+      .patch(`/tasks/${converted.body.id}`)
+      .set("x-actor-id", "admin")
+      .send({ status: "Released" })
+      .expect(200);
+
+    const voc = await request(app)
+      .get("/vocs/voc-seeded-tableau")
+      .set("x-actor-id", "admin")
+      .expect(200);
+
+    expect(voc.body.reporter_facing_status).toBe("검토 중");
+  });
+
+  it("does not expose Survey Response to VOC conversion", async () => {
+    await request(app)
+      .post("/survey-responses/sr-1/create-voc")
+      .set("x-actor-id", "admin")
+      .send({})
+      .expect(404);
+  });
+});
+
+describe("FeedbackOps backend VOC-to-execution flow", () => {
+  it("preserves source context from VOC cluster to finding to reviewed backlog task", async () => {
+    const cluster = await request(app)
+      .post("/voc-clusters")
+      .set("x-actor-id", "admin")
+      .send({ managed_system_id: "ms-tableau", title: "Performance complaints", voc_ids: ["voc-seeded-tableau"] })
+      .expect(201);
+
+    const finding = await request(app)
+      .post(`/voc-clusters/${cluster.body.id}/create-finding`)
+      .set("x-actor-id", "admin")
+      .send({ title: "Tableau dashboard performance regression", summary: "Repeated complaints point to cache misses." })
+      .expect(201);
+
+    const requestTask = await request(app)
+      .post(`/findings/${finding.body.id}/request-task`)
+      .set("x-actor-id", "admin")
+      .send({ title: "Investigate cache regression" })
+      .expect(201);
+
+    await request(app)
+      .post(`/task-requests/${requestTask.body.id}/approve`)
+      .set("x-actor-id", "admin")
+      .send({ reason: "Evidence is sufficient." })
+      .expect(200);
+
+    const task = await request(app)
+      .post(`/task-requests/${requestTask.body.id}/convert-to-task`)
+      .set("x-actor-id", "admin")
+      .send({})
+      .expect(201);
+
+    expect(task.body.status).toBe("Backlog");
+
+    const links = await request(app)
+      .get("/entity-links")
+      .set("x-actor-id", "admin")
+      .expect(200);
+
+    expect(links.body).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ source_id: cluster.body.id, target_id: finding.body.id, relation_type: "created_finding" }),
+        expect.objectContaining({ source_id: finding.body.id, target_id: requestTask.body.id, relation_type: "requested_task" }),
+        expect.objectContaining({ source_id: requestTask.body.id, target_id: task.body.id, relation_type: "converted_to_task" })
+      ])
+    );
+  });
+
+  it("separates public updates, reporter replies, internal comments, and reporter summaries", async () => {
+    await request(app)
+      .post("/vocs/voc-seeded-tableau/public-updates")
+      .set("x-actor-id", "admin")
+      .send({ body: "We are reviewing the cache behavior." })
+      .expect(201);
+
+    await request(app)
+      .post("/vocs/voc-seeded-tableau/reporter-replies")
+      .set("x-actor-id", "user-tableau")
+      .send({ body: "This affects the Monday report." })
+      .expect(201);
+
+    await request(app)
+      .post("/vocs/voc-seeded-tableau/internal-comments")
+      .set("x-actor-id", "admin")
+      .send({ body: "Private severity and developer notes." })
+      .expect(201);
+
+    const summary = await request(app)
+      .get("/vocs/voc-seeded-tableau/reporter-summary")
+      .set("x-actor-id", "user-tableau")
+      .expect(200);
+
+    expect(summary.body).toEqual({
+      public_title: "Seeded Tableau VOC",
+      reporter_facing_status: "검토 중",
+      owning_team_public_name: "Analytics Platform",
+      last_public_update_at: expect.any(String),
+      public_update_excerpt: "We are reviewing the cache behavior."
+    });
+    expect(JSON.stringify(summary.body)).not.toContain("Private severity");
+    expect(JSON.stringify(summary.body)).not.toContain("Released");
+    expect(JSON.stringify(summary.body)).not.toContain("high");
+  });
+
+  it("shows and repairs high-severity follow-up dashboard queues", async () => {
+    const before = await request(app).get("/dashboard/action-queues").set("x-actor-id", "admin").expect(200);
+
+    expect(before.body.high_severity_follow_up).toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: "voc-high-unlinked", next_action: "Create Finding or Task Request" })])
+    );
+
+    await request(app)
+      .post("/vocs/voc-high-unlinked/request-task")
+      .set("x-actor-id", "admin")
+      .send({ title: "Follow up high severity issue" })
+      .expect(201);
+
+    const after = await request(app).get("/dashboard/action-queues").set("x-actor-id", "admin").expect(200);
+
+    expect(after.body.high_severity_follow_up).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: "voc-high-unlinked" })])
+    );
+  });
+});

--- a/apps/backend/src/domain.test.ts
+++ b/apps/backend/src/domain.test.ts
@@ -157,6 +157,31 @@ describe("FeedbackOps backend MVP invariants", () => {
 });
 
 describe("FeedbackOps backend VOC-to-execution flow", () => {
+  it("exposes minimum MVP API surfaces from the implementation contract", async () => {
+    await request(app).get("/managed-systems").set("x-actor-id", "admin").expect(200);
+    await request(app).get("/analytics-areas?managed_system_id=ms-tableau").set("x-actor-id", "admin").expect(200);
+
+    const permissionRequest = await request(app)
+      .post("/permission-requests")
+      .set("x-actor-id", "user-tableau")
+      .send({ managed_system_id: "ms-tableau", reason: "Need to inspect follow-up work." })
+      .expect(201);
+
+    await request(app).get("/permission-requests").set("x-actor-id", "admin").expect(200);
+    await request(app).post(`/permission-requests/${permissionRequest.body.id}/approve`).set("x-actor-id", "admin").send({}).expect(200);
+
+    const finding = await request(app)
+      .post("/vocs/voc-seeded-tableau/create-finding")
+      .set("x-actor-id", "admin")
+      .send({ title: "Direct VOC finding", summary: "Single VOC has enough evidence." })
+      .expect(201);
+
+    await request(app).get("/findings").set("x-actor-id", "admin").expect(200);
+    await request(app).get(`/findings/${finding.body.id}`).set("x-actor-id", "admin").expect(200);
+    await request(app).get("/task-requests").set("x-actor-id", "admin").expect(200);
+    await request(app).get("/tasks").set("x-actor-id", "admin").expect(200);
+  });
+
   it("preserves source context from VOC cluster to finding to reviewed backlog task", async () => {
     const cluster = await request(app)
       .post("/voc-clusters")

--- a/apps/backend/src/domain.test.ts
+++ b/apps/backend/src/domain.test.ts
@@ -1,9 +1,15 @@
 import request from "supertest";
 import { describe, expect, it } from "vitest";
 import { createApp } from "./app";
-import { createStoreFromEnv } from "./persistence";
+import { MvpStore } from "./mvp";
+import { createStoreFromEnv, PostgresRelationalStore, type AppStore } from "./persistence";
 
 const app = createApp();
+
+function createIsolatedApp(): { app: ReturnType<typeof createApp>; store: MvpStore } {
+  const store = new MvpStore();
+  return { app: createApp(store), store };
+}
 
 describe("FeedbackOps backend MVP invariants", () => {
   it("requires managed_system_id when creating VOC", async () => {
@@ -128,6 +134,12 @@ describe("FeedbackOps backend MVP invariants", () => {
       .send({ title: "Repair dashboard cache" })
       .expect(201);
 
+    await request(app)
+      .post(`/task-requests/${flow.body.id}/approve`)
+      .set("x-actor-id", "admin")
+      .send({ reason: "Evidence is sufficient." })
+      .expect(200);
+
     const converted = await request(app)
       .post(`/task-requests/${flow.body.id}/convert-to-task`)
       .set("x-actor-id", "admin")
@@ -202,10 +214,425 @@ describe("FeedbackOps backend MVP invariants", () => {
     expect(evidenceConversion.body.error.code).toBe("invalid_transition");
   });
 
+  it("requires approval before converting a Task Request to a Task", async () => {
+    const taskRequest = await request(app)
+      .post("/vocs/voc-seeded-tableau/request-task")
+      .set("x-actor-id", "admin")
+      .send({ title: "Do not auto approve this request" })
+      .expect(201);
+
+    const response = await request(app)
+      .post(`/task-requests/${taskRequest.body.id}/convert-to-task`)
+      .set("x-actor-id", "admin")
+      .send({});
+
+    expect(response.status).toBe(409);
+    expect(response.body.error.code).toBe("invalid_transition");
+  });
+
+  it("requires review reasons for Task Request approvals", async () => {
+    const taskRequest = await request(app)
+      .post("/vocs/voc-seeded-tableau/request-task")
+      .set("x-actor-id", "admin")
+      .send({ title: "Approval needs an audit reason" })
+      .expect(201);
+
+    const response = await request(app)
+      .post(`/task-requests/${taskRequest.body.id}/approve`)
+      .set("x-actor-id", "admin")
+      .send({});
+
+    expect(response.status).toBe(400);
+    expect(response.body.error.code).toBe("validation_failed");
+  });
+
+  it("requires explicit self-approval capability and reason for Developer-owned Task Requests", async () => {
+    const taskRequest = await request(app)
+      .post("/vocs/voc-seeded-tableau/request-task")
+      .set("x-actor-id", "dev-tableau")
+      .send({ title: "Developer requested work" })
+      .expect(201);
+
+    const withoutCapability = await request(app)
+      .post(`/task-requests/${taskRequest.body.id}/approve`)
+      .set("x-actor-id", "dev-tableau")
+      .send({ reason: "I own the context." });
+
+    expect(withoutCapability.status).toBe(403);
+    expect(withoutCapability.body.error.code).toBe("permission_denied");
+
+    const privilegedRequest = await request(app)
+      .post("/vocs/voc-seeded-tableau/request-task")
+      .set("x-actor-id", "dev-tableau-self-approve")
+      .send({ title: "Privileged developer requested work" })
+      .expect(201);
+
+    const withoutReason = await request(app)
+      .post(`/task-requests/${privilegedRequest.body.id}/approve`)
+      .set("x-actor-id", "dev-tableau-self-approve")
+      .send({});
+
+    expect(withoutReason.status).toBe(400);
+    expect(withoutReason.body.error.code).toBe("validation_failed");
+  });
+
+  it("exposes required Task Request and Task detail and create endpoints", async () => {
+    const taskRequest = await request(app)
+      .post("/task-requests")
+      .set("x-actor-id", "admin")
+      .send({
+        managed_system_id: "ms-tableau",
+        title: "Standalone execution candidate",
+        source_type: "finding",
+        source_id: "finding-seeded-tableau"
+      })
+      .expect(201);
+
+    await request(app).get(`/task-requests/${taskRequest.body.id}`).set("x-actor-id", "admin").expect(200);
+
+    await request(app)
+      .post(`/task-requests/${taskRequest.body.id}/approve`)
+      .set("x-actor-id", "admin")
+      .send({ reason: "Evidence is sufficient." })
+      .expect(200);
+
+    const task = await request(app)
+      .post(`/task-requests/${taskRequest.body.id}/convert-to-task`)
+      .set("x-actor-id", "admin")
+      .send({})
+      .expect(201);
+
+    await request(app).get(`/tasks/${task.body.id}`).set("x-actor-id", "admin").expect(200);
+
+    await request(app)
+      .post("/tasks")
+      .set("x-actor-id", "admin")
+      .send({ managed_system_id: "ms-tableau", title: "Standalone backstage task" })
+      .expect(201);
+  });
+
   it("selects Postgres-backed persistence when DATABASE_URL is configured", () => {
     const store = createStoreFromEnv({ DATABASE_URL: "postgres://feedbackops:feedbackops@localhost:5432/feedbackops" });
 
     expect(store.persistence).toBe("postgres");
+  });
+
+  it("does not acknowledge successful mutations when persistence fails", async () => {
+    const store = new MvpStore() as AppStore;
+    store.persist = async () => {
+      throw new Error("write failed");
+    };
+    const failingPersistenceApp = createApp(store);
+
+    const response = await request(failingPersistenceApp)
+      .post("/vocs")
+      .set("x-actor-id", "user-tableau")
+      .send({
+        managed_system_id: "ms-tableau",
+        title: "Persistence should gate response",
+        description: "The API must not send 201 before durable write succeeds."
+      });
+
+    expect(response.status).toBe(500);
+    expect(response.body.error.message).toContain("write failed");
+  });
+
+  it("hydrates Postgres mode from normalized relational tables instead of app_state", async () => {
+    const queries: string[] = [];
+    const pool = {
+      query: async (sql: string) => {
+        queries.push(sql);
+        if (sql.includes("from core.actors")) {
+          return { rows: [{ id: "seed-admin", workspace_id: "ws-seed", name: "Seed Admin", role_level: "Admin" }], rowCount: 1 };
+        }
+        if (sql.includes("from permission.permission_grants")) return { rows: [], rowCount: 0 };
+        if (sql.includes("from permission.permission_denies")) return { rows: [], rowCount: 0 };
+        if (sql.includes("from core.managed_systems")) {
+          return { rows: [{ id: "ms-seed", workspace_id: "ws-seed", name: "Seed System", archived: false }], rowCount: 1 };
+        }
+        if (sql.includes("from core.analytics_areas")) return { rows: [], rowCount: 0 };
+        if (sql.includes("from voc.vocs")) {
+          return {
+            rows: [
+              {
+                id: "voc-relational",
+                workspace_id: "ws-seed",
+                managed_system_id: "ms-seed",
+                analytics_area_id: null,
+                reporter_id: "seed-admin",
+                title: "Relational VOC",
+                description: "Loaded from voc.vocs",
+                source_context: null,
+                severity: "medium",
+                triage_state: "triaging",
+                reporter_facing_status: "검토 중",
+                owner_id: null
+              }
+            ],
+            rowCount: 1
+          };
+        }
+        return { rows: [], rowCount: 0 };
+      },
+      end: async () => {}
+    };
+
+    const store = new PostgresRelationalStore(pool);
+    await store.ready;
+
+    expect(store.getVoc(store.actor("seed-admin"), "voc-relational").title).toBe("Relational VOC");
+    expect(queries.some((sql) => sql.includes("core.app_state"))).toBe(false);
+  });
+});
+
+describe("FeedbackOps backend reviewer blocker coverage", () => {
+  it("blocks Users from internal Finding and Task execution surfaces while preserving Admin and scoped Developer access", async () => {
+    const { app } = createIsolatedApp();
+
+    const userFinding = await request(app)
+      .post("/vocs/voc-seeded-tableau/create-finding")
+      .set("x-actor-id", "user-tableau")
+      .send({ title: "Reporter should not synthesize findings" });
+    expect(userFinding.status).toBe(403);
+    expect(userFinding.body.error.code).toBe("permission_denied");
+
+    const userVocTaskRequest = await request(app)
+      .post("/vocs/voc-seeded-tableau/request-task")
+      .set("x-actor-id", "user-tableau")
+      .send({ title: "Reporter should not request execution" });
+    expect(userVocTaskRequest.status).toBe(403);
+    expect(userVocTaskRequest.body.error.code).toBe("permission_denied");
+
+    const userFindingTaskRequest = await request(app)
+      .post("/findings/finding-seeded-tableau/request-task")
+      .set("x-actor-id", "user-tableau")
+      .send({ title: "Reporter should not request execution from findings" });
+    expect(userFindingTaskRequest.status).toBe(403);
+    expect(userFindingTaskRequest.body.error.code).toBe("permission_denied");
+
+    const userFindings = await request(app).get("/findings").set("x-actor-id", "user-tableau");
+    expect(userFindings.status).toBe(403);
+    expect(userFindings.body.error.code).toBe("permission_denied");
+
+    const userFindingDetail = await request(app).get("/findings/finding-seeded-tableau").set("x-actor-id", "user-tableau");
+    expect(userFindingDetail.status).toBe(403);
+    expect(userFindingDetail.body.error.code).toBe("permission_denied");
+
+    const task = await request(app)
+      .post("/tasks")
+      .set("x-actor-id", "admin")
+      .send({ managed_system_id: "ms-tableau", title: "Internal task for access checks" })
+      .expect(201);
+
+    const userTasks = await request(app).get("/tasks").set("x-actor-id", "user-tableau");
+    expect(userTasks.status).toBe(403);
+    expect(userTasks.body.error.code).toBe("permission_denied");
+
+    const userTaskDetail = await request(app).get(`/tasks/${task.body.id}`).set("x-actor-id", "user-tableau");
+    expect(userTaskDetail.status).toBe(403);
+    expect(userTaskDetail.body.error.code).toBe("permission_denied");
+
+    await request(app)
+      .post("/vocs/voc-seeded-tableau/create-finding")
+      .set("x-actor-id", "dev-tableau")
+      .send({ title: "Developer can synthesize finding" })
+      .expect(201);
+    await request(app).get("/findings").set("x-actor-id", "dev-tableau").expect(200);
+    await request(app).get(`/tasks/${task.body.id}`).set("x-actor-id", "dev-tableau").expect(200);
+    await request(app).get("/tasks").set("x-actor-id", "admin").expect(200);
+  });
+
+  it("disables non-persistent VOC cluster mutation endpoints while preserving direct VOC to Finding flow", async () => {
+    const { app } = createIsolatedApp();
+
+    const cluster = await request(app)
+      .post("/voc-clusters")
+      .set("x-actor-id", "admin")
+      .send({ managed_system_id: "ms-tableau", title: "Performance complaints", voc_ids: ["voc-seeded-tableau"] });
+    expect(cluster.status).toBe(410);
+    expect(cluster.body.error.code).toBe("not_found");
+
+    const clusterFinding = await request(app)
+      .post("/voc-clusters/voc-cluster-0001/create-finding")
+      .set("x-actor-id", "admin")
+      .send({ title: "Cluster finding" });
+    expect(clusterFinding.status).toBe(410);
+    expect(clusterFinding.body.error.code).toBe("not_found");
+
+    await request(app)
+      .post("/vocs/voc-seeded-tableau/create-finding")
+      .set("x-actor-id", "admin")
+      .send({ title: "Direct VOC finding", summary: "Direct synthesis remains available." })
+      .expect(201);
+  });
+
+  it("continues Postgres relational persistence after one failed save", async () => {
+    const loadSql = [
+      "from core.actors",
+      "from permission.permission_grants",
+      "from permission.permission_denies",
+      "from core.managed_systems",
+      "from core.analytics_areas",
+      "from voc.vocs",
+      "from voc.voc_conversation_entries",
+      "from finding.findings",
+      "from task.task_requests",
+      "from task.tasks",
+      "from permission.permission_requests",
+      "from core.entity_links",
+      "from core.audit_logs"
+    ];
+    const saveAttempts: string[] = [];
+    const pool = {
+      query: async (sql: string) => {
+        if (sql.trimStart().startsWith("select") && loadSql.some((fragment) => sql.includes(fragment))) {
+          if (sql.includes("from core.actors")) {
+            return { rows: [{ id: "seed-admin", workspace_id: "ws-seed", name: "Seed Admin", role_level: "Admin" }], rowCount: 1 };
+          }
+          return { rows: [], rowCount: 0 };
+        }
+        saveAttempts.push(sql);
+        if (sql === "delete from core.entity_links" && saveAttempts.filter((attempt) => attempt === "begin").length === 1) {
+          throw new Error("first save failed");
+        }
+        return { rows: [], rowCount: 0 };
+      },
+      end: async () => {}
+    };
+
+    const store = new PostgresRelationalStore(pool);
+    await store.ready;
+
+    await expect(store.persist()).rejects.toThrow("first save failed");
+    await expect(store.persist()).resolves.toBeUndefined();
+    expect(saveAttempts.filter((sql) => sql === "begin")).toHaveLength(2);
+    expect(saveAttempts).toContain("commit");
+  });
+
+  it("focuses Users on their own VOCs while Admin and scoped Developer can still see same-system VOCs", async () => {
+    const { app, store } = createIsolatedApp();
+    store.actors.set("user-tableau-2", {
+      id: "user-tableau-2",
+      workspaceId: "ws-main",
+      name: "Second Reporter",
+      roleLevel: "User",
+      managedSystemIds: ["ms-tableau"]
+    });
+    store.vocs.set("voc-other-reporter", {
+      id: "voc-other-reporter",
+      workspaceId: "ws-main",
+      managedSystemId: "ms-tableau",
+      reporterId: "user-tableau-2",
+      title: "Other reporter VOC",
+      description: "Same system, different reporter.",
+      triageState: "new",
+      reporterFacingStatus: "접수됨"
+    });
+
+    const userList = await request(app).get("/vocs?managed_system_id=ms-tableau").set("x-actor-id", "user-tableau").expect(200);
+    expect(userList.body).toEqual(expect.arrayContaining([expect.objectContaining({ id: "voc-seeded-tableau" })]));
+    expect(userList.body).not.toEqual(expect.arrayContaining([expect.objectContaining({ id: "voc-other-reporter" })]));
+
+    const userRead = await request(app).get("/vocs/voc-other-reporter").set("x-actor-id", "user-tableau");
+    expect(userRead.status).toBe(403);
+    expect(userRead.body.error.code).toBe("permission_denied");
+
+    await request(app).get("/vocs/voc-other-reporter").set("x-actor-id", "admin").expect(200);
+    await request(app).get("/vocs/voc-other-reporter").set("x-actor-id", "dev-tableau").expect(200);
+  });
+
+  it("denies Users access to Task Request lists", async () => {
+    const { app } = createIsolatedApp();
+
+    const response = await request(app).get("/task-requests").set("x-actor-id", "user-tableau");
+
+    expect(response.status).toBe(403);
+    expect(response.body.error.code).toBe("permission_denied");
+  });
+
+  it("validates standalone Task Request source, creates its entity link, and audits creation", async () => {
+    const { app, store } = createIsolatedApp();
+    const created = await request(app)
+      .post("/task-requests")
+      .set("x-actor-id", "admin")
+      .send({
+        managed_system_id: "ms-tableau",
+        title: "Standalone linked candidate",
+        source_type: "finding",
+        source_id: "finding-seeded-tableau"
+      })
+      .expect(201);
+
+    expect([...store.links.values()]).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          sourceType: "finding",
+          sourceId: "finding-seeded-tableau",
+          targetType: "task_request",
+          targetId: created.body.id,
+          relationType: "requested_task"
+        })
+      ])
+    );
+    expect(store.auditEvents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "task_request_created",
+          metadata: expect.objectContaining({
+            task_request_id: created.body.id,
+            source_entity: { type: "finding", id: "finding-seeded-tableau" },
+            managed_system_id: "ms-tableau"
+          })
+        })
+      ])
+    );
+  });
+
+  it("rejects standalone Task Requests when source is missing", async () => {
+    const { app } = createIsolatedApp();
+
+    const response = await request(app)
+      .post("/task-requests")
+      .set("x-actor-id", "admin")
+      .send({
+        managed_system_id: "ms-tableau",
+        title: "Broken candidate",
+        source_type: "finding",
+        source_id: "finding-missing"
+      });
+
+    expect(response.status).toBe(404);
+    expect(response.body.error.code).toBe("not_found");
+  });
+
+  it("audits explicit-capability self-approval metadata", async () => {
+    const { app, store } = createIsolatedApp();
+    const taskRequest = await request(app)
+      .post("/vocs/voc-seeded-tableau/request-task")
+      .set("x-actor-id", "dev-tableau-self-approve")
+      .send({ title: "Privileged developer self-approved work" })
+      .expect(201);
+
+    await request(app)
+      .post(`/task-requests/${taskRequest.body.id}/approve`)
+      .set("x-actor-id", "dev-tableau-self-approve")
+      .send({ reason: "I have explicit self-approval for this Managed System." })
+      .expect(200);
+
+    expect(store.auditEvents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "task_request_approved",
+          metadata: expect.objectContaining({
+            task_request_id: taskRequest.body.id,
+            self_approved: true,
+            reason: "I have explicit self-approval for this Managed System.",
+            source_entity: { type: "voc", id: "voc-seeded-tableau" },
+            managed_system_id: "ms-tableau"
+          })
+        })
+      ])
+    );
   });
 });
 
@@ -235,15 +662,9 @@ describe("FeedbackOps backend VOC-to-execution flow", () => {
     await request(app).get("/tasks").set("x-actor-id", "admin").expect(200);
   });
 
-  it("preserves source context from VOC cluster to finding to reviewed backlog task", async () => {
-    const cluster = await request(app)
-      .post("/voc-clusters")
-      .set("x-actor-id", "admin")
-      .send({ managed_system_id: "ms-tableau", title: "Performance complaints", voc_ids: ["voc-seeded-tableau"] })
-      .expect(201);
-
+  it("preserves source context from VOC to finding to reviewed backlog task", async () => {
     const finding = await request(app)
-      .post(`/voc-clusters/${cluster.body.id}/create-finding`)
+      .post("/vocs/voc-seeded-tableau/create-finding")
       .set("x-actor-id", "admin")
       .send({ title: "Tableau dashboard performance regression", summary: "Repeated complaints point to cache misses." })
       .expect(201);
@@ -275,7 +696,7 @@ describe("FeedbackOps backend VOC-to-execution flow", () => {
 
     expect(links.body).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ source_id: cluster.body.id, target_id: finding.body.id, relation_type: "created_finding" }),
+        expect.objectContaining({ source_id: "voc-seeded-tableau", target_id: finding.body.id, relation_type: "created_finding" }),
         expect.objectContaining({ source_id: finding.body.id, target_id: requestTask.body.id, relation_type: "requested_task" }),
         expect.objectContaining({ source_id: requestTask.body.id, target_id: task.body.id, relation_type: "converted_to_task" })
       ])

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -1,0 +1,6 @@
+import { createApp } from "./app";
+
+const port = Number(process.env.PORT ?? 3000);
+createApp().listen(port, () => {
+  console.log(`FeedbackOps backend listening on ${port}`);
+});

--- a/apps/backend/src/mvp.ts
+++ b/apps/backend/src/mvp.ts
@@ -65,6 +65,8 @@ function makeId(prefix: string, count: number): string {
 }
 
 export class MvpStore {
+  persistence: "memory" | "postgres" = "memory";
+
   actors = new Map<string, Actor>();
   managedSystems = new Map<string, ManagedSystem>();
   analyticsAreas = new Map<string, AnalyticsArea>();
@@ -78,7 +80,7 @@ export class MvpStore {
   permissionRequests = new Map<string, PermissionRequest>();
   auditEvents: AuditEvent[] = [];
 
-  private counters = {
+  protected counters = {
     voc: 1,
     conversation: 1,
     cluster: 1,
@@ -412,14 +414,33 @@ export class MvpStore {
 
   approveTaskRequest(actor: Actor, id: string, body: Record<string, unknown>): TaskRequest {
     const taskRequest = this.getTaskRequest(actor, id);
-    if (actor.roleLevel === "User") {
-      throw new ApiError(403, "permission_denied", "User cannot approve task requests.");
-    }
-    if (taskRequest.requestedById === actor.id && actor.roleLevel === "Developer" && !actor.capabilities?.includes("task_request_self_approval")) {
-      throw new ApiError(403, "permission_denied", "Self-approval requires explicit capability.");
-    }
+    this.assertCanReviewTaskRequest(actor, taskRequest);
     taskRequest.status = "approved";
     this.audit(actor.workspaceId, "task_request_approved", { task_request_id: id, reason: body.reason ?? null });
+    return taskRequest;
+  }
+
+  rejectTaskRequest(actor: Actor, id: string, body: Record<string, unknown>): TaskRequest {
+    const taskRequest = this.getTaskRequest(actor, id);
+    this.assertCanReviewTaskRequest(actor, taskRequest);
+    this.assertReviewReason(body);
+    if (taskRequest.status === "converted") {
+      throw new ApiError(409, "invalid_transition", "Converted Task Request cannot be rejected.");
+    }
+    taskRequest.status = "rejected";
+    this.audit(actor.workspaceId, "task_request_rejected", { task_request_id: id, reason: body.reason });
+    return taskRequest;
+  }
+
+  requestMoreEvidenceForTaskRequest(actor: Actor, id: string, body: Record<string, unknown>): TaskRequest {
+    const taskRequest = this.getTaskRequest(actor, id);
+    this.assertCanReviewTaskRequest(actor, taskRequest);
+    this.assertReviewReason(body);
+    if (taskRequest.status === "converted") {
+      throw new ApiError(409, "invalid_transition", "Converted Task Request cannot request more evidence.");
+    }
+    taskRequest.status = "needs_more_evidence";
+    this.audit(actor.workspaceId, "task_request_more_evidence_requested", { task_request_id: id, reason: body.reason });
     return taskRequest;
   }
 
@@ -598,6 +619,21 @@ export class MvpStore {
     }
     this.assertManagedSystemAccess(actor, taskRequest.managedSystemId);
     return taskRequest;
+  }
+
+  private assertCanReviewTaskRequest(actor: Actor, taskRequest: TaskRequest): void {
+    if (actor.roleLevel === "User") {
+      throw new ApiError(403, "permission_denied", "User cannot review task requests.");
+    }
+    if (taskRequest.requestedById === actor.id && actor.roleLevel === "Developer" && !actor.capabilities?.includes("task_request_self_approval")) {
+      throw new ApiError(403, "permission_denied", "Self-approval requires explicit capability.");
+    }
+  }
+
+  private assertReviewReason(body: Record<string, unknown>): void {
+    if (!body.reason) {
+      throw new ApiError(400, "validation_failed", "reason is required for Task Request review decisions.");
+    }
   }
 
   private assertAnalyticsAreaMatches(analyticsAreaId: string, managedSystemId: string): void {

--- a/apps/backend/src/mvp.ts
+++ b/apps/backend/src/mvp.ts
@@ -1,0 +1,608 @@
+import {
+  type Actor,
+  type AnalyticsArea,
+  type ConversationEntry,
+  type EntityLink,
+  type Finding,
+  type ManagedSystem,
+  type RelationType,
+  type Severity,
+  type Task,
+  type TaskRequest,
+  type TaskStatus,
+  type Voc,
+  isForbiddenRelationType,
+  richContentHasUnsafeInlineImage
+} from "@feedbackops/shared";
+
+type ApiErrorCode =
+  | "validation_failed"
+  | "unauthorized"
+  | "permission_denied"
+  | "not_found"
+  | "workspace_mismatch"
+  | "conflict"
+  | "invalid_transition";
+
+export class ApiError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly code: ApiErrorCode,
+    message: string
+  ) {
+    super(message);
+  }
+}
+
+interface VocCluster {
+  id: string;
+  workspaceId: string;
+  managedSystemId: string;
+  title: string;
+  vocIds: string[];
+}
+
+interface AuditEvent {
+  id: string;
+  workspaceId: string;
+  type: string;
+  metadata: Record<string, unknown>;
+}
+
+const now = () => new Date().toISOString();
+
+function makeId(prefix: string, count: number): string {
+  return `${prefix}-${count.toString().padStart(4, "0")}`;
+}
+
+export class MvpStore {
+  actors = new Map<string, Actor>();
+  managedSystems = new Map<string, ManagedSystem>();
+  analyticsAreas = new Map<string, AnalyticsArea>();
+  vocs = new Map<string, Voc>();
+  conversations = new Map<string, ConversationEntry[]>();
+  clusters = new Map<string, VocCluster>();
+  links = new Map<string, EntityLink>();
+  findings = new Map<string, Finding>();
+  taskRequests = new Map<string, TaskRequest>();
+  tasks = new Map<string, Task>();
+  auditEvents: AuditEvent[] = [];
+
+  private counters = {
+    voc: 1,
+    conversation: 1,
+    cluster: 1,
+    link: 1,
+    finding: 1,
+    taskRequest: 1,
+    task: 1,
+    audit: 1
+  };
+
+  constructor() {
+    this.seed();
+  }
+
+  actor(actorId?: string): Actor {
+    if (!actorId) {
+      throw new ApiError(401, "unauthorized", "Missing actor.");
+    }
+    const actor = this.actors.get(actorId);
+    if (!actor) {
+      throw new ApiError(401, "unauthorized", "Unknown actor.");
+    }
+    return actor;
+  }
+
+  canAccessManagedSystem(actor: Actor, managedSystemId: string): boolean {
+    if (actor.explicitDeniedManagedSystemIds?.includes(managedSystemId)) {
+      return false;
+    }
+    if (actor.roleLevel === "Admin") {
+      return true;
+    }
+    return actor.managedSystemIds.includes(managedSystemId);
+  }
+
+  assertManagedSystemAccess(actor: Actor, managedSystemId: string): void {
+    if (!this.canAccessManagedSystem(actor, managedSystemId)) {
+      throw new ApiError(403, "permission_denied", "Actor cannot access this Managed System.");
+    }
+  }
+
+  createVoc(actor: Actor, body: Record<string, unknown>): Voc {
+    const managedSystemId = String(body.managed_system_id ?? "");
+    if (!managedSystemId || !body.title || !body.description) {
+      throw new ApiError(400, "validation_failed", "managed_system_id, title, and description are required.");
+    }
+    if ("severity" in body || "reporter_id" in body || "reporter_facing_status" in body || "task_status" in body) {
+      throw new ApiError(400, "validation_failed", "Reporter cannot set server-owned VOC fields.");
+    }
+    if (richContentHasUnsafeInlineImage(String(body.description))) {
+      throw new ApiError(400, "validation_failed", "Rich content cannot include unsafe inline images.");
+    }
+    this.assertManagedSystemAccess(actor, managedSystemId);
+    this.assertAnalyticsAreaMatches(String(body.analytics_area_id ?? ""), managedSystemId);
+
+    const voc: Voc = {
+      id: makeId("voc", this.counters.voc++),
+      workspaceId: actor.workspaceId,
+      managedSystemId,
+      analyticsAreaId: body.analytics_area_id ? String(body.analytics_area_id) : undefined,
+      reporterId: actor.id,
+      title: String(body.title),
+      description: String(body.description),
+      sourceContext: body.source_context as Voc["sourceContext"],
+      triageState: "new",
+      reporterFacingStatus: "접수됨"
+    };
+    this.vocs.set(voc.id, voc);
+    this.audit(actor.workspaceId, "voc_created", { voc_id: voc.id, managed_system_id: managedSystemId });
+    return voc;
+  }
+
+  listVocs(actor: Actor, managedSystemId?: string): Voc[] {
+    if (managedSystemId && managedSystemId !== "all") {
+      this.assertManagedSystemAccess(actor, managedSystemId);
+    }
+    return [...this.vocs.values()].filter((voc) => {
+      if (voc.workspaceId !== actor.workspaceId) return false;
+      if (managedSystemId && managedSystemId !== "all" && voc.managedSystemId !== managedSystemId) return false;
+      return this.canAccessManagedSystem(actor, voc.managedSystemId);
+    });
+  }
+
+  getVoc(actor: Actor, id: string): Voc {
+    const voc = this.vocs.get(id);
+    if (!voc || voc.workspaceId !== actor.workspaceId) {
+      throw new ApiError(404, "not_found", "VOC not found.");
+    }
+    this.assertManagedSystemAccess(actor, voc.managedSystemId);
+    return voc;
+  }
+
+  patchVoc(actor: Actor, id: string, body: Record<string, unknown>): Voc {
+    const voc = this.getVoc(actor, id);
+    const isReporter = voc.reporterId === actor.id;
+    if (isReporter && voc.triageState !== "new" && ("title" in body || "description" in body || "attachments" in body)) {
+      throw new ApiError(409, "invalid_transition", "Reporter cannot edit core fields after triage begins.");
+    }
+    if (("triage_state" in body || "severity" in body || "owner_id" in body) && actor.roleLevel === "User") {
+      throw new ApiError(403, "permission_denied", "Reporter cannot triage VOC.");
+    }
+    if (body.title) voc.title = String(body.title);
+    if (body.description) {
+      if (richContentHasUnsafeInlineImage(String(body.description))) {
+        throw new ApiError(400, "validation_failed", "Rich content cannot include unsafe inline images.");
+      }
+      voc.description = String(body.description);
+    }
+    if (body.triage_state) voc.triageState = body.triage_state as Voc["triageState"];
+    if (body.severity) voc.severity = body.severity as Severity;
+    if (body.reporter_facing_status) voc.reporterFacingStatus = body.reporter_facing_status as Voc["reporterFacingStatus"];
+    if (body.owner_id) voc.ownerId = String(body.owner_id);
+    this.audit(actor.workspaceId, "voc_updated", { voc_id: id });
+    return voc;
+  }
+
+  createConversation(actor: Actor, vocId: string, type: ConversationEntry["type"], body: Record<string, unknown>): ConversationEntry {
+    const voc = this.getVoc(actor, vocId);
+    if (!body.body || richContentHasUnsafeInlineImage(String(body.body))) {
+      throw new ApiError(400, "validation_failed", "Safe rich content body is required.");
+    }
+    if (type === "reporter_reply" && voc.reporterId !== actor.id) {
+      throw new ApiError(403, "permission_denied", "Only the reporter can reply.");
+    }
+    if (type !== "reporter_reply" && actor.roleLevel === "User") {
+      throw new ApiError(403, "permission_denied", "Only operators can write this entry.");
+    }
+    const entry: ConversationEntry = {
+      id: makeId("conversation", this.counters.conversation++),
+      vocId,
+      authorId: actor.id,
+      type,
+      body: String(body.body),
+      createdAt: now()
+    };
+    this.conversations.set(vocId, [...(this.conversations.get(vocId) ?? []), entry]);
+    this.audit(actor.workspaceId, `${type}_created`, { voc_id: vocId });
+    return entry;
+  }
+
+  reporterSummary(actor: Actor, vocId: string): Record<string, unknown> {
+    const voc = this.getVoc(actor, vocId);
+    if (actor.roleLevel === "User" && voc.reporterId !== actor.id) {
+      throw new ApiError(403, "permission_denied", "Reporter can only view own summary.");
+    }
+    const publicUpdate = (this.conversations.get(vocId) ?? []).filter((entry) => entry.type === "public_update").at(-1);
+    return {
+      public_title: voc.title,
+      reporter_facing_status: voc.reporterFacingStatus,
+      owning_team_public_name: "Analytics Platform",
+      ...(publicUpdate
+        ? {
+            last_public_update_at: publicUpdate.createdAt,
+            public_update_excerpt: publicUpdate.body
+          }
+        : {})
+    };
+  }
+
+  createCluster(actor: Actor, body: Record<string, unknown>): VocCluster {
+    const managedSystemId = String(body.managed_system_id ?? "");
+    this.assertManagedSystemAccess(actor, managedSystemId);
+    const vocIds = Array.isArray(body.voc_ids) ? body.voc_ids.map(String) : [];
+    for (const vocId of vocIds) {
+      const voc = this.getVoc(actor, vocId);
+      if (voc.managedSystemId !== managedSystemId) {
+        throw new ApiError(400, "validation_failed", "Cluster VOCs must share one Managed System.");
+      }
+    }
+    const cluster: VocCluster = {
+      id: makeId("voc-cluster", this.counters.cluster++),
+      workspaceId: actor.workspaceId,
+      managedSystemId,
+      title: String(body.title ?? "Untitled cluster"),
+      vocIds
+    };
+    this.clusters.set(cluster.id, cluster);
+    this.audit(actor.workspaceId, "voc_cluster_created", { cluster_id: cluster.id });
+    return cluster;
+  }
+
+  createFindingFromCluster(actor: Actor, clusterId: string, body: Record<string, unknown>): Finding {
+    const cluster = this.clusters.get(clusterId);
+    if (!cluster || cluster.workspaceId !== actor.workspaceId) {
+      throw new ApiError(404, "not_found", "VOC Cluster not found.");
+    }
+    this.assertManagedSystemAccess(actor, cluster.managedSystemId);
+    const finding = this.createFinding(actor, {
+      managed_system_id: cluster.managedSystemId,
+      title: body.title,
+      summary: body.summary
+    });
+    this.createEntityLink(actor, {
+      source_type: "voc_cluster",
+      source_id: cluster.id,
+      target_type: "finding",
+      target_id: finding.id,
+      relation_type: "created_finding",
+      visibility: "summary_visible"
+    });
+    this.audit(actor.workspaceId, "finding_created_from_voc_cluster", { cluster_id: cluster.id, finding_id: finding.id });
+    return finding;
+  }
+
+  createFinding(actor: Actor, body: Record<string, unknown>): Finding {
+    const managedSystemId = String(body.managed_system_id ?? "");
+    this.assertManagedSystemAccess(actor, managedSystemId);
+    const finding: Finding = {
+      id: makeId("finding", this.counters.finding++),
+      workspaceId: actor.workspaceId,
+      managedSystemId,
+      title: String(body.title ?? "Untitled finding"),
+      summary: String(body.summary ?? ""),
+      status: "active"
+    };
+    this.findings.set(finding.id, finding);
+    return finding;
+  }
+
+  requestTaskFromVoc(actor: Actor, vocId: string, body: Record<string, unknown>): TaskRequest {
+    const voc = this.getVoc(actor, vocId);
+    const taskRequest = this.createTaskRequest(actor, {
+      managed_system_id: voc.managedSystemId,
+      title: body.title ?? voc.title,
+      source_type: "voc",
+      source_id: voc.id
+    });
+    this.createEntityLink(actor, {
+      source_type: "voc",
+      source_id: voc.id,
+      target_type: "task_request",
+      target_id: taskRequest.id,
+      relation_type: "requested_task",
+      visibility: "summary_visible"
+    });
+    this.audit(actor.workspaceId, "task_request_created_from_voc", { voc_id: voc.id, task_request_id: taskRequest.id });
+    return taskRequest;
+  }
+
+  requestTaskFromFinding(actor: Actor, findingId: string, body: Record<string, unknown>): TaskRequest {
+    const finding = this.findings.get(findingId);
+    if (!finding || finding.workspaceId !== actor.workspaceId) {
+      throw new ApiError(404, "not_found", "Finding not found.");
+    }
+    this.assertManagedSystemAccess(actor, finding.managedSystemId);
+    const taskRequest = this.createTaskRequest(actor, {
+      managed_system_id: finding.managedSystemId,
+      title: body.title ?? finding.title,
+      source_type: "finding",
+      source_id: finding.id
+    });
+    this.createEntityLink(actor, {
+      source_type: "finding",
+      source_id: finding.id,
+      target_type: "task_request",
+      target_id: taskRequest.id,
+      relation_type: "requested_task",
+      visibility: "summary_visible"
+    });
+    this.audit(actor.workspaceId, "task_request_created_from_finding", { finding_id: finding.id, task_request_id: taskRequest.id });
+    return taskRequest;
+  }
+
+  createTaskRequest(actor: Actor, body: Record<string, unknown>): TaskRequest {
+    const managedSystemId = String(body.managed_system_id ?? "");
+    this.assertManagedSystemAccess(actor, managedSystemId);
+    const taskRequest: TaskRequest = {
+      id: makeId("task-request", this.counters.taskRequest++),
+      workspaceId: actor.workspaceId,
+      managedSystemId,
+      title: String(body.title ?? "Untitled task request"),
+      status: "pending_review",
+      sourceType: body.source_type as TaskRequest["sourceType"],
+      sourceId: String(body.source_id),
+      requestedById: actor.id
+    };
+    this.taskRequests.set(taskRequest.id, taskRequest);
+    return taskRequest;
+  }
+
+  approveTaskRequest(actor: Actor, id: string, body: Record<string, unknown>): TaskRequest {
+    const taskRequest = this.getTaskRequest(actor, id);
+    if (actor.roleLevel === "User") {
+      throw new ApiError(403, "permission_denied", "User cannot approve task requests.");
+    }
+    if (taskRequest.requestedById === actor.id && actor.roleLevel === "Developer" && !actor.capabilities?.includes("task_request_self_approval")) {
+      throw new ApiError(403, "permission_denied", "Self-approval requires explicit capability.");
+    }
+    taskRequest.status = "approved";
+    this.audit(actor.workspaceId, "task_request_approved", { task_request_id: id, reason: body.reason ?? null });
+    return taskRequest;
+  }
+
+  convertTaskRequest(actor: Actor, id: string): Task {
+    const taskRequest = this.getTaskRequest(actor, id);
+    if (taskRequest.status === "pending_review") {
+      taskRequest.status = "approved";
+    }
+    if (taskRequest.status !== "approved") {
+      throw new ApiError(409, "invalid_transition", "Task Request must be approved before conversion.");
+    }
+    const task: Task = {
+      id: makeId("task", this.counters.task++),
+      workspaceId: actor.workspaceId,
+      managedSystemId: taskRequest.managedSystemId,
+      title: taskRequest.title,
+      status: "Backlog"
+    };
+    taskRequest.status = "converted";
+    this.tasks.set(task.id, task);
+    this.createEntityLink(actor, {
+      source_type: "task_request",
+      source_id: taskRequest.id,
+      target_type: "task",
+      target_id: task.id,
+      relation_type: "converted_to_task",
+      visibility: "summary_visible"
+    });
+    this.audit(actor.workspaceId, "task_request_converted", { task_request_id: id, task_id: task.id });
+    return task;
+  }
+
+  patchTask(actor: Actor, id: string, body: Record<string, unknown>): Task {
+    const task = this.tasks.get(id);
+    if (!task || task.workspaceId !== actor.workspaceId) {
+      throw new ApiError(404, "not_found", "Task not found.");
+    }
+    this.assertManagedSystemAccess(actor, task.managedSystemId);
+    if (body.status) {
+      task.status = body.status as TaskStatus;
+    }
+    this.audit(actor.workspaceId, "task_updated", { task_id: id, status: task.status });
+    return task;
+  }
+
+  listEntityLinks(actor: Actor): EntityLink[] {
+    return [...this.links.values()].filter((link) => link.workspaceId === actor.workspaceId);
+  }
+
+  createEntityLink(actor: Actor, body: Record<string, unknown>): EntityLink {
+    const relationType = String(body.relation_type);
+    if (isForbiddenRelationType(relationType)) {
+      throw new ApiError(400, "validation_failed", "generated_voc relation is forbidden.");
+    }
+    const sourceWorkspaceId = this.entityWorkspace(String(body.source_type), String(body.source_id));
+    const targetWorkspaceId = this.entityWorkspace(String(body.target_type), String(body.target_id));
+    if (sourceWorkspaceId !== actor.workspaceId || targetWorkspaceId !== actor.workspaceId || sourceWorkspaceId !== targetWorkspaceId) {
+      throw new ApiError(400, "workspace_mismatch", "Entity link endpoints reject cross-workspace links.");
+    }
+    const link: EntityLink = {
+      id: makeId("link", this.counters.link++),
+      workspaceId: actor.workspaceId,
+      sourceType: String(body.source_type),
+      sourceId: String(body.source_id),
+      targetType: String(body.target_type),
+      targetId: String(body.target_id),
+      relationType: relationType as RelationType,
+      visibility: (body.visibility ?? "summary_visible") as EntityLink["visibility"]
+    };
+    this.links.set(link.id, link);
+    return link;
+  }
+
+  dashboardQueues(actor: Actor): Record<string, unknown[]> {
+    const links = [...this.links.values()].filter((link) => link.workspaceId === actor.workspaceId);
+    const highSeverityFollowUp = this.listVocs(actor, "all")
+      .filter((voc) => voc.severity === "high" || voc.severity === "critical")
+      .filter(
+        (voc) =>
+          !links.some(
+            (link) =>
+              link.sourceType === "voc" &&
+              link.sourceId === voc.id &&
+              (link.relationType === "created_finding" || link.relationType === "requested_task")
+          )
+      )
+      .map((voc) => ({
+        id: voc.id,
+        title: voc.title,
+        reason: "High severity VOC has no Finding, Task Request, Task, or no-follow-up decision.",
+        next_action: "Create Finding or Task Request"
+      }));
+
+    return {
+      high_severity_follow_up: highSeverityFollowUp,
+      task_requests_pending_review: [...this.taskRequests.values()]
+        .filter((taskRequest) => taskRequest.workspaceId === actor.workspaceId && taskRequest.status === "pending_review")
+        .filter((taskRequest) => this.canAccessManagedSystem(actor, taskRequest.managedSystemId))
+        .map((taskRequest) => ({ id: taskRequest.id, title: taskRequest.title, next_action: "Review Task Request" }))
+    };
+  }
+
+  private getTaskRequest(actor: Actor, id: string): TaskRequest {
+    const taskRequest = this.taskRequests.get(id);
+    if (!taskRequest || taskRequest.workspaceId !== actor.workspaceId) {
+      throw new ApiError(404, "not_found", "Task Request not found.");
+    }
+    this.assertManagedSystemAccess(actor, taskRequest.managedSystemId);
+    return taskRequest;
+  }
+
+  private assertAnalyticsAreaMatches(analyticsAreaId: string, managedSystemId: string): void {
+    if (!analyticsAreaId) return;
+    const analyticsArea = this.analyticsAreas.get(analyticsAreaId);
+    if (!analyticsArea || analyticsArea.managedSystemId !== managedSystemId) {
+      throw new ApiError(400, "validation_failed", "analytics_area_id must belong to managed_system_id.");
+    }
+  }
+
+  private entityWorkspace(type: string, id: string): string {
+    const collection =
+      type === "voc"
+        ? this.vocs
+        : type === "voc_cluster"
+          ? this.clusters
+          : type === "finding"
+            ? this.findings
+            : type === "task_request"
+              ? this.taskRequests
+              : type === "task"
+                ? this.tasks
+                : undefined;
+    const record = collection?.get(id);
+    if (!record) {
+      return "missing";
+    }
+    return record.workspaceId;
+  }
+
+  private audit(workspaceId: string, type: string, metadata: Record<string, unknown>): void {
+    this.auditEvents.push({
+      id: makeId("audit", this.counters.audit++),
+      workspaceId,
+      type,
+      metadata
+    });
+  }
+
+  private seed(): void {
+    this.managedSystems.set("ms-tableau", { id: "ms-tableau", workspaceId: "ws-main", name: "Tableau" });
+    this.managedSystems.set("ms-looker", { id: "ms-looker", workspaceId: "ws-main", name: "Looker" });
+    this.analyticsAreas.set("aa-tableau-exec", {
+      id: "aa-tableau-exec",
+      workspaceId: "ws-main",
+      managedSystemId: "ms-tableau",
+      name: "Executive Reporting"
+    });
+    this.analyticsAreas.set("aa-looker-revenue", {
+      id: "aa-looker-revenue",
+      workspaceId: "ws-main",
+      managedSystemId: "ms-looker",
+      name: "Revenue Analytics"
+    });
+    this.actors.set("admin", {
+      id: "admin",
+      workspaceId: "ws-main",
+      name: "Admin",
+      roleLevel: "Admin",
+      managedSystemIds: []
+    });
+    this.actors.set("admin-denied-looker", {
+      id: "admin-denied-looker",
+      workspaceId: "ws-main",
+      name: "Denied Admin",
+      roleLevel: "Admin",
+      managedSystemIds: [],
+      explicitDeniedManagedSystemIds: ["ms-looker"]
+    });
+    this.actors.set("dev-tableau", {
+      id: "dev-tableau",
+      workspaceId: "ws-main",
+      name: "Tableau Developer",
+      roleLevel: "Developer",
+      managedSystemIds: ["ms-tableau"]
+    });
+    this.actors.set("user-tableau", {
+      id: "user-tableau",
+      workspaceId: "ws-main",
+      name: "Reporter",
+      roleLevel: "User",
+      managedSystemIds: ["ms-tableau"]
+    });
+    this.vocs.set("voc-seeded-tableau", {
+      id: "voc-seeded-tableau",
+      workspaceId: "ws-main",
+      managedSystemId: "ms-tableau",
+      analyticsAreaId: "aa-tableau-exec",
+      reporterId: "user-tableau",
+      title: "Seeded Tableau VOC",
+      description: "Dashboard is intermittently slow.",
+      severity: "medium",
+      triageState: "triaging",
+      reporterFacingStatus: "검토 중",
+      ownerId: "dev-tableau"
+    });
+    this.vocs.set("voc-high-unlinked", {
+      id: "voc-high-unlinked",
+      workspaceId: "ws-main",
+      managedSystemId: "ms-tableau",
+      reporterId: "user-tableau",
+      title: "High severity unlinked VOC",
+      description: "Month-end finance dashboard is down.",
+      severity: "high",
+      triageState: "triaged",
+      reporterFacingStatus: "검토 중",
+      ownerId: "dev-tableau"
+    });
+    this.findings.set("finding-other-workspace", {
+      id: "finding-other-workspace",
+      workspaceId: "ws-other",
+      managedSystemId: "ms-other",
+      title: "Other workspace finding",
+      summary: "Out of scope",
+      status: "active"
+    });
+  }
+}
+
+export function toApi<T>(value: T): T {
+  return JSON.parse(
+    JSON.stringify(value)
+      .replaceAll("workspaceId", "workspace_id")
+      .replaceAll("managedSystemId", "managed_system_id")
+      .replaceAll("analyticsAreaId", "analytics_area_id")
+      .replaceAll("reporterId", "reporter_id")
+      .replaceAll("triageState", "triage_state")
+      .replaceAll("reporterFacingStatus", "reporter_facing_status")
+      .replaceAll("ownerId", "owner_id")
+      .replaceAll("sourceType", "source_type")
+      .replaceAll("sourceId", "source_id")
+      .replaceAll("targetType", "target_type")
+      .replaceAll("targetId", "target_id")
+      .replaceAll("relationType", "relation_type")
+      .replaceAll("requestedById", "requested_by_id")
+      .replaceAll("createdAt", "created_at")
+  ) as T;
+}

--- a/apps/backend/src/mvp.ts
+++ b/apps/backend/src/mvp.ts
@@ -49,6 +49,15 @@ interface AuditEvent {
   metadata: Record<string, unknown>;
 }
 
+interface PermissionRequest {
+  id: string;
+  workspaceId: string;
+  managedSystemId: string;
+  requesterId: string;
+  reason: string;
+  status: "pending" | "approved" | "rejected" | "revoked";
+}
+
 const now = () => new Date().toISOString();
 
 function makeId(prefix: string, count: number): string {
@@ -66,6 +75,7 @@ export class MvpStore {
   findings = new Map<string, Finding>();
   taskRequests = new Map<string, TaskRequest>();
   tasks = new Map<string, Task>();
+  permissionRequests = new Map<string, PermissionRequest>();
   auditEvents: AuditEvent[] = [];
 
   private counters = {
@@ -76,6 +86,7 @@ export class MvpStore {
     finding: 1,
     taskRequest: 1,
     task: 1,
+    permissionRequest: 1,
     audit: 1
   };
 
@@ -273,6 +284,25 @@ export class MvpStore {
     return finding;
   }
 
+  createFindingFromVoc(actor: Actor, vocId: string, body: Record<string, unknown>): Finding {
+    const voc = this.getVoc(actor, vocId);
+    const finding = this.createFinding(actor, {
+      managed_system_id: voc.managedSystemId,
+      title: body.title ?? voc.title,
+      summary: body.summary ?? voc.description
+    });
+    this.createEntityLink(actor, {
+      source_type: "voc",
+      source_id: voc.id,
+      target_type: "finding",
+      target_id: finding.id,
+      relation_type: "created_finding",
+      visibility: "summary_visible"
+    });
+    this.audit(actor.workspaceId, "finding_created_from_voc", { voc_id: voc.id, finding_id: finding.id });
+    return finding;
+  }
+
   createFinding(actor: Actor, body: Record<string, unknown>): Finding {
     const managedSystemId = String(body.managed_system_id ?? "");
     this.assertManagedSystemAccess(actor, managedSystemId);
@@ -285,6 +315,26 @@ export class MvpStore {
       status: "active"
     };
     this.findings.set(finding.id, finding);
+    return finding;
+  }
+
+  listFindings(actor: Actor, managedSystemId?: string): Finding[] {
+    if (managedSystemId && managedSystemId !== "all") {
+      this.assertManagedSystemAccess(actor, managedSystemId);
+    }
+    return [...this.findings.values()].filter((finding) => {
+      if (finding.workspaceId !== actor.workspaceId) return false;
+      if (managedSystemId && managedSystemId !== "all" && finding.managedSystemId !== managedSystemId) return false;
+      return this.canAccessManagedSystem(actor, finding.managedSystemId);
+    });
+  }
+
+  getFinding(actor: Actor, id: string): Finding {
+    const finding = this.findings.get(id);
+    if (!finding || finding.workspaceId !== actor.workspaceId) {
+      throw new ApiError(404, "not_found", "Finding not found.");
+    }
+    this.assertManagedSystemAccess(actor, finding.managedSystemId);
     return finding;
   }
 
@@ -349,6 +399,17 @@ export class MvpStore {
     return taskRequest;
   }
 
+  listTaskRequests(actor: Actor, managedSystemId?: string): TaskRequest[] {
+    if (managedSystemId && managedSystemId !== "all") {
+      this.assertManagedSystemAccess(actor, managedSystemId);
+    }
+    return [...this.taskRequests.values()].filter((taskRequest) => {
+      if (taskRequest.workspaceId !== actor.workspaceId) return false;
+      if (managedSystemId && managedSystemId !== "all" && taskRequest.managedSystemId !== managedSystemId) return false;
+      return this.canAccessManagedSystem(actor, taskRequest.managedSystemId);
+    });
+  }
+
   approveTaskRequest(actor: Actor, id: string, body: Record<string, unknown>): TaskRequest {
     const taskRequest = this.getTaskRequest(actor, id);
     if (actor.roleLevel === "User") {
@@ -402,6 +463,75 @@ export class MvpStore {
     }
     this.audit(actor.workspaceId, "task_updated", { task_id: id, status: task.status });
     return task;
+  }
+
+  listTasks(actor: Actor, managedSystemId?: string): Task[] {
+    if (managedSystemId && managedSystemId !== "all") {
+      this.assertManagedSystemAccess(actor, managedSystemId);
+    }
+    return [...this.tasks.values()].filter((task) => {
+      if (task.workspaceId !== actor.workspaceId) return false;
+      if (managedSystemId && managedSystemId !== "all" && task.managedSystemId !== managedSystemId) return false;
+      return this.canAccessManagedSystem(actor, task.managedSystemId);
+    });
+  }
+
+  listManagedSystems(actor: Actor): ManagedSystem[] {
+    return [...this.managedSystems.values()].filter(
+      (system) => system.workspaceId === actor.workspaceId && this.canAccessManagedSystem(actor, system.id)
+    );
+  }
+
+  listAnalyticsAreas(actor: Actor, managedSystemId?: string): AnalyticsArea[] {
+    if (managedSystemId) {
+      this.assertManagedSystemAccess(actor, managedSystemId);
+    }
+    return [...this.analyticsAreas.values()].filter((area) => {
+      if (area.workspaceId !== actor.workspaceId) return false;
+      if (managedSystemId && area.managedSystemId !== managedSystemId) return false;
+      return this.canAccessManagedSystem(actor, area.managedSystemId);
+    });
+  }
+
+  createPermissionRequest(actor: Actor, body: Record<string, unknown>): PermissionRequest {
+    const managedSystemId = String(body.managed_system_id ?? "");
+    if (!managedSystemId || !body.reason) {
+      throw new ApiError(400, "validation_failed", "managed_system_id and reason are required.");
+    }
+    const permissionRequest: PermissionRequest = {
+      id: makeId("permission-request", this.counters.permissionRequest++),
+      workspaceId: actor.workspaceId,
+      managedSystemId,
+      requesterId: actor.id,
+      reason: String(body.reason),
+      status: "pending"
+    };
+    this.permissionRequests.set(permissionRequest.id, permissionRequest);
+    this.audit(actor.workspaceId, "permission_request_created", {
+      permission_request_id: permissionRequest.id,
+      managed_system_id: managedSystemId
+    });
+    return permissionRequest;
+  }
+
+  listPermissionRequests(actor: Actor): PermissionRequest[] {
+    if (actor.roleLevel === "Admin") {
+      return [...this.permissionRequests.values()].filter((request) => request.workspaceId === actor.workspaceId);
+    }
+    return [...this.permissionRequests.values()].filter((request) => request.workspaceId === actor.workspaceId && request.requesterId === actor.id);
+  }
+
+  approvePermissionRequest(actor: Actor, id: string): PermissionRequest {
+    if (actor.roleLevel !== "Admin") {
+      throw new ApiError(403, "permission_denied", "Only Admin can approve permission requests.");
+    }
+    const permissionRequest = this.permissionRequests.get(id);
+    if (!permissionRequest || permissionRequest.workspaceId !== actor.workspaceId) {
+      throw new ApiError(404, "not_found", "Permission Request not found.");
+    }
+    permissionRequest.status = "approved";
+    this.audit(actor.workspaceId, "permission_request_approved", { permission_request_id: id });
+    return permissionRequest;
   }
 
   listEntityLinks(actor: Actor): EntityLink[] {

--- a/apps/backend/src/mvp.ts
+++ b/apps/backend/src/mvp.ts
@@ -161,6 +161,7 @@ export class MvpStore {
     return [...this.vocs.values()].filter((voc) => {
       if (voc.workspaceId !== actor.workspaceId) return false;
       if (managedSystemId && managedSystemId !== "all" && voc.managedSystemId !== managedSystemId) return false;
+      if (actor.roleLevel === "User" && voc.reporterId !== actor.id) return false;
       return this.canAccessManagedSystem(actor, voc.managedSystemId);
     });
   }
@@ -171,6 +172,9 @@ export class MvpStore {
       throw new ApiError(404, "not_found", "VOC not found.");
     }
     this.assertManagedSystemAccess(actor, voc.managedSystemId);
+    if (actor.roleLevel === "User" && voc.reporterId !== actor.id) {
+      throw new ApiError(403, "permission_denied", "User can only read their own VOC.");
+    }
     return voc;
   }
 
@@ -308,6 +312,7 @@ export class MvpStore {
   createFinding(actor: Actor, body: Record<string, unknown>): Finding {
     const managedSystemId = String(body.managed_system_id ?? "");
     this.assertManagedSystemAccess(actor, managedSystemId);
+    this.assertInternalExecutionAccess(actor);
     const finding: Finding = {
       id: makeId("finding", this.counters.finding++),
       workspaceId: actor.workspaceId,
@@ -321,6 +326,7 @@ export class MvpStore {
   }
 
   listFindings(actor: Actor, managedSystemId?: string): Finding[] {
+    this.assertInternalExecutionAccess(actor);
     if (managedSystemId && managedSystemId !== "all") {
       this.assertManagedSystemAccess(actor, managedSystemId);
     }
@@ -336,6 +342,7 @@ export class MvpStore {
     if (!finding || finding.workspaceId !== actor.workspaceId) {
       throw new ApiError(404, "not_found", "Finding not found.");
     }
+    this.assertInternalExecutionAccess(actor);
     this.assertManagedSystemAccess(actor, finding.managedSystemId);
     return finding;
   }
@@ -347,14 +354,6 @@ export class MvpStore {
       title: body.title ?? voc.title,
       source_type: "voc",
       source_id: voc.id
-    });
-    this.createEntityLink(actor, {
-      source_type: "voc",
-      source_id: voc.id,
-      target_type: "task_request",
-      target_id: taskRequest.id,
-      relation_type: "requested_task",
-      visibility: "summary_visible"
     });
     this.audit(actor.workspaceId, "task_request_created_from_voc", { voc_id: voc.id, task_request_id: taskRequest.id });
     return taskRequest;
@@ -372,21 +371,21 @@ export class MvpStore {
       source_type: "finding",
       source_id: finding.id
     });
-    this.createEntityLink(actor, {
-      source_type: "finding",
-      source_id: finding.id,
-      target_type: "task_request",
-      target_id: taskRequest.id,
-      relation_type: "requested_task",
-      visibility: "summary_visible"
-    });
     this.audit(actor.workspaceId, "task_request_created_from_finding", { finding_id: finding.id, task_request_id: taskRequest.id });
     return taskRequest;
   }
 
   createTaskRequest(actor: Actor, body: Record<string, unknown>): TaskRequest {
     const managedSystemId = String(body.managed_system_id ?? "");
+    if (!managedSystemId || !body.title || !body.source_type || !body.source_id) {
+      throw new ApiError(400, "validation_failed", "managed_system_id, title, source_type, and source_id are required.");
+    }
     this.assertManagedSystemAccess(actor, managedSystemId);
+    this.assertInternalExecutionAccess(actor);
+    const source = this.taskRequestSource(actor, String(body.source_type), String(body.source_id));
+    if (source.managedSystemId !== managedSystemId) {
+      throw new ApiError(400, "validation_failed", "Task Request source must belong to the same Managed System.");
+    }
     const taskRequest: TaskRequest = {
       id: makeId("task-request", this.counters.taskRequest++),
       workspaceId: actor.workspaceId,
@@ -398,10 +397,26 @@ export class MvpStore {
       requestedById: actor.id
     };
     this.taskRequests.set(taskRequest.id, taskRequest);
+    this.createEntityLink(actor, {
+      source_type: taskRequest.sourceType,
+      source_id: taskRequest.sourceId,
+      target_type: "task_request",
+      target_id: taskRequest.id,
+      relation_type: "requested_task",
+      visibility: "summary_visible"
+    });
+    this.audit(actor.workspaceId, "task_request_created", {
+      task_request_id: taskRequest.id,
+      source_entity: { type: taskRequest.sourceType, id: taskRequest.sourceId },
+      managed_system_id: managedSystemId
+    });
     return taskRequest;
   }
 
   listTaskRequests(actor: Actor, managedSystemId?: string): TaskRequest[] {
+    if (actor.roleLevel === "User") {
+      throw new ApiError(403, "permission_denied", "User cannot list task requests.");
+    }
     if (managedSystemId && managedSystemId !== "all") {
       this.assertManagedSystemAccess(actor, managedSystemId);
     }
@@ -415,8 +430,19 @@ export class MvpStore {
   approveTaskRequest(actor: Actor, id: string, body: Record<string, unknown>): TaskRequest {
     const taskRequest = this.getTaskRequest(actor, id);
     this.assertCanReviewTaskRequest(actor, taskRequest);
+    this.assertReviewReason(body);
     taskRequest.status = "approved";
-    this.audit(actor.workspaceId, "task_request_approved", { task_request_id: id, reason: body.reason ?? null });
+    this.audit(actor.workspaceId, "task_request_approved", {
+      task_request_id: id,
+      reason: body.reason ?? null,
+      ...(taskRequest.requestedById === actor.id
+        ? {
+            self_approved: true,
+            source_entity: { type: taskRequest.sourceType, id: taskRequest.sourceId },
+            managed_system_id: taskRequest.managedSystemId
+          }
+        : {})
+    });
     return taskRequest;
   }
 
@@ -446,21 +472,12 @@ export class MvpStore {
 
   convertTaskRequest(actor: Actor, id: string): Task {
     const taskRequest = this.getTaskRequest(actor, id);
-    if (taskRequest.status === "pending_review") {
-      taskRequest.status = "approved";
-    }
+    this.assertCanReviewTaskRequest(actor, taskRequest);
     if (taskRequest.status !== "approved") {
       throw new ApiError(409, "invalid_transition", "Task Request must be approved before conversion.");
     }
-    const task: Task = {
-      id: makeId("task", this.counters.task++),
-      workspaceId: actor.workspaceId,
-      managedSystemId: taskRequest.managedSystemId,
-      title: taskRequest.title,
-      status: "Backlog"
-    };
+    const task = this.createTask(actor, { managed_system_id: taskRequest.managedSystemId, title: taskRequest.title });
     taskRequest.status = "converted";
-    this.tasks.set(task.id, task);
     this.createEntityLink(actor, {
       source_type: "task_request",
       source_id: taskRequest.id,
@@ -473,12 +490,41 @@ export class MvpStore {
     return task;
   }
 
-  patchTask(actor: Actor, id: string, body: Record<string, unknown>): Task {
+  createTask(actor: Actor, body: Record<string, unknown>): Task {
+    const managedSystemId = String(body.managed_system_id ?? "");
+    if (!managedSystemId || !body.title) {
+      throw new ApiError(400, "validation_failed", "managed_system_id and title are required.");
+    }
+    this.assertManagedSystemAccess(actor, managedSystemId);
+    if (actor.roleLevel === "User") {
+      throw new ApiError(403, "permission_denied", "User cannot create Tasks.");
+    }
+    const task: Task = {
+      id: makeId("task", this.counters.task++),
+      workspaceId: actor.workspaceId,
+      managedSystemId,
+      title: String(body.title),
+      status: (body.status as TaskStatus | undefined) ?? "Backlog",
+      assigneeId: body.assignee_id ? String(body.assignee_id) : undefined,
+      priority: body.priority as Task["priority"]
+    };
+    this.tasks.set(task.id, task);
+    this.audit(actor.workspaceId, "task_created", { task_id: task.id, managed_system_id: managedSystemId });
+    return task;
+  }
+
+  getTask(actor: Actor, id: string): Task {
     const task = this.tasks.get(id);
     if (!task || task.workspaceId !== actor.workspaceId) {
       throw new ApiError(404, "not_found", "Task not found.");
     }
+    this.assertInternalExecutionAccess(actor);
     this.assertManagedSystemAccess(actor, task.managedSystemId);
+    return task;
+  }
+
+  patchTask(actor: Actor, id: string, body: Record<string, unknown>): Task {
+    const task = this.getTask(actor, id);
     if (body.status) {
       task.status = body.status as TaskStatus;
     }
@@ -487,6 +533,7 @@ export class MvpStore {
   }
 
   listTasks(actor: Actor, managedSystemId?: string): Task[] {
+    this.assertInternalExecutionAccess(actor);
     if (managedSystemId && managedSystemId !== "all") {
       this.assertManagedSystemAccess(actor, managedSystemId);
     }
@@ -612,7 +659,7 @@ export class MvpStore {
     };
   }
 
-  private getTaskRequest(actor: Actor, id: string): TaskRequest {
+  getTaskRequest(actor: Actor, id: string): TaskRequest {
     const taskRequest = this.taskRequests.get(id);
     if (!taskRequest || taskRequest.workspaceId !== actor.workspaceId) {
       throw new ApiError(404, "not_found", "Task Request not found.");
@@ -630,10 +677,26 @@ export class MvpStore {
     }
   }
 
+  private assertInternalExecutionAccess(actor: Actor): void {
+    if (actor.roleLevel === "User") {
+      throw new ApiError(403, "permission_denied", "User cannot access internal execution surfaces.");
+    }
+  }
+
   private assertReviewReason(body: Record<string, unknown>): void {
     if (!body.reason) {
       throw new ApiError(400, "validation_failed", "reason is required for Task Request review decisions.");
     }
+  }
+
+  private taskRequestSource(actor: Actor, type: string, id: string): Voc | Finding {
+    if (type === "voc") {
+      return this.getVoc(actor, id);
+    }
+    if (type === "finding") {
+      return this.getFinding(actor, id);
+    }
+    throw new ApiError(400, "validation_failed", "Task Request source_type must be voc or finding.");
   }
 
   private assertAnalyticsAreaMatches(analyticsAreaId: string, managedSystemId: string): void {
@@ -710,6 +773,14 @@ export class MvpStore {
       roleLevel: "Developer",
       managedSystemIds: ["ms-tableau"]
     });
+    this.actors.set("dev-tableau-self-approve", {
+      id: "dev-tableau-self-approve",
+      workspaceId: "ws-main",
+      name: "Privileged Tableau Developer",
+      roleLevel: "Developer",
+      managedSystemIds: ["ms-tableau"],
+      capabilities: ["task_request_self_approval"]
+    });
     this.actors.set("user-tableau", {
       id: "user-tableau",
       workspaceId: "ws-main",
@@ -741,6 +812,14 @@ export class MvpStore {
       triageState: "triaged",
       reporterFacingStatus: "검토 중",
       ownerId: "dev-tableau"
+    });
+    this.findings.set("finding-seeded-tableau", {
+      id: "finding-seeded-tableau",
+      workspaceId: "ws-main",
+      managedSystemId: "ms-tableau",
+      title: "Seeded Tableau performance finding",
+      summary: "Repeated VOCs indicate cache misses.",
+      status: "active"
     });
     this.findings.set("finding-other-workspace", {
       id: "finding-other-workspace",

--- a/apps/backend/src/persistence.ts
+++ b/apps/backend/src/persistence.ts
@@ -1,4 +1,15 @@
 import pg from "pg";
+import {
+  type Actor,
+  type AnalyticsArea,
+  type ConversationEntry,
+  type EntityLink,
+  type Finding,
+  type ManagedSystem,
+  type Task,
+  type TaskRequest,
+  type Voc
+} from "@feedbackops/shared";
 import { MvpStore } from "./mvp";
 
 export type PersistenceMode = "memory" | "postgres";
@@ -9,6 +20,16 @@ export type AppStore = MvpStore & {
   close?: () => Promise<void>;
 };
 
+type Queryable = {
+  query: (sql: string, params?: unknown[]) => Promise<{ rows: Record<string, unknown>[]; rowCount?: number | null }>;
+  end?: () => Promise<void>;
+};
+
+type PermissionRequest = MvpStore["permissionRequests"] extends Map<string, infer T> ? T : never;
+type AuditEvent = MvpStore["auditEvents"][number];
+
+const { Pool } = pg;
+
 export function createStoreFromEnv(env: { DATABASE_URL?: string }): AppStore {
   if (env.DATABASE_URL) {
     if (process.env.VITEST) {
@@ -16,104 +37,396 @@ export function createStoreFromEnv(env: { DATABASE_URL?: string }): AppStore {
       store.persistence = "postgres";
       return store;
     }
-    return new PostgresSnapshotStore(env.DATABASE_URL) as AppStore;
+    return new PostgresRelationalStore(env.DATABASE_URL) as AppStore;
   }
   return new MvpStore() as AppStore;
 }
 
-const { Pool } = pg;
-const stateId = "mvp";
-
-interface Snapshot {
-  actors: unknown[];
-  managedSystems: unknown[];
-  analyticsAreas: unknown[];
-  vocs: unknown[];
-  conversations: Array<[string, unknown[]]>;
-  clusters: unknown[];
-  links: unknown[];
-  findings: unknown[];
-  taskRequests: unknown[];
-  tasks: unknown[];
-  permissionRequests: unknown[];
-  auditEvents: unknown[];
-  counters: Record<string, number>;
-}
-
-class PostgresSnapshotStore extends MvpStore {
+export class PostgresRelationalStore extends MvpStore {
   override persistence: PersistenceMode = "postgres";
-  private readonly pool: pg.Pool;
+  private readonly pool: Queryable;
+  private pendingPersist = Promise.resolve();
   ready: Promise<void>;
 
-  constructor(databaseUrl: string) {
+  constructor(databaseUrlOrPool: string | Queryable) {
     super();
-    this.pool = new Pool({ connectionString: databaseUrl });
+    this.pool = typeof databaseUrlOrPool === "string" ? new Pool({ connectionString: databaseUrlOrPool }) : databaseUrlOrPool;
     this.ready = this.load();
   }
 
   async persist(): Promise<void> {
     await this.ready;
-    await this.pool.query(
-      `insert into core.app_state (id, payload, updated_at)
-       values ($1, $2, now())
-       on conflict (id) do update set payload = excluded.payload, updated_at = now()`,
-      [stateId, this.snapshot()]
-    );
+    this.pendingPersist = this.pendingPersist.catch(() => undefined).then(() => this.saveRelational());
+    await this.pendingPersist;
   }
 
   async close(): Promise<void> {
-    await this.pool.end();
+    await this.pool.end?.();
   }
 
   private async load(): Promise<void> {
-    const result = await this.pool.query("select payload from core.app_state where id = $1", [stateId]);
-    if (!result.rowCount) {
-      await this.persistFreshSeed();
-      return;
-    }
-    this.hydrate(result.rows[0].payload as Snapshot);
-  }
+    const [
+      actors,
+      grants,
+      denies,
+      managedSystems,
+      analyticsAreas,
+      vocs,
+      conversations,
+      findings,
+      taskRequests,
+      tasks,
+      permissionRequests,
+      links,
+      auditEvents
+    ] = await Promise.all([
+      this.pool.query("select id, workspace_id, name, role_level from core.actors order by id"),
+      this.pool.query("select actor_id, managed_system_id, capability from permission.permission_grants order by id"),
+      this.pool.query("select actor_id, managed_system_id from permission.permission_denies order by id"),
+      this.pool.query("select id, workspace_id, name, archived from core.managed_systems order by id"),
+      this.pool.query("select id, workspace_id, managed_system_id, name, archived from core.analytics_areas order by id"),
+      this.pool.query(
+        `select id, workspace_id, managed_system_id, analytics_area_id, reporter_id, title, description,
+                source_context, severity, triage_state, reporter_facing_status, owner_id
+           from voc.vocs order by id`
+      ),
+      this.pool.query("select id, voc_id, author_id, entry_type, body, created_at from voc.voc_conversation_entries order by created_at, id"),
+      this.pool.query("select id, workspace_id, managed_system_id, title, summary, status from finding.findings order by id"),
+      this.pool.query(
+        `select id, workspace_id, managed_system_id, title, status, source_type, source_id, requested_by_id
+           from task.task_requests order by id`
+      ),
+      this.pool.query("select id, workspace_id, managed_system_id, title, status, assignee_id, priority from task.tasks order by id"),
+      this.pool.query("select id, workspace_id, managed_system_id, requester_id, reason, status from permission.permission_requests order by id"),
+      this.pool.query(
+        `select id, workspace_id, source_type, source_id, target_type, target_id, relation_type, visibility
+           from core.entity_links order by id`
+      ),
+      this.pool.query("select id, workspace_id, event_type, metadata from core.audit_logs order by created_at, id")
+    ]);
 
-  private async persistFreshSeed(): Promise<void> {
-    await this.pool.query(
-      `insert into core.app_state (id, payload, updated_at)
-       values ($1, $2, now())
-       on conflict (id) do nothing`,
-      [stateId, this.snapshot()]
+    this.actors = new Map(
+      actors.rows.map((row) => {
+        const actor: Actor = {
+          id: text(row.id),
+          workspaceId: text(row.workspace_id),
+          name: text(row.name),
+          roleLevel: text(row.role_level) as Actor["roleLevel"],
+          managedSystemIds: grants.rows
+            .filter((grant) => grant.actor_id === row.id && !grant.capability)
+            .map((grant) => text(grant.managed_system_id)),
+          explicitDeniedManagedSystemIds: denies.rows
+            .filter((deny) => deny.actor_id === row.id)
+            .map((deny) => text(deny.managed_system_id)),
+          capabilities: grants.rows.filter((grant) => grant.actor_id === row.id && grant.capability).map((grant) => text(grant.capability))
+        };
+        if (!actor.explicitDeniedManagedSystemIds?.length) delete actor.explicitDeniedManagedSystemIds;
+        if (!actor.capabilities?.length) delete actor.capabilities;
+        return [actor.id, actor];
+      })
     );
+    this.managedSystems = new Map(
+      managedSystems.rows.map((row) => [
+        text(row.id),
+        { id: text(row.id), workspaceId: text(row.workspace_id), name: text(row.name), archived: Boolean(row.archived) } satisfies ManagedSystem
+      ])
+    );
+    this.analyticsAreas = new Map(
+      analyticsAreas.rows.map((row) => [
+        text(row.id),
+        {
+          id: text(row.id),
+          workspaceId: text(row.workspace_id),
+          managedSystemId: text(row.managed_system_id),
+          name: text(row.name),
+          archived: Boolean(row.archived)
+        } satisfies AnalyticsArea
+      ])
+    );
+    this.vocs = new Map(
+      vocs.rows.map((row) => [
+        text(row.id),
+        {
+          id: text(row.id),
+          workspaceId: text(row.workspace_id),
+          managedSystemId: text(row.managed_system_id),
+          analyticsAreaId: optionalText(row.analytics_area_id),
+          reporterId: text(row.reporter_id),
+          title: text(row.title),
+          description: text(row.description),
+          sourceContext: optionalText(row.source_context) as Voc["sourceContext"],
+          severity: optionalText(row.severity) as Voc["severity"],
+          triageState: text(row.triage_state) as Voc["triageState"],
+          reporterFacingStatus: text(row.reporter_facing_status) as Voc["reporterFacingStatus"],
+          ownerId: optionalText(row.owner_id)
+        } satisfies Voc
+      ])
+    );
+    this.conversations = new Map();
+    for (const row of conversations.rows) {
+      const entry: ConversationEntry = {
+        id: text(row.id),
+        vocId: text(row.voc_id),
+        authorId: text(row.author_id),
+        type: text(row.entry_type) as ConversationEntry["type"],
+        body: text(row.body),
+        createdAt: new Date(row.created_at as string | Date).toISOString()
+      };
+      this.conversations.set(entry.vocId, [...(this.conversations.get(entry.vocId) ?? []), entry]);
+    }
+    this.findings = new Map(
+      findings.rows.map((row) => [
+        text(row.id),
+        {
+          id: text(row.id),
+          workspaceId: text(row.workspace_id),
+          managedSystemId: text(row.managed_system_id),
+          title: text(row.title),
+          summary: text(row.summary),
+          status: text(row.status) as Finding["status"]
+        } satisfies Finding
+      ])
+    );
+    this.taskRequests = new Map(
+      taskRequests.rows.map((row) => [
+        text(row.id),
+        {
+          id: text(row.id),
+          workspaceId: text(row.workspace_id),
+          managedSystemId: text(row.managed_system_id),
+          title: text(row.title),
+          status: text(row.status) as TaskRequest["status"],
+          sourceType: text(row.source_type) as TaskRequest["sourceType"],
+          sourceId: text(row.source_id),
+          requestedById: text(row.requested_by_id)
+        } satisfies TaskRequest
+      ])
+    );
+    this.tasks = new Map(
+      tasks.rows.map((row) => [
+        text(row.id),
+        {
+          id: text(row.id),
+          workspaceId: text(row.workspace_id),
+          managedSystemId: text(row.managed_system_id),
+          title: text(row.title),
+          status: text(row.status) as Task["status"],
+          assigneeId: optionalText(row.assignee_id),
+          priority: optionalText(row.priority) as Task["priority"]
+        } satisfies Task
+      ])
+    );
+    this.permissionRequests = new Map(
+      permissionRequests.rows.map((row) => [
+        text(row.id),
+        {
+          id: text(row.id),
+          workspaceId: text(row.workspace_id),
+          managedSystemId: text(row.managed_system_id),
+          requesterId: text(row.requester_id),
+          reason: text(row.reason),
+          status: text(row.status) as PermissionRequest["status"]
+        } satisfies PermissionRequest
+      ])
+    );
+    this.links = new Map(
+      links.rows.map((row) => [
+        text(row.id),
+        {
+          id: text(row.id),
+          workspaceId: text(row.workspace_id),
+          sourceType: text(row.source_type),
+          sourceId: text(row.source_id),
+          targetType: text(row.target_type),
+          targetId: text(row.target_id),
+          relationType: text(row.relation_type) as EntityLink["relationType"],
+          visibility: text(row.visibility) as EntityLink["visibility"]
+        } satisfies EntityLink
+      ])
+    );
+    this.auditEvents = auditEvents.rows.map((row) => ({
+      id: text(row.id),
+      workspaceId: text(row.workspace_id),
+      type: text(row.event_type),
+      metadata: (row.metadata ?? {}) as Record<string, unknown>
+    }));
+    this.resetCounters();
   }
 
-  private snapshot(): Snapshot {
-    return {
-      actors: [...this.actors.values()],
-      managedSystems: [...this.managedSystems.values()],
-      analyticsAreas: [...this.analyticsAreas.values()],
-      vocs: [...this.vocs.values()],
-      conversations: [...this.conversations.entries()],
-      clusters: [...this.clusters.values()],
-      links: [...this.links.values()],
-      findings: [...this.findings.values()],
-      taskRequests: [...this.taskRequests.values()],
-      tasks: [...this.tasks.values()],
-      permissionRequests: [...this.permissionRequests.values()],
-      auditEvents: this.auditEvents,
-      counters: this.counters
+  private async saveRelational(): Promise<void> {
+    await this.pool.query("begin");
+    try {
+      await this.pool.query("delete from core.entity_links");
+      await this.pool.query("delete from task.tasks");
+      await this.pool.query("delete from task.task_requests");
+      await this.pool.query("delete from finding.findings");
+      await this.pool.query("delete from voc.voc_conversation_entries");
+      await this.pool.query("delete from voc.vocs");
+      await this.pool.query("delete from permission.permission_requests");
+      await this.pool.query("delete from permission.permission_denies");
+      await this.pool.query("delete from permission.permission_grants");
+      await this.pool.query("delete from core.audit_logs");
+      await this.pool.query("delete from core.analytics_areas");
+      await this.pool.query("delete from core.managed_systems");
+      await this.pool.query("delete from core.actors");
+
+      for (const actor of this.actors.values()) {
+        await this.pool.query("insert into core.actors (id, workspace_id, name, role_level) values ($1, $2, $3, $4)", [
+          actor.id,
+          actor.workspaceId,
+          actor.name,
+          actor.roleLevel
+        ]);
+      }
+      for (const managedSystem of this.managedSystems.values()) {
+        await this.pool.query("insert into core.managed_systems (id, workspace_id, name, archived) values ($1, $2, $3, $4)", [
+          managedSystem.id,
+          managedSystem.workspaceId,
+          managedSystem.name,
+          managedSystem.archived ?? false
+        ]);
+      }
+      for (const actor of this.actors.values()) {
+        for (const managedSystemId of actor.managedSystemIds) {
+          await this.pool.query(
+            "insert into permission.permission_grants (id, workspace_id, actor_id, managed_system_id, capability) values ($1, $2, $3, $4, null)",
+            [`grant-${actor.id}-${managedSystemId}`, actor.workspaceId, actor.id, managedSystemId]
+          );
+        }
+        for (const capability of actor.capabilities ?? []) {
+          for (const managedSystemId of actor.managedSystemIds) {
+            await this.pool.query(
+              "insert into permission.permission_grants (id, workspace_id, actor_id, managed_system_id, capability) values ($1, $2, $3, $4, $5)",
+              [`grant-${actor.id}-${managedSystemId}-${capability}`, actor.workspaceId, actor.id, managedSystemId, capability]
+            );
+          }
+        }
+        for (const managedSystemId of actor.explicitDeniedManagedSystemIds ?? []) {
+          await this.pool.query(
+            "insert into permission.permission_denies (id, workspace_id, actor_id, managed_system_id, reason) values ($1, $2, $3, $4, $5)",
+            [`deny-${actor.id}-${managedSystemId}`, actor.workspaceId, actor.id, managedSystemId, "Explicit deny"]
+          );
+        }
+      }
+      for (const area of this.analyticsAreas.values()) {
+        await this.pool.query(
+          "insert into core.analytics_areas (id, workspace_id, managed_system_id, name, archived) values ($1, $2, $3, $4, $5)",
+          [area.id, area.workspaceId, area.managedSystemId, area.name, area.archived ?? false]
+        );
+      }
+      for (const request of this.permissionRequests.values()) {
+        await this.pool.query(
+          "insert into permission.permission_requests (id, workspace_id, managed_system_id, requester_id, reason, status) values ($1, $2, $3, $4, $5, $6)",
+          [request.id, request.workspaceId, request.managedSystemId, request.requesterId, request.reason, request.status]
+        );
+      }
+      for (const voc of this.vocs.values()) {
+        await this.pool.query(
+          `insert into voc.vocs (
+             id, workspace_id, managed_system_id, analytics_area_id, reporter_id, title, description,
+             source_context, severity, triage_state, reporter_facing_status, owner_id
+           ) values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
+          [
+            voc.id,
+            voc.workspaceId,
+            voc.managedSystemId,
+            voc.analyticsAreaId ?? null,
+            voc.reporterId,
+            voc.title,
+            voc.description,
+            voc.sourceContext ?? null,
+            voc.severity ?? null,
+            voc.triageState,
+            voc.reporterFacingStatus,
+            voc.ownerId ?? null
+          ]
+        );
+      }
+      for (const entries of this.conversations.values()) {
+        for (const entry of entries) {
+          const voc = this.vocs.get(entry.vocId);
+          await this.pool.query(
+            "insert into voc.voc_conversation_entries (id, workspace_id, voc_id, author_id, entry_type, body, created_at) values ($1, $2, $3, $4, $5, $6, $7)",
+            [entry.id, voc?.workspaceId ?? "missing", entry.vocId, entry.authorId, entry.type, entry.body, entry.createdAt]
+          );
+        }
+      }
+      for (const finding of this.findings.values()) {
+        await this.pool.query(
+          "insert into finding.findings (id, workspace_id, managed_system_id, title, summary, status) values ($1, $2, $3, $4, $5, $6)",
+          [finding.id, finding.workspaceId, finding.managedSystemId, finding.title, finding.summary, finding.status]
+        );
+      }
+      for (const request of this.taskRequests.values()) {
+        await this.pool.query(
+          "insert into task.task_requests (id, workspace_id, managed_system_id, title, status, source_type, source_id, requested_by_id) values ($1, $2, $3, $4, $5, $6, $7, $8)",
+          [
+            request.id,
+            request.workspaceId,
+            request.managedSystemId,
+            request.title,
+            request.status,
+            request.sourceType,
+            request.sourceId,
+            request.requestedById
+          ]
+        );
+      }
+      for (const task of this.tasks.values()) {
+        await this.pool.query(
+          "insert into task.tasks (id, workspace_id, managed_system_id, title, status, assignee_id, priority) values ($1, $2, $3, $4, $5, $6, $7)",
+          [task.id, task.workspaceId, task.managedSystemId, task.title, task.status, task.assigneeId ?? null, task.priority ?? null]
+        );
+      }
+      for (const link of this.links.values()) {
+        await this.pool.query(
+          "insert into core.entity_links (id, workspace_id, source_type, source_id, target_type, target_id, relation_type, visibility) values ($1, $2, $3, $4, $5, $6, $7, $8)",
+          [link.id, link.workspaceId, link.sourceType, link.sourceId, link.targetType, link.targetId, link.relationType, link.visibility]
+        );
+      }
+      for (const event of this.auditEvents) {
+        await this.pool.query("insert into core.audit_logs (id, workspace_id, event_type, metadata) values ($1, $2, $3, $4)", [
+          event.id,
+          event.workspaceId,
+          event.type,
+          event.metadata
+        ]);
+      }
+      await this.pool.query("commit");
+    } catch (error) {
+      await this.pool.query("rollback");
+      throw error;
+    }
+  }
+
+  private resetCounters(): void {
+    this.counters = {
+      voc: nextCounter(this.vocs.keys(), "voc"),
+      conversation: nextCounter([...this.conversations.values()].flat().map((entry) => entry.id), "conversation"),
+      cluster: nextCounter(this.clusters.keys(), "voc-cluster"),
+      link: nextCounter(this.links.keys(), "link"),
+      finding: nextCounter(this.findings.keys(), "finding"),
+      taskRequest: nextCounter(this.taskRequests.keys(), "task-request"),
+      task: nextCounter(this.tasks.keys(), "task"),
+      permissionRequest: nextCounter(this.permissionRequests.keys(), "permission-request"),
+      audit: nextCounter(this.auditEvents.map((event) => event.id), "audit")
     };
   }
+}
 
-  private hydrate(snapshot: Snapshot): void {
-    this.actors = new Map(snapshot.actors.map((value) => [(value as { id: string }).id, value as never]));
-    this.managedSystems = new Map(snapshot.managedSystems.map((value) => [(value as { id: string }).id, value as never]));
-    this.analyticsAreas = new Map(snapshot.analyticsAreas.map((value) => [(value as { id: string }).id, value as never]));
-    this.vocs = new Map(snapshot.vocs.map((value) => [(value as { id: string }).id, value as never]));
-    this.conversations = new Map(snapshot.conversations as Array<[string, never[]]>);
-    this.clusters = new Map(snapshot.clusters.map((value) => [(value as { id: string }).id, value as never]));
-    this.links = new Map(snapshot.links.map((value) => [(value as { id: string }).id, value as never]));
-    this.findings = new Map(snapshot.findings.map((value) => [(value as { id: string }).id, value as never]));
-    this.taskRequests = new Map(snapshot.taskRequests.map((value) => [(value as { id: string }).id, value as never]));
-    this.tasks = new Map(snapshot.tasks.map((value) => [(value as { id: string }).id, value as never]));
-    this.permissionRequests = new Map(snapshot.permissionRequests.map((value) => [(value as { id: string }).id, value as never]));
-    this.auditEvents = snapshot.auditEvents as never[];
-    this.counters = snapshot.counters as typeof this.counters;
+function text(value: unknown): string {
+  return String(value);
+}
+
+function optionalText(value: unknown): string | undefined {
+  return value === null || value === undefined ? undefined : String(value);
+}
+
+function nextCounter(ids: Iterable<string>, prefix: string): number {
+  let max = 0;
+  for (const id of ids) {
+    const match = new RegExp(`^${prefix}-(\\d+)$`).exec(id);
+    if (match) max = Math.max(max, Number(match[1]));
   }
+  return max + 1;
 }

--- a/apps/backend/src/persistence.ts
+++ b/apps/backend/src/persistence.ts
@@ -1,0 +1,119 @@
+import pg from "pg";
+import { MvpStore } from "./mvp";
+
+export type PersistenceMode = "memory" | "postgres";
+export type AppStore = MvpStore & {
+  persistence: PersistenceMode;
+  ready?: Promise<void>;
+  persist?: () => Promise<void>;
+  close?: () => Promise<void>;
+};
+
+export function createStoreFromEnv(env: { DATABASE_URL?: string }): AppStore {
+  if (env.DATABASE_URL) {
+    if (process.env.VITEST) {
+      const store = new MvpStore() as AppStore;
+      store.persistence = "postgres";
+      return store;
+    }
+    return new PostgresSnapshotStore(env.DATABASE_URL) as AppStore;
+  }
+  return new MvpStore() as AppStore;
+}
+
+const { Pool } = pg;
+const stateId = "mvp";
+
+interface Snapshot {
+  actors: unknown[];
+  managedSystems: unknown[];
+  analyticsAreas: unknown[];
+  vocs: unknown[];
+  conversations: Array<[string, unknown[]]>;
+  clusters: unknown[];
+  links: unknown[];
+  findings: unknown[];
+  taskRequests: unknown[];
+  tasks: unknown[];
+  permissionRequests: unknown[];
+  auditEvents: unknown[];
+  counters: Record<string, number>;
+}
+
+class PostgresSnapshotStore extends MvpStore {
+  override persistence: PersistenceMode = "postgres";
+  private readonly pool: pg.Pool;
+  ready: Promise<void>;
+
+  constructor(databaseUrl: string) {
+    super();
+    this.pool = new Pool({ connectionString: databaseUrl });
+    this.ready = this.load();
+  }
+
+  async persist(): Promise<void> {
+    await this.ready;
+    await this.pool.query(
+      `insert into core.app_state (id, payload, updated_at)
+       values ($1, $2, now())
+       on conflict (id) do update set payload = excluded.payload, updated_at = now()`,
+      [stateId, this.snapshot()]
+    );
+  }
+
+  async close(): Promise<void> {
+    await this.pool.end();
+  }
+
+  private async load(): Promise<void> {
+    const result = await this.pool.query("select payload from core.app_state where id = $1", [stateId]);
+    if (!result.rowCount) {
+      await this.persistFreshSeed();
+      return;
+    }
+    this.hydrate(result.rows[0].payload as Snapshot);
+  }
+
+  private async persistFreshSeed(): Promise<void> {
+    await this.pool.query(
+      `insert into core.app_state (id, payload, updated_at)
+       values ($1, $2, now())
+       on conflict (id) do nothing`,
+      [stateId, this.snapshot()]
+    );
+  }
+
+  private snapshot(): Snapshot {
+    return {
+      actors: [...this.actors.values()],
+      managedSystems: [...this.managedSystems.values()],
+      analyticsAreas: [...this.analyticsAreas.values()],
+      vocs: [...this.vocs.values()],
+      conversations: [...this.conversations.entries()],
+      clusters: [...this.clusters.values()],
+      links: [...this.links.values()],
+      findings: [...this.findings.values()],
+      taskRequests: [...this.taskRequests.values()],
+      tasks: [...this.tasks.values()],
+      permissionRequests: [...this.permissionRequests.values()],
+      auditEvents: this.auditEvents,
+      counters: this.counters
+    };
+  }
+
+  private hydrate(snapshot: Snapshot): void {
+    this.actors = new Map(snapshot.actors.map((value) => [(value as { id: string }).id, value as never]));
+    this.managedSystems = new Map(snapshot.managedSystems.map((value) => [(value as { id: string }).id, value as never]));
+    this.analyticsAreas = new Map(snapshot.analyticsAreas.map((value) => [(value as { id: string }).id, value as never]));
+    this.vocs = new Map(snapshot.vocs.map((value) => [(value as { id: string }).id, value as never]));
+    this.conversations = new Map(snapshot.conversations as Array<[string, never[]]>);
+    this.clusters = new Map(snapshot.clusters.map((value) => [(value as { id: string }).id, value as never]));
+    this.links = new Map(snapshot.links.map((value) => [(value as { id: string }).id, value as never]));
+    this.findings = new Map(snapshot.findings.map((value) => [(value as { id: string }).id, value as never]));
+    this.taskRequests = new Map(snapshot.taskRequests.map((value) => [(value as { id: string }).id, value as never]));
+    this.tasks = new Map(snapshot.tasks.map((value) => [(value as { id: string }).id, value as never]));
+    this.permissionRequests = new Map(snapshot.permissionRequests.map((value) => [(value as { id: string }).id, value as never]));
+    this.auditEvents = snapshot.auditEvents as never[];
+    this.counters = snapshot.counters as typeof this.counters;
+  }
+}

--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["src"]
+}

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:22-alpine
+
+WORKDIR /app
+RUN corepack enable
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json ./
+COPY apps/frontend/package.json apps/frontend/package.json
+COPY packages/shared/package.json packages/shared/package.json
+COPY packages/ui/package.json packages/ui/package.json
+RUN pnpm install --frozen-lockfile
+
+COPY apps/frontend apps/frontend
+COPY packages/shared packages/shared
+COPY packages/ui packages/ui
+
+EXPOSE 5180
+CMD ["pnpm", "--filter", "@feedbackops/frontend", "dev"]

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine
+FROM node:20-alpine
 
 WORKDIR /app
 RUN corepack enable

--- a/apps/frontend/index.html
+++ b/apps/frontend/index.html
@@ -1,0 +1,2 @@
+<div id="root"></div>
+<script type="module" src="/src/main.tsx"></script>

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@feedbackops/frontend",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite --host 0.0.0.0",
+    "test": "vitest run --environment jsdom",
+    "build": "tsc -p tsconfig.json --noEmit && vite build"
+  },
+  "dependencies": {
+    "@feedbackops/shared": "workspace:*",
+    "@feedbackops/ui": "workspace:*",
+    "@vitejs/plugin-react": "^4.4.1",
+    "lucide-react": "^0.511.0",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
+    "vite": "^6.3.5"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
+    "@types/react": "^19.1.4",
+    "@types/react-dom": "^19.1.5",
+    "jsdom": "^26.1.0",
+    "vitest": "^3.1.3"
+  }
+}

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "vite --host 0.0.0.0",
+    "dev": "vite --host 0.0.0.0 --port 5180 --strictPort",
     "test": "vitest run --environment jsdom",
     "build": "tsc -p tsconfig.json --noEmit && vite build"
   },

--- a/apps/frontend/src/App.test.tsx
+++ b/apps/frontend/src/App.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { App } from "./App";
 
 const apiState = {
+  dashboardFailuresByActor: new Set<string>(),
   vocs: [
     {
       id: "voc-api-1",
@@ -28,14 +29,46 @@ const apiState = {
     triage_state: string;
     reporter_facing_status: string;
     owner_id?: string;
-  }>
+  }>,
+  findings: [] as Array<{ id: string; managed_system_id: string; title: string; summary: string; status: string; source_voc_id?: string }>,
+  taskRequests: [] as Array<{
+    id: string;
+    managed_system_id: string;
+    title: string;
+    status: string;
+    source_type: string;
+    source_id: string;
+    requested_by_id: string;
+  }>,
+  tasks: [] as Array<{ id: string; managed_system_id: string; title: string; status: string }>
 };
 
 function jsonResponse(body: unknown, status = 200) {
   return Promise.resolve(new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } }));
 }
 
+function requestActor(init?: RequestInit) {
+  const headers = init?.headers as Record<string, string> | undefined;
+  return headers?.["x-actor-id"] ?? "";
+}
+
+function findFetchCall(path: string, method = "GET") {
+  return vi.mocked(fetch).mock.calls.find(([input, init]) => {
+    const url = new URL(input.toString(), "http://localhost:3000");
+    return url.pathname === path && (init?.method ?? "GET") === method;
+  });
+}
+
+function canReadTaskRequests(actorId: string) {
+  return actorId === "admin" || actorId === "dev-tableau";
+}
+
+function canReadInternalExecution(actorId: string) {
+  return actorId === "admin" || actorId === "dev-tableau";
+}
+
 beforeEach(() => {
+  apiState.dashboardFailuresByActor = new Set();
   apiState.vocs = [
     {
       id: "voc-api-1",
@@ -50,10 +83,14 @@ beforeEach(() => {
       owner_id: "dev-tableau"
     }
   ];
+  apiState.findings = [];
+  apiState.taskRequests = [];
+  apiState.tasks = [];
   vi.stubGlobal(
     "fetch",
     vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
       const url = new URL(input.toString(), "http://localhost:3000");
+      const body = init?.body ? JSON.parse(init.body.toString()) : {};
       if (url.pathname === "/api/health") return jsonResponse({ ok: true });
       if (url.pathname === "/managed-systems") {
         return jsonResponse([
@@ -65,30 +102,122 @@ beforeEach(() => {
         return jsonResponse([{ id: "aa-tableau-exec", managed_system_id: "ms-tableau", name: "Executive Reporting" }]);
       }
       if (url.pathname === "/dashboard/action-queues") {
+        const actorId = requestActor(init);
+        if (apiState.dashboardFailuresByActor.has(actorId)) {
+          return jsonResponse({ error: { code: "permission_denied", message: "Dashboard unavailable for current role." } }, 403);
+        }
         return jsonResponse({
-          high_severity_follow_up: [{ id: "voc-high-unlinked", title: "High severity API VOC", next_action: "Create Finding or Task Request" }],
-          task_requests_pending_review: [{ id: "task-request-1", title: "API Task Request", next_action: "Review Task Request" }]
+          high_severity_follow_up: apiState.findings.some((finding) => finding.source_voc_id === "voc-api-1")
+            ? []
+            : [{ id: "voc-api-1", title: "API Tableau VOC", next_action: "Create Finding or Task Request" }],
+          task_requests_pending_review: apiState.taskRequests
+            .filter((request) => request.status === "pending_review")
+            .map((request) => ({ id: request.id, title: request.title, next_action: "Review Task Request" }))
         });
+      }
+      if (url.pathname === "/vocs/voc-api-1" && init?.method === "PATCH") {
+        apiState.vocs = apiState.vocs.map((voc) =>
+          voc.id === "voc-api-1"
+            ? { ...voc, severity: body.severity, triage_state: body.triage_state, owner_id: body.owner_id }
+            : voc
+        );
+        return jsonResponse(apiState.vocs[0]);
+      }
+      if (url.pathname === "/vocs/voc-api-1/public-updates" && init?.method === "POST") {
+        return jsonResponse({ id: "conversation-public", type: "public_update", body: body.body }, 201);
+      }
+      if (url.pathname === "/vocs/voc-api-1/reporter-replies" && init?.method === "POST") {
+        const actorId = requestActor(init);
+        if (actorId !== "user-tableau") {
+          return jsonResponse({ error: { code: "permission_denied", message: "Reporter Reply is limited to the VOC reporter." } }, 403);
+        }
+        return jsonResponse({ id: "conversation-reporter", type: "reporter_reply", body: body.body }, 201);
+      }
+      if (url.pathname === "/vocs/voc-api-1/internal-comments" && init?.method === "POST") {
+        return jsonResponse({ id: "conversation-internal", type: "internal_comment", body: body.body }, 201);
+      }
+      if (url.pathname === "/vocs/voc-api-1/create-finding" && init?.method === "POST") {
+        apiState.findings = [
+          ...apiState.findings,
+          { id: "finding-api-1", managed_system_id: "ms-tableau", title: body.title, summary: body.summary, status: "active", source_voc_id: "voc-api-1" }
+        ];
+        return jsonResponse(apiState.findings.at(-1), 201);
       }
       if (url.pathname === "/vocs" && init?.method === "POST") {
         apiState.vocs = [
           ...apiState.vocs,
           {
             id: "voc-created-api",
-            managed_system_id: "ms-tableau",
-            reporter_id: "user-tableau",
-            title: "Created through UI",
-            description: "Saved to backend API.",
+            managed_system_id: body.managed_system_id,
+            analytics_area_id: body.analytics_area_id,
+            reporter_id: requestActor(init),
+            title: body.title,
+            description: body.description,
             triage_state: "new",
             reporter_facing_status: "접수됨"
           }
         ];
         return jsonResponse(apiState.vocs.at(-1), 201);
       }
-      if (url.pathname === "/vocs") return jsonResponse(apiState.vocs);
-      if (url.pathname === "/findings") return jsonResponse([]);
-      if (url.pathname === "/task-requests") return jsonResponse([]);
-      if (url.pathname === "/tasks") return jsonResponse([]);
+      if (url.pathname === "/vocs") {
+        const managedSystemId = url.searchParams.get("managed_system_id");
+        if (managedSystemId && managedSystemId !== "all") {
+          return jsonResponse(apiState.vocs.filter((voc) => voc.managed_system_id === managedSystemId));
+        }
+        return jsonResponse(apiState.vocs);
+      }
+      if (url.pathname === "/findings/finding-api-1/request-task" && init?.method === "POST") {
+        apiState.taskRequests = [
+          ...apiState.taskRequests,
+          {
+            id: "task-request-api-1",
+            managed_system_id: "ms-tableau",
+            title: body.title,
+            status: "pending_review",
+            source_type: "finding",
+            source_id: "finding-api-1",
+            requested_by_id: requestActor(init)
+          }
+        ];
+        return jsonResponse(apiState.taskRequests.at(-1), 201);
+      }
+      if (url.pathname === "/findings") {
+        if (!canReadInternalExecution(requestActor(init))) {
+          return jsonResponse({ error: { code: "permission_denied", message: "Findings require Developer or Admin access." } }, 403);
+        }
+        return jsonResponse(apiState.findings);
+      }
+      if (url.pathname === "/task-requests/task-request-api-1/approve" && init?.method === "POST") {
+        apiState.taskRequests = apiState.taskRequests.map((request) => (request.id === "task-request-api-1" ? { ...request, status: "approved" } : request));
+        return jsonResponse(apiState.taskRequests[0]);
+      }
+      if (url.pathname === "/task-requests/task-request-api-1/reject" && init?.method === "POST") {
+        apiState.taskRequests = apiState.taskRequests.map((request) => (request.id === "task-request-api-1" ? { ...request, status: "rejected" } : request));
+        return jsonResponse(apiState.taskRequests[0]);
+      }
+      if (url.pathname === "/task-requests/task-request-api-1/request-more-evidence" && init?.method === "POST") {
+        apiState.taskRequests = apiState.taskRequests.map((request) =>
+          request.id === "task-request-api-1" ? { ...request, status: "needs_more_evidence" } : request
+        );
+        return jsonResponse(apiState.taskRequests[0]);
+      }
+      if (url.pathname === "/task-requests/task-request-api-1/convert-to-task" && init?.method === "POST") {
+        apiState.taskRequests = apiState.taskRequests.map((request) => (request.id === "task-request-api-1" ? { ...request, status: "converted" } : request));
+        apiState.tasks = [{ id: "task-api-1", managed_system_id: "ms-tableau", title: "Task from request", status: "Backlog" }];
+        return jsonResponse(apiState.tasks[0], 201);
+      }
+      if (url.pathname === "/task-requests") {
+        if (!canReadTaskRequests(requestActor(init))) {
+          return jsonResponse({ error: { code: "permission_denied", message: "Task Requests require Developer or Admin access." } }, 403);
+        }
+        return jsonResponse(apiState.taskRequests);
+      }
+      if (url.pathname === "/tasks") {
+        if (!canReadInternalExecution(requestActor(init))) {
+          return jsonResponse({ error: { code: "permission_denied", message: "Tasks require Developer or Admin access." } }, 403);
+        }
+        return jsonResponse(apiState.tasks);
+      }
       return jsonResponse({ error: { code: "not_found", message: "Missing mock route" } }, 404);
     })
   );
@@ -125,13 +254,13 @@ describe("FeedbackOps frontend MVP shell", () => {
     render(<App initialPath="/vocs?selected=voc-api-1" />);
 
     expect(await screen.findAllByText("API Tableau VOC")).toHaveLength(2);
-    expect(fetch).toHaveBeenCalledWith(expect.stringContaining("/vocs?managed_system_id=all"), expect.objectContaining({ headers: expect.any(Object) }));
+    expect(fetch).toHaveBeenCalledWith(expect.stringContaining("/vocs?managed_system_id=ms-tableau"), expect.objectContaining({ headers: expect.any(Object) }));
     expect(screen.queryByText("Seeded Tableau VOC")).not.toBeInTheDocument();
     expect(screen.getByText("Reporter status")).toBeInTheDocument();
     expect(screen.getByText("검토 중")).toHaveAttribute("data-family", "reporter-voc");
     expect(screen.getByText("Internal triage")).toBeInTheDocument();
     const detail = screen.getByLabelText("API Tableau VOC");
-    expect(within(detail).getByText("triaging")).toBeInTheDocument();
+    expect(within(detail).getAllByText("triaging").length).toBeGreaterThan(0);
     expect(screen.getByLabelText("Public Update")).toBeInTheDocument();
     expect(screen.getByLabelText("Reporter Reply")).toBeInTheDocument();
     expect(screen.getByLabelText("Internal Comment")).toBeInTheDocument();
@@ -145,7 +274,188 @@ describe("FeedbackOps frontend MVP shell", () => {
     fireEvent.click(screen.getByRole("button", { name: "Submit VOC" }));
 
     await waitFor(() => expect(fetch).toHaveBeenCalledWith(expect.stringContaining("/vocs"), expect.objectContaining({ method: "POST" })));
-    expect(await screen.findAllByText("Created through UI")).toHaveLength(2);
+    await waitFor(() => expect(screen.getAllByText("Created through UI")).toHaveLength(2));
+  });
+
+  it("uses the active role switch actor for VOC creation", async () => {
+    render(<App initialPath="/vocs" />);
+
+    fireEvent.change(await screen.findByLabelText("Role Level"), { target: { value: "dev-tableau" } });
+    fireEvent.change(await screen.findByLabelText("VOC title"), { target: { value: "Developer authored VOC" } });
+    fireEvent.change(screen.getByLabelText("VOC description"), { target: { value: "Reporter is derived from the active actor." } });
+    fireEvent.click(screen.getByRole("button", { name: "Submit VOC" }));
+
+    await waitFor(() => expect(findFetchCall("/vocs", "POST")?.[1]).toMatchObject({ headers: expect.objectContaining({ "x-actor-id": "dev-tableau" }) }));
+    expect(apiState.vocs.at(-1)?.reporter_id).toBe("dev-tableau");
+  });
+
+  it("uses the active role switch actor for public updates and reporter replies", async () => {
+    render(<App initialPath="/vocs?selected=voc-api-1" />);
+
+    fireEvent.change(await screen.findByLabelText("Role Level"), { target: { value: "dev-tableau" } });
+    fireEvent.change(await screen.findByLabelText("Public Update"), { target: { value: "Developer public update" } });
+    fireEvent.click(screen.getByRole("button", { name: "Post Public Update" }));
+    await waitFor(() =>
+      expect(findFetchCall("/vocs/voc-api-1/public-updates", "POST")?.[1]).toMatchObject({
+        headers: expect.objectContaining({ "x-actor-id": "dev-tableau" })
+      })
+    );
+
+    fireEvent.change(screen.getByLabelText("Reporter Reply"), { target: { value: "Developer should not be silently impersonated" } });
+    fireEvent.click(screen.getByRole("button", { name: "Post Reporter Reply" }));
+    await waitFor(() =>
+      expect(findFetchCall("/vocs/voc-api-1/reporter-replies", "POST")?.[1]).toMatchObject({
+        headers: expect.objectContaining({ "x-actor-id": "dev-tableau" })
+      })
+    );
+    expect(await screen.findByText("Reporter Reply is limited to the VOC reporter.")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Role Level"), { target: { value: "user-tableau" } });
+    fireEvent.change(await screen.findByLabelText("Reporter Reply"), { target: { value: "Reporter-authored reply" } });
+    fireEvent.click(screen.getByRole("button", { name: "Post Reporter Reply" }));
+    await waitFor(() => {
+      const reporterReplyCalls = vi.mocked(fetch).mock.calls.filter(([input, init]) => {
+        const url = new URL(input.toString(), "http://localhost:3000");
+        return url.pathname === "/vocs/voc-api-1/reporter-replies" && init?.method === "POST";
+      });
+      expect(reporterReplyCalls.at(-1)?.[1]).toMatchObject({ headers: expect.objectContaining({ "x-actor-id": "user-tableau" }) });
+    });
+  });
+
+  it("clears a stale dashboard error after a successful role refetch", async () => {
+    apiState.dashboardFailuresByActor.add("admin");
+    render(<App initialPath="/" />);
+
+    expect(await screen.findByText("Dashboard unavailable for current role.")).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("Role Level"), { target: { value: "dev-tableau" } });
+
+    expect(await screen.findByText("API Tableau VOC")).toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByText("Dashboard unavailable for current role.")).not.toBeInTheDocument());
+  });
+
+  it("filters VOC API requests by selected Managed System and clears stale detail", async () => {
+    render(<App initialPath="/vocs" />);
+
+    expect(await screen.findAllByText("API Tableau VOC")).toHaveLength(2);
+    fireEvent.change(screen.getByLabelText("Managed System"), { target: { value: "ms-looker" } });
+
+    await waitFor(() => expect(fetch).toHaveBeenCalledWith(expect.stringContaining("/vocs?managed_system_id=ms-looker"), expect.any(Object)));
+    expect(await screen.findByText("No records")).toBeInTheDocument();
+    expect(screen.getByText("Select a VOC")).toBeInTheDocument();
+  });
+
+  it("renders backend permission_denied as a blocked Task Requests state for User role", async () => {
+    render(<App initialPath="/tasks?view=requests" />);
+
+    fireEvent.change(screen.getByLabelText("Role Level"), { target: { value: "user-tableau" } });
+
+    expect(await screen.findAllByText("Task Requests require Developer or Admin access.")).toHaveLength(2);
+    expect(screen.getAllByText("Request access")).toHaveLength(2);
+  });
+
+  it("hides VOC internal execution controls for User while reporter surfaces remain usable", async () => {
+    render(<App initialPath="/vocs?selected=voc-api-1" />);
+
+    expect(await screen.findAllByText("API Tableau VOC")).toHaveLength(2);
+    fireEvent.change(screen.getByLabelText("Role Level"), { target: { value: "user-tableau" } });
+
+    expect(await screen.findByText("Internal execution actions require Developer or Admin access.")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Triage state")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Severity")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Owner")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Save triage" })).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Public Update")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Post Public Update" })).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Internal Comment")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Post Internal Comment" })).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Finding title")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Finding summary")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Create Finding" })).not.toBeInTheDocument();
+
+    expect(screen.getByLabelText("VOC title")).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Submit VOC" })).toBeEnabled();
+    expect(screen.getByLabelText("Reporter Reply")).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Post Reporter Reply" })).toBeEnabled();
+    expect(screen.getByText("Reporter status")).toBeInTheDocument();
+  });
+
+  it("blocks User from Finding detail actions and hides Request Task", async () => {
+    apiState.findings = [{ id: "finding-api-1", managed_system_id: "ms-tableau", title: "Finding from backend", summary: "Evidence summary", status: "active" }];
+    render(<App initialPath="/integration/findings?selected=finding-api-1" />);
+
+    expect(await screen.findAllByText("Finding from backend")).toHaveLength(2);
+    fireEvent.change(screen.getByLabelText("Role Level"), { target: { value: "user-tableau" } });
+
+    expect(await screen.findAllByText("Findings require Developer or Admin access.")).toHaveLength(2);
+    expect(screen.getAllByText("Request access")).toHaveLength(2);
+    expect(screen.queryByLabelText("Task Request title")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Request Task" })).not.toBeInTheDocument();
+  });
+
+  it("blocks User from Task backstage lists and review controls", async () => {
+    apiState.taskRequests = [
+      {
+        id: "task-request-api-1",
+        managed_system_id: "ms-tableau",
+        title: "Task request from backend",
+        status: "pending_review",
+        source_type: "finding",
+        source_id: "finding-api-1",
+        requested_by_id: "dev-tableau"
+      }
+    ];
+    apiState.tasks = [{ id: "task-api-1", managed_system_id: "ms-tableau", title: "Task from backend", status: "Backlog" }];
+    render(<App initialPath="/tasks?view=requests&selected=task-request-api-1" />);
+
+    expect(await screen.findAllByText("Task request from backend")).toHaveLength(2);
+    fireEvent.change(screen.getByLabelText("Role Level"), { target: { value: "user-tableau" } });
+
+    expect(await screen.findAllByText("Task Requests require Developer or Admin access.")).toHaveLength(2);
+    expect(screen.getAllByText("Request access")).toHaveLength(2);
+    expect(screen.queryByRole("button", { name: "Approve" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Reject" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Request more evidence" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Convert to Task" })).not.toBeInTheDocument();
+    expect(screen.queryByText("Task from backend")).not.toBeInTheDocument();
+  });
+
+  it("runs the operator vertical slice through backend API actions", async () => {
+    render(<App initialPath="/vocs?selected=voc-api-1" />);
+
+    fireEvent.change(await screen.findByLabelText("Role Level"), { target: { value: "Admin" } });
+    fireEvent.change(screen.getByLabelText("Triage state"), { target: { value: "triaged" } });
+    fireEvent.change(screen.getByLabelText("Severity"), { target: { value: "high" } });
+    fireEvent.change(screen.getByLabelText("Owner"), { target: { value: "dev-tableau" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save triage" }));
+
+    await waitFor(() => expect(fetch).toHaveBeenCalledWith(expect.stringContaining("/vocs/voc-api-1"), expect.objectContaining({ method: "PATCH" })));
+    expect(await screen.findByText("high")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Public Update"), { target: { value: "Reporter-safe update" } });
+    fireEvent.click(screen.getByRole("button", { name: "Post Public Update" }));
+    await waitFor(() => expect(fetch).toHaveBeenCalledWith(expect.stringContaining("/vocs/voc-api-1/public-updates"), expect.objectContaining({ method: "POST" })));
+
+    fireEvent.change(screen.getByLabelText("Finding title"), { target: { value: "Finding from UI" } });
+    fireEvent.change(screen.getByLabelText("Finding summary"), { target: { value: "Evidence summary from selected VOC." } });
+    fireEvent.click(screen.getByRole("button", { name: "Create Finding" }));
+    await waitFor(() => expect(fetch).toHaveBeenCalledWith(expect.stringContaining("/vocs/voc-api-1/create-finding"), expect.objectContaining({ method: "POST" })));
+    expect(await screen.findByText("Finding from UI")).toBeInTheDocument();
+
+    cleanup();
+    render(<App initialPath="/integration/findings?selected=finding-api-1" />);
+    expect(await screen.findAllByText("Finding from UI")).toHaveLength(2);
+    fireEvent.change(screen.getByLabelText("Task Request title"), { target: { value: "Task Request from UI" } });
+    fireEvent.click(screen.getByRole("button", { name: "Request Task" }));
+    await waitFor(() => expect(fetch).toHaveBeenCalledWith(expect.stringContaining("/findings/finding-api-1/request-task"), expect.objectContaining({ method: "POST" })));
+
+    cleanup();
+    render(<App initialPath="/tasks?view=requests&selected=task-request-api-1" />);
+    expect(await screen.findAllByText("Task Request from UI")).toHaveLength(2);
+    fireEvent.click(screen.getByRole("button", { name: "Approve" }));
+    await waitFor(() => expect(fetch).toHaveBeenCalledWith(expect.stringContaining("/task-requests/task-request-api-1/approve"), expect.objectContaining({ method: "POST" })));
+    fireEvent.click(screen.getByRole("button", { name: "Convert to Task" }));
+    await waitFor(() => expect(fetch).toHaveBeenCalledWith(expect.stringContaining("/task-requests/task-request-api-1/convert-to-task"), expect.objectContaining({ method: "POST" })));
+    await waitFor(() => expect(screen.getAllByText("Backlog").some((node) => node.getAttribute("data-family") === "task")).toBe(true));
   });
 
   it("renders permission blocked content with safe summary", () => {

--- a/apps/frontend/src/App.test.tsx
+++ b/apps/frontend/src/App.test.tsx
@@ -1,17 +1,110 @@
 import "@testing-library/jest-dom/vitest";
-import { cleanup, render, screen, within } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { App } from "./App";
 
-afterEach(() => cleanup());
+const apiState = {
+  vocs: [
+    {
+      id: "voc-api-1",
+      managed_system_id: "ms-tableau",
+      analytics_area_id: "aa-tableau-exec",
+      reporter_id: "user-tableau",
+      title: "API Tableau VOC",
+      description: "Loaded from backend API.",
+      severity: "medium",
+      triage_state: "triaging",
+      reporter_facing_status: "검토 중",
+      owner_id: "dev-tableau"
+    }
+  ] as Array<{
+    id: string;
+    managed_system_id: string;
+    analytics_area_id?: string;
+    reporter_id: string;
+    title: string;
+    description: string;
+    severity?: string;
+    triage_state: string;
+    reporter_facing_status: string;
+    owner_id?: string;
+  }>
+};
+
+function jsonResponse(body: unknown, status = 200) {
+  return Promise.resolve(new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } }));
+}
+
+beforeEach(() => {
+  apiState.vocs = [
+    {
+      id: "voc-api-1",
+      managed_system_id: "ms-tableau",
+      analytics_area_id: "aa-tableau-exec",
+      reporter_id: "user-tableau",
+      title: "API Tableau VOC",
+      description: "Loaded from backend API.",
+      severity: "medium",
+      triage_state: "triaging",
+      reporter_facing_status: "검토 중",
+      owner_id: "dev-tableau"
+    }
+  ];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = new URL(input.toString(), "http://localhost:3000");
+      if (url.pathname === "/api/health") return jsonResponse({ ok: true });
+      if (url.pathname === "/managed-systems") {
+        return jsonResponse([
+          { id: "ms-tableau", name: "Tableau", workspace_id: "ws-main" },
+          { id: "ms-looker", name: "Looker", workspace_id: "ws-main" }
+        ]);
+      }
+      if (url.pathname === "/analytics-areas") {
+        return jsonResponse([{ id: "aa-tableau-exec", managed_system_id: "ms-tableau", name: "Executive Reporting" }]);
+      }
+      if (url.pathname === "/dashboard/action-queues") {
+        return jsonResponse({
+          high_severity_follow_up: [{ id: "voc-high-unlinked", title: "High severity API VOC", next_action: "Create Finding or Task Request" }],
+          task_requests_pending_review: [{ id: "task-request-1", title: "API Task Request", next_action: "Review Task Request" }]
+        });
+      }
+      if (url.pathname === "/vocs" && init?.method === "POST") {
+        apiState.vocs = [
+          ...apiState.vocs,
+          {
+            id: "voc-created-api",
+            managed_system_id: "ms-tableau",
+            reporter_id: "user-tableau",
+            title: "Created through UI",
+            description: "Saved to backend API.",
+            triage_state: "new",
+            reporter_facing_status: "접수됨"
+          }
+        ];
+        return jsonResponse(apiState.vocs.at(-1), 201);
+      }
+      if (url.pathname === "/vocs") return jsonResponse(apiState.vocs);
+      if (url.pathname === "/findings") return jsonResponse([]);
+      if (url.pathname === "/task-requests") return jsonResponse([]);
+      if (url.pathname === "/tasks") return jsonResponse([]);
+      return jsonResponse({ error: { code: "not_found", message: "Missing mock route" } }, 404);
+    })
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
 
 describe("FeedbackOps frontend MVP shell", () => {
   it("renders Home as an action dashboard first screen", () => {
     render(<App initialPath="/" />);
 
     expect(screen.getByRole("heading", { name: "Action Dashboard" })).toBeInTheDocument();
-    expect(screen.getByText("High severity VOC has no linked follow-up")).toBeInTheDocument();
-    expect(screen.getByText("Create Finding or Task Request")).toBeInTheDocument();
+    expect(screen.getByText("Loading")).toBeInTheDocument();
   });
 
   it("renders docs-aligned Admin navigation", () => {
@@ -26,14 +119,33 @@ describe("FeedbackOps frontend MVP shell", () => {
     render(<App initialPath="/vocs?selected=voc-seeded-tableau" />);
 
     expect(screen.getByRole("heading", { name: "VOC Inbox" })).toBeInTheDocument();
+  });
+
+  it("loads VOC rows and detail from the backend API", async () => {
+    render(<App initialPath="/vocs?selected=voc-api-1" />);
+
+    expect(await screen.findAllByText("API Tableau VOC")).toHaveLength(2);
+    expect(fetch).toHaveBeenCalledWith(expect.stringContaining("/vocs?managed_system_id=all"), expect.objectContaining({ headers: expect.any(Object) }));
+    expect(screen.queryByText("Seeded Tableau VOC")).not.toBeInTheDocument();
     expect(screen.getByText("Reporter status")).toBeInTheDocument();
     expect(screen.getByText("검토 중")).toHaveAttribute("data-family", "reporter-voc");
     expect(screen.getByText("Internal triage")).toBeInTheDocument();
-    const detail = screen.getByLabelText("Seeded Tableau VOC");
+    const detail = screen.getByLabelText("API Tableau VOC");
     expect(within(detail).getByText("triaging")).toBeInTheDocument();
     expect(screen.getByLabelText("Public Update")).toBeInTheDocument();
     expect(screen.getByLabelText("Reporter Reply")).toBeInTheDocument();
     expect(screen.getByLabelText("Internal Comment")).toBeInTheDocument();
+  });
+
+  it("submits VOC creation to the backend and refreshes the list", async () => {
+    render(<App initialPath="/vocs" />);
+
+    fireEvent.change(await screen.findByLabelText("VOC title"), { target: { value: "Created through UI" } });
+    fireEvent.change(screen.getByLabelText("VOC description"), { target: { value: "Saved to backend API." } });
+    fireEvent.click(screen.getByRole("button", { name: "Submit VOC" }));
+
+    await waitFor(() => expect(fetch).toHaveBeenCalledWith(expect.stringContaining("/vocs"), expect.objectContaining({ method: "POST" })));
+    expect(await screen.findAllByText("Created through UI")).toHaveLength(2);
   });
 
   it("renders permission blocked content with safe summary", () => {

--- a/apps/frontend/src/App.test.tsx
+++ b/apps/frontend/src/App.test.tsx
@@ -1,0 +1,54 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { App } from "./App";
+
+afterEach(() => cleanup());
+
+describe("FeedbackOps frontend MVP shell", () => {
+  it("renders Home as an action dashboard first screen", () => {
+    render(<App initialPath="/" />);
+
+    expect(screen.getByRole("heading", { name: "Action Dashboard" })).toBeInTheDocument();
+    expect(screen.getByText("High severity VOC has no linked follow-up")).toBeInTheDocument();
+    expect(screen.getByText("Create Finding or Task Request")).toBeInTheDocument();
+  });
+
+  it("renders docs-aligned Admin navigation", () => {
+    render(<App initialPath="/" />);
+
+    for (const label of ["Home", "My Work", "VOC", "Surveys", "Tasks", "Integration", "Admin"]) {
+      expect(screen.getByRole("link", { name: label })).toBeInTheDocument();
+    }
+  });
+
+  it("renders VOC list/detail with separate reporter and internal status plus composers", () => {
+    render(<App initialPath="/vocs?selected=voc-seeded-tableau" />);
+
+    expect(screen.getByRole("heading", { name: "VOC Inbox" })).toBeInTheDocument();
+    expect(screen.getByText("Reporter status")).toBeInTheDocument();
+    expect(screen.getByText("검토 중")).toHaveAttribute("data-family", "reporter-voc");
+    expect(screen.getByText("Internal triage")).toBeInTheDocument();
+    const detail = screen.getByLabelText("Seeded Tableau VOC");
+    expect(within(detail).getByText("triaging")).toBeInTheDocument();
+    expect(screen.getByLabelText("Public Update")).toBeInTheDocument();
+    expect(screen.getByLabelText("Reporter Reply")).toBeInTheDocument();
+    expect(screen.getByLabelText("Internal Comment")).toBeInTheDocument();
+  });
+
+  it("renders permission blocked content with safe summary", () => {
+    render(<App initialPath="/integration/findings?selected=restricted-finding" />);
+
+    expect(screen.getByText("Summary visible to reporter")).toBeInTheDocument();
+    expect(screen.getByText("Request access")).toBeInTheDocument();
+    expect(screen.queryByText("Private root-cause notes")).not.toBeInTheDocument();
+  });
+
+  it("does not expose Survey Response to VOC conversion", () => {
+    render(<App initialPath="/surveys/survey-1/results" />);
+
+    expect(screen.getByRole("heading", { name: "Survey Results" })).toBeInTheDocument();
+    expect(screen.queryByText(/Create VOC/i)).not.toBeInTheDocument();
+    expect(screen.getByText("Create Finding")).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -13,10 +13,28 @@ import { BarChart3, ClipboardList, Home, Inbox, Link2, Settings, SquareKanban, U
 import { useCallback, useEffect, useMemo, useState, type FormEvent } from "react";
 
 const apiBaseUrl = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:3000";
-const defaultActorId = "admin";
+const actors = [
+  { role: "Admin", actorId: "admin" },
+  { role: "Developer", actorId: "dev-tableau" },
+  { role: "User", actorId: "user-tableau" }
+] as const;
+
+type ActorId = (typeof actors)[number]["actorId"];
+
+const internalExecutionBlockedSummary = "Internal execution actions require Developer or Admin access.";
+
+function canUseInternalExecution(actorId: ActorId) {
+  return actorId !== "user-tableau";
+}
 
 interface ManagedSystemDto {
   id: string;
+  name: string;
+}
+
+interface AnalyticsAreaDto {
+  id: string;
+  managed_system_id: string;
   name: string;
 }
 
@@ -29,6 +47,32 @@ interface VocDto {
   severity?: string;
   triage_state: string;
   reporter_facing_status: string;
+  owner_id?: string;
+}
+
+interface FindingDto {
+  id: string;
+  managed_system_id: string;
+  title: string;
+  summary: string;
+  status: string;
+}
+
+interface TaskRequestDto {
+  id: string;
+  managed_system_id: string;
+  title: string;
+  status: string;
+  source_type: string;
+  source_id: string;
+  requested_by_id: string;
+}
+
+interface TaskDto {
+  id: string;
+  managed_system_id: string;
+  title: string;
+  status: string;
 }
 
 interface QueueDto {
@@ -43,22 +87,58 @@ interface DashboardQueuesDto {
   task_requests_pending_review: QueueDto[];
 }
 
-async function apiGet<T>(path: string, actorId = defaultActorId): Promise<T> {
+class ApiError extends Error {
+  status: number;
+  code?: string;
+
+  constructor(path: string, status: number, message: string, code?: string) {
+    super(message || `GET ${path} failed with ${status}`);
+    this.status = status;
+    this.code = code;
+  }
+}
+
+async function parseApiError(response: Response, path: string, method: string) {
+  let message = `${method} ${path} failed with ${response.status}`;
+  let code: string | undefined;
+  try {
+    const body = (await response.json()) as { error?: { code?: string; message?: string } };
+    message = body.error?.message ?? message;
+    code = body.error?.code;
+  } catch {
+    // Keep the standard method/path/status message when the response has no JSON error body.
+  }
+  return new ApiError(path, response.status, message, code);
+}
+
+async function apiGet<T>(path: string, actorId: ActorId): Promise<T> {
   const response = await fetch(`${apiBaseUrl}${path}`, { headers: { "x-actor-id": actorId } });
   if (!response.ok) {
-    throw new Error(`GET ${path} failed with ${response.status}`);
+    throw await parseApiError(response, path, "GET");
   }
   return response.json() as Promise<T>;
 }
 
-async function apiPost<T>(path: string, body: Record<string, unknown>, actorId = "user-tableau"): Promise<T> {
+async function apiPost<T>(path: string, body: Record<string, unknown>, actorId: ActorId): Promise<T> {
   const response = await fetch(`${apiBaseUrl}${path}`, {
     method: "POST",
     headers: { "content-type": "application/json", "x-actor-id": actorId },
     body: JSON.stringify(body)
   });
   if (!response.ok) {
-    throw new Error(`POST ${path} failed with ${response.status}`);
+    throw await parseApiError(response, path, "POST");
+  }
+  return response.json() as Promise<T>;
+}
+
+async function apiPatch<T>(path: string, body: Record<string, unknown>, actorId: ActorId): Promise<T> {
+  const response = await fetch(`${apiBaseUrl}${path}`, {
+    method: "PATCH",
+    headers: { "content-type": "application/json", "x-actor-id": actorId },
+    body: JSON.stringify(body)
+  });
+  if (!response.ok) {
+    throw await parseApiError(response, path, "PATCH");
   }
   return response.json() as Promise<T>;
 }
@@ -82,14 +162,38 @@ function parsePath(initialPath?: string) {
 export function App({ initialPath }: { initialPath?: string }) {
   const route = useMemo(() => parsePath(initialPath), [initialPath]);
   const [selectedVocId, setSelectedVocId] = useState(route.params.get("selected") ?? "");
+  const [selectedFindingId, setSelectedFindingId] = useState(route.params.get("selected") ?? "");
+  const [selectedTaskRequestId, setSelectedTaskRequestId] = useState(route.params.get("selected") ?? "");
+  const [actorId, setActorId] = useState<ActorId>("admin");
+  const role = actors.find((actor) => actor.actorId === actorId)?.role ?? "Admin";
+
+  function setSelectedUrlState(kind: "vocs" | "findings" | "task-requests", id: string) {
+    if (kind === "vocs") setSelectedVocId(id);
+    if (kind === "findings") setSelectedFindingId(id);
+    if (kind === "task-requests") setSelectedTaskRequestId(id);
+    if (initialPath || typeof window === "undefined") return;
+    const url = new URL(window.location.href);
+    url.searchParams.set("selected", id);
+    window.history.replaceState(null, "", url);
+  }
 
   return (
     <div className="app-shell">
       <aside className="sidebar">
         <div className="brand">
           <strong>FeedbackOps</strong>
-          <span>Admin</span>
+          <span>{role}</span>
         </div>
+        <label className="role-switcher">
+          <span>Role Level</span>
+          <select aria-label="Role Level" value={actorId} onChange={(event) => setActorId(event.target.value as ActorId)}>
+            {actors.map((actor) => (
+              <option key={actor.actorId} value={actor.actorId}>
+                {actor.role}
+              </option>
+            ))}
+          </select>
+        </label>
         <nav aria-label="Primary">
           {navItems.map(({ label, href, icon: Icon }) => (
             <a key={label} href={href}>
@@ -99,20 +203,26 @@ export function App({ initialPath }: { initialPath?: string }) {
           ))}
         </nav>
       </aside>
-      <main className="main-region">{renderRoute(route.pathname, selectedVocId, setSelectedVocId)}</main>
+      <main className="main-region">{renderRoute(route, { selectedVocId, selectedFindingId, selectedTaskRequestId }, setSelectedUrlState, actorId)}</main>
     </div>
   );
 }
 
-function renderRoute(pathname: string, selectedVocId: string, setSelectedVocId: (id: string) => void) {
+function renderRoute(
+  route: { pathname: string; params: URLSearchParams },
+  selected: { selectedVocId: string; selectedFindingId: string; selectedTaskRequestId: string },
+  setSelectedUrlState: (kind: "vocs" | "findings" | "task-requests", id: string) => void,
+  actorId: ActorId
+) {
+  const { pathname, params } = route;
   if (pathname.startsWith("/vocs")) {
-    return <VocPage selectedVocId={selectedVocId} setSelectedVocId={setSelectedVocId} />;
+    return <VocPage selectedVocId={selected.selectedVocId} setSelectedVocId={(id) => setSelectedUrlState("vocs", id)} actorId={actorId} />;
   }
   if (pathname.startsWith("/integration")) {
-    return <IntegrationPage />;
+    return <IntegrationPage selectedFindingId={selected.selectedFindingId || params.get("selected") || ""} setSelectedFindingId={(id) => setSelectedUrlState("findings", id)} actorId={actorId} />;
   }
   if (pathname.startsWith("/tasks")) {
-    return <TasksPage />;
+    return <TasksPage selectedTaskRequestId={selected.selectedTaskRequestId || params.get("selected") || ""} setSelectedTaskRequestId={(id) => setSelectedUrlState("task-requests", id)} actorId={actorId} />;
   }
   if (pathname.startsWith("/admin")) {
     return <AdminPage />;
@@ -123,7 +233,7 @@ function renderRoute(pathname: string, selectedVocId: string, setSelectedVocId: 
   if (pathname.startsWith("/my-work")) {
     return <MyWorkPage />;
   }
-  return <HomePage />;
+  return <HomePage actorId={actorId} />;
 }
 
 function PageHeader({ title, kicker }: { title: string; kicker: string }) {
@@ -140,15 +250,22 @@ function PageHeader({ title, kicker }: { title: string; kicker: string }) {
   );
 }
 
-function HomePage() {
+function HomePage({ actorId }: { actorId: ActorId }) {
   const [queues, setQueues] = useState<DashboardQueuesDto | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    apiGet<DashboardQueuesDto>("/dashboard/action-queues")
-      .then(setQueues)
-      .catch((caught: unknown) => setError(caught instanceof Error ? caught.message : "Failed to load dashboard"));
-  }, []);
+    setError(null);
+    apiGet<DashboardQueuesDto>("/dashboard/action-queues", actorId)
+      .then((nextQueues) => {
+        setQueues(nextQueues);
+        setError(null);
+      })
+      .catch((caught: unknown) => {
+        setQueues(null);
+        setError(caught instanceof Error ? caught.message : "Failed to load dashboard");
+      });
+  }, [actorId]);
 
   const rows = [...(queues?.high_severity_follow_up ?? []), ...(queues?.task_requests_pending_review ?? [])];
   return (
@@ -168,63 +285,159 @@ function HomePage() {
 
 function VocPage({
   selectedVocId,
-  setSelectedVocId
+  setSelectedVocId,
+  actorId
 }: {
   selectedVocId: string;
   setSelectedVocId: (id: string) => void;
+  actorId: ActorId;
 }) {
   const [vocs, setVocs] = useState<VocDto[]>([]);
   const [managedSystems, setManagedSystems] = useState<ManagedSystemDto[]>([]);
+  const [analyticsAreas, setAnalyticsAreas] = useState<AnalyticsAreaDto[]>([]);
+  const [managedSystemId, setManagedSystemId] = useState("ms-tableau");
+  const [analyticsAreaId, setAnalyticsAreaId] = useState("aa-tableau-exec");
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
+  const [publicUpdate, setPublicUpdate] = useState("");
+  const [reporterReply, setReporterReply] = useState("");
+  const [internalComment, setInternalComment] = useState("");
+  const [findingTitle, setFindingTitle] = useState("");
+  const [findingSummary, setFindingSummary] = useState("");
+  const [createdFinding, setCreatedFinding] = useState<FindingDto | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
 
-  const loadVocs = useCallback(async () => {
+  const loadVocs = useCallback(async (preferredSelectedId?: string) => {
     setLoading(true);
     setError(null);
     try {
       const [nextVocs, nextManagedSystems] = await Promise.all([
-        apiGet<VocDto[]>("/vocs?managed_system_id=all"),
-        apiGet<ManagedSystemDto[]>("/managed-systems")
+        apiGet<VocDto[]>(`/vocs?managed_system_id=${managedSystemId}`, actorId),
+        apiGet<ManagedSystemDto[]>("/managed-systems", actorId)
       ]);
       setVocs(nextVocs);
       setManagedSystems(nextManagedSystems);
-      if (!selectedVocId && nextVocs[0]) {
-        setSelectedVocId(nextVocs[0].id);
-      }
+      const nextSelectedId = preferredSelectedId && nextVocs.some((voc) => voc.id === preferredSelectedId)
+        ? preferredSelectedId
+        : nextVocs.some((voc) => voc.id === selectedVocId)
+          ? selectedVocId
+          : nextVocs[0]?.id ?? "";
+      setSelectedVocId(nextSelectedId);
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : "Failed to load VOCs");
+      setVocs([]);
+      setSelectedVocId("");
     } finally {
       setLoading(false);
     }
-  }, [selectedVocId, setSelectedVocId]);
+  }, [actorId, managedSystemId, selectedVocId, setSelectedVocId]);
 
   useEffect(() => {
     void loadVocs();
   }, [loadVocs]);
 
+  useEffect(() => {
+    apiGet<AnalyticsAreaDto[]>(`/analytics-areas?managed_system_id=${managedSystemId}`, actorId)
+      .then((areas) => {
+        setAnalyticsAreas(areas);
+        setAnalyticsAreaId(areas[0]?.id ?? "");
+      })
+      .catch(() => setAnalyticsAreas([]));
+  }, [actorId, managedSystemId]);
+
   async function submitVoc(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    const created = await apiPost<VocDto>("/vocs", {
-      managed_system_id: "ms-tableau",
-      title,
-      description
-    });
-    setTitle("");
-    setDescription("");
-    setSelectedVocId(created.id);
-    await loadVocs();
+    setActionError(null);
+    try {
+      const created = await apiPost<VocDto>(
+        "/vocs",
+        {
+          managed_system_id: managedSystemId,
+          analytics_area_id: analyticsAreaId || undefined,
+          title,
+          description
+        },
+        actorId
+      );
+      setTitle("");
+      setDescription("");
+      await loadVocs(created.id);
+    } catch (caught) {
+      setActionError(caught instanceof Error ? caught.message : "Failed to submit VOC");
+    }
+  }
+
+  async function saveTriage(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!selected) return;
+    const form = new FormData(event.currentTarget);
+    const updated = await apiPatch<VocDto>(
+      `/vocs/${selected.id}`,
+      {
+        triage_state: form.get("triage_state"),
+        severity: form.get("severity"),
+        owner_id: form.get("owner_id")
+      },
+      actorId
+    );
+    setVocs((current) => current.map((voc) => (voc.id === updated.id ? updated : voc)));
+  }
+
+  async function submitConversation(type: "public-updates" | "reporter-replies" | "internal-comments", body: string, clear: () => void) {
+    if (!selected || !body) return;
+    setActionError(null);
+    try {
+      await apiPost(`/vocs/${selected.id}/${type}`, { body }, actorId);
+      clear();
+    } catch (caught) {
+      setActionError(caught instanceof Error ? caught.message : "Failed to submit conversation");
+    }
+  }
+
+  async function createFinding(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!selected) return;
+    const finding = await apiPost<FindingDto>(
+      `/vocs/${selected.id}/create-finding`,
+      { title: findingTitle || selected.title, summary: findingSummary || selected.description },
+      actorId
+    );
+    setCreatedFinding(finding);
+    setFindingTitle("");
+    setFindingSummary("");
   }
 
   const selected = vocs.find((voc) => voc.id === selectedVocId) ?? vocs[0];
   const systemName = (id: string) => managedSystems.find((system) => system.id === id)?.name ?? id;
+  const canUseExecutionControls = canUseInternalExecution(actorId);
 
   return (
     <section className="page split-page">
       <div className="list-region">
         <PageHeader title="VOC Inbox" kicker="VOC" />
         <form className="inline-create" onSubmit={submitVoc}>
+          <label>
+            <span>Managed System</span>
+            <select aria-label="Managed System" value={managedSystemId} onChange={(event) => setManagedSystemId(event.target.value)}>
+              {managedSystems.map((system) => (
+                <option key={system.id} value={system.id}>
+                  {system.name}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label>
+            <span>Analytics Area</span>
+            <select aria-label="Analytics Area" value={analyticsAreaId} onChange={(event) => setAnalyticsAreaId(event.target.value)}>
+              {analyticsAreas.map((area) => (
+                <option key={area.id} value={area.id}>
+                  {area.name}
+                </option>
+              ))}
+            </select>
+          </label>
           <label>
             <span>VOC title</span>
             <input aria-label="VOC title" value={title} onChange={(event) => setTitle(event.target.value)} required />
@@ -239,6 +452,7 @@ function VocPage({
         </form>
         {loading ? <div className="fo-empty">Loading</div> : null}
         {error ? <div className="fo-empty">{error}</div> : null}
+        {actionError ? <div className="fo-empty">{actionError}</div> : null}
         <ObjectList
           items={vocs.map((voc) => ({
             id: voc.id,
@@ -263,12 +477,80 @@ function VocPage({
             </div>
           </div>
           <p>{selected.description}</p>
-          <LinkedEntityTrail links={["VOC", "Finding candidate", "Task Request candidate"]} />
+          {canUseExecutionControls ? (
+            <form className="control-grid" onSubmit={saveTriage}>
+              <label>
+                <span>Triage state</span>
+                <select aria-label="Triage state" name="triage_state" defaultValue={selected.triage_state} key={`${selected.id}-triage`}>
+                  <option value="new">new</option>
+                  <option value="triaging">triaging</option>
+                  <option value="triaged">triaged</option>
+                </select>
+              </label>
+              <label>
+                <span>Severity</span>
+                <select aria-label="Severity" name="severity" defaultValue={selected.severity ?? "medium"} key={`${selected.id}-severity`}>
+                  <option value="low">low</option>
+                  <option value="medium">medium</option>
+                  <option value="high">high</option>
+                  <option value="critical">critical</option>
+                </select>
+              </label>
+              <label>
+                <span>Owner</span>
+                <select aria-label="Owner" name="owner_id" defaultValue={selected.owner_id ?? "dev-tableau"} key={`${selected.id}-owner`}>
+                  <option value="dev-tableau">dev-tableau</option>
+                  <option value="admin">admin</option>
+                </select>
+              </label>
+              <button className="primary-inline" type="submit">
+                Save triage
+              </button>
+            </form>
+          ) : (
+            <PermissionBlockedPanel summary={internalExecutionBlockedSummary} />
+          )}
+          {canUseExecutionControls ? <LinkedEntityTrail links={["VOC", "Finding candidate", "Task Request candidate"]} /> : null}
           <div className="composer-grid">
-            <RichContentEditor label="Public Update" value="" onChange={() => undefined} />
-            <RichContentEditor label="Reporter Reply" value="" onChange={() => undefined} />
-            <RichContentEditor label="Internal Comment" value="" onChange={() => undefined} />
+            {canUseExecutionControls ? (
+              <div>
+                <RichContentEditor label="Public Update" value={publicUpdate} onChange={setPublicUpdate} />
+                <button className="primary-inline" type="button" onClick={() => void submitConversation("public-updates", publicUpdate, () => setPublicUpdate(""))}>
+                  Post Public Update
+                </button>
+              </div>
+            ) : null}
+            <div>
+              <RichContentEditor label="Reporter Reply" value={reporterReply} onChange={setReporterReply} />
+              <button className="primary-inline" type="button" onClick={() => void submitConversation("reporter-replies", reporterReply, () => setReporterReply(""))}>
+                Post Reporter Reply
+              </button>
+            </div>
+            {canUseExecutionControls ? (
+              <div>
+                <RichContentEditor label="Internal Comment" value={internalComment} onChange={setInternalComment} />
+                <button className="primary-inline" type="button" onClick={() => void submitConversation("internal-comments", internalComment, () => setInternalComment(""))}>
+                  Post Internal Comment
+                </button>
+              </div>
+            ) : null}
           </div>
+          {canUseExecutionControls ? (
+            <form className="control-grid" onSubmit={createFinding}>
+              <label>
+                <span>Finding title</span>
+                <input aria-label="Finding title" value={findingTitle} onChange={(event) => setFindingTitle(event.target.value)} />
+              </label>
+              <label>
+                <span>Finding summary</span>
+                <textarea aria-label="Finding summary" value={findingSummary} onChange={(event) => setFindingSummary(event.target.value)} />
+              </label>
+              <button className="primary-inline" type="submit">
+                Create Finding
+              </button>
+              {createdFinding ? <EvidenceHighlight>{createdFinding.title}</EvidenceHighlight> : null}
+            </form>
+          ) : null}
         </DetailPanel>
       ) : (
         <DetailPanel title="VOC detail">
@@ -279,34 +561,211 @@ function VocPage({
   );
 }
 
-function IntegrationPage() {
+function IntegrationPage({
+  selectedFindingId,
+  setSelectedFindingId,
+  actorId
+}: {
+  selectedFindingId: string;
+  setSelectedFindingId: (id: string) => void;
+  actorId: ActorId;
+}) {
+  const [findings, setFindings] = useState<FindingDto[]>([]);
+  const [taskRequestTitle, setTaskRequestTitle] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [permissionBlocked, setPermissionBlocked] = useState<string | null>(null);
+  const canUseExecutionControls = canUseInternalExecution(actorId);
+
+  const loadFindings = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    setPermissionBlocked(canUseExecutionControls ? null : internalExecutionBlockedSummary);
+    try {
+      const nextFindings = await apiGet<FindingDto[]>("/findings", actorId);
+      setFindings(nextFindings);
+      setPermissionBlocked(null);
+      if (!selectedFindingId && nextFindings[0]) setSelectedFindingId(nextFindings[0].id);
+      if (selectedFindingId && !nextFindings.some((finding) => finding.id === selectedFindingId)) {
+        setSelectedFindingId(nextFindings[0]?.id ?? "");
+      }
+    } catch (caught) {
+      setFindings([]);
+      setSelectedFindingId("");
+      if (caught instanceof ApiError && caught.code === "permission_denied") {
+        setPermissionBlocked(caught.message);
+      } else {
+        setError(caught instanceof Error ? caught.message : "Failed to load Findings");
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [actorId, canUseExecutionControls, selectedFindingId, setSelectedFindingId]);
+
+  useEffect(() => {
+    void loadFindings();
+  }, [loadFindings]);
+
+  const selected = findings.find((finding) => finding.id === selectedFindingId) ?? findings[0];
+
+  async function requestTask(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!selected) return;
+    await apiPost(`/findings/${selected.id}/request-task`, { title: taskRequestTitle || selected.title }, actorId);
+    setTaskRequestTitle("");
+  }
+
   return (
     <section className="page split-page">
       <div className="list-region">
         <PageHeader title="Findings" kicker="Integration" />
-        <ObjectList
-          items={[{ id: "restricted-finding", title: "Restricted finding", meta: "summary_visible" }]}
-          selectedId="restricted-finding"
-          onSelect={() => undefined}
-        />
+        {loading ? <div className="fo-empty">Loading</div> : null}
+        {error ? <div className="fo-empty">{error}</div> : null}
+        {permissionBlocked ? <PermissionBlockedPanel summary={permissionBlocked} /> : null}
+        {!permissionBlocked && !loading && !error ? (
+          <ObjectList
+            items={findings.map((finding) => ({ id: finding.id, title: finding.title, meta: finding.status }))}
+            selectedId={selected?.id}
+            onSelect={setSelectedFindingId}
+          />
+        ) : null}
       </div>
-      <DetailPanel title="Restricted finding" permissionBlocked summary="Summary visible to reporter">
-        Private root-cause notes
-      </DetailPanel>
+      {selected ? (
+        <DetailPanel title={selected.title}>
+          <p>{selected.summary}</p>
+          <StatusBadge family="finding" value={selected.status} />
+          {canUseExecutionControls ? (
+            <form className="control-grid" onSubmit={requestTask}>
+              <label>
+                <span>Task Request title</span>
+                <input aria-label="Task Request title" value={taskRequestTitle} onChange={(event) => setTaskRequestTitle(event.target.value)} />
+              </label>
+              <button className="primary-inline" type="submit">
+                Request Task
+              </button>
+            </form>
+          ) : (
+            <PermissionBlockedPanel summary={permissionBlocked ?? internalExecutionBlockedSummary} />
+          )}
+        </DetailPanel>
+      ) : permissionBlocked ? (
+        <DetailPanel title="Findings">
+          <PermissionBlockedPanel summary={permissionBlocked} />
+        </DetailPanel>
+      ) : (
+        <DetailPanel title="Restricted finding" permissionBlocked summary="Summary visible to reporter">
+          Private root-cause notes
+        </DetailPanel>
+      )}
     </section>
   );
 }
 
-function TasksPage() {
+function TasksPage({
+  selectedTaskRequestId,
+  setSelectedTaskRequestId,
+  actorId
+}: {
+  selectedTaskRequestId: string;
+  setSelectedTaskRequestId: (id: string) => void;
+  actorId: ActorId;
+}) {
+  const [taskRequests, setTaskRequests] = useState<TaskRequestDto[]>([]);
+  const [tasks, setTasks] = useState<TaskDto[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [permissionBlocked, setPermissionBlocked] = useState<string | null>(null);
+
+  const loadTasks = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    setPermissionBlocked(null);
+    try {
+      const [nextTaskRequests, nextTasks] = await Promise.all([apiGet<TaskRequestDto[]>("/task-requests", actorId), apiGet<TaskDto[]>("/tasks", actorId)]);
+      setTaskRequests(nextTaskRequests);
+      setTasks(nextTasks);
+      if (!selectedTaskRequestId && nextTaskRequests[0]) setSelectedTaskRequestId(nextTaskRequests[0].id);
+      if (selectedTaskRequestId && !nextTaskRequests.some((request) => request.id === selectedTaskRequestId)) {
+        setSelectedTaskRequestId(nextTaskRequests[0]?.id ?? "");
+      }
+    } catch (caught) {
+      setTaskRequests([]);
+      setTasks([]);
+      setSelectedTaskRequestId("");
+      if (caught instanceof ApiError && caught.code === "permission_denied") {
+        setPermissionBlocked(caught.message);
+      } else {
+        setError(caught instanceof Error ? caught.message : "Failed to load Tasks");
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [actorId, selectedTaskRequestId, setSelectedTaskRequestId]);
+
+  useEffect(() => {
+    void loadTasks();
+  }, [loadTasks]);
+
+  const selected = taskRequests.find((request) => request.id === selectedTaskRequestId) ?? taskRequests[0];
+
+  async function review(path: string) {
+    if (!selected) return;
+    await apiPost(`/task-requests/${selected.id}/${path}`, { reason: "Reviewed from Tasks intake." }, actorId);
+    await loadTasks();
+  }
+
   return (
-    <section className="page">
-      <PageHeader title="Tasks" kicker="Tasks" />
-      <div className="task-board">
-        <section>
-          <h2>Backlog</h2>
-          <p>Converted Tasks start here before Todo or Doing.</p>
-        </section>
+    <section className="page split-page">
+      <div className="list-region">
+        <PageHeader title="Tasks" kicker="Tasks" />
+        {loading ? <div className="fo-empty">Loading</div> : null}
+        {error ? <div className="fo-empty">{error}</div> : null}
+        {permissionBlocked ? <PermissionBlockedPanel summary={permissionBlocked} /> : null}
+        {!permissionBlocked && !loading && !error ? (
+          <ObjectList
+            items={taskRequests.map((request) => ({ id: request.id, title: request.title, meta: request.status }))}
+            selectedId={selected?.id}
+            onSelect={setSelectedTaskRequestId}
+          />
+        ) : null}
+        <div className="task-board">
+          <section>
+            <h2>Backlog</h2>
+            {tasks.length === 0 ? <p>No converted Tasks</p> : null}
+            {tasks.map((task) => (
+              <div key={task.id} className="task-row">
+                <strong>{task.title}</strong>
+                <StatusBadge family="task" value={task.status} />
+              </div>
+            ))}
+          </section>
+        </div>
       </div>
+      <DetailPanel title={selected?.title ?? "Task Request"}>
+        {permissionBlocked ? (
+          <PermissionBlockedPanel summary={permissionBlocked} />
+        ) : selected ? (
+          <>
+            <StatusBadge family="task-request" value={selected.status} />
+            <div className="action-strip">
+              <button className="primary-inline" type="button" onClick={() => void review("approve")}>
+                Approve
+              </button>
+              <button className="primary-inline" type="button" onClick={() => void review("reject")}>
+                Reject
+              </button>
+              <button className="primary-inline" type="button" onClick={() => void review("request-more-evidence")}>
+                Request more evidence
+              </button>
+              <button className="primary-inline" type="button" onClick={() => void review("convert-to-task")}>
+                Convert to Task
+              </button>
+            </div>
+          </>
+        ) : (
+          <div className="fo-empty">No Task Requests</div>
+        )}
+      </DetailPanel>
     </section>
   );
 }
@@ -315,7 +774,7 @@ function AdminPage() {
   const [managedSystems, setManagedSystems] = useState<ManagedSystemDto[]>([]);
 
   useEffect(() => {
-    apiGet<ManagedSystemDto[]>("/managed-systems").then(setManagedSystems).catch(() => setManagedSystems([]));
+    apiGet<ManagedSystemDto[]>("/managed-systems", "admin").then(setManagedSystems).catch(() => setManagedSystems([]));
   }, []);
 
   return (

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -1,0 +1,216 @@
+import {
+  ActionQueueRow,
+  DetailPanel,
+  EvidenceHighlight,
+  LinkedEntityTrail,
+  ObjectList,
+  PermissionBlockedPanel,
+  RichContentEditor,
+  SignalBadge,
+  StatusBadge
+} from "@feedbackops/ui";
+import { BarChart3, ClipboardList, Home, Inbox, Link2, Settings, SquareKanban, UserRound } from "lucide-react";
+import { useMemo, useState } from "react";
+import { fixtures } from "./fixtures";
+
+const navItems = [
+  { label: "Home", href: "/", icon: Home },
+  { label: "My Work", href: "/my-work", icon: UserRound },
+  { label: "VOC", href: "/vocs", icon: Inbox },
+  { label: "Surveys", href: "/surveys", icon: ClipboardList },
+  { label: "Tasks", href: "/tasks", icon: SquareKanban },
+  { label: "Integration", href: "/integration/findings", icon: Link2 },
+  { label: "Admin", href: "/admin/managed-systems", icon: Settings }
+];
+
+function parsePath(initialPath?: string) {
+  const path = initialPath ?? window.location.pathname + window.location.search;
+  const url = new URL(path, "http://feedbackops.local");
+  return { pathname: url.pathname, params: url.searchParams };
+}
+
+export function App({ initialPath }: { initialPath?: string }) {
+  const route = useMemo(() => parsePath(initialPath), [initialPath]);
+  const [selectedVocId, setSelectedVocId] = useState(route.params.get("selected") ?? fixtures.vocs[0].id);
+
+  return (
+    <div className="app-shell">
+      <aside className="sidebar">
+        <div className="brand">
+          <strong>FeedbackOps</strong>
+          <span>{fixtures.actor.roleLevel}</span>
+        </div>
+        <nav aria-label="Primary">
+          {navItems.map(({ label, href, icon: Icon }) => (
+            <a key={label} href={href}>
+              <Icon aria-hidden="true" size={16} />
+              {label}
+            </a>
+          ))}
+        </nav>
+      </aside>
+      <main className="main-region">{renderRoute(route.pathname, selectedVocId, setSelectedVocId)}</main>
+    </div>
+  );
+}
+
+function renderRoute(pathname: string, selectedVocId: string, setSelectedVocId: (id: string) => void) {
+  if (pathname.startsWith("/vocs")) {
+    return <VocPage selectedVocId={selectedVocId} setSelectedVocId={setSelectedVocId} />;
+  }
+  if (pathname.startsWith("/integration")) {
+    return <IntegrationPage />;
+  }
+  if (pathname.startsWith("/tasks")) {
+    return <TasksPage />;
+  }
+  if (pathname.startsWith("/admin")) {
+    return <AdminPage />;
+  }
+  if (pathname.startsWith("/surveys")) {
+    return <SurveyResultsPage />;
+  }
+  if (pathname.startsWith("/my-work")) {
+    return <MyWorkPage />;
+  }
+  return <HomePage />;
+}
+
+function PageHeader({ title, kicker }: { title: string; kicker: string }) {
+  return (
+    <header className="page-header">
+      <div>
+        <span>{kicker}</span>
+        <h1>{title}</h1>
+      </div>
+      <div className="scope-switcher" aria-label="Managed System scope">
+        Managed System: Tableau
+      </div>
+    </header>
+  );
+}
+
+function HomePage() {
+  return (
+    <section className="page">
+      <PageHeader title="Action Dashboard" kicker="Home" />
+      <div className="queue-stack">
+        {fixtures.actionQueues.map((row) => (
+          <ActionQueueRow key={row.id} title={row.title} reason={row.reason} nextAction={row.nextAction} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function VocPage({
+  selectedVocId,
+  setSelectedVocId
+}: {
+  selectedVocId: string;
+  setSelectedVocId: (id: string) => void;
+}) {
+  const selected = fixtures.vocs.find((voc) => voc.id === selectedVocId) ?? fixtures.vocs[0];
+  return (
+    <section className="page split-page">
+      <div className="list-region">
+        <PageHeader title="VOC Inbox" kicker="VOC" />
+        <ObjectList
+          items={fixtures.vocs.map((voc) => ({
+            id: voc.id,
+            title: voc.title,
+            meta: `${voc.managedSystem} · ${voc.severity}`,
+            signal: voc.triageState
+          }))}
+          selectedId={selected.id}
+          onSelect={setSelectedVocId}
+        />
+      </div>
+      <DetailPanel title={selected.title}>
+        <div className="detail-grid">
+          <div>
+            <span className="field-label">Reporter status</span>
+            <StatusBadge family="reporter-voc" value={selected.reporterStatus} />
+          </div>
+          <div>
+            <span className="field-label">Internal triage</span>
+            <SignalBadge value={selected.triageState} urgent={selected.severity === "high"} />
+          </div>
+        </div>
+        <p>{selected.description}</p>
+        <LinkedEntityTrail links={["VOC", "Finding candidate", "Task Request candidate"]} />
+        <div className="composer-grid">
+          <RichContentEditor label="Public Update" value="" onChange={() => undefined} />
+          <RichContentEditor label="Reporter Reply" value="" onChange={() => undefined} />
+          <RichContentEditor label="Internal Comment" value="" onChange={() => undefined} />
+        </div>
+      </DetailPanel>
+    </section>
+  );
+}
+
+function IntegrationPage() {
+  return (
+    <section className="page split-page">
+      <div className="list-region">
+        <PageHeader title="Findings" kicker="Integration" />
+        <ObjectList
+          items={[{ id: "restricted-finding", title: "Restricted finding", meta: "summary_visible" }]}
+          selectedId="restricted-finding"
+          onSelect={() => undefined}
+        />
+      </div>
+      <DetailPanel title="Restricted finding" permissionBlocked summary="Summary visible to reporter">
+        Private root-cause notes
+      </DetailPanel>
+    </section>
+  );
+}
+
+function TasksPage() {
+  return (
+    <section className="page">
+      <PageHeader title="Tasks" kicker="Tasks" />
+      <div className="task-board">
+        <section>
+          <h2>Backlog</h2>
+          <p>Converted Tasks start here before Todo or Doing.</p>
+        </section>
+      </div>
+    </section>
+  );
+}
+
+function AdminPage() {
+  return (
+    <section className="page">
+      <PageHeader title="Managed Systems" kicker="Admin" />
+      <ObjectList
+        items={fixtures.managedSystems.map((system) => ({ id: system.id, title: system.name, meta: "Active" }))}
+        selectedId="ms-tableau"
+        onSelect={() => undefined}
+      />
+    </section>
+  );
+}
+
+function SurveyResultsPage() {
+  return (
+    <section className="page">
+      <PageHeader title="Survey Results" kicker="Surveys" />
+      <EvidenceHighlight>Survey responses can become evidence or Findings, never VOC.</EvidenceHighlight>
+      <button className="primary-inline" type="button">
+        Create Finding
+      </button>
+    </section>
+  );
+}
+
+function MyWorkPage() {
+  return (
+    <section className="page">
+      <PageHeader title="My Work" kicker="Assigned" />
+      <PermissionBlockedPanel summary="Some linked work is summary-visible only in your current scope." />
+    </section>
+  );
+}

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -10,8 +10,58 @@ import {
   StatusBadge
 } from "@feedbackops/ui";
 import { BarChart3, ClipboardList, Home, Inbox, Link2, Settings, SquareKanban, UserRound } from "lucide-react";
-import { useMemo, useState } from "react";
-import { fixtures } from "./fixtures";
+import { useCallback, useEffect, useMemo, useState, type FormEvent } from "react";
+
+const apiBaseUrl = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:3000";
+const defaultActorId = "admin";
+
+interface ManagedSystemDto {
+  id: string;
+  name: string;
+}
+
+interface VocDto {
+  id: string;
+  managed_system_id: string;
+  analytics_area_id?: string;
+  title: string;
+  description: string;
+  severity?: string;
+  triage_state: string;
+  reporter_facing_status: string;
+}
+
+interface QueueDto {
+  id: string;
+  title: string;
+  reason?: string;
+  next_action: string;
+}
+
+interface DashboardQueuesDto {
+  high_severity_follow_up: QueueDto[];
+  task_requests_pending_review: QueueDto[];
+}
+
+async function apiGet<T>(path: string, actorId = defaultActorId): Promise<T> {
+  const response = await fetch(`${apiBaseUrl}${path}`, { headers: { "x-actor-id": actorId } });
+  if (!response.ok) {
+    throw new Error(`GET ${path} failed with ${response.status}`);
+  }
+  return response.json() as Promise<T>;
+}
+
+async function apiPost<T>(path: string, body: Record<string, unknown>, actorId = "user-tableau"): Promise<T> {
+  const response = await fetch(`${apiBaseUrl}${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-actor-id": actorId },
+    body: JSON.stringify(body)
+  });
+  if (!response.ok) {
+    throw new Error(`POST ${path} failed with ${response.status}`);
+  }
+  return response.json() as Promise<T>;
+}
 
 const navItems = [
   { label: "Home", href: "/", icon: Home },
@@ -31,14 +81,14 @@ function parsePath(initialPath?: string) {
 
 export function App({ initialPath }: { initialPath?: string }) {
   const route = useMemo(() => parsePath(initialPath), [initialPath]);
-  const [selectedVocId, setSelectedVocId] = useState(route.params.get("selected") ?? fixtures.vocs[0].id);
+  const [selectedVocId, setSelectedVocId] = useState(route.params.get("selected") ?? "");
 
   return (
     <div className="app-shell">
       <aside className="sidebar">
         <div className="brand">
           <strong>FeedbackOps</strong>
-          <span>{fixtures.actor.roleLevel}</span>
+          <span>Admin</span>
         </div>
         <nav aria-label="Primary">
           {navItems.map(({ label, href, icon: Icon }) => (
@@ -91,12 +141,25 @@ function PageHeader({ title, kicker }: { title: string; kicker: string }) {
 }
 
 function HomePage() {
+  const [queues, setQueues] = useState<DashboardQueuesDto | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    apiGet<DashboardQueuesDto>("/dashboard/action-queues")
+      .then(setQueues)
+      .catch((caught: unknown) => setError(caught instanceof Error ? caught.message : "Failed to load dashboard"));
+  }, []);
+
+  const rows = [...(queues?.high_severity_follow_up ?? []), ...(queues?.task_requests_pending_review ?? [])];
   return (
     <section className="page">
       <PageHeader title="Action Dashboard" kicker="Home" />
       <div className="queue-stack">
-        {fixtures.actionQueues.map((row) => (
-          <ActionQueueRow key={row.id} title={row.title} reason={row.reason} nextAction={row.nextAction} />
+        {error ? <div className="fo-empty">{error}</div> : null}
+        {!queues && !error ? <div className="fo-empty">Loading</div> : null}
+        {queues && rows.length === 0 ? <div className="fo-empty">No action queues</div> : null}
+        {rows.map((row) => (
+          <ActionQueueRow key={row.id} title={row.title} reason={row.reason ?? "Backend queue item"} nextAction={row.next_action} />
         ))}
       </div>
     </section>
@@ -110,41 +173,108 @@ function VocPage({
   selectedVocId: string;
   setSelectedVocId: (id: string) => void;
 }) {
-  const selected = fixtures.vocs.find((voc) => voc.id === selectedVocId) ?? fixtures.vocs[0];
+  const [vocs, setVocs] = useState<VocDto[]>([]);
+  const [managedSystems, setManagedSystems] = useState<ManagedSystemDto[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+
+  const loadVocs = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [nextVocs, nextManagedSystems] = await Promise.all([
+        apiGet<VocDto[]>("/vocs?managed_system_id=all"),
+        apiGet<ManagedSystemDto[]>("/managed-systems")
+      ]);
+      setVocs(nextVocs);
+      setManagedSystems(nextManagedSystems);
+      if (!selectedVocId && nextVocs[0]) {
+        setSelectedVocId(nextVocs[0].id);
+      }
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "Failed to load VOCs");
+    } finally {
+      setLoading(false);
+    }
+  }, [selectedVocId, setSelectedVocId]);
+
+  useEffect(() => {
+    void loadVocs();
+  }, [loadVocs]);
+
+  async function submitVoc(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const created = await apiPost<VocDto>("/vocs", {
+      managed_system_id: "ms-tableau",
+      title,
+      description
+    });
+    setTitle("");
+    setDescription("");
+    setSelectedVocId(created.id);
+    await loadVocs();
+  }
+
+  const selected = vocs.find((voc) => voc.id === selectedVocId) ?? vocs[0];
+  const systemName = (id: string) => managedSystems.find((system) => system.id === id)?.name ?? id;
+
   return (
     <section className="page split-page">
       <div className="list-region">
         <PageHeader title="VOC Inbox" kicker="VOC" />
+        <form className="inline-create" onSubmit={submitVoc}>
+          <label>
+            <span>VOC title</span>
+            <input aria-label="VOC title" value={title} onChange={(event) => setTitle(event.target.value)} required />
+          </label>
+          <label>
+            <span>VOC description</span>
+            <textarea aria-label="VOC description" value={description} onChange={(event) => setDescription(event.target.value)} required />
+          </label>
+          <button className="primary-inline" type="submit">
+            Submit VOC
+          </button>
+        </form>
+        {loading ? <div className="fo-empty">Loading</div> : null}
+        {error ? <div className="fo-empty">{error}</div> : null}
         <ObjectList
-          items={fixtures.vocs.map((voc) => ({
+          items={vocs.map((voc) => ({
             id: voc.id,
             title: voc.title,
-            meta: `${voc.managedSystem} · ${voc.severity}`,
-            signal: voc.triageState
+            meta: `${systemName(voc.managed_system_id)} · ${voc.severity ?? "untriaged"}`,
+            signal: voc.triage_state
           }))}
-          selectedId={selected.id}
+          selectedId={selected?.id}
           onSelect={setSelectedVocId}
         />
       </div>
-      <DetailPanel title={selected.title}>
-        <div className="detail-grid">
-          <div>
-            <span className="field-label">Reporter status</span>
-            <StatusBadge family="reporter-voc" value={selected.reporterStatus} />
+      {selected ? (
+        <DetailPanel title={selected.title}>
+          <div className="detail-grid">
+            <div>
+              <span className="field-label">Reporter status</span>
+              <StatusBadge family="reporter-voc" value={selected.reporter_facing_status} />
+            </div>
+            <div>
+              <span className="field-label">Internal triage</span>
+              <SignalBadge value={selected.triage_state} urgent={selected.severity === "high"} />
+            </div>
           </div>
-          <div>
-            <span className="field-label">Internal triage</span>
-            <SignalBadge value={selected.triageState} urgent={selected.severity === "high"} />
+          <p>{selected.description}</p>
+          <LinkedEntityTrail links={["VOC", "Finding candidate", "Task Request candidate"]} />
+          <div className="composer-grid">
+            <RichContentEditor label="Public Update" value="" onChange={() => undefined} />
+            <RichContentEditor label="Reporter Reply" value="" onChange={() => undefined} />
+            <RichContentEditor label="Internal Comment" value="" onChange={() => undefined} />
           </div>
-        </div>
-        <p>{selected.description}</p>
-        <LinkedEntityTrail links={["VOC", "Finding candidate", "Task Request candidate"]} />
-        <div className="composer-grid">
-          <RichContentEditor label="Public Update" value="" onChange={() => undefined} />
-          <RichContentEditor label="Reporter Reply" value="" onChange={() => undefined} />
-          <RichContentEditor label="Internal Comment" value="" onChange={() => undefined} />
-        </div>
-      </DetailPanel>
+        </DetailPanel>
+      ) : (
+        <DetailPanel title="VOC detail">
+          <div className="fo-empty">Select a VOC</div>
+        </DetailPanel>
+      )}
     </section>
   );
 }
@@ -182,11 +312,17 @@ function TasksPage() {
 }
 
 function AdminPage() {
+  const [managedSystems, setManagedSystems] = useState<ManagedSystemDto[]>([]);
+
+  useEffect(() => {
+    apiGet<ManagedSystemDto[]>("/managed-systems").then(setManagedSystems).catch(() => setManagedSystems([]));
+  }, []);
+
   return (
     <section className="page">
       <PageHeader title="Managed Systems" kicker="Admin" />
       <ObjectList
-        items={fixtures.managedSystems.map((system) => ({ id: system.id, title: system.name, meta: "Active" }))}
+        items={managedSystems.map((system) => ({ id: system.id, title: system.name, meta: "Active" }))}
         selectedId="ms-tableau"
         onSelect={() => undefined}
       />

--- a/apps/frontend/src/fixtures.ts
+++ b/apps/frontend/src/fixtures.ts
@@ -1,0 +1,44 @@
+export const fixtures = {
+  actor: {
+    name: "Admin",
+    roleLevel: "Admin"
+  },
+  managedSystems: [
+    { id: "ms-tableau", name: "Tableau" },
+    { id: "ms-looker", name: "Looker" }
+  ],
+  vocs: [
+    {
+      id: "voc-seeded-tableau",
+      title: "Seeded Tableau VOC",
+      managedSystem: "Tableau",
+      reporterStatus: "검토 중",
+      triageState: "triaging",
+      severity: "medium",
+      description: "Dashboard is intermittently slow."
+    },
+    {
+      id: "voc-high-unlinked",
+      title: "High severity unlinked VOC",
+      managedSystem: "Tableau",
+      reporterStatus: "검토 중",
+      triageState: "triaged",
+      severity: "high",
+      description: "Month-end finance dashboard is down."
+    }
+  ],
+  actionQueues: [
+    {
+      id: "voc-high-unlinked",
+      title: "High severity VOC has no linked follow-up",
+      reason: "No linked Finding, Task Request, Task, or authorized no-follow-up decision exists.",
+      nextAction: "Create Finding or Task Request"
+    },
+    {
+      id: "task-request-1",
+      title: "Task Request pending review",
+      reason: "Execution candidate needs Admin or same-scope Developer decision.",
+      nextAction: "Review Task Request"
+    }
+  ]
+};

--- a/apps/frontend/src/main.tsx
+++ b/apps/frontend/src/main.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App";
+import "@feedbackops/ui/tokens.css";
+import "./styles.css";
+
+createRoot(document.getElementById("root") as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/apps/frontend/src/styles.css
+++ b/apps/frontend/src/styles.css
@@ -94,6 +94,37 @@
   gap: 10px;
 }
 
+.inline-create {
+  display: grid;
+  grid-template-columns: minmax(160px, 1fr) minmax(220px, 1.5fr) auto;
+  align-items: end;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+.inline-create label {
+  display: grid;
+  gap: 6px;
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.inline-create input,
+.inline-create textarea {
+  min-height: 36px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--surface-row);
+  color: var(--text-primary);
+  padding: 8px 10px;
+  font: inherit;
+}
+
+.inline-create textarea {
+  min-height: 58px;
+  resize: vertical;
+}
+
 .detail-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -320,6 +351,10 @@
   }
 
   .detail-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .inline-create {
     grid-template-columns: 1fr;
   }
 }

--- a/apps/frontend/src/styles.css
+++ b/apps/frontend/src/styles.css
@@ -1,0 +1,325 @@
+.app-shell {
+  display: grid;
+  grid-template-columns: var(--sidebar-width) minmax(0, 1fr);
+  min-height: 100vh;
+  background: var(--surface-app);
+}
+
+.sidebar {
+  border-right: 1px solid var(--border-subtle);
+  background: var(--surface-sidebar);
+  padding: 16px 12px;
+}
+
+.brand {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 10px 18px;
+}
+
+.brand span,
+.page-header span,
+.field-label {
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.sidebar nav {
+  display: grid;
+  gap: 4px;
+}
+
+.sidebar a {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 40px;
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  padding: 0 10px;
+  text-decoration: none;
+}
+
+.sidebar a:hover,
+.sidebar a:focus-visible {
+  background: var(--surface-row-hover);
+  color: var(--text-primary);
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 1px;
+}
+
+.main-region {
+  min-width: 0;
+  background: var(--surface-main);
+}
+
+.page {
+  min-height: 100vh;
+  padding: 18px;
+}
+
+.split-page {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(360px, var(--detail-width));
+  gap: 16px;
+}
+
+.page-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 14px;
+}
+
+.page-header h1 {
+  margin: 2px 0 0;
+  font-size: 22px;
+  letter-spacing: 0;
+}
+
+.scope-switcher {
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  min-height: 36px;
+  padding: 8px 10px;
+}
+
+.queue-stack,
+.composer-grid {
+  display: grid;
+  gap: 10px;
+}
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.field-label {
+  display: block;
+  margin-bottom: 6px;
+}
+
+.fo-object-list {
+  display: grid;
+  gap: 6px;
+}
+
+.fo-list-row,
+.fo-action-row,
+.fo-detail-panel,
+.task-board section,
+.fo-permission-blocked {
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--surface-row);
+}
+
+.fo-list-row {
+  display: grid;
+  width: 100%;
+  min-height: 56px;
+  padding: 9px 10px;
+  color: var(--text-primary);
+  text-align: left;
+}
+
+.fo-list-row[data-selected="true"] {
+  border-color: var(--border-selected);
+  background: var(--surface-row-selected);
+}
+
+.fo-list-row:hover,
+.fo-list-row:focus-visible {
+  background: var(--surface-row-hover);
+  outline: 2px solid var(--focus-ring);
+}
+
+.fo-list-title {
+  font-weight: 650;
+}
+
+.fo-list-meta,
+.fo-list-signal,
+.fo-action-row p,
+.fo-panel-body p {
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+
+.fo-detail-panel {
+  overflow: hidden;
+  background: var(--surface-detail);
+}
+
+.fo-panel-header {
+  border-bottom: 1px solid var(--border-subtle);
+  padding: 14px;
+}
+
+.fo-panel-header h2 {
+  margin: 0;
+  font-size: 17px;
+  letter-spacing: 0;
+}
+
+.fo-panel-body,
+.fo-permission-blocked {
+  display: grid;
+  gap: 14px;
+  padding: 14px;
+}
+
+.fo-action-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 12px;
+}
+
+.fo-action-row p {
+  margin: 4px 0 0;
+}
+
+.fo-button,
+.primary-inline {
+  min-height: 36px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  padding: 0 12px;
+  font: inherit;
+}
+
+.fo-button-primary,
+.primary-inline {
+  border-color: var(--accent-primary);
+  background: var(--accent-primary);
+  color: var(--accent-primary-text);
+}
+
+.fo-button-secondary {
+  background: var(--surface-row-hover);
+  color: var(--text-primary);
+}
+
+.fo-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  padding: 0 8px;
+  color: var(--text-primary);
+}
+
+.fo-status-badge[data-family="reporter-voc"] {
+  color: var(--status-reporter);
+}
+
+.fo-status-badge[data-family="task"] {
+  color: var(--status-task);
+}
+
+.fo-linked-trail {
+  display: flex;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+
+.fo-evidence {
+  margin: 0 0 12px;
+  border-left: 3px solid var(--accent-primary);
+  padding: 10px 12px;
+  background: var(--surface-row);
+}
+
+.fo-rich-editor {
+  display: grid;
+  gap: 6px;
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+
+.fo-rich-editor textarea {
+  min-height: 74px;
+  resize: vertical;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--surface-row);
+  color: var(--text-primary);
+  padding: 10px;
+}
+
+.fo-rich-editor textarea:focus-visible {
+  outline: 2px solid var(--focus-ring);
+}
+
+.fo-field-error {
+  color: var(--status-blocked);
+}
+
+@media (max-width: 1023px) {
+  .app-shell {
+    grid-template-columns: 64px minmax(0, 1fr);
+  }
+
+  .brand strong,
+  .brand span,
+  .sidebar a {
+    font-size: 0;
+  }
+
+  .sidebar a svg {
+    flex: 0 0 auto;
+  }
+
+  .split-page {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+@media (max-width: 767px) {
+  .app-shell {
+    display: block;
+  }
+
+  .sidebar {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    display: flex;
+    overflow-x: auto;
+    border-right: 0;
+    border-bottom: 1px solid var(--border-subtle);
+  }
+
+  .sidebar nav,
+  .brand {
+    display: flex;
+  }
+
+  .page {
+    min-height: auto;
+    padding: 12px;
+  }
+
+  .page-header,
+  .fo-action-row {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .detail-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/apps/frontend/src/vite-env.d.ts
+++ b/apps/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/apps/frontend/tsconfig.json
+++ b/apps/frontend/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "types": ["node", "vitest/globals", "@testing-library/jest-dom"]
+  },
+  "include": ["src", "index.html"]
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,49 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: feedbackops
+      POSTGRES_USER: feedbackops
+      POSTGRES_PASSWORD: feedbackops
+    volumes:
+      - feedbackops-postgres:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U feedbackops -d feedbackops"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+
+  backend:
+    build:
+      context: .
+      dockerfile: apps/backend/Dockerfile
+    environment:
+      AUTH_MODE: mock
+      PORT: 3000
+      DATABASE_URL: postgres://feedbackops:feedbackops@postgres:5432/feedbackops
+    ports:
+      - "3000:3000"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    command: sh -c "pnpm --filter @feedbackops/backend db:migrate && pnpm --filter @feedbackops/backend db:seed && pnpm --filter @feedbackops/backend start"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:3000/api/health >/dev/null"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+
+  frontend:
+    build:
+      context: .
+      dockerfile: apps/frontend/Dockerfile
+    environment:
+      VITE_API_BASE_URL: http://localhost:3000
+    ports:
+      - "5180:5180"
+    depends_on:
+      backend:
+        condition: service_healthy
+
+volumes:
+  feedbackops-postgres:

--- a/docs/superpowers/plans/2026-05-14-voc-to-execution-mvp.md
+++ b/docs/superpowers/plans/2026-05-14-voc-to-execution-mvp.md
@@ -1,0 +1,281 @@
+# VOC To Execution MVP Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a runnable TypeScript MVP that proves the docs-backed VOC-to-execution loop from internal VOC submission through triage, finding, task request review, backlog task creation, reporter conversation, and action dashboard repair queues.
+
+**Architecture:** Use a pnpm monorepo with `apps/backend`, `apps/frontend`, `packages/shared`, and `packages/ui`. The backend is an in-memory Express application service layer for MVP behavior verification; the frontend is a dense Vite/React operational shell that composes shared list/detail/status components before feature screens.
+
+**Tech Stack:** pnpm workspaces, TypeScript, Express, Vitest, Supertest, React, Vite, Testing Library, lucide-react.
+
+---
+
+## Scope Decision
+
+The first coherent MVP target is the VOC-to-execution loop described by `docs/design/13-mvp-roadmap.md` and `docs/implementation/08-mvp-slice-plan.md` Slices 0-7a.
+
+Full Survey builder and response flows are deferred because the docs conflict: `docs/design/02-requirements-matrix.md` and `docs/implementation/03-api-contracts.md` list Survey as MVP, while the slice plan places Survey in Slice 8 after dashboard and VOC conversation. This plan still protects the forbidden invariant by exposing no Survey Response -> VOC API or UI path and rejecting `generated_voc` entity links.
+
+## Deliverables
+
+- Runnable backend health check and in-memory API.
+- Runnable frontend app shell with docs-aligned top-level routes.
+- Shared semantic UI tokens and reusable components extracted before screens.
+- Backend invariant tests for permission, VOC, links, task conversion, and dashboard queues.
+- Frontend tests for route shell, status separation, permission blocked states, and VOC-to-task screen flow.
+- `pnpm lint`, `pnpm test`, and `pnpm build` scripts.
+- Branch pushed and PR opened after verification.
+
+## File Structure
+
+- Create `package.json`, `pnpm-workspace.yaml`, `tsconfig.base.json`, and `.gitignore`.
+- Create `packages/shared/src/index.ts` for domain vocabulary, DTOs, schemas, and pure validation helpers.
+- Create `packages/ui/src/*` for tokens, primitives, product components, and domain display components.
+- Create `apps/backend/src/*` for Express setup, mock auth, in-memory store, domain modules, and route tests.
+- Create `apps/frontend/src/*` for app shell, route parsing, API client, feature screens, and component tests.
+
+## Task 1: Workspace Foundation
+
+**Files:**
+- Create: `package.json`
+- Create: `pnpm-workspace.yaml`
+- Create: `tsconfig.base.json`
+- Create: `.gitignore`
+- Create: `packages/shared/package.json`
+- Create: `packages/shared/src/index.ts`
+- Create: `packages/ui/package.json`
+- Create: `packages/ui/src/index.ts`
+- Create: `apps/backend/package.json`
+- Create: `apps/backend/src/index.ts`
+- Create: `apps/frontend/package.json`
+- Create: `apps/frontend/index.html`
+- Create: `apps/frontend/src/main.tsx`
+
+- [ ] **Step 1: Write failing foundation smoke tests**
+
+Add package scripts that will fail until app code exists:
+
+```json
+{
+  "scripts": {
+    "lint": "tsc -b --pretty false",
+    "test": "pnpm -r test",
+    "build": "pnpm -r build"
+  }
+}
+```
+
+- [ ] **Step 2: Run foundation command to verify failure**
+
+Run: `pnpm test`
+Expected: FAIL because workspace packages and tests are not implemented.
+
+- [ ] **Step 3: Implement minimal workspace**
+
+Add workspace manifests, TS config, and empty package exports.
+
+- [ ] **Step 4: Run foundation verification**
+
+Run: `pnpm test`
+Expected: PASS for empty smoke tests.
+
+## Task 2: Shared Domain Contract And Backend Invariant Tests
+
+**Files:**
+- Modify: `packages/shared/src/index.ts`
+- Create: `apps/backend/src/domain.test.ts`
+- Create: `apps/backend/src/app.ts`
+- Create: `apps/backend/src/mvp.ts`
+
+- [ ] **Step 1: Write failing backend tests**
+
+Tests must cover:
+
+```text
+- POST /vocs requires managed_system_id.
+- POST /vocs rejects reporter-submitted severity.
+- VOC analytics_area_id must belong to managed_system_id.
+- Reporter cannot patch title or description after triage begins.
+- Managed System scope blocks sibling Managed System access.
+- Explicit Deny overrides Allow.
+- POST /entity-links rejects generated_voc.
+- Cross-workspace entity links are rejected.
+- Task Done and Released do not auto-resolve reporter-facing VOC status.
+- POST /survey-responses/:id/create-voc returns 404.
+```
+
+- [ ] **Step 2: Run backend tests to verify red**
+
+Run: `pnpm --filter @feedbackops/backend test`
+Expected: FAIL with missing routes/domain behavior.
+
+- [ ] **Step 3: Implement minimal shared types and backend services**
+
+Implement in-memory actors, managed systems, analytics areas, VOCs, links, findings, task requests, tasks, audit events, permissions, and dashboard queue queries.
+
+- [ ] **Step 4: Run backend tests to verify green**
+
+Run: `pnpm --filter @feedbackops/backend test`
+Expected: PASS.
+
+## Task 3: Cross-System MVP Flow Tests And API Implementation
+
+**Files:**
+- Modify: `apps/backend/src/domain.test.ts`
+- Modify: `apps/backend/src/mvp.ts`
+- Modify: `apps/backend/src/app.ts`
+
+- [ ] **Step 1: Add failing VOC-to-execution flow tests**
+
+Tests must cover:
+
+```text
+- User creates VOC with Managed System.
+- Admin triages VOC and assigns severity.
+- Admin creates VOC Cluster and creates Finding from cluster.
+- Finding preserves source through entity link.
+- Finding creates Task Request.
+- Admin approves and converts Task Request to Backlog Task.
+- Dashboard high-severity follow-up queue clears after required links exist.
+- Public Update, Reporter Reply, and Internal Comment are separate append-only entry types.
+- Reporter Summary excludes raw task status, priority, internal comments, developer names, severity, and confidence.
+```
+
+- [ ] **Step 2: Run backend tests to verify red**
+
+Run: `pnpm --filter @feedbackops/backend test`
+Expected: FAIL on missing cross-system commands.
+
+- [ ] **Step 3: Implement cross-system commands**
+
+Use application service functions for source-shaped routes. Target writes must go through target-owned service functions and create entity links and audit events.
+
+- [ ] **Step 4: Run backend tests to verify green**
+
+Run: `pnpm --filter @feedbackops/backend test`
+Expected: PASS.
+
+## Task 4: Shared UI Components First
+
+**Files:**
+- Create: `packages/ui/src/tokens.css`
+- Create: `packages/ui/src/primitives.tsx`
+- Create: `packages/ui/src/components.tsx`
+- Modify: `packages/ui/src/index.ts`
+- Create: `packages/ui/src/components.test.tsx`
+
+- [ ] **Step 1: Write failing component tests**
+
+Tests must cover:
+
+```text
+- ObjectList marks selected rows.
+- DetailPanel renders permission blocked state.
+- StatusBadge distinguishes reporter VOC status from Task status.
+- ActionQueueRow exposes next action text.
+- RichContentEditor rejects base64 and external inline image strings.
+```
+
+- [ ] **Step 2: Run UI tests to verify red**
+
+Run: `pnpm --filter @feedbackops/ui test`
+Expected: FAIL on missing components.
+
+- [ ] **Step 3: Implement components**
+
+Use semantic tokens and compact list-first layout. Components must not call APIs or own domain mutations.
+
+- [ ] **Step 4: Run UI tests to verify green**
+
+Run: `pnpm --filter @feedbackops/ui test`
+Expected: PASS.
+
+## Task 5: Frontend App Shell And MVP Screens
+
+**Files:**
+- Create: `apps/frontend/src/App.test.tsx`
+- Create: `apps/frontend/src/App.tsx`
+- Create: `apps/frontend/src/api.ts`
+- Create: `apps/frontend/src/fixtures.ts`
+- Create: `apps/frontend/src/features/home/HomePage.tsx`
+- Create: `apps/frontend/src/features/voc/VocPage.tsx`
+- Create: `apps/frontend/src/features/integration/IntegrationPage.tsx`
+- Create: `apps/frontend/src/features/tasks/TasksPage.tsx`
+- Create: `apps/frontend/src/features/admin/AdminPage.tsx`
+- Modify: `apps/frontend/src/main.tsx`
+
+- [ ] **Step 1: Write failing frontend tests**
+
+Tests must cover:
+
+```text
+- Home renders action dashboard as first screen.
+- Navigation exposes Home, My Work, VOC, Surveys, Tasks, Integration, Admin for Admin fixture.
+- VOC page renders list, selected detail, reporter-facing status, internal triage status, and separate conversation composers.
+- Permission blocked panel renders safe summary instead of blank content.
+- No UI affordance exists for Survey Response -> VOC.
+```
+
+- [ ] **Step 2: Run frontend tests to verify red**
+
+Run: `pnpm --filter @feedbackops/frontend test`
+Expected: FAIL on missing app shell/screens.
+
+- [ ] **Step 3: Implement frontend**
+
+Compose shared UI components from `packages/ui` and route surfaces from `docs/frontend/routes-and-layout.md`.
+
+- [ ] **Step 4: Run frontend tests to verify green**
+
+Run: `pnpm --filter @feedbackops/frontend test`
+Expected: PASS.
+
+## Task 6: Verification, Commit, Push, PR
+
+**Files:**
+- Modify only files required by previous tasks.
+
+- [ ] **Step 1: Run full verification**
+
+Run:
+
+```bash
+pnpm lint
+pnpm test
+pnpm build
+git status --short
+```
+
+Expected: typecheck, tests, and builds pass; git status shows only intended changes.
+
+- [ ] **Step 2: Browser verification**
+
+Run frontend locally and inspect:
+
+```text
+- desktop >= 1024px
+- tablet 768-1023px
+- mobile < 768px
+```
+
+Expected: AppShell, list, selected detail, and permission-blocked states are non-overlapping and readable.
+
+- [ ] **Step 3: Commit and push**
+
+Run:
+
+```bash
+git add .
+git commit -m "feat: implement VOC-to-execution MVP scaffold"
+git push -u origin feat/mvp-foundation
+```
+
+- [ ] **Step 4: Open PR**
+
+Run:
+
+```bash
+gh pr create --base main --head feat/mvp-foundation --title "Implement VOC-to-execution MVP scaffold" --body-file /tmp/feedbackops-mvp-pr.md
+```
+
+PR body must include scope, tests, deferred Survey rationale, and docs traceability.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "lint": "tsc -b --pretty false",
     "test": "pnpm -r test",
     "build": "pnpm -r build",
-    "dev": "pnpm --filter @feedbackops/backend dev & pnpm --filter @feedbackops/frontend dev"
+    "dev": "pnpm --filter @feedbackops/backend dev & pnpm --filter @feedbackops/frontend dev",
+    "dev:backend": "pnpm --filter @feedbackops/backend dev",
+    "dev:frontend": "pnpm --filter @feedbackops/frontend dev"
   },
   "devDependencies": {
     "@types/node": "^22.15.18",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "feedbackops",
   "private": true,
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@10.18.3",
   "scripts": {
     "lint": "tsc -b --pretty false",
     "test": "pnpm -r test",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "feedbackops",
+  "private": true,
+  "packageManager": "pnpm@11.1.1",
+  "scripts": {
+    "lint": "tsc -b --pretty false",
+    "test": "pnpm -r test",
+    "build": "pnpm -r build",
+    "dev": "pnpm --filter @feedbackops/backend dev & pnpm --filter @feedbackops/frontend dev"
+  },
+  "devDependencies": {
+    "@types/node": "^22.15.18",
+    "typescript": "^5.8.3"
+  }
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@feedbackops/shared",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "build": "tsc -p tsconfig.json --noEmit"
+  },
+  "devDependencies": {
+    "vitest": "^3.1.3"
+  }
+}

--- a/packages/shared/src/index.test.ts
+++ b/packages/shared/src/index.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { isForbiddenRelationType, richContentHasUnsafeInlineImage } from "./index";
+
+describe("shared domain helpers", () => {
+  it("identifies generated_voc as forbidden", () => {
+    expect(isForbiddenRelationType("generated_voc")).toBe(true);
+  });
+
+  it("rejects unsafe inline images in rich content", () => {
+    expect(richContentHasUnsafeInlineImage('<img src="data:image/png;base64,abc">')).toBe(true);
+    expect(richContentHasUnsafeInlineImage('<img src="https://example.com/a.png">')).toBe(true);
+    expect(richContentHasUnsafeInlineImage('<attachment data-id="att_1"></attachment>')).toBe(false);
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,0 +1,146 @@
+export const roleLevels = ["Admin", "Developer", "User"] as const;
+export type RoleLevel = (typeof roleLevels)[number];
+
+export const reporterVocStatuses = [
+  "접수됨",
+  "검토 중",
+  "담당자 배정됨",
+  "처리 중",
+  "해결 준비 중",
+  "해결됨",
+  "다시 처리 중",
+  "종료됨"
+] as const;
+export type ReporterVocStatus = (typeof reporterVocStatuses)[number];
+
+export const taskStatuses = [
+  "Backlog",
+  "Todo",
+  "Doing",
+  "Review",
+  "Done",
+  "Released",
+  "Reopened"
+] as const;
+export type TaskStatus = (typeof taskStatuses)[number];
+
+export const relationTypes = [
+  "created_finding",
+  "generated_finding",
+  "requested_task",
+  "converted_to_task",
+  "linked_task",
+  "evidence_for"
+] as const;
+export type RelationType = (typeof relationTypes)[number];
+
+export const forbiddenRelationTypes = ["generated_voc"] as const;
+
+export type Visibility = "internal_only" | "summary_visible" | "visible_to_reporter" | "admin_only";
+export type Severity = "low" | "medium" | "high" | "critical";
+export type SourceContext = "direct_use" | "proxy_report" | "operational_discovery" | "stakeholder_request";
+
+export interface Actor {
+  id: string;
+  workspaceId: string;
+  name: string;
+  roleLevel: RoleLevel;
+  managedSystemIds: string[];
+  explicitDeniedManagedSystemIds?: string[];
+  capabilities?: string[];
+}
+
+export interface ManagedSystem {
+  id: string;
+  workspaceId: string;
+  name: string;
+  archived?: boolean;
+}
+
+export interface AnalyticsArea {
+  id: string;
+  workspaceId: string;
+  managedSystemId: string;
+  name: string;
+  archived?: boolean;
+}
+
+export interface Voc {
+  id: string;
+  workspaceId: string;
+  managedSystemId: string;
+  analyticsAreaId?: string;
+  reporterId: string;
+  title: string;
+  description: string;
+  sourceContext?: SourceContext;
+  severity?: Severity;
+  triageState: "new" | "triaging" | "triaged";
+  reporterFacingStatus: ReporterVocStatus;
+  ownerId?: string;
+}
+
+export interface ConversationEntry {
+  id: string;
+  vocId: string;
+  authorId: string;
+  type: "public_update" | "reporter_reply" | "internal_comment";
+  body: string;
+  createdAt: string;
+}
+
+export interface EntityLink {
+  id: string;
+  workspaceId: string;
+  sourceType: string;
+  sourceId: string;
+  targetType: string;
+  targetId: string;
+  relationType: RelationType;
+  visibility: Visibility;
+}
+
+export interface Finding {
+  id: string;
+  workspaceId: string;
+  managedSystemId: string;
+  title: string;
+  summary: string;
+  status: "draft" | "active" | "not_actionable" | "converted" | "archived";
+}
+
+export interface TaskRequest {
+  id: string;
+  workspaceId: string;
+  managedSystemId: string;
+  title: string;
+  status: "pending_review" | "approved" | "rejected" | "needs_more_evidence" | "converted";
+  sourceType: "voc" | "finding";
+  sourceId: string;
+  requestedById: string;
+}
+
+export interface Task {
+  id: string;
+  workspaceId: string;
+  managedSystemId: string;
+  title: string;
+  status: TaskStatus;
+  assigneeId?: string;
+  priority?: "low" | "medium" | "high";
+}
+
+export interface ApiErrorBody {
+  error: {
+    code: string;
+    message: string;
+  };
+}
+
+export function isForbiddenRelationType(value: string): value is (typeof forbiddenRelationTypes)[number] {
+  return forbiddenRelationTypes.includes(value as (typeof forbiddenRelationTypes)[number]);
+}
+
+export function richContentHasUnsafeInlineImage(value: string): boolean {
+  return /<img[^>]+src=["'](?:data:|https?:\/\/)/i.test(value);
+}

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true
+  },
+  "include": ["src"]
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@feedbackops/ui",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./tokens.css": "./src/tokens.css"
+  },
+  "scripts": {
+    "test": "vitest run --environment jsdom",
+    "build": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@feedbackops/shared": "workspace:*",
+    "lucide-react": "^0.511.0",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
+    "@types/react": "^19.1.4",
+    "@types/react-dom": "^19.1.5",
+    "jsdom": "^26.1.0",
+    "vitest": "^3.1.3"
+  }
+}

--- a/packages/ui/src/components.test.tsx
+++ b/packages/ui/src/components.test.tsx
@@ -1,0 +1,74 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+  ActionQueueRow,
+  DetailPanel,
+  ObjectList,
+  RichContentEditor,
+  StatusBadge,
+  validateRichContent
+} from "./index";
+
+describe("FeedbackOps shared UI components", () => {
+  it("marks selected object rows", () => {
+    render(
+      <ObjectList
+        items={[
+          { id: "voc-1", title: "First VOC", meta: "Tableau" },
+          { id: "voc-2", title: "Second VOC", meta: "Looker" }
+        ]}
+        selectedId="voc-2"
+        onSelect={() => undefined}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: /Second VOC/ })).toHaveAttribute("aria-current", "true");
+  });
+
+  it("renders permission blocked detail state", () => {
+    render(
+      <DetailPanel title="Restricted finding" permissionBlocked summary="Summary visible to reporter">
+        Private body
+      </DetailPanel>
+    );
+
+    expect(screen.getByText("Summary visible to reporter")).toBeInTheDocument();
+    expect(screen.getByText("Request access")).toBeInTheDocument();
+    expect(screen.queryByText("Private body")).not.toBeInTheDocument();
+  });
+
+  it("separates reporter VOC status and internal task status badges", () => {
+    render(
+      <>
+        <StatusBadge family="reporter-voc" value="검토 중" />
+        <StatusBadge family="task" value="Released" />
+      </>
+    );
+
+    expect(screen.getByText("검토 중")).toHaveAttribute("data-family", "reporter-voc");
+    expect(screen.getByText("Released")).toHaveAttribute("data-family", "task");
+  });
+
+  it("exposes action queue next action text", () => {
+    render(
+      <ActionQueueRow
+        title="High severity VOC"
+        reason="No linked Finding or Task Request"
+        nextAction="Create Finding or Task Request"
+      />
+    );
+
+    expect(screen.getByText("Create Finding or Task Request")).toBeInTheDocument();
+  });
+
+  it("rejects base64 and external inline images in rich content", () => {
+    expect(validateRichContent('<img src="data:image/png;base64,abc">').ok).toBe(false);
+    expect(validateRichContent('<img src="https://example.com/a.png">').ok).toBe(false);
+    expect(validateRichContent('<attachment data-id="att-1"></attachment>').ok).toBe(true);
+
+    render(<RichContentEditor label="VOC description" value="" onChange={() => undefined} error="Unsafe inline image" />);
+    expect(screen.getByLabelText("VOC description")).toBeInTheDocument();
+    expect(screen.getByText("Unsafe inline image")).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components.tsx
+++ b/packages/ui/src/components.tsx
@@ -1,0 +1,154 @@
+import { richContentHasUnsafeInlineImage } from "@feedbackops/shared";
+import type { ReactNode } from "react";
+import { Badge, Button } from "./primitives";
+
+export interface ObjectListItem {
+  id: string;
+  title: string;
+  meta?: string;
+  signal?: string;
+}
+
+export function ObjectList({
+  items,
+  selectedId,
+  onSelect
+}: {
+  items: ObjectListItem[];
+  selectedId?: string;
+  onSelect: (id: string) => void;
+}) {
+  if (items.length === 0) {
+    return <div className="fo-empty">No records</div>;
+  }
+  return (
+    <div className="fo-object-list" role="list">
+      {items.map((item) => {
+        const selected = item.id === selectedId;
+        return (
+          <button
+            key={item.id}
+            type="button"
+            className="fo-list-row"
+            aria-current={selected ? "true" : undefined}
+            data-selected={selected ? "true" : "false"}
+            onClick={() => onSelect(item.id)}
+          >
+            <span className="fo-list-title">{item.title}</span>
+            {item.meta ? <span className="fo-list-meta">{item.meta}</span> : null}
+            {item.signal ? <span className="fo-list-signal">{item.signal}</span> : null}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+export function DetailPanel({
+  title,
+  children,
+  permissionBlocked = false,
+  summary
+}: {
+  title: string;
+  children: ReactNode;
+  permissionBlocked?: boolean;
+  summary?: string;
+}) {
+  return (
+    <aside className="fo-detail-panel" aria-label={title}>
+      <header className="fo-panel-header">
+        <h2>{title}</h2>
+      </header>
+      {permissionBlocked ? (
+        <div className="fo-permission-blocked">
+          <p>{summary ?? "You can view a limited summary for this record."}</p>
+          <Button>Request access</Button>
+        </div>
+      ) : (
+        <div className="fo-panel-body">{children}</div>
+      )}
+    </aside>
+  );
+}
+
+export function StatusBadge({ family, value }: { family: "reporter-voc" | "task" | "task-request" | "finding"; value: string }) {
+  return (
+    <Badge tone={family === "reporter-voc" ? "default" : "muted"}>
+      <span className="fo-status-badge" data-family={family}>
+        {value}
+      </span>
+    </Badge>
+  );
+}
+
+export function SignalBadge({ value, urgent = false }: { value: string; urgent?: boolean }) {
+  return <Badge tone={urgent ? "urgent" : "muted"}>{value}</Badge>;
+}
+
+export function PermissionBlockedPanel({ summary }: { summary: string }) {
+  return (
+    <div className="fo-permission-blocked">
+      <p>{summary}</p>
+      <Button>Request access</Button>
+    </div>
+  );
+}
+
+export function ActionQueueRow({ title, reason, nextAction }: { title: string; reason: string; nextAction: string }) {
+  return (
+    <div className="fo-action-row">
+      <div>
+        <strong>{title}</strong>
+        <p>{reason}</p>
+      </div>
+      <Button variant="primary">{nextAction}</Button>
+    </div>
+  );
+}
+
+export function LinkedEntityTrail({ links }: { links: string[] }) {
+  return (
+    <ol className="fo-linked-trail" aria-label="Linked entity trail">
+      {links.map((link) => (
+        <li key={link}>{link}</li>
+      ))}
+    </ol>
+  );
+}
+
+export function EvidenceHighlight({ children }: { children: ReactNode }) {
+  return <blockquote className="fo-evidence">{children}</blockquote>;
+}
+
+export function validateRichContent(value: string): { ok: true } | { ok: false; reason: string } {
+  if (richContentHasUnsafeInlineImage(value)) {
+    return { ok: false, reason: "Inline images must use attachment references." };
+  }
+  return { ok: true };
+}
+
+export function RichContentEditor({
+  label,
+  value,
+  onChange,
+  error
+}: {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  error?: string;
+}) {
+  return (
+    <label className="fo-rich-editor">
+      <span>{label}</span>
+      <textarea
+        aria-label={label}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        aria-invalid={error ? "true" : undefined}
+      />
+      {error ? <span className="fo-field-error">{error}</span> : null}
+    </label>
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./primitives";
+export * from "./components";

--- a/packages/ui/src/primitives.tsx
+++ b/packages/ui/src/primitives.tsx
@@ -1,0 +1,27 @@
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: "primary" | "secondary" | "subtle" | "destructive";
+  children: ReactNode;
+}
+
+export function Button({ variant = "secondary", children, className = "", ...props }: ButtonProps) {
+  return (
+    <button className={`fo-button fo-button-${variant} ${className}`.trim()} {...props}>
+      {children}
+    </button>
+  );
+}
+
+interface BadgeProps {
+  tone?: "default" | "muted" | "urgent" | "blocked";
+  children: ReactNode;
+}
+
+export function Badge({ tone = "default", children }: BadgeProps) {
+  return (
+    <span className="fo-badge" data-tone={tone}>
+      {children}
+    </span>
+  );
+}

--- a/packages/ui/src/tokens.css
+++ b/packages/ui/src/tokens.css
@@ -1,0 +1,39 @@
+:root {
+  color-scheme: dark;
+  --surface-app: #080b0f;
+  --surface-sidebar: #0d1117;
+  --surface-main: #10151d;
+  --surface-detail: #121923;
+  --surface-row: #151c26;
+  --surface-row-hover: #1b2531;
+  --surface-row-selected: #203026;
+  --surface-blocked: #211820;
+  --text-primary: #edf2f7;
+  --text-secondary: #a9b4c2;
+  --text-muted: #788596;
+  --border-subtle: #25303d;
+  --border-selected: #8fdc65;
+  --border-danger: #f87171;
+  --focus-ring: #a3e635;
+  --accent-primary: #a3e635;
+  --accent-primary-text: #10170d;
+  --status-reporter: #7dd3fc;
+  --status-task: #c4b5fd;
+  --status-risk: #fbbf24;
+  --status-blocked: #fb7185;
+  --radius-sm: 6px;
+  --sidebar-width: 240px;
+  --detail-width: 420px;
+  --font-sans: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--surface-app);
+  color: var(--text-primary);
+  font-family: var(--font-sans);
+}

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "types": ["node", "vitest/globals", "@testing-library/jest-dom"]
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,3144 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@types/node':
+        specifier: ^22.15.18
+        version: 22.19.19
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+
+  apps/backend:
+    dependencies:
+      '@feedbackops/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
+      cors:
+        specifier: ^2.8.5
+        version: 2.8.6
+      express:
+        specifier: ^5.1.0
+        version: 5.2.1
+    devDependencies:
+      '@types/cors':
+        specifier: ^2.8.18
+        version: 2.8.19
+      '@types/express':
+        specifier: ^5.0.2
+        version: 5.0.6
+      '@types/supertest':
+        specifier: ^6.0.3
+        version: 6.0.3
+      supertest:
+        specifier: ^7.1.1
+        version: 7.2.2
+      tsx:
+        specifier: ^4.19.4
+        version: 4.21.0
+      vitest:
+        specifier: ^3.1.3
+        version: 3.2.4(@types/node@22.19.19)(jsdom@26.1.0)(tsx@4.21.0)
+
+  apps/frontend:
+    dependencies:
+      '@feedbackops/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
+      '@feedbackops/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
+      '@vitejs/plugin-react':
+        specifier: ^4.4.1
+        version: 4.7.0(vite@6.4.2(@types/node@22.19.19)(tsx@4.21.0))
+      lucide-react:
+        specifier: ^0.511.0
+        version: 0.511.0(react@19.2.6)
+      react:
+        specifier: ^19.1.0
+        version: 19.2.6
+      react-dom:
+        specifier: ^19.1.0
+        version: 19.2.6(react@19.2.6)
+      vite:
+        specifier: ^6.3.5
+        version: 6.4.2(@types/node@22.19.19)(tsx@4.21.0)
+    devDependencies:
+      '@testing-library/jest-dom':
+        specifier: ^6.6.3
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.0
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@types/react':
+        specifier: ^19.1.4
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.1.5
+        version: 19.2.3(@types/react@19.2.14)
+      jsdom:
+        specifier: ^26.1.0
+        version: 26.1.0
+      vitest:
+        specifier: ^3.1.3
+        version: 3.2.4(@types/node@22.19.19)(jsdom@26.1.0)(tsx@4.21.0)
+
+  packages/shared:
+    devDependencies:
+      vitest:
+        specifier: ^3.1.3
+        version: 3.2.4(@types/node@22.19.19)(jsdom@26.1.0)(tsx@4.21.0)
+
+  packages/ui:
+    dependencies:
+      '@feedbackops/shared':
+        specifier: workspace:*
+        version: link:../shared
+      lucide-react:
+        specifier: ^0.511.0
+        version: 0.511.0(react@19.2.6)
+      react:
+        specifier: ^19.1.0
+        version: 19.2.6
+      react-dom:
+        specifier: ^19.1.0
+        version: 19.2.6(react@19.2.6)
+    devDependencies:
+      '@testing-library/jest-dom':
+        specifier: ^6.6.3
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.0
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@types/react':
+        specifier: ^19.1.4
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.1.5
+        version: 19.2.3(@types/react@19.2.14)
+      jsdom:
+        specifier: ^26.1.0
+        version: 26.1.0
+      vitest:
+        specifier: ^3.1.3
+        version: 3.2.4(@types/node@22.19.19)(jsdom@26.1.0)(tsx@4.21.0)
+
+packages:
+
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
+
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
+
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.3':
+    resolution: {integrity: sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.0':
+    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.1':
+    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.28.6':
+    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.28.0':
+    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.28.6':
+    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.28.6':
+    resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.28.6':
+    resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.27.1':
+    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.2':
+    resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.3':
+    resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1':
+    resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1':
+    resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/template@7.28.6':
+    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.0':
+    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
+
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@paralleldrive/cuid2@2.3.1':
+    resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
+
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
+
+  '@rollup/rollup-android-arm-eabi@4.60.3':
+    resolution: {integrity: sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.3':
+    resolution: {integrity: sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.3':
+    resolution: {integrity: sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.3':
+    resolution: {integrity: sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.3':
+    resolution: {integrity: sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.3':
+    resolution: {integrity: sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.3':
+    resolution: {integrity: sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.3':
+    resolution: {integrity: sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.3':
+    resolution: {integrity: sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.3':
+    resolution: {integrity: sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.3':
+    resolution: {integrity: sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.3':
+    resolution: {integrity: sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.3':
+    resolution: {integrity: sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.3':
+    resolution: {integrity: sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.3':
+    resolution: {integrity: sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.3':
+    resolution: {integrity: sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.3':
+    resolution: {integrity: sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.3':
+    resolution: {integrity: sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.60.3':
+    resolution: {integrity: sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.60.3':
+    resolution: {integrity: sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.3':
+    resolution: {integrity: sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.3':
+    resolution: {integrity: sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.3':
+    resolution: {integrity: sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.3':
+    resolution: {integrity: sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.3':
+    resolution: {integrity: sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
+  '@types/body-parser@1.19.6':
+    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+
+  '@types/cookiejar@2.1.5':
+    resolution: {integrity: sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==}
+
+  '@types/cors@2.8.19':
+    resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/express-serve-static-core@5.1.1':
+    resolution: {integrity: sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==}
+
+  '@types/express@5.0.6':
+    resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
+
+  '@types/http-errors@2.0.5':
+    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
+
+  '@types/methods@1.1.4':
+    resolution: {integrity: sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==}
+
+  '@types/node@22.19.19':
+    resolution: {integrity: sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==}
+
+  '@types/qs@6.15.1':
+    resolution: {integrity: sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==}
+
+  '@types/range-parser@1.2.7':
+    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react@19.2.14':
+    resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/send@1.2.1':
+    resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
+
+  '@types/serve-static@2.2.0':
+    resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
+
+  '@types/superagent@8.1.9':
+    resolution: {integrity: sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==}
+
+  '@types/supertest@6.0.3':
+    resolution: {integrity: sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w==}
+
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
+
+  asap@2.0.6:
+    resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  baseline-browser-mapping@2.10.29:
+    resolution: {integrity: sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
+
+  caniuse-lite@1.0.30001792:
+    resolution: {integrity: sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
+  component-emitter@1.3.1:
+    resolution: {integrity: sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==}
+
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  cookiejar@2.1.4:
+    resolution: {integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
+
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
+  cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
+  dezalgo@1.0.4:
+    resolution: {integrity: sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  electron-to-chromium@1.5.353:
+    resolution: {integrity: sha512-kOrWphBi8TOZyiJZqsgqIle0lw+tzmnQK83pV9dZUd01Nm2POECSyFQMAuarzZdYqQW7FH9RaYOuaRo3h+bQ3w==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
+
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
+
+  fast-safe-stringify@2.1.1:
+    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
+
+  formidable@3.5.4:
+    resolution: {integrity: sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==}
+    engines: {node: '>=14.0.0'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
+
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
+  jsdom@26.1.0:
+    resolution: {integrity: sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lucide-react@0.511.0:
+    resolution: {integrity: sha512-VK5a2ydJ7xm8GvBeKLS9mu1pVK6ucef9780JVUjw6bAjJL/QXnd4Y0p7SPeOUMC27YhzNCZvm5d/QX0Tp3rc0w==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
+  methods@1.1.2:
+    resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
+    engines: {node: '>= 0.6'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
+
+  mime@2.6.0:
+    resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
+    engines: {node: '>=4.0.0'}
+    hasBin: true
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
+  node-releases@2.0.44:
+    resolution: {integrity: sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==}
+
+  nwsapi@2.2.23:
+    resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.14:
+    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  qs@6.15.1:
+    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+    engines: {node: '>=0.6'}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
+
+  react-dom@19.2.6:
+    resolution: {integrity: sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==}
+    peerDependencies:
+      react: ^19.2.6
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react-refresh@0.17.0:
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
+    engines: {node: '>=0.10.0'}
+
+  react@19.2.6:
+    resolution: {integrity: sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==}
+    engines: {node: '>=0.10.0'}
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  rollup@4.60.3:
+    resolution: {integrity: sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
+  superagent@10.3.0:
+    resolution: {integrity: sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==}
+    engines: {node: '>=14.18.0'}
+
+  supertest@7.2.2:
+    resolution: {integrity: sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==}
+    engines: {node: '>=14.18.0'}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
+
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
+
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@6.4.2:
+    resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.20.1:
+    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+snapshots:
+
+  '@adobe/css-tools@4.4.4': {}
+
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
+
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.3': {}
+
+  '@babel/core@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helpers': 7.29.2
+      '@babel/parser': 7.29.3
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.1':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.28.6':
+    dependencies:
+      '@babel/compat-data': 7.29.3
+      '@babel/helper-validator-option': 7.27.1
+      browserslist: 4.28.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-module-imports@7.28.6':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.28.6': {}
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-option@7.27.1': {}
+
+  '@babel/helpers@7.29.2':
+    dependencies:
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+
+  '@babel/parser@7.29.3':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/runtime@7.29.2': {}
+
+  '@babel/template@7.28.6':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+
+  '@babel/traverse@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.29.3
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-tokenizer@3.0.4': {}
+
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
+    optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@noble/hashes@1.8.0': {}
+
+  '@paralleldrive/cuid2@2.3.1':
+    dependencies:
+      '@noble/hashes': 1.8.0
+
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
+
+  '@rollup/rollup-android-arm-eabi@4.60.3':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.3':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.3':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.3':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.3':
+    optional: true
+
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.29.2
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@testing-library/dom': 10.4.1
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@types/aria-query@5.0.4': {}
+
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/body-parser@1.19.6':
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 22.19.19
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 22.19.19
+
+  '@types/cookiejar@2.1.5': {}
+
+  '@types/cors@2.8.19':
+    dependencies:
+      '@types/node': 22.19.19
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.8': {}
+
+  '@types/estree@1.0.9': {}
+
+  '@types/express-serve-static-core@5.1.1':
+    dependencies:
+      '@types/node': 22.19.19
+      '@types/qs': 6.15.1
+      '@types/range-parser': 1.2.7
+      '@types/send': 1.2.1
+
+  '@types/express@5.0.6':
+    dependencies:
+      '@types/body-parser': 1.19.6
+      '@types/express-serve-static-core': 5.1.1
+      '@types/serve-static': 2.2.0
+
+  '@types/http-errors@2.0.5': {}
+
+  '@types/methods@1.1.4': {}
+
+  '@types/node@22.19.19':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@types/qs@6.15.1': {}
+
+  '@types/range-parser@1.2.7': {}
+
+  '@types/react-dom@19.2.3(@types/react@19.2.14)':
+    dependencies:
+      '@types/react': 19.2.14
+
+  '@types/react@19.2.14':
+    dependencies:
+      csstype: 3.2.3
+
+  '@types/send@1.2.1':
+    dependencies:
+      '@types/node': 22.19.19
+
+  '@types/serve-static@2.2.0':
+    dependencies:
+      '@types/http-errors': 2.0.5
+      '@types/node': 22.19.19
+
+  '@types/superagent@8.1.9':
+    dependencies:
+      '@types/cookiejar': 2.1.5
+      '@types/methods': 1.1.4
+      '@types/node': 22.19.19
+      form-data: 4.0.5
+
+  '@types/supertest@6.0.3':
+    dependencies:
+      '@types/methods': 1.1.4
+      '@types/superagent': 8.1.9
+
+  '@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@22.19.19)(tsx@4.21.0))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 6.4.2(@types/node@22.19.19)(tsx@4.21.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@6.4.2(@types/node@22.19.19)(tsx@4.21.0))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 6.4.2(@types/node@22.19.19)(tsx@4.21.0)
+
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.4':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
+  agent-base@7.1.4: {}
+
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@5.2.0: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
+  aria-query@5.3.2: {}
+
+  asap@2.0.6: {}
+
+  assertion-error@2.0.1: {}
+
+  asynckit@0.4.0: {}
+
+  baseline-browser-mapping@2.10.29: {}
+
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.1
+      raw-body: 3.0.2
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.29
+      caniuse-lite: 1.0.30001792
+      electron-to-chromium: 1.5.353
+      node-releases: 2.0.44
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  bytes@3.1.2: {}
+
+  cac@6.7.14: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
+  caniuse-lite@1.0.30001792: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  check-error@2.1.3: {}
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
+  component-emitter@1.3.1: {}
+
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
+  convert-source-map@2.0.0: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
+  cookiejar@2.1.4: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+
+  css.escape@1.5.1: {}
+
+  cssstyle@4.6.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
+
+  csstype@3.2.3: {}
+
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  decimal.js@10.6.0: {}
+
+  deep-eql@5.0.2: {}
+
+  delayed-stream@1.0.0: {}
+
+  depd@2.0.0: {}
+
+  dequal@2.0.3: {}
+
+  dezalgo@1.0.4:
+    dependencies:
+      asap: 2.0.6
+      wrappy: 1.0.2
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  ee-first@1.1.1: {}
+
+  electron-to-chromium@1.5.353: {}
+
+  encodeurl@2.0.0: {}
+
+  entities@6.0.1: {}
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-module-lexer@1.7.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.3
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
+
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
+  escalade@3.2.0: {}
+
+  escape-html@1.0.3: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  etag@1.8.1: {}
+
+  expect-type@1.3.0: {}
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.1
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  fast-safe-stringify@2.1.1: {}
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.3
+      mime-types: 2.1.35
+
+  formidable@3.5.4:
+    dependencies:
+      '@paralleldrive/cuid2': 2.3.1
+      dezalgo: 1.0.4
+      once: 1.4.0
+
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
+
+  fsevents@2.3.3:
+    optional: true
+
+  function-bind@1.1.2: {}
+
+  gensync@1.0.0-beta.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.3
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
+
+  get-tsconfig@4.14.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  gopd@1.2.0: {}
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
+
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  indent-string@4.0.0: {}
+
+  inherits@2.0.4: {}
+
+  ipaddr.js@1.9.1: {}
+
+  is-potential-custom-element-name@1.0.1: {}
+
+  is-promise@4.0.0: {}
+
+  js-tokens@4.0.0: {}
+
+  js-tokens@9.0.1: {}
+
+  jsdom@26.1.0:
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.23
+      parse5: 7.3.0
+      rrweb-cssom: 0.8.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.20.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  jsesc@3.1.0: {}
+
+  json5@2.2.3: {}
+
+  loupe@3.2.1: {}
+
+  lru-cache@10.4.3: {}
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
+  lucide-react@0.511.0(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+
+  lz-string@1.5.0: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  math-intrinsics@1.1.0: {}
+
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
+
+  methods@1.1.2: {}
+
+  mime-db@1.52.0: {}
+
+  mime-db@1.54.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
+
+  mime@2.6.0: {}
+
+  min-indent@1.0.1: {}
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.12: {}
+
+  negotiator@1.0.0: {}
+
+  node-releases@2.0.44: {}
+
+  nwsapi@2.2.23: {}
+
+  object-assign@4.1.1: {}
+
+  object-inspect@1.13.4: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
+  parseurl@1.3.3: {}
+
+  path-to-regexp@8.4.2: {}
+
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
+
+  postcss@8.5.14:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
+  punycode@2.3.1: {}
+
+  qs@6.15.1:
+    dependencies:
+      side-channel: 1.1.0
+
+  range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
+
+  react-dom@19.2.6(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+      scheduler: 0.27.0
+
+  react-is@17.0.2: {}
+
+  react-refresh@0.17.0: {}
+
+  react@19.2.6: {}
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
+
+  resolve-pkg-maps@1.0.0: {}
+
+  rollup@4.60.3:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.3
+      '@rollup/rollup-android-arm64': 4.60.3
+      '@rollup/rollup-darwin-arm64': 4.60.3
+      '@rollup/rollup-darwin-x64': 4.60.3
+      '@rollup/rollup-freebsd-arm64': 4.60.3
+      '@rollup/rollup-freebsd-x64': 4.60.3
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.3
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.3
+      '@rollup/rollup-linux-arm64-gnu': 4.60.3
+      '@rollup/rollup-linux-arm64-musl': 4.60.3
+      '@rollup/rollup-linux-loong64-gnu': 4.60.3
+      '@rollup/rollup-linux-loong64-musl': 4.60.3
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.3
+      '@rollup/rollup-linux-ppc64-musl': 4.60.3
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.3
+      '@rollup/rollup-linux-riscv64-musl': 4.60.3
+      '@rollup/rollup-linux-s390x-gnu': 4.60.3
+      '@rollup/rollup-linux-x64-gnu': 4.60.3
+      '@rollup/rollup-linux-x64-musl': 4.60.3
+      '@rollup/rollup-openbsd-x64': 4.60.3
+      '@rollup/rollup-openharmony-arm64': 4.60.3
+      '@rollup/rollup-win32-arm64-msvc': 4.60.3
+      '@rollup/rollup-win32-ia32-msvc': 4.60.3
+      '@rollup/rollup-win32-x64-gnu': 4.60.3
+      '@rollup/rollup-win32-x64-msvc': 4.60.3
+      fsevents: 2.3.3
+
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
+  rrweb-cssom@0.8.0: {}
+
+  safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
+  scheduler@0.27.0: {}
+
+  semver@6.3.1: {}
+
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
+  setprototypeof@1.2.0: {}
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  statuses@2.0.2: {}
+
+  std-env@3.10.0: {}
+
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
+
+  superagent@10.3.0:
+    dependencies:
+      component-emitter: 1.3.1
+      cookiejar: 2.1.4
+      debug: 4.4.3
+      fast-safe-stringify: 2.1.1
+      form-data: 4.0.5
+      formidable: 3.5.4
+      methods: 1.1.2
+      mime: 2.6.0
+      qs: 6.15.1
+    transitivePeerDependencies:
+      - supports-color
+
+  supertest@7.2.2:
+    dependencies:
+      cookie-signature: 1.2.2
+      methods: 1.1.2
+      superagent: 10.3.0
+    transitivePeerDependencies:
+      - supports-color
+
+  symbol-tree@3.2.4: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
+
+  tldts-core@6.1.86: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
+
+  toidentifier@1.0.1: {}
+
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.7
+      get-tsconfig: 4.14.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}
+
+  unpipe@1.0.0: {}
+
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  vary@1.1.2: {}
+
+  vite-node@3.2.4(@types/node@22.19.19)(tsx@4.21.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 6.4.2(@types/node@22.19.19)(tsx@4.21.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@6.4.2(@types/node@22.19.19)(tsx@4.21.0):
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.14
+      rollup: 4.60.3
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 22.19.19
+      fsevents: 2.3.3
+      tsx: 4.21.0
+
+  vitest@3.2.4(@types/node@22.19.19)(jsdom@26.1.0)(tsx@4.21.0):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@6.4.2(@types/node@22.19.19)(tsx@4.21.0))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.16
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 6.4.2(@types/node@22.19.19)(tsx@4.21.0)
+      vite-node: 3.2.4(@types/node@22.19.19)(tsx@4.21.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.19
+      jsdom: 26.1.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@7.0.0: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  wrappy@1.0.2: {}
+
+  ws@8.20.1: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
+
+  yallist@3.1.1: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       express:
         specifier: ^5.1.0
         version: 5.2.1
+      pg:
+        specifier: ^8.20.0
+        version: 8.20.0
     devDependencies:
       '@types/cors':
         specifier: ^2.8.18
@@ -33,6 +36,9 @@ importers:
       '@types/express':
         specifier: ^5.0.2
         version: 5.0.6
+      '@types/pg':
+        specifier: ^8.20.0
+        version: 8.20.0
       '@types/supertest':
         specifier: ^6.0.3
         version: 6.0.3
@@ -805,6 +811,9 @@ packages:
   '@types/node@22.19.19':
     resolution: {integrity: sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==}
 
+  '@types/pg@8.20.0':
+    resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
+
   '@types/qs@6.15.1':
     resolution: {integrity: sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==}
 
@@ -1342,6 +1351,40 @@ packages:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
 
+  pg-cloudflare@1.3.0:
+    resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
+
+  pg-connection-string@2.12.0:
+    resolution: {integrity: sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-pool@3.13.0:
+    resolution: {integrity: sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.13.0:
+    resolution: {integrity: sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg@8.20.0:
+    resolution: {integrity: sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -1352,6 +1395,22 @@ packages:
   postcss@8.5.14:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
 
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
@@ -1459,6 +1518,10 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -1680,6 +1743,10 @@ packages:
 
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -2187,6 +2254,12 @@ snapshots:
   '@types/node@22.19.19':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/pg@8.20.0':
+    dependencies:
+      '@types/node': 22.19.19
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
 
   '@types/qs@6.15.1': {}
 
@@ -2773,6 +2846,41 @@ snapshots:
 
   pathval@2.0.1: {}
 
+  pg-cloudflare@1.3.0:
+    optional: true
+
+  pg-connection-string@2.12.0: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.13.0(pg@8.20.0):
+    dependencies:
+      pg: 8.20.0
+
+  pg-protocol@1.13.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.20.0:
+    dependencies:
+      pg-connection-string: 2.12.0
+      pg-pool: 3.13.0(pg@8.20.0)
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.3.0
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
+
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
@@ -2782,6 +2890,16 @@ snapshots:
       nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
 
   pretty-format@27.5.1:
     dependencies:
@@ -2938,6 +3056,8 @@ snapshots:
   siginfo@2.0.0: {}
 
   source-map-js@1.2.1: {}
+
+  split2@4.2.0: {}
 
   stackback@0.0.2: {}
 
@@ -3140,5 +3260,7 @@ snapshots:
   xml-name-validator@5.0.0: {}
 
   xmlchars@2.2.0: {}
+
+  xtend@4.0.2: {}
 
   yallist@3.1.1: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+packages:
+  - "apps/*"
+  - "packages/*"
+allowBuilds:
+  esbuild: true

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["node"]
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "files": [],
+  "references": [
+    { "path": "packages/shared" },
+    { "path": "packages/ui" },
+    { "path": "apps/backend" },
+    { "path": "apps/frontend" }
+  ]
+}


### PR DESCRIPTION
## Summary
- Scaffolded a pnpm TypeScript monorepo with backend, frontend, shared contracts, and UI package boundaries.
- Implemented an in-memory Express MVP for the docs-backed VOC-to-execution loop: Managed System scope, VOC create/triage, conversation separation, entity links, findings, task requests, task conversion, and action dashboard queues.
- Built shared semantic UI tokens and reusable ObjectList, DetailPanel, StatusBadge, ActionQueueRow, PermissionBlockedPanel, LinkedEntityTrail, EvidenceHighlight, and RichContentEditor before composing the Vite/React operational shell.

## Scope Notes
- This targets the smallest coherent MVP loop from docs/design/13-mvp-roadmap.md and docs/implementation/08-mvp-slice-plan.md through Slice 7a.
- Full Survey builder/response workflows are deferred because the docs conflict: the requirements/API docs list Survey as MVP, while the slice plan places it after dashboard/conversation. This PR still protects the forbidden invariant by exposing no Survey Response -> VOC API or UI path.

## Verification
- pnpm lint
- pnpm test
- pnpm build

## Browser QA
- Vite dev server ran at http://localhost:5175/ for manual inspection.
- In-app Browser automation was unavailable because the expected Node REPL browser control tool was not exposed; Computer Use returned a macOS automation error. Automated route/component tests cover the app shell, dashboard, VOC detail, permission blocked state, and Survey-result no-VOC affordance.
