### PR TITLE
feat(slice3 #23): sanitizer per-attr value schemas + canonical doc rebuild

### DIFF
--- a/apps/backend/src/lib/rich-content/__tests__/sanitize.test.ts
+++ b/apps/backend/src/lib/rich-content/__tests__/sanitize.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { sanitizeTipTap } from '../sanitize.js';
+import type { RichContentFieldsCode } from '../sanitize.js';
 
 const surface = 'voc-description' as const;
 
@@ -84,5 +85,335 @@ describe('sanitizeTipTap (voc-description)', () => {
   it('rejects doc with non-doc root', () => {
     const res = sanitizeTipTap({ surface, doc: { type: 'paragraph' } as never });
     expect(res.ok).toBe(false);
+  });
+});
+
+// ── Attr allowlist ─────────────────────────────────────────────────────────────
+
+const VALID_UUID = '00000000-0000-4000-8000-000000000001';
+const VALID_UUID_2 = '11111111-1111-4111-8111-111111111111';
+
+function attachmentDoc(attrs: Record<string, unknown>) {
+  return { type: 'doc' as const, content: [{ type: 'attachmentRef', attrs }] };
+}
+function mentionDoc(attrs: Record<string, unknown>) {
+  return {
+    type: 'doc' as const,
+    content: [{ type: 'mention', attrs }],
+  };
+}
+function codeBlockDoc(attrs?: Record<string, unknown>) {
+  return {
+    type: 'doc' as const,
+    content: [{ type: 'codeBlock', ...(attrs !== undefined ? { attrs } : {}) }],
+  };
+}
+function linkDoc(attrs: Record<string, unknown>) {
+  return {
+    type: 'doc' as const,
+    content: [
+      {
+        type: 'paragraph',
+        content: [{ type: 'text', text: 'x', marks: [{ type: 'link', attrs }] }],
+      },
+    ],
+  };
+}
+
+describe('attr allowlist — positive cases', () => {
+  it('attachmentRef with valid uuid id (voc-description)', () => {
+    const res = sanitizeTipTap({ surface: 'voc-description', doc: attachmentDoc({ id: VALID_UUID }) });
+    expect(res.ok).toBe(true);
+  });
+
+  it('mention with valid actor_id (internal-comment)', () => {
+    const res = sanitizeTipTap({ surface: 'internal-comment', doc: mentionDoc({ actor_id: VALID_UUID }) });
+    expect(res.ok).toBe(true);
+  });
+
+  it('codeBlock with language null (internal-comment)', () => {
+    const res = sanitizeTipTap({ surface: 'internal-comment', doc: codeBlockDoc({ language: null }) });
+    expect(res.ok).toBe(true);
+  });
+
+  it('codeBlock with language string (internal-comment)', () => {
+    const res = sanitizeTipTap({ surface: 'internal-comment', doc: codeBlockDoc({ language: 'ts' }) });
+    expect(res.ok).toBe(true);
+  });
+
+  it('codeBlock with empty attrs {} (internal-comment)', () => {
+    const res = sanitizeTipTap({ surface: 'internal-comment', doc: codeBlockDoc({}) });
+    expect(res.ok).toBe(true);
+  });
+
+  it('codeBlock with no attrs (internal-comment)', () => {
+    const res = sanitizeTipTap({ surface: 'internal-comment', doc: codeBlockDoc() });
+    expect(res.ok).toBe(true);
+  });
+
+  it('link mark with https href (voc-description)', () => {
+    const res = sanitizeTipTap({ surface: 'voc-description', doc: linkDoc({ href: 'https://example.com' }) });
+    expect(res.ok).toBe(true);
+  });
+
+  it('link mark with http href (reporter-reply)', () => {
+    const res = sanitizeTipTap({ surface: 'reporter-reply', doc: linkDoc({ href: 'http://example.com' }) });
+    expect(res.ok).toBe(true);
+  });
+
+  it('paragraph with absent attrs → output has no attrs field', () => {
+    const res = sanitizeTipTap({ surface: 'voc-description', doc: { type: 'doc', content: [{ type: 'paragraph' }] } });
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      const para = (res.doc as { content: Array<{ attrs?: unknown }> }).content?.[0];
+      expect(para).not.toHaveProperty('attrs');
+    }
+  });
+
+  it('paragraph with empty attrs {} → output has no attrs field (canonical)', () => {
+    const res = sanitizeTipTap({
+      surface: 'voc-description',
+      doc: { type: 'doc', content: [{ type: 'paragraph', attrs: {} }] } as never,
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      const para = (res.doc as { content: Array<{ attrs?: unknown }> }).content?.[0];
+      expect(para).not.toHaveProperty('attrs');
+    }
+  });
+
+  it('attachmentRef with valid uuid (reporter-reply)', () => {
+    const res = sanitizeTipTap({ surface: 'reporter-reply', doc: attachmentDoc({ id: VALID_UUID }) });
+    expect(res.ok).toBe(true);
+  });
+
+  it('attachmentRef with valid uuid (internal-comment)', () => {
+    const res = sanitizeTipTap({ surface: 'internal-comment', doc: attachmentDoc({ id: VALID_UUID_2 }) });
+    expect(res.ok).toBe(true);
+  });
+});
+
+describe('attr allowlist — canonical output', () => {
+  it('unknown top-level field on paragraph is dropped', () => {
+    const res = sanitizeTipTap({
+      surface: 'voc-description',
+      doc: { type: 'doc', content: [{ type: 'paragraph', foo: 'bar' }] } as never,
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      const para = (res.doc as { content: Array<Record<string, unknown>> }).content?.[0];
+      expect(para).not.toHaveProperty('foo');
+    }
+  });
+
+  it('doc is rebuilt; does not return original object reference', () => {
+    const input = { type: 'doc' as const, content: [{ type: 'paragraph', extraField: 'x' }] };
+    const res = sanitizeTipTap({ surface: 'voc-description', doc: input as never });
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.doc).not.toBe(input);
+    }
+  });
+});
+
+describe('attr allowlist — negative: disallowed keys', () => {
+  it.each<[string, string, Parameters<typeof sanitizeTipTap>[0], RichContentFieldsCode | undefined, string]>([
+    [
+      'attachmentRef with extra onclick key',
+      'voc-description',
+      { surface: 'voc-description', doc: attachmentDoc({ id: VALID_UUID, onclick: 'x' }) },
+      'disallowed_attr_key',
+      'attrs.onclick',
+    ],
+    [
+      'paragraph with align key (no nodeAttrs entry)',
+      'voc-description',
+      {
+        surface: 'voc-description',
+        doc: { type: 'doc', content: [{ type: 'paragraph', attrs: { align: 'left' } }] } as never,
+      },
+      undefined,
+      'attrs',
+    ],
+    [
+      'link mark with extra target key',
+      'voc-description',
+      { surface: 'voc-description', doc: linkDoc({ href: 'https://example.com', target: '_blank' }) },
+      'disallowed_attr_key',
+      'marks[0].attrs.target',
+    ],
+    [
+      'mention with extra label key (internal-comment)',
+      'internal-comment',
+      {
+        surface: 'internal-comment',
+        doc: mentionDoc({ actor_id: VALID_UUID, label: '<x>' }),
+      },
+      'disallowed_attr_key',
+      'attrs.label',
+    ],
+  ])('%s → 422 disallowed_attr_key, path ends %s', (_label, _surf, args, expectedFieldsCode, pathSuffix) => {
+    const res = sanitizeTipTap(args);
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.error.code).toBe('rich_content.disallowed_node');
+      expect(res.error.fields_code).toBe(expectedFieldsCode);
+      expect(res.error.path).toBeDefined();
+      expect(res.error.path).toContain(pathSuffix);
+    }
+  });
+});
+
+describe('attr allowlist — negative: invalid values', () => {
+  it.each<[string, Record<string, unknown>]>([
+    ['non-uuid string', { id: 'not-a-uuid' }],
+    ['null id', { id: null }],
+    ['number id', { id: 123 }],
+    ['boolean id', { id: true }],
+    ['very long string (uuid regex fails)', { id: 'a'.repeat(50_000) }],
+  ])('attachmentRef.id = %s → 422 invalid_attr_value', (_label, attrs) => {
+    const res = sanitizeTipTap({ surface: 'voc-description', doc: attachmentDoc(attrs) });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.error.code).toBe('rich_content.disallowed_node');
+      expect(res.error.fields_code).toBe('invalid_attr_value');
+      expect(res.error.path).toContain('attrs.id');
+    }
+  });
+
+  it.each<[string, Record<string, unknown>]>([
+    ['non-uuid string', { actor_id: 'not-a-uuid' }],
+    ['null actor_id', { actor_id: null }],
+    ['number actor_id', { actor_id: 123 }],
+    ['boolean actor_id', { actor_id: true }],
+  ])('mention.actor_id = %s → 422 invalid_attr_value (internal-comment)', (_label, attrs) => {
+    const res = sanitizeTipTap({ surface: 'internal-comment', doc: mentionDoc(attrs) });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.error.code).toBe('rich_content.disallowed_node');
+      expect(res.error.fields_code).toBe('invalid_attr_value');
+      expect(res.error.path).toContain('attrs.actor_id');
+    }
+  });
+
+  it('link.href = javascript:alert(1) → 422 (invalid scheme)', () => {
+    const res = sanitizeTipTap({ surface: 'voc-description', doc: linkDoc({ href: 'javascript:alert(1)' }) });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.error.code).toBe('rich_content.disallowed_node');
+      expect(res.error.fields_code).toBe('invalid_attr_value');
+    }
+  });
+
+  it('link.href too long (>2048) → 422 invalid_attr_value', () => {
+    const res = sanitizeTipTap({
+      surface: 'voc-description',
+      doc: linkDoc({ href: 'http://' + 'a'.repeat(3000) }),
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.error.code).toBe('rich_content.disallowed_node');
+      expect(res.error.fields_code).toBe('invalid_attr_value');
+    }
+  });
+
+  it('link.href = "not a url" → 422 invalid_attr_value', () => {
+    const res = sanitizeTipTap({ surface: 'voc-description', doc: linkDoc({ href: 'not a url' }) });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.error.code).toBe('rich_content.disallowed_node');
+      expect(res.error.fields_code).toBe('invalid_attr_value');
+    }
+  });
+
+  // ── Cycle-1 M1: URL credential / scheme-spoof guard ─────────────────────
+  it.each([
+    ['user-only', 'https://user@evil.example/path'],
+    ['user+pass', 'https://user:pass@evil.example/path'],
+    ['empty-user-but-password', 'https://:pass@evil.example/path'],
+  ])('link.href with credentials (%s) → 422 invalid_attr_value', (_label, href) => {
+    const res = sanitizeTipTap({ surface: 'voc-description', doc: linkDoc({ href }) });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.error.code).toBe('rich_content.disallowed_node');
+      expect(res.error.fields_code).toBe('invalid_attr_value');
+    }
+  });
+
+  it('link.href with percent-encoded scheme attempt → 422 (URL parse normalizes scheme; %6A%61… stays in path)', () => {
+    // 'java%73cript:alert(1)' — `new URL()` rejects this as no valid scheme,
+    // so the URL-parse branch fails before scheme allowlist check.
+    const res = sanitizeTipTap({ surface: 'voc-description', doc: linkDoc({ href: 'java%73cript:alert(1)' }) });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.error.code).toBe('rich_content.disallowed_node');
+      expect(res.error.fields_code).toBe('invalid_attr_value');
+    }
+  });
+
+  it('link.href with IPv6 literal (https://[::1]/) → accepted (URL parses, scheme ok, no creds)', () => {
+    const res = sanitizeTipTap({ surface: 'voc-description', doc: linkDoc({ href: 'https://[::1]/x' }) });
+    expect(res.ok).toBe(true);
+  });
+
+  it('link.href with IDN host (xn-- punycode) → accepted', () => {
+    const res = sanitizeTipTap({
+      surface: 'voc-description',
+      doc: linkDoc({ href: 'https://xn--80akhbyknj4f.example/path' }),
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it('codeBlock.language = 33-char string → 422 invalid_attr_value (internal-comment)', () => {
+    const res = sanitizeTipTap({
+      surface: 'internal-comment',
+      doc: codeBlockDoc({ language: 'a'.repeat(33) }),
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.error.code).toBe('rich_content.disallowed_node');
+      expect(res.error.fields_code).toBe('invalid_attr_value');
+      expect(res.error.path).toContain('attrs.language');
+    }
+  });
+});
+
+describe('attr allowlist — negative: attrs shape', () => {
+  it.each([
+    ['null', null],
+    ['array', []],
+    ['string', 'string'],
+  ])('attachmentRef.attrs = %s → 422', (_label, badAttrs) => {
+    const res = sanitizeTipTap({
+      surface: 'voc-description',
+      doc: { type: 'doc', content: [{ type: 'attachmentRef', attrs: badAttrs }] } as never,
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.error.code).toBe('rich_content.disallowed_node');
+      expect(res.error.path).toContain('attrs');
+    }
+  });
+});
+
+describe('attr allowlist — missing required keys', () => {
+  it('attachmentRef missing id → 422 invalid_attr_value', () => {
+    const res = sanitizeTipTap({ surface: 'voc-description', doc: attachmentDoc({}) });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.error.code).toBe('rich_content.disallowed_node');
+      expect(res.error.fields_code).toBe('invalid_attr_value');
+      expect(res.error.path).toContain('attrs.id');
+    }
+  });
+
+  it('link mark missing href → 422 invalid_attr_value', () => {
+    const res = sanitizeTipTap({ surface: 'voc-description', doc: linkDoc({}) });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.error.code).toBe('rich_content.disallowed_node');
+      expect(res.error.fields_code).toBe('invalid_attr_value');
+      expect(res.error.path).toContain('attrs.href');
+    }
   });
 });

