### PR TITLE
feat(slice3 #24): sanitizer maxDepth + maxNodes + maxMarks caps

### DIFF
--- a/apps/backend/src/lib/rich-content/__tests__/sanitize.test.ts
+++ b/apps/backend/src/lib/rich-content/__tests__/sanitize.test.ts
@@ -417,3 +417,193 @@ describe('attr allowlist — missing required keys', () => {
     }
   });
 });
+
+// ── Depth / node / mark caps (DoS guard, issue #24) ──────────────────────────
+
+// nestedListDoc(N): doc → bulletList → listItem → bulletList → listItem → ...
+//   (N levels of list wrapping) → paragraph → text
+// Max depth formula: 2*N + 2  (each loop adds 2 levels: bulletList + listItem)
+// N=15 → depth 32 = cap (ok), N=16 → paragraph at depth 33 > cap (fail).
+function nestedListDoc(depth: number) {
+  let node: any = { type: 'paragraph', content: [{ type: 'text', text: 'x' }] };
+  for (let i = 0; i < depth; i++) {
+    node = { type: 'bulletList', content: [{ type: 'listItem', content: [node] }] };
+  }
+  return { type: 'doc', content: [node] };
+}
+
+// wideDoc(W): doc with W paragraphs each containing one text node.
+// nodeCount = 1 (doc) + 2*W → cap 5000 → W=2499 ok (4999 nodes), W=2500 fail (5001).
+function wideDoc(width: number) {
+  return {
+    type: 'doc',
+    content: Array.from({ length: width }, () => ({ type: 'paragraph', content: [{ type: 'text', text: 'x' }] })),
+  };
+}
+
+describe('depth / node / mark caps', () => {
+  // ── Depth ──────────────────────────────────────────────────────────────────
+
+  it('depth 5 (nestedListDoc(1), max depth 4) → ok', () => {
+    const res = sanitizeTipTap({ surface, doc: nestedListDoc(1) as never });
+    expect(res.ok).toBe(true);
+  });
+
+  it('nestedListDoc(15) → max depth 32 = cap → ok (boundary)', () => {
+    const res = sanitizeTipTap({ surface, doc: nestedListDoc(15) as never });
+    expect(res.ok).toBe(true);
+  });
+
+  it('nestedListDoc(16) → paragraph at depth 33 > cap → 422 max depth', () => {
+    const res = sanitizeTipTap({ surface, doc: nestedListDoc(16) as never });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.error.code).toBe('rich_content.disallowed_node');
+      expect(res.error.reason).toMatch(/max depth/);
+    }
+  });
+
+  it('nestedListDoc(100) → 422 max depth (no RangeError)', () => {
+    const res = sanitizeTipTap({ surface, doc: nestedListDoc(100) as never });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.error.reason).toMatch(/max depth/);
+    }
+  });
+
+  it('rejects 10k depth without stack overflow (fast-fail under 500ms)', () => {
+    const start = Date.now();
+    const res = sanitizeTipTap({ surface, doc: nestedListDoc(10_000) as never });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.error.reason).toMatch(/max depth/);
+    }
+    expect(Date.now() - start).toBeLessThan(500);
+  });
+
+  // ── Node count ─────────────────────────────────────────────────────────────
+
+  it('wideDoc(100) → ok', () => {
+    const res = sanitizeTipTap({ surface, doc: wideDoc(100) as never });
+    expect(res.ok).toBe(true);
+  });
+
+  it('wideDoc(2499) → 4999 nodes ≤ cap → ok', () => {
+    const res = sanitizeTipTap({ surface, doc: wideDoc(2499) as never });
+    expect(res.ok).toBe(true);
+  });
+
+  it('exact-5000 nodes (boundary, inclusive) → ok', () => {
+    // doc + 4999 empty paragraphs = 5000 nodes exactly. Pins inclusive boundary
+    // (>maxNodes rejects, not >=). Cycle-1 codex MINOR.
+    const docExact5000 = {
+      type: 'doc',
+      content: Array.from({ length: 4999 }, () => ({ type: 'paragraph' })),
+    };
+    const res = sanitizeTipTap({ surface, doc: docExact5000 as never });
+    expect(res.ok).toBe(true);
+  });
+
+  it('exact-5001 nodes (boundary +1) → 422 max node', () => {
+    const docExact5001 = {
+      type: 'doc',
+      content: Array.from({ length: 5000 }, () => ({ type: 'paragraph' })),
+    };
+    const res = sanitizeTipTap({ surface, doc: docExact5001 as never });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.error.reason).toMatch(/max node/);
+    }
+  });
+
+  it('wideDoc(2500) → 5001 nodes > cap → 422 max node', () => {
+    const res = sanitizeTipTap({ surface, doc: wideDoc(2500) as never });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.error.code).toBe('rich_content.disallowed_node');
+      expect(res.error.reason).toMatch(/max node/);
+    }
+  });
+
+  // ── Mark count ─────────────────────────────────────────────────────────────
+
+  it('single text node with 100 bold marks → ok', () => {
+    const res = sanitizeTipTap({
+      surface,
+      doc: {
+        type: 'doc',
+        content: [{
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'x', marks: Array.from({ length: 100 }, () => ({ type: 'bold' })) }],
+        }],
+      } as never,
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it('single text node with 1500 bold marks → 422 max mark (mark fan-out BLOCKER)', () => {
+    const res = sanitizeTipTap({
+      surface,
+      doc: {
+        type: 'doc',
+        content: [{
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'x', marks: Array.from({ length: 1500 }, () => ({ type: 'bold' })) }],
+        }],
+      } as never,
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.error.code).toBe('rich_content.disallowed_node');
+      expect(res.error.reason).toMatch(/max mark/);
+    }
+  });
+
+  // ── Counter-placement regression ───────────────────────────────────────────
+
+  // 6 paragraphs × 200 bold marks = 1200 total marks > 1000 cap.
+  // Node count = 1 (doc) + 6*2 (paragraph + text) = 13 << 5000 cap.
+  // Reason must be max mark, NOT max node.
+  it('6 paragraphs each with 200 bold marks → mark cap fires before node cap', () => {
+    const res = sanitizeTipTap({
+      surface,
+      doc: {
+        type: 'doc',
+        content: Array.from({ length: 6 }, () => ({
+          type: 'paragraph',
+          content: [{
+            type: 'text',
+            text: 'x',
+            marks: Array.from({ length: 200 }, () => ({ type: 'bold' })),
+          }],
+        })),
+      } as never,
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.error.reason).toMatch(/max mark/);
+      expect(res.error.reason).not.toMatch(/max node/);
+    }
+  });
+
+  // ── Text byte cap regression ───────────────────────────────────────────────
+
+  it('50KB text inside depth-5 doc → text byte cap fires (not depth/node cap)', () => {
+    const big = 'a'.repeat(50 * 1024 + 1);
+    const res = sanitizeTipTap({
+      surface,
+      doc: {
+        type: 'doc',
+        content: [{ type: 'paragraph', content: [{ type: 'text', text: big }] }],
+      } as never,
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.error.code).toBe('rich_content.disallowed_node');
+      expect(res.error.reason).toMatch(/max bytes/);
+      expect(res.error.reason).toMatch(/51200/); // cap value rendered
+      expect(res.error.reason).not.toMatch(/max depth/);
+      expect(res.error.reason).not.toMatch(/max node/);
+    }
+  });
+});

