### PR TITLE
chore: git workflow rules + pre-push hook

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# .githooks/pre-push
+#
+# Block direct pushes to `main` unless the push is README-only.
+# Per AGENTS.md §"Git Workflow": main is reserved for `develop` → `main` PR merges
+# at slice completion; README updates are the only allowed direct push.
+#
+# Limitations:
+#   - Client-side hook. Bypassable with `git push --no-verify`.
+#   - Defense-in-depth only. Branch protection rules on GitHub are the real gate.
+#   - Each developer must enable: `git config core.hooksPath .githooks`
+#     (or run `pnpm run install:hooks` if/when that script is added).
+
+set -euo pipefail
+
+protected_branch="main"
+zero="0000000000000000000000000000000000000000"
+
+# Allowed file patterns for direct push to main (basic regex, anchored).
+# README, README.md, README.ko.md, etc.
+allowed_pattern='^README(\.[A-Za-z0-9.-]+)?$'
+
+while read -r local_ref local_sha remote_ref remote_sha; do
+  if [[ "$remote_ref" != "refs/heads/$protected_branch" ]]; then
+    continue
+  fi
+
+  # Deletion of main — block.
+  if [[ "$local_sha" == "$zero" ]]; then
+    echo "pre-push: refusing to delete '$protected_branch'." >&2
+    exit 1
+  fi
+
+  # Determine commit range to inspect.
+  if [[ "$remote_sha" == "$zero" ]]; then
+    # First push of this branch (very unlikely for main). Inspect all commits.
+    range="$local_sha"
+    files=$(git diff-tree --no-commit-id --name-only -r "$local_sha")
+  else
+    range="$remote_sha..$local_sha"
+    files=$(git diff --name-only "$range")
+  fi
+
+  # Nothing changed? Nothing to block.
+  if [[ -z "$files" ]]; then
+    continue
+  fi
+
+  # Reject if any changed file is outside the allowed pattern.
+  bad=$(printf '%s\n' "$files" | grep -Ev "$allowed_pattern" || true)
+  if [[ -n "$bad" ]]; then
+    {
+      echo ""
+      echo "pre-push: refusing direct push to '$protected_branch'."
+      echo ""
+      echo "Per AGENTS.md §Git Workflow, only README updates may push directly to main."
+      echo "Slice completion → open a PR 'develop' → 'main' instead."
+      echo ""
+      echo "Files blocking push (range: $range):"
+      printf '%s\n' "$bad" | sed 's/^/  - /'
+      echo ""
+      echo "Bypass (use sparingly, e.g. emergency hot-fix authorised by repo owner):"
+      echo "  git push --no-verify"
+      echo ""
+    } >&2
+    exit 1
+  fi
+done
+
+exit 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,20 @@
 - For multi-step work, define success criteria and verify them before claiming completion.
 - If domain rules conflict with generic framework habits, follow the domain rules.
 
+## Git Workflow
+
+- **Per-issue feature branch.** New work starts on `feature/<issue-number>-<slug>` (e.g. `feature/14-patch-vocs-triage`) branched from `develop`. Never commit directly to `develop` or `main`.
+- **Issue complete → merge to `develop`.** When all task ACs pass and adversarial review clears, open a PR `feature/<n>-<slug>` → `develop`. After PR review the user merges (squash or merge, user's call). Delete the feature branch on merge.
+- **Slice complete → PR `develop` → `main`.** When every issue in a Slice milestone closes and Slice exit criteria (per `docs/implementation/08-mvp-slice-plan.md`) are met, open a PR `develop` → `main`. The user merges to release.
+- **No agent push to `main`.** Even after Slice completion, the user owns the final `develop` → `main` merge and any tag/release.
+- **Branch naming.** `feature/<issue>-<short-kebab>` for issues, `fix/<issue>-<slug>` for hot-fixes on `develop`, `chore/<slug>` for branch-less housekeeping (lint, gitignore) that may target `develop` directly via small PR.
+- **Exception — pre-existing direct-to-main commits.** Slices 1–3 shipped directly to `main` (before this rule landed). From the next issue onward, follow the workflow above.
+- **Pre-push hook enforces main protection locally.** `.githooks/pre-push` blocks any direct push to `main` that touches files other than `README*`. Enable once per clone:
+  ```bash
+  git config core.hooksPath .githooks
+  ```
+  Limitations: client-side, bypassable with `git push --no-verify`. Server-side enforcement via GitHub branch protection rules is the real gate — configure under repo Settings → Branches → `main` → "Require a pull request before merging".
+
 ## Monorepo Boundaries
 
 Do not place source code at the repository root. Keep cross-app code in `packages/*` only when both apps need it.


### PR DESCRIPTION
## Summary

- Add `## Git Workflow` section to `AGENTS.md` codifying the per-issue feature branch + develop staging + slice-completion PR flow.
- Add `.githooks/pre-push` blocking direct pushes to `main` that touch any file outside `README*`.
- Update memory note `feedback_orchestration` rule #1 to reference the new workflow.

## How to enable the hook (once per clone)

```bash
git config core.hooksPath .githooks
```

## Limitations

- Pre-push hook is client-side and can be bypassed with `git push --no-verify`.
- Real enforcement comes from GitHub branch protection rules — configure under repo Settings → Branches → `main` → "Require a pull request before merging". Optionally also restrict who can push.

## Test plan

- [ ] On a feature branch with non-README changes, `git push origin HEAD:main` should be rejected by the hook with the AGENTS.md guidance message.
- [ ] On a feature branch with only `README.md` changes, the hook allows the push.
- [ ] `git push --no-verify origin HEAD:main` bypasses the hook (documented limitation).

## Bootstrap note

First branch under the new workflow. Slices 1–3 shipped pre-rule directly on `main` — exception per AGENTS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)