--- a/apps/backend/src/lib/rich-content/__tests__/surface-allowlists.test.ts
+++ b/apps/backend/src/lib/rich-content/__tests__/surface-allowlists.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { sanitizeTipTap } from '../sanitize.js';
+import { SURFACE_ALLOWLISTS, SURFACES } from '../surface-allowlists.js';
 
 function doc(...children: unknown[]) {
   return { type: 'doc' as const, content: children };
@@ -208,5 +209,29 @@ describe('sanitizeTipTap (internal-comment)', () => {
     });
     expect(res.ok).toBe(false);
     if (!res.ok) expect(res.error.code).toBe('rich_content.disallowed_node');
+  });
+});
+
+// ── Static drift assertions ────────────────────────────────────────────────────
+
+describe('surface allowlist drift assertions', () => {
+  it.each(SURFACES)('%s: every nodeAttrs key must be in nodes set', (surface) => {
+    const allowlist = SURFACE_ALLOWLISTS[surface];
+    const nodeAttrKeys = Object.keys(allowlist.nodeAttrs);
+    for (const key of nodeAttrKeys) {
+      expect(allowlist.nodes.has(key),
+        `surface '${surface}': nodeAttrs key '${key}' not in nodes set`,
+      ).toBe(true);
+    }
+  });
+
+  it.each(SURFACES)('%s: every markAttrs key must be in marks set', (surface) => {
+    const allowlist = SURFACE_ALLOWLISTS[surface];
+    const markAttrKeys = Object.keys(allowlist.markAttrs);
+    for (const key of markAttrKeys) {
+      expect(allowlist.marks.has(key),
+        `surface '${surface}': markAttrs key '${key}' not in marks set`,
+      ).toBe(true);
+    }
   });
 });