--- a/apps/backend/src/lib/rich-content/sanitize.ts
+++ b/apps/backend/src/lib/rich-content/sanitize.ts
@@ -227,8 +227,20 @@ export function sanitizeTipTap(args: {
   }
 
   let totalText = 0;
+  let nodeCount = 0;
+  let markCount = 0;
 
   const visitMark = (raw: unknown, path: string): { mark: CleanMark } | { error: RichContentError } => {
+    markCount++;
+    if (markCount > allow.maxMarks) {
+      return {
+        error: {
+          code: 'rich_content.disallowed_node',
+          reason: `max mark count exceeded (cap: ${allow.maxMarks})`,
+          path,
+        },
+      };
+    }
     if (!isPlainObject(raw) || typeof raw.type !== 'string') {
       return {
         error: {
@@ -259,7 +271,26 @@ export function sanitizeTipTap(args: {
     return { mark: cleanMark };
   };
 
-  const visit = (raw: unknown, path: string): VisitResult => {
+  const visit = (raw: unknown, path: string, depth: number): VisitResult => {
+    nodeCount++;
+    if (nodeCount > allow.maxNodes) {
+      return {
+        error: {
+          code: 'rich_content.disallowed_node',
+          reason: `max node count exceeded (cap: ${allow.maxNodes})`,
+          path,
+        },
+      };
+    }
+    if (depth > allow.maxDepth) {
+      return {
+        error: {
+          code: 'rich_content.disallowed_node',
+          reason: `max depth exceeded (cap: ${allow.maxDepth})`,
+          path,
+        },
+      };
+    }
     if (!isPlainObject(raw) || typeof raw.type !== 'string') {
       return {
         error: {
@@ -301,7 +332,7 @@ export function sanitizeTipTap(args: {
         return {
           error: {
             code: 'rich_content.disallowed_node',
-            reason: 'text content exceeds 50KB cap',
+            reason: `text content exceeds max bytes (cap: ${allow.maxTextBytes})`,
             path,
           },
         };
@@ -327,7 +358,7 @@ export function sanitizeTipTap(args: {
     const cleanContent: CleanNode[] = [];
     if (Array.isArray(node.content)) {
       for (let i = 0; i < node.content.length; i++) {
-        const childResult = visit(node.content[i], `${path}.content[${i}]`);
+        const childResult = visit(node.content[i], `${path}.content[${i}]`, depth + 1);
         if ('error' in childResult) return childResult;
         cleanContent.push(childResult.node);
       }
@@ -351,7 +382,7 @@ export function sanitizeTipTap(args: {
     return { node: cleanNode };
   };
 
-  const rootResult = visit(root, '$');
+  const rootResult = visit(root, '$', 0);
   if ('error' in rootResult) return { ok: false, error: rootResult.error };
   return { ok: true, doc: rootResult.node as unknown as TipTapDoc };
 }

--- a/apps/backend/src/lib/rich-content/surface-allowlists.ts
+++ b/apps/backend/src/lib/rich-content/surface-allowlists.ts
@@ -24,6 +24,20 @@ export type AttrSchema =
 
 // ── SurfaceAllowlist ──────────────────────────────────────────────────────────
 
+// DoS caps — these are hard structural limits, NOT UX allowances.
+// They exist to prevent adversarial payloads from exhausting the V8 call stack
+// (deep nesting) or burning CPU (extremely wide / mark-heavy documents).
+//
+// Depth counts edges from the root doc node (depth 0) to the deepest descendant.
+// A typical rich TipTap document with ~6 list levels and inline structure reaches
+// depth ~12; cap at 32 gives ~2.5× safety margin with zero impact on real content.
+//
+// Node and mark counts are cumulative over the whole document (not per-level).
+// Real internal-comment threads rarely exceed a few hundred nodes; 5 000 / 1 000
+// provide ~10× headroom while hard-capping adversarial fan-out.
+//
+// Per-surface override is reserved for future tuning; all surfaces share these
+// defaults as locked in the cycle-1 plan review for issue #24.
 export interface SurfaceAllowlist {
   nodes: ReadonlySet<string>;
   marks: ReadonlySet<string>;
@@ -37,6 +51,10 @@ export interface SurfaceAllowlist {
   allowedLinkSchemes: ReadonlySet<string>;
   // hard cap on total text content (chars). Spec: 50 KB.
   maxTextBytes: number;
+  // DoS structural caps (see header comment above).
+  maxDepth: number;
+  maxNodes: number;
+  maxMarks: number;
 }
 
 // ── Shared scheme sets ────────────────────────────────────────────────────────
@@ -73,6 +91,9 @@ export const SURFACE_ALLOWLISTS: Readonly<Record<Surface, SurfaceAllowlist>> = {
     },
     allowedLinkSchemes: HTTP_ONLY,
     maxTextBytes: 50 * 1024,
+    maxDepth: 32,
+    maxNodes: 5000,
+    maxMarks: 1000,
   },
 
   // public-update: no links, no attachments, no mentions, no images.
@@ -84,6 +105,9 @@ export const SURFACE_ALLOWLISTS: Readonly<Record<Surface, SurfaceAllowlist>> = {
     markAttrs: {},
     allowedLinkSchemes: new Set<string>(),
     maxTextBytes: 50 * 1024,
+    maxDepth: 32,
+    maxNodes: 5000,
+    maxMarks: 1000,
   },
 
   // reporter-reply: attachmentRef node allowed (value layer rejects non-empty
@@ -103,6 +127,9 @@ export const SURFACE_ALLOWLISTS: Readonly<Record<Surface, SurfaceAllowlist>> = {
     },
     allowedLinkSchemes: HTTP_ONLY,
     maxTextBytes: 50 * 1024,
+    maxDepth: 32,
+    maxNodes: 5000,
+    maxMarks: 1000,
   },
 
   // internal-comment: full feature set — codeBlock, mention, attachmentRef,
@@ -130,5 +157,8 @@ export const SURFACE_ALLOWLISTS: Readonly<Record<Surface, SurfaceAllowlist>> = {
     },
     allowedLinkSchemes: HTTP_ONLY,
     maxTextBytes: 50 * 1024,
+    maxDepth: 32,
+    maxNodes: 5000,
+    maxMarks: 1000,
   },
 };


### PR DESCRIPTION
Closes #24.

P0 blocking #18. Prevents authenticated DoS via deeply-nested or mark-fan-out TipTap payloads.

## Summary
- `visit()` takes `depth` param; outer-closure `nodeCount` + `markCount`.
- Both counters check **first** in `visit()` / `visitMark()`, before any shape/type work.
- All 4 surfaces: `maxDepth=32`, `maxNodes=5000`, `maxMarks=1000`.
- Text-cap reason now interpolates `allow.maxTextBytes` (cycle-1 plan MINOR).
- `rich_content.disallowed_node` (ADR-0012 enum unchanged), `reason` distinguishes (`max depth/node/mark exceeded (cap: N)`).

## Threats addressed
- Deep nesting (10k+ levels) → stack overflow. Now: 422 in ms.
- Mark fan-out (one text node + 50k marks) escaping nodeCount. Now: 422 via separate `maxMarks` counter (cycle-1 plan BLOCKER fix).
- Wide branching CPU burn → 422 via `maxNodes`.

## Verify
- `pnpm -w typecheck` — pass.
- `pnpm --filter @fops/backend test` — **519/519** live Postgres (+14 from 505).
- 2-cycle review: codex CLI + Opus — 0 BLOCKER/MAJOR.

## Out of scope
- Iterative rewrite of `visit()` — depth param is sufficient + simpler; canonical-rebuild logic stays in closure.
- Per-surface cap variation — kept uniform for now; SurfaceAllowlist accepts overrides for future tuning.
- Integration tests — unit covers; existing 422 mapping unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)