--- a/apps/backend/src/lib/rich-content/sanitize.ts
+++ b/apps/backend/src/lib/rich-content/sanitize.ts
@@ -2,94 +2,361 @@
 // pure — no DB, no I/O — so it composes inside any tx. Result is a
 // discriminated union so callers can map to ADR-0012 codes without throwing
 // on validation paths.
+//
+// Rev 2 (issue #23): rebuilds a canonical doc (only {type, attrs?, marks?,
+// text?, content?}) so unknown top-level fields cannot leak to the renderer.
+// Also validates per-attr value schemas (uuid, url, bounded string).
 
 import type { TipTapDoc } from '@fops/shared';
 
-import { SURFACE_ALLOWLISTS, type Surface } from './surface-allowlists.js';
+import { SURFACE_ALLOWLISTS, type AttrSchema, type Surface } from './surface-allowlists.js';
+
+// ── Re-exported types (ADR-0012 closed enum — do not add codes here; see F-ADR-0012-ATTR-CODE) ──
 
 export type RichContentErrorCode =
   | 'rich_content.disallowed_node'
   | 'rich_content.external_image_forbidden';
 
+// fields_code differentiates sub-failure modes within a single ADR-0012 code.
+// Service callers map this to fields[].code (disallowed_attr_key / invalid_attr_value).
+// Undefined means the general disallowed_node case.
+export type RichContentFieldsCode =
+  | 'disallowed_node'
+  | 'disallowed_attr_key'
+  | 'invalid_attr_value';
+
 export interface RichContentError {
   code: RichContentErrorCode;
   reason: string;
   path?: string;
+  fields_code?: RichContentFieldsCode;
 }
 
 export type SanitizeResult =
   | { ok: true; doc: TipTapDoc }
   | { ok: false; error: RichContentError };
 
-interface Node {
+// ── Internal types ────────────────────────────────────────────────────────────
+
+interface RawNode {
   type: string;
-  content?: Node[];
-  marks?: Mark[];
+  content?: unknown[];
+  marks?: unknown[];
+  text?: unknown;
+  attrs?: unknown;
+  [key: string]: unknown;
+}
+
+interface CleanMark {
+  type: string;
+  attrs?: Record<string, unknown>;
+}
+
+interface CleanNode {
+  type: string;
+  attrs?: Record<string, unknown>;
   text?: string;
-  attrs?: Record<string, unknown>;
+  marks?: CleanMark[];
+  content?: CleanNode[];
 }
-interface Mark {
-  type: string;
-  attrs?: Record<string, unknown>;
+
+type VisitResult = { node: CleanNode } | { error: RichContentError };
+
+// ── UUID regex ────────────────────────────────────────────────────────────────
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// ── Attr schema validators ────────────────────────────────────────────────────
+
+function validateAttrValue(
+  schema: AttrSchema,
+  value: unknown,
+): string | null /* null = ok, string = error reason */ {
+  if (schema.kind === 'uuid') {
+    if (typeof value !== 'string' || !UUID_RE.test(value)) {
+      return `must be a valid UUID string`;
+    }
+    return null;
+  }
+  if (schema.kind === 'url') {
+    if (typeof value !== 'string') {
+      return `must be a string`;
+    }
+    if (value.length > schema.maxLen) {
+      return `exceeds max length ${schema.maxLen}`;
+    }
+    let parsed: URL;
+    try {
+      parsed = new URL(value);
+    } catch {
+      return `not a valid URL`;
+    }
+    if (!schema.schemes.has(parsed.protocol)) {
+      return `URL scheme ${parsed.protocol} not allowed`;
+    }
+    // Phishing guard (cycle-1 M1): reject embedded credentials. `https://a@evil`
+    // renders as evil but reads as a — the deception vector even when XSS is closed.
+    if (parsed.username !== '' || parsed.password !== '') {
+      return `URL must not contain credentials`;
+    }
+    return null;
+  }
+  if (schema.kind === 'string') {
+    if (schema.nullable && value === null) {
+      return null;
+    }
+    if (typeof value !== 'string') {
+      return schema.nullable ? `must be a string or null` : `must be a string`;
+    }
+    if (value.length > schema.maxLen) {
+      return `exceeds max length ${schema.maxLen}`;
+    }
+    return null;
+  }
+  return `unknown schema kind`;
 }
+
+// ── Plain-object guard ────────────────────────────────────────────────────────
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+// ── Attrs validation ──────────────────────────────────────────────────────────
+
+function validateAttrs(
+  attrSchemas: Readonly<Record<string, AttrSchema>> | undefined,
+  rawAttrs: unknown,
+  basePath: string,
+): { error: RichContentError } | { cleanAttrs: Record<string, unknown> } {
+  // If rawAttrs is present but not a plain object → shape error.
+  if (rawAttrs !== undefined && !isPlainObject(rawAttrs)) {
+    return {
+      error: {
+        code: 'rich_content.disallowed_node',
+        reason: 'attrs must be a plain object',
+        path: `${basePath}.attrs`,
+        // no fields_code — shape failure maps to default disallowed_node
+      },
+    };
+  }
+
+  const attrsObj: Record<string, unknown> = (rawAttrs as Record<string, unknown> | undefined) ?? {};
+
+  // No schema entry → attrs must be absent or empty.
+  if (!attrSchemas) {
+    const keys = Object.keys(attrsObj);
+    if (keys.length > 0) {
+      return {
+        error: {
+          code: 'rich_content.disallowed_node',
+          reason: `no attrs are allowed on this node/mark; found key '${keys[0]}'`,
+          path: `${basePath}.attrs`,
+          // no fields_code — node has no attr schema at all; treat as disallowed_node
+        },
+      };
+    }
+    return { cleanAttrs: {} };
+  }
+
+  // Schema entry exists — check required keys, unknown keys, value shape.
+  // Check required first so missing-required surfaces before unknown-key.
+  for (const [key, schema] of Object.entries(attrSchemas)) {
+    if (schema.required && !(key in attrsObj)) {
+      return {
+        error: {
+          code: 'rich_content.disallowed_node',
+          reason: `required attr '${key}' is missing`,
+          path: `${basePath}.attrs.${key}`,
+          fields_code: 'invalid_attr_value',
+        },
+      };
+    }
+  }
+
+  // Reject unknown keys.
+  for (const key of Object.keys(attrsObj)) {
+    if (!(key in attrSchemas)) {
+      return {
+        error: {
+          code: 'rich_content.disallowed_node',
+          reason: `attr key '${key}' is not allowed`,
+          path: `${basePath}.attrs.${key}`,
+          fields_code: 'disallowed_attr_key',
+        },
+      };
+    }
+  }
+
+  // Validate present values.
+  const cleanAttrs: Record<string, unknown> = {};
+  for (const [key, schema] of Object.entries(attrSchemas)) {
+    if (!(key in attrsObj)) {
+      // Optional key absent — omit from clean output.
+      continue;
+    }
+    const value = attrsObj[key];
+    const reason = validateAttrValue(schema, value);
+    if (reason !== null) {
+      return {
+        error: {
+          code: 'rich_content.disallowed_node',
+          reason: `attr '${key}' ${reason}`,
+          path: `${basePath}.attrs.${key}`,
+          fields_code: 'invalid_attr_value',
+        },
+      };
+    }
+    cleanAttrs[key] = value;
+  }
+
+  return { cleanAttrs };
+}
+
+// ── Main sanitizer ────────────────────────────────────────────────────────────
 
 export function sanitizeTipTap(args: {
   surface: Surface;
   doc: TipTapDoc;
 }): SanitizeResult {
   const allow = SURFACE_ALLOWLISTS[args.surface];
-  const root = args.doc as unknown as Node;
+  const root = args.doc as unknown as RawNode;
 
   if (!root || root.type !== 'doc') {
     return err('rich_content.disallowed_node', 'root must be a doc node', '$');
   }
 
   let totalText = 0;
-  const visit = (node: Node, path: string): RichContentError | null => {
+
+  const visitMark = (raw: unknown, path: string): { mark: CleanMark } | { error: RichContentError } => {
+    if (!isPlainObject(raw) || typeof raw.type !== 'string') {
+      return {
+        error: {
+          code: 'rich_content.disallowed_node',
+          reason: 'mark must be a plain object with a type string',
+          path,
+        },
+      };
+    }
+    const markType = raw.type;
+    if (!allow.marks.has(markType)) {
+      return {
+        error: {
+          code: 'rich_content.disallowed_node',
+          reason: `mark ${markType} not allowed`,
+          path,
+        },
+      };
+    }
+    const markAttrSchemas = allow.markAttrs[markType];
+    const attrsResult = validateAttrs(markAttrSchemas, raw.attrs, path);
+    if ('error' in attrsResult) return attrsResult;
+
+    const cleanMark: CleanMark = { type: markType };
+    if (Object.keys(attrsResult.cleanAttrs).length > 0) {
+      cleanMark.attrs = attrsResult.cleanAttrs;
+    }
+    return { mark: cleanMark };
+  };
+
+  const visit = (raw: unknown, path: string): VisitResult => {
+    if (!isPlainObject(raw) || typeof raw.type !== 'string') {
+      return {
+        error: {
+          code: 'rich_content.disallowed_node',
+          reason: 'node must be a plain object with a type string',
+          path,
+        },
+      };
+    }
+
+    const node = raw as RawNode;
+
+    // 1. Image check (specific code).
     if (node.type === 'image') {
-      return { code: 'rich_content.external_image_forbidden', reason: 'image node not permitted', path };
+      return {
+        error: {
+          code: 'rich_content.external_image_forbidden',
+          reason: 'image node not permitted',
+          path,
+        },
+      };
     }
+
+    // 2. Node type allowlist.
     if (!allow.nodes.has(node.type)) {
-      return { code: 'rich_content.disallowed_node', reason: `node ${node.type} not allowed`, path };
+      return {
+        error: {
+          code: 'rich_content.disallowed_node',
+          reason: `node ${node.type} not allowed`,
+          path,
+        },
+      };
     }
+
+    // 3. Text byte cap.
     if (typeof node.text === 'string') {
       totalText += Buffer.byteLength(node.text, 'utf8');
       if (totalText > allow.maxTextBytes) {
-        return { code: 'rich_content.disallowed_node', reason: 'text content exceeds 50KB cap', path };
+        return {
+          error: {
+            code: 'rich_content.disallowed_node',
+            reason: 'text content exceeds 50KB cap',
+            path,
+          },
+        };
       }
     }
+
+    // 4. Attrs validation.
+    const nodeAttrSchemas = allow.nodeAttrs[node.type];
+    const attrsResult = validateAttrs(nodeAttrSchemas, node.attrs, path);
+    if ('error' in attrsResult) return attrsResult;
+
+    // 5. Marks validation (rebuild canonical mark list).
+    const cleanMarks: CleanMark[] = [];
     if (Array.isArray(node.marks)) {
-      for (const mark of node.marks) {
-        if (!allow.marks.has(mark.type)) {
-          return { code: 'rich_content.disallowed_node', reason: `mark ${mark.type} not allowed`, path };
-        }
-        if (mark.type === 'link') {
-          const href = typeof mark.attrs?.href === 'string' ? mark.attrs.href : '';
-          const schemeMatch = href.match(/^([a-z][a-z0-9+.-]*):/i);
-          const scheme = schemeMatch?.[1] ? `${schemeMatch[1].toLowerCase()}:` : '';
-          if (!scheme || !allow.allowedLinkSchemes.has(scheme)) {
-            return {
-              code: 'rich_content.disallowed_node',
-              reason: `link scheme ${scheme || '<missing>'} not allowed`,
-              path,
-            };
-          }
-        }
+      for (let i = 0; i < node.marks.length; i++) {
+        const markResult = visitMark(node.marks[i], `${path}.marks[${i}]`);
+        if ('error' in markResult) return markResult;
+        cleanMarks.push(markResult.mark);
       }
     }
+
+    // 6. Recurse content.
+    const cleanContent: CleanNode[] = [];
     if (Array.isArray(node.content)) {
       for (let i = 0; i < node.content.length; i++) {
-        const child = visit(node.content[i] as Node, `${path}.content[${i}]`);
-        if (child) return child;
+        const childResult = visit(node.content[i], `${path}.content[${i}]`);
+        if ('error' in childResult) return childResult;
+        cleanContent.push(childResult.node);
       }
     }
-    return null;
+
+    // 7. Build canonical clean node (omit empty attrs, empty marks, empty content).
+    const cleanNode: CleanNode = { type: node.type };
+    if (Object.keys(attrsResult.cleanAttrs).length > 0) {
+      cleanNode.attrs = attrsResult.cleanAttrs;
+    }
+    if (typeof node.text === 'string') {
+      cleanNode.text = node.text;
+    }
+    if (cleanMarks.length > 0) {
+      cleanNode.marks = cleanMarks;
+    }
+    if (cleanContent.length > 0) {
+      cleanNode.content = cleanContent;
+    }
+
+    return { node: cleanNode };
   };
 
-  const error = visit(root, '$');
-  if (error) return { ok: false, error };
-  return { ok: true, doc: args.doc };
+  const rootResult = visit(root, '$');
+  if ('error' in rootResult) return { ok: false, error: rootResult.error };
+  return { ok: true, doc: rootResult.node as unknown as TipTapDoc };
 }
+
+// ── Helper ────────────────────────────────────────────────────────────────────
 
 function err(code: RichContentErrorCode, reason: string, path: string): SanitizeResult {
   return { ok: false, error: { code, reason, path } };

--- a/apps/backend/src/lib/rich-content/surface-allowlists.ts
+++ b/apps/backend/src/lib/rich-content/surface-allowlists.ts
@@ -1,7 +1,11 @@
 // apps/backend/src/lib/rich-content/surface-allowlists.ts
-// Per-surface node + mark allowlists. Spec: docs/frontend/specs/voc.md §5.7.
-// Backend sanitizer is the authoritative gate (ADR-0011); the client toolbar
-// is UX guidance only. Surfaces extend additively as later slices ship.
+// Per-surface node + mark allowlists with per-attr value schemas.
+// Spec: docs/frontend/specs/voc.md §5.7. ADR-0011 names this layer authoritative.
+//
+// Layering note: the sanitizer enforces attr *shape* here (type, format, length).
+// Service-layer business rules (e.g. rejecting non-empty attachments[] until the
+// storage slice ships) are enforced separately in conversation-service.ts. These
+// two gates are intentionally distinct; do not collapse them.
 
 export const SURFACES = [
   'voc-description',
@@ -11,16 +15,47 @@ export const SURFACES = [
 ] as const;
 export type Surface = (typeof SURFACES)[number];
 
+// ── AttrSchema ────────────────────────────────────────────────────────────────
+
+export type AttrSchema =
+  | { kind: 'uuid'; required: boolean }
+  | { kind: 'url'; schemes: ReadonlySet<string>; maxLen: number; required: boolean }
+  | { kind: 'string'; maxLen: number; nullable: boolean; required: boolean };
+
+// ── SurfaceAllowlist ──────────────────────────────────────────────────────────
+
 export interface SurfaceAllowlist {
   nodes: ReadonlySet<string>;
   marks: ReadonlySet<string>;
-  // http(s) only — sanitizer rejects javascript:, data:, file:
+  // nodeAttrs: node type → allowed attr key → value schema.
+  // A node type NOT present here means attrs must be absent or empty {}.
+  nodeAttrs: Readonly<Record<string, Readonly<Record<string, AttrSchema>>>>;
+  // markAttrs: mark type → allowed attr key → value schema.
+  // A mark type NOT present here means attrs must be absent or empty {}.
+  markAttrs: Readonly<Record<string, Readonly<Record<string, AttrSchema>>>>;
+  // Retained for back-compat reads in tests; sanitizer now uses link's AttrSchema.
   allowedLinkSchemes: ReadonlySet<string>;
   // hard cap on total text content (chars). Spec: 50 KB.
   maxTextBytes: number;
 }
 
+// ── Shared scheme sets ────────────────────────────────────────────────────────
+
 const HTTP_ONLY = new Set(['http:', 'https:']);
+
+// ── Shared attr schemas ───────────────────────────────────────────────────────
+
+const uuidRequired: AttrSchema = { kind: 'uuid', required: true };
+
+const attachmentRefAttrs: Readonly<Record<string, AttrSchema>> = {
+  id: uuidRequired,
+};
+
+const linkMarkAttrs: Readonly<Record<string, AttrSchema>> = {
+  href: { kind: 'url', schemes: HTTP_ONLY, maxLen: 2048, required: true },
+};
+
+// ── Surface definitions ───────────────────────────────────────────────────────
 
 export const SURFACE_ALLOWLISTS: Readonly<Record<Surface, SurfaceAllowlist>> = {
   'voc-description': {
@@ -30,17 +65,27 @@ export const SURFACE_ALLOWLISTS: Readonly<Record<Surface, SurfaceAllowlist>> = {
       'attachmentRef',
     ]),
     marks: new Set(['bold', 'italic', 'underline', 'code', 'link']),
+    nodeAttrs: {
+      attachmentRef: attachmentRefAttrs,
+    },
+    markAttrs: {
+      link: linkMarkAttrs,
+    },
     allowedLinkSchemes: HTTP_ONLY,
     maxTextBytes: 50 * 1024,
   },
-  // Tightened for Slice 3 #16 per spec §5.7 table.
+
   // public-update: no links, no attachments, no mentions, no images.
+  // No nodeAttrs or markAttrs entries: all attrs must be absent or empty.
   'public-update': {
     nodes: new Set(['doc', 'paragraph', 'text', 'bulletList', 'orderedList', 'listItem']),
     marks: new Set(['bold', 'italic']),
+    nodeAttrs: {},
+    markAttrs: {},
     allowedLinkSchemes: new Set<string>(),
     maxTextBytes: 50 * 1024,
   },
+
   // reporter-reply: attachmentRef node allowed (value layer rejects non-empty
   // attachments[] until storage slice ships); link mark allowed http/https.
   'reporter-reply': {
@@ -50,9 +95,16 @@ export const SURFACE_ALLOWLISTS: Readonly<Record<Surface, SurfaceAllowlist>> = {
       'attachmentRef',
     ]),
     marks: new Set(['bold', 'italic', 'code', 'link']),
+    nodeAttrs: {
+      attachmentRef: attachmentRefAttrs,
+    },
+    markAttrs: {
+      link: linkMarkAttrs,
+    },
     allowedLinkSchemes: HTTP_ONLY,
     maxTextBytes: 50 * 1024,
   },
+
   // internal-comment: full feature set — codeBlock, mention, attachmentRef,
   // bold, italic, code, link.
   'internal-comment': {
@@ -63,6 +115,19 @@ export const SURFACE_ALLOWLISTS: Readonly<Record<Surface, SurfaceAllowlist>> = {
       'mention', 'attachmentRef',
     ]),
     marks: new Set(['bold', 'italic', 'code', 'link']),
+    nodeAttrs: {
+      attachmentRef: attachmentRefAttrs,
+      mention: {
+        // Canonical attr name per conversation-service.ts:517 (codex major finding).
+        actor_id: uuidRequired,
+      },
+      codeBlock: {
+        language: { kind: 'string', maxLen: 32, nullable: true, required: false },
+      },
+    },
+    markAttrs: {
+      link: linkMarkAttrs,
+    },
     allowedLinkSchemes: HTTP_ONLY,
     maxTextBytes: 50 * 1024,
   },

--- a/apps/backend/src/modules/voc/__tests__/create-voc.integration.test.ts
+++ b/apps/backend/src/modules/voc/__tests__/create-voc.integration.test.ts
@@ -510,7 +510,18 @@ describe.skipIf(!runIntegration)('POST /vocs (#13)', () => {
   });
 
   // ── 12. Sanitizer rejections ──────────────────────────────────────────
-  it.each<[string, () => unknown, 'rich_content.external_image_forbidden' | 'rich_content.disallowed_node']>([
+  // expectedFieldsCode follows sanitize.ts fields_code semantics post-#23:
+  //   - node-type / mark-type / shape failures → 'disallowed_node'
+  //   - bad attr key → 'disallowed_attr_key'
+  //   - bad attr value (URL scheme, UUID, length, etc.) → 'invalid_attr_value'
+  it.each<
+    [
+      string,
+      () => unknown,
+      'rich_content.external_image_forbidden' | 'rich_content.disallowed_node',
+      string,
+    ]
+  >([
     [
       'image node',
       () => ({
@@ -518,6 +529,7 @@ describe.skipIf(!runIntegration)('POST /vocs (#13)', () => {
         content: [{ type: 'image', attrs: { src: 'https://x.example/a.png' } }],
       }),
       'rich_content.external_image_forbidden',
+      'external_image_forbidden',
     ],
     [
       'mention node',
@@ -526,6 +538,7 @@ describe.skipIf(!runIntegration)('POST /vocs (#13)', () => {
         content: [{ type: 'mention', attrs: { id: 'u-1' } }],
       }),
       'rich_content.disallowed_node',
+      'disallowed_node',
     ],
     [
       'javascript: link',
@@ -545,6 +558,7 @@ describe.skipIf(!runIntegration)('POST /vocs (#13)', () => {
         ],
       }),
       'rich_content.disallowed_node',
+      'invalid_attr_value',
     ],
     [
       'oversized text >50KB',
@@ -555,6 +569,7 @@ describe.skipIf(!runIntegration)('POST /vocs (#13)', () => {
         ],
       }),
       'rich_content.disallowed_node',
+      'disallowed_node',
     ],
     [
       'strike mark',
@@ -568,8 +583,9 @@ describe.skipIf(!runIntegration)('POST /vocs (#13)', () => {
         ],
       }),
       'rich_content.disallowed_node',
+      'disallowed_node',
     ],
-  ])('sanitizer rejects %s → 422 %s', async (_label, buildDoc, expectedCode) => {
+  ])('sanitizer rejects %s → 422 %s', async (_label, buildDoc, expectedCode, expectedFieldsCode) => {
     const admin = await loginAs(app, 'mock-admin-1');
     const msId = await createMs(app, admin, 'it-voc-san', 'San MS');
     const reporter = await loginAs(app, 'mock-user-1');
@@ -586,11 +602,38 @@ describe.skipIf(!runIntegration)('POST /vocs (#13)', () => {
     expect(res.statusCode).toBe(422);
     expect(res.json().code).toBe(expectedCode);
     expect(res.json().detail?.fields?.[0]?.path).toEqual(['description_rich_content']);
-    expect(res.json().detail?.fields?.[0]?.code).toBe(
-      expectedCode === 'rich_content.external_image_forbidden'
-        ? 'external_image_forbidden'
-        : 'disallowed_node',
+    expect(res.json().detail?.fields?.[0]?.code).toBe(expectedFieldsCode);
+  });
+
+  // ── 12b. Sanitizer attr-injection (#23) ─────────────────────────────────
+  it('sanitizer rejects attachmentRef.attrs with disallowed_attr_key → 422', async () => {
+    const admin = await loginAs(app, 'mock-admin-1');
+    const msId = await createMs(app, admin, 'it-voc-atki', 'AtKI MS');
+    const reporter = await loginAs(app, 'mock-user-1');
+    const attrInjectionDoc = {
+      type: 'doc',
+      content: [
+        {
+          type: 'attachmentRef',
+          attrs: { id: randomUUID(), onclick: 'x' },
+        },
+      ],
+    };
+    const res = await postVoc(
+      app,
+      reporter,
+      {
+        primary_managed_system_id: msId,
+        title: 'x',
+        description_rich_content: attrInjectionDoc,
+      },
+      randomUUID(),
     );
+    expect(res.statusCode).toBe(422);
+    expect(res.json().code).toBe('rich_content.disallowed_node');
+    expect(res.json().detail?.fields?.[0]?.path).toEqual(['description_rich_content']);
+    expect(res.json().detail?.fields?.[0]?.code).toBe('disallowed_attr_key');
+    expect(res.json().detail?.hint).toMatch(/attrs\.onclick$/);
   });
 
   // ── 13. attachments: [] accepted ──────────────────────────────────────

--- a/apps/backend/src/modules/voc/__tests__/post-internal-comment.integration.test.ts
+++ b/apps/backend/src/modules/voc/__tests__/post-internal-comment.integration.test.ts
@@ -418,6 +418,83 @@ describe.skipIf(!runIntegration)('POST /vocs/:id/internal-comments (#16 C5)', ()
     expect(res.json<{ code: string }>().code).toBe('conflict.record_archived');
   });
 
+  // ── Sanitizer attr-injection (#23) ────────────────────────────────────
+
+  it('body with mention.attrs disallowed label key → 422 disallowed_attr_key', async () => {
+    const msId = await insertMsDirectly(dbHandle, WORKSPACE_ID, `${uid(SLUG_PREFIX)}-atki`, 'AtKI MS');
+    const voc = await insertVoc(msId, 'AtKI VOC');
+
+    const attrInjectionDoc = {
+      type: 'doc',
+      content: [
+        {
+          type: 'mention',
+          attrs: { actor_id: randomUUID(), label: '<x>' },
+        },
+      ],
+    };
+
+    const res = await postInternalComment(adminCookie, voc.id, {
+      body_rich_content: attrInjectionDoc,
+      mentions: [],
+    });
+
+    expect(res.statusCode).toBe(422);
+    expect(res.json<{ code: string }>().code).toBe('rich_content.disallowed_node');
+    expect(res.json<{ detail: { fields: Array<{ path: string[]; code: string }> } }>().detail?.fields?.[0]?.path).toEqual(['body_rich_content']);
+    expect(res.json<{ detail: { fields: Array<{ path: string[]; code: string }> } }>().detail?.fields?.[0]?.code).toBe('disallowed_attr_key');
+    expect(res.json<{ detail: { hint: string } }>().detail?.hint).toMatch(/attrs\.label$/);
+  });
+
+  // ── codeBlock.language round-trip (#23 cycle-1 M2) ──────────────────────
+  // Verifies sanitizer's nullable-string schema + canonical doc rebuild persists
+  // and returns the language attr (null / string / absent) intact through JSONB.
+
+  it.each<[string, unknown, unknown]>([
+    ['language=null', null, null],
+    ['language="ts"', 'ts', 'ts'],
+    ['language absent', undefined, undefined],
+  ])('codeBlock %s round-trips through internal-comment', async (_label, langIn, langExpected) => {
+    const msId = await insertMsDirectly(dbHandle, WORKSPACE_ID, `${uid(SLUG_PREFIX)}-cblk`, 'CodeBlock MS');
+    const voc = await insertVoc(msId, 'CodeBlock VOC');
+
+    const codeBlockNode: Record<string, unknown> = { type: 'codeBlock', content: [{ type: 'text', text: 'console.log(1)' }] };
+    if (langIn !== undefined) {
+      codeBlockNode.attrs = { language: langIn };
+    }
+    const body = { type: 'doc', content: [codeBlockNode] };
+
+    const res = await postInternalComment(adminCookie, voc.id, {
+      body_rich_content: body,
+      mentions: [],
+    });
+    expect(res.statusCode).toBe(201);
+
+    type Reply = { internal_comment: { id: string; body_rich_content: { content: Array<{ type: string; attrs?: { language?: unknown } }> } } };
+    const reply = res.json<Reply>();
+    const cb = reply.internal_comment.body_rich_content.content[0]!;
+    expect(cb.type).toBe('codeBlock');
+    if (langExpected === undefined) {
+      // Canonical rebuild omits empty/absent attrs.
+      expect(cb.attrs).toBeUndefined();
+    } else {
+      expect(cb.attrs?.language).toBe(langExpected);
+    }
+
+    // Verify persisted row matches envelope.
+    const persisted = await dbHandle.pool.query<{ body_rich_content: { content: Array<{ type: string; attrs?: { language?: unknown } }> } }>(
+      `select body_rich_content from voc.voc_internal_comments where id = $1`,
+      [reply.internal_comment.id],
+    );
+    const persistedCb = persisted.rows[0]?.body_rich_content.content[0];
+    expect(persistedCb?.type).toBe('codeBlock');
+    if (langExpected === undefined) {
+      expect(persistedCb?.attrs).toBeUndefined();
+    } else {
+      expect(persistedCb?.attrs?.language).toBe(langExpected);
+    }
+  });
+
   // ── Rate limit: 11th POST within 60s → 429 ──
 
   it('rate limit: 11th POST within 60s → 429 rate_limited.actor', async () => {

--- a/apps/backend/src/modules/voc/__tests__/post-public-update.integration.test.ts
+++ b/apps/backend/src/modules/voc/__tests__/post-public-update.integration.test.ts
@@ -374,6 +374,44 @@ describe.skipIf(!runIntegration)('POST /vocs/:id/public-updates (#16 C5)', () =>
     expect(res.json<{ code: string }>().code).toBe('permission.scope_required');
   });
 
+  // ── Sanitizer attr-injection (#23) ────────────────────────────────────
+
+  it('body with link mark (not in public-update allowlist) + extra target attr → 422 disallowed_node', async () => {
+    const msId = await insertMsDirectly(dbHandle, WORKSPACE_ID, `${uid(SLUG_PREFIX)}-atki`, 'AtKI MS');
+    const voc = await insertVoc(msId, 'AtKI VOC');
+
+    // public-update has no attachmentRef; use link mark on paragraph instead.
+    // Note: link mark itself is NOT in public-update marks allowlist (bold/italic only),
+    // so the mark-type rejection fires before attr-key inspection.
+    // Per plan: "link mark with {href, target: '_blank'} (since public-update has no attachmentRef)"
+    // — assert disallowed_node (mark type rejected, link is not in public-update allowlist).
+    const attrInjectionDoc = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'click',
+              marks: [{ type: 'link', attrs: { href: 'https://example.com', target: '_blank' } }],
+            },
+          ],
+        },
+      ],
+    };
+
+    const res = await postPublicUpdate(adminCookie, voc.id, {
+      skip_public_update: false,
+      body_rich_content: attrInjectionDoc,
+      next_reporter_facing_status: 'received',
+    });
+
+    expect(res.statusCode).toBe(422);
+    expect(res.json<{ code: string }>().code).toBe('rich_content.disallowed_node');
+    expect(res.json<{ detail: { fields: Array<{ path: string[]; code: string }> } }>().detail?.fields?.[0]?.path).toEqual(['body_rich_content']);
+  });
+
   // ── gate stub: evaluateReporterStatusGate returns null ──
 
   it('gate stub: ERROR_CODES contains reporter_facing_status.gate_blocked', () => {

--- a/apps/backend/src/modules/voc/__tests__/post-reporter-reply.integration.test.ts
+++ b/apps/backend/src/modules/voc/__tests__/post-reporter-reply.integration.test.ts
@@ -255,6 +255,33 @@ describe.skipIf(!runIntegration)('POST /vocs/:id/reporter-replies (#16 C5)', () 
     expect(res.json<{ code: string }>().code).toBe('attachment.unsupported_pending_storage_slice');
   });
 
+  // ── Sanitizer attr-injection (#23) ────────────────────────────────────
+
+  it('body with attachmentRef.attrs disallowed_attr_key → 422 disallowed_attr_key', async () => {
+    const msId = await insertMsDirectly(dbHandle, WORKSPACE_ID, `${uid(SLUG_PREFIX)}-atki`, 'AtKI MS');
+    const voc = await insertVoc(msId, 'AtKI VOC');
+
+    const attrInjectionDoc = {
+      type: 'doc',
+      content: [
+        {
+          type: 'attachmentRef',
+          attrs: { id: randomUUID(), onclick: 'x' },
+        },
+      ],
+    };
+
+    const res = await postReporterReply(reporterCookie, voc.id, {
+      body_rich_content: attrInjectionDoc,
+    });
+
+    expect(res.statusCode).toBe(422);
+    expect(res.json<{ code: string }>().code).toBe('rich_content.disallowed_node');
+    expect(res.json<{ detail: { fields: Array<{ path: string[]; code: string }> } }>().detail?.fields?.[0]?.path).toEqual(['body_rich_content']);
+    expect(res.json<{ detail: { fields: Array<{ path: string[]; code: string }> } }>().detail?.fields?.[0]?.code).toBe('disallowed_attr_key');
+    expect(res.json<{ detail: { hint: string } }>().detail?.hint).toMatch(/attrs\.onclick$/);
+  });
+
   // ── Status field on envelope unchanged after reply ──
 
   it('reporter_facing_status on voc envelope unchanged after reply', async () => {

--- a/apps/backend/src/modules/voc/conversation-service.ts
+++ b/apps/backend/src/modules/voc/conversation-service.ts
@@ -176,7 +176,7 @@ function sanitizeOrThrow(
           path: ['body_rich_content'],
           code: result.error.code === 'rich_content.external_image_forbidden'
             ? 'external_image_forbidden'
-            : 'disallowed_node',
+            : (result.error.fields_code ?? 'disallowed_node'),
         },
       ],
       hint: result.error.path,

--- a/apps/backend/src/modules/voc/service.ts
+++ b/apps/backend/src/modules/voc/service.ts
@@ -100,7 +100,7 @@ export function createVocService(deps: VocServiceDeps) {
             path: ['description_rich_content'],
             code: sanitized.error.code === 'rich_content.external_image_forbidden'
               ? 'external_image_forbidden'
-              : 'disallowed_node',
+              : (sanitized.error.fields_code ?? 'disallowed_node'),
           },
         ],
         hint: sanitized.error.path,


### PR DESCRIPTION
Closes #23.

P0 blocking #18 (VOC FE renderer). Stored-XSS prevention by per-attr value schemas + canonical doc rebuild.

## Summary
- `AttrSchema` discriminated union: `uuid`, `url` (`new URL()` parsed, scheme allowlist, maxLen, credential reject), `string` (nullable, maxLen).
- Per-surface `nodeAttrs` / `markAttrs`: `attachmentRef.id`, `mention.actor_id`, `codeBlock.language` (nullable string ≤32), `link.href` (http/https, ≤2048, no creds).
- Sanitizer **rebuilds** a canonical TipTap doc — unknown top-level fields dropped; empty `attrs`/`marks`/`content` omitted.
- `fields[].code` differentiates: `disallowed_node` / `disallowed_attr_key` / `invalid_attr_value`. ADR-0012 wire enum unchanged.

## Threats addressed
- Stored XSS via attacker attr keys (`onclick`, `src='javascript:…'`) on allowlisted node types.
- Stored XSS via bad attr values bypassing key allowlist (`mention.actor_id = '<script>'`).
- Phishing via URL credentials (`https://trusted@evil`).
- Drift via unknown top-level node/mark fields.

## Out of scope (filed as follow-ups, see review docs)
- Render-time client sanitizer (#18 prereq, `F-RENDER-SANITIZE`).
- `rel="noopener noreferrer"` on `target=_blank` (#18 scope, `F-RENDER-LINK-REL`).
- ADR-0012 closed-enum extension for `disallowed_attr` / `missing_required_attr` (`F-ADR-0012-ATTR-CODE`).
- BE-exported canonical fixtures for FE renderer tests (`F-RICH-FIXTURE`).
- Atomic-leaf enforcement for `attachmentRef` / `mention` (`F-RICH-LEAF-NODES`).
- DoS via deep nesting → #24 owns.

## Verify
- `pnpm -w typecheck` — pass.
- `pnpm --filter @fops/backend test` — **505/505** live Postgres (baseline 448, +57).
- 2-cycle adversarial review: codex CLI (cycle-1) + Opus subagent (cycle-2). No unresolved BLOCKER/MAJOR.

## Test plan
- [x] Backend unit + integration green.
- [x] Typecheck.
- [x] Cycle-1 + Cycle-2 reviews.
- [ ] Post-merge: file 5 follow-up issues.
- [ ] Post-merge: memory + llmwiki sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)