### PR TITLE
feat(slice3 #17): PATCH /vocs/:id/description Reporter pre-triage edit — Slice 3 BE EXIT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ test-results
 
 # Local Claude Code harness settings — per-developer
 .claude/settings.json
+report/

--- a/apps/backend/src/lib/json/__tests__/stable-stringify.test.ts
+++ b/apps/backend/src/lib/json/__tests__/stable-stringify.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { stableStringify } from '../stable-stringify.js';
+
+describe('stableStringify', () => {
+  it('produces same output regardless of key insertion order (flat object)', () => {
+    const a = stableStringify({ b: 1, a: 2 });
+    const b = stableStringify({ a: 2, b: 1 });
+    expect(a).toBe(b);
+    expect(a).toBe('{"a":2,"b":1}');
+  });
+
+  it('sorts nested object keys recursively', () => {
+    const a = stableStringify({ x: { b: 1, a: 2 } });
+    const b = stableStringify({ x: { a: 2, b: 1 } });
+    expect(a).toBe(b);
+    expect(a).toBe('{"x":{"a":2,"b":1}}');
+  });
+
+  it('preserves array order — [1,2] !== [2,1]', () => {
+    const a = stableStringify([1, 2]);
+    const b = stableStringify([2, 1]);
+    expect(a).not.toBe(b);
+    expect(a).toBe('[1,2]');
+    expect(b).toBe('[2,1]');
+  });
+
+  it('handles null', () => {
+    expect(stableStringify(null)).toBe('null');
+  });
+
+  it('handles strings', () => {
+    expect(stableStringify('hello')).toBe('"hello"');
+  });
+
+  it('handles numbers', () => {
+    expect(stableStringify(42)).toBe('42');
+  });
+
+  it('handles booleans', () => {
+    expect(stableStringify(true)).toBe('true');
+    expect(stableStringify(false)).toBe('false');
+  });
+
+  it('handles empty object', () => {
+    expect(stableStringify({})).toBe('{}');
+  });
+
+  it('handles empty array', () => {
+    expect(stableStringify([])).toBe('[]');
+  });
+
+  it('handles array of objects with shuffled keys', () => {
+    const a = stableStringify([{ b: 1, a: 2 }, { d: 3, c: 4 }]);
+    const b = stableStringify([{ a: 2, b: 1 }, { c: 4, d: 3 }]);
+    expect(a).toBe(b);
+  });
+
+  it('TipTap-like doc with shuffled attrs sorts deterministically', () => {
+    const doc1 = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          attrs: { id: 'abc', class: 'prose' },
+          content: [{ type: 'text', text: 'hello' }],
+        },
+      ],
+    };
+    const doc2 = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          attrs: { class: 'prose', id: 'abc' },
+          content: [{ type: 'text', text: 'hello' }],
+        },
+      ],
+    };
+    expect(stableStringify(doc1)).toBe(stableStringify(doc2));
+  });
+});

--- a/apps/backend/src/lib/json/stable-stringify.ts
+++ b/apps/backend/src/lib/json/stable-stringify.ts
@@ -1,0 +1,23 @@
+// Recursive sorted-key JSON serializer for deterministic SHA-256 input.
+// Arrays preserve order (TipTap doc semantics depend on node sequence).
+// Primitives (string, number, boolean, null, undefined) delegate to
+// JSON.stringify so NaN/Infinity/undefined edge cases are handled
+// consistently with the standard library.
+
+export function stableStringify(v: unknown): string {
+  if (v === null || v === undefined) {
+    return JSON.stringify(v) ?? 'null';
+  }
+  if (Array.isArray(v)) {
+    const items = v.map((item) => stableStringify(item));
+    return `[${items.join(',')}]`;
+  }
+  if (typeof v === 'object') {
+    const obj = v as Record<string, unknown>;
+    const keys = Object.keys(obj).sort();
+    const pairs = keys.map((k) => `${JSON.stringify(k)}:${stableStringify(obj[k])}`);
+    return `{${pairs.join(',')}}`;
+  }
+  // primitives: string, number, boolean
+  return JSON.stringify(v);
+}

--- a/apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts
+++ b/apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts
@@ -1,0 +1,1080 @@
+// PATCH /vocs/:id/description integration tests — Slice 3 #17 acceptance coverage.
+//
+// Mirrors patch-voc.integration.test.ts harness.
+// Gate: DATABASE_URL + WORKSPACE_ID. Skips if not configured.
+
+import { randomUUID } from 'node:crypto';
+
+import type { FastifyInstance } from 'fastify';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import { loadConfig } from '../../../config.js';
+import { type DbHandle, createDb } from '../../../db/client.js';
+import { SESSION_COOKIE_NAME } from '../../../middleware/require-session.js';
+import { buildServer } from '../../../server.js';
+
+const APP_URL = process.env.DATABASE_URL ?? '';
+const MIGRATE_URL = process.env.DATABASE_URL_MIGRATE ?? '';
+const WORKSPACE_ID = process.env.WORKSPACE_ID ?? '';
+const runIntegration = Boolean(APP_URL && WORKSPACE_ID);
+
+// ── helpers ──────────────────────────────────────────────────────────────
+function extractSessionCookie(setCookie: string | string[] | undefined): string | null {
+  if (!setCookie) return null;
+  const arr = Array.isArray(setCookie) ? setCookie : [setCookie];
+  for (const c of arr) {
+    const m = c.match(new RegExp(`${SESSION_COOKIE_NAME}=([^;]+)`));
+    if (m?.[1]) return m[1];
+  }
+  return null;
+}
+
+async function loginAs(app: FastifyInstance, externalId: string): Promise<string> {
+  const res = await app.inject({
+    method: 'POST',
+    url: '/auth/mock-login',
+    headers: { 'user-agent': 'integration-test' },
+    payload: { external_id: externalId },
+  });
+  const cookie = extractSessionCookie(res.headers['set-cookie']);
+  if (!cookie) throw new Error(`mock-login failed: ${res.statusCode} ${res.body}`);
+  return cookie;
+}
+
+async function createMs(
+  app: FastifyInstance,
+  cookie: string,
+  slug: string,
+  name: string,
+): Promise<string> {
+  const res = await app.inject({
+    method: 'POST',
+    url: '/managed-systems',
+    headers: { cookie: `${SESSION_COOKIE_NAME}=${cookie}`, 'content-type': 'application/json' },
+    payload: { slug, name },
+  });
+  if (res.statusCode !== 201) throw new Error(`createMs failed: ${res.statusCode} ${res.body}`);
+  return res.json().id;
+}
+
+function paragraphDoc(text: string) {
+  return {
+    type: 'doc' as const,
+    content: [
+      {
+        type: 'paragraph',
+        content: [{ type: 'text', text }],
+      },
+    ],
+  };
+}
+
+async function postVoc(
+  app: FastifyInstance,
+  cookie: string,
+  body: Record<string, unknown>,
+  idempotencyKey: string,
+) {
+  const res = await app.inject({
+    method: 'POST',
+    url: '/vocs',
+    headers: {
+      cookie: `${SESSION_COOKIE_NAME}=${cookie}`,
+      'content-type': 'application/json',
+      'idempotency-key': idempotencyKey,
+    },
+    payload: body,
+  });
+  if (res.statusCode !== 201) throw new Error(`postVoc failed: ${res.statusCode} ${res.body}`);
+  return res.json() as { id: string; display_id: string; updated_at: string };
+}
+
+function patchDescription(
+  app: FastifyInstance,
+  cookie: string,
+  vocId: string,
+  body: Record<string, unknown>,
+  opts: { idempotencyKey?: string; ifMatch?: string } = {},
+) {
+  const headers: Record<string, string> = {
+    cookie: `${SESSION_COOKIE_NAME}=${cookie}`,
+    'content-type': 'application/json',
+  };
+  if (opts.idempotencyKey !== undefined) headers['idempotency-key'] = opts.idempotencyKey;
+  if (opts.ifMatch !== undefined) headers['if-match'] = opts.ifMatch;
+  return app.inject({
+    method: 'PATCH',
+    url: `/vocs/${vocId}/description`,
+    headers,
+    payload: body,
+  });
+}
+
+// Inserts a reporter-role actor directly. Returns id + externalId.
+async function insertReporterActor(
+  dbHandle: DbHandle,
+  workspaceId: string,
+  suffix: string,
+): Promise<{ id: string; externalId: string }> {
+  const externalId = `mock-reporter-${suffix}`;
+  const res = await dbHandle.pool.query<{ id: string }>(
+    `insert into core.actors (workspace_id, external_id, email, display_name, role_level, actor_type)
+       values ($1, $2, $3, $4, 'user', 'internal_member')
+       on conflict (workspace_id, external_id) do update set email = excluded.email
+       returning id`,
+    [workspaceId, externalId, `reporter-${suffix}@local`, `Reporter ${suffix}`],
+  );
+  const id = res.rows[0]?.id;
+  if (!id) throw new Error(`insertReporterActor failed for ${externalId}`);
+  return { id, externalId };
+}
+
+// Inserts a developer-role actor directly.
+async function insertDevActor(
+  dbHandle: DbHandle,
+  workspaceId: string,
+  suffix: string,
+): Promise<{ id: string; externalId: string }> {
+  const externalId = `mock-dev-desc-${suffix}`;
+  const res = await dbHandle.pool.query<{ id: string }>(
+    `insert into core.actors (workspace_id, external_id, email, display_name, role_level, actor_type)
+       values ($1, $2, $3, $4, 'developer', 'internal_member')
+       on conflict (workspace_id, external_id) do update set email = excluded.email
+       returning id`,
+    [workspaceId, externalId, `dev-desc-${suffix}@local`, `Dev Desc ${suffix}`],
+  );
+  const id = res.rows[0]?.id;
+  if (!id) throw new Error(`insertDevActor failed for ${externalId}`);
+  return { id, externalId };
+}
+
+// Grants voc.triage for a managed system.
+async function grantVocTriage(
+  dbHandle: DbHandle,
+  workspaceId: string,
+  actorId: string,
+  msId: string,
+  grantedByActorId: string,
+): Promise<void> {
+  await dbHandle.pool.query(
+    `insert into permission.permission_grants
+       (workspace_id, actor_id, capability, managed_system_id, granted_by_actor_id)
+     values ($1, $2, 'voc.triage', $3, $4)
+     on conflict do nothing`,
+    [workspaceId, actorId, msId, grantedByActorId],
+  );
+}
+
+// Archives a VOC row directly.
+async function archiveVoc(dbHandle: DbHandle, vocId: string): Promise<void> {
+  await dbHandle.pool.query(
+    `update voc.vocs set archived_at = now() where id = $1`,
+    [vocId],
+  );
+}
+
+// Archives a managed system directly.
+async function archiveMs(dbHandle: DbHandle, msId: string): Promise<void> {
+  await dbHandle.pool.query(
+    `update core.managed_systems set archived_at = now() where id = $1`,
+    [msId],
+  );
+}
+
+// Forces triage_state to a non-untriaged value directly.
+async function forceTriageState(
+  dbHandle: DbHandle,
+  vocId: string,
+  state: string,
+): Promise<void> {
+  await dbHandle.pool.query(
+    `update voc.vocs set triage_state = $2, updated_at = now() where id = $1`,
+    [vocId, state],
+  );
+}
+
+// Returns audit detail rows for a given subject + event.
+async function getAuditDetail(
+  vocId: string,
+  eventType: string,
+): Promise<Record<string, unknown> | null> {
+  if (!MIGRATE_URL) return null;
+  const ops = createDb(MIGRATE_URL);
+  try {
+    const rows = await ops.pool.query<{ detail: Record<string, unknown> }>(
+      `select detail from core.audit_log where subject_id = $1 and event_type = $2 order by created_at asc limit 1`,
+      [vocId, eventType],
+    );
+    return rows.rows[0]?.detail ?? null;
+  } finally {
+    await ops.close();
+  }
+}
+
+// Counts audit rows of a given type for subject.
+async function countAuditRows(vocId: string, eventType: string): Promise<number> {
+  if (!MIGRATE_URL) return -1;
+  const ops = createDb(MIGRATE_URL);
+  try {
+    const rows = await ops.pool.query<{ n: string }>(
+      `select count(*) as n from core.audit_log where subject_id = $1 and event_type = $2`,
+      [vocId, eventType],
+    );
+    return parseInt(rows.rows[0]?.n ?? '0', 10);
+  } finally {
+    await ops.close();
+  }
+}
+
+describe.skipIf(!runIntegration)('PATCH /vocs/:id/description (#17)', () => {
+  let dbHandle: DbHandle;
+  let app: FastifyInstance;
+  let adminActorId: string;
+
+  async function cleanupProductTables() {
+    await dbHandle.pool.query(
+      `delete from permission.permission_grants
+        where workspace_id = $1
+          and actor_id in (
+            select id from core.actors
+              where (external_id like 'mock-dev-desc-%' or external_id like 'mock-reporter-%')
+                and workspace_id = $1
+          )`,
+      [WORKSPACE_ID],
+    );
+    await dbHandle.pool.query(
+      `delete from voc.vocs
+        where primary_managed_system_id in (
+          select id from core.managed_systems where slug like 'it-pd-%'
+        )`,
+    );
+    await dbHandle.pool.query(
+      `delete from core.analytics_areas
+        where managed_system_id in (
+          select id from core.managed_systems where slug like 'it-pd-%'
+        )`,
+    );
+    await dbHandle.pool.query(`delete from core.managed_systems where slug like 'it-pd-%'`);
+    await dbHandle.pool.query('delete from core.idempotency_keys');
+    await dbHandle.pool.query('delete from core.rate_limits');
+    await dbHandle.pool.query(
+      `delete from core.sessions where created_user_agent_summary = 'integration-test'
+         or actor_id in (
+           select id from core.actors
+             where (external_id like 'mock-dev-desc-%' or external_id like 'mock-reporter-%')
+               and workspace_id = $1
+         )`,
+      [WORKSPACE_ID],
+    );
+    await dbHandle.pool.query(
+      `delete from core.actors
+        where (external_id like 'mock-dev-desc-%' or external_id like 'mock-reporter-%')
+          and workspace_id = $1`,
+      [WORKSPACE_ID],
+    );
+  }
+
+  async function cleanupAuditLog() {
+    if (!MIGRATE_URL) return;
+    const ops = createDb(MIGRATE_URL);
+    try {
+      await ops.pool.query(
+        `delete from core.audit_log
+          where event_type in (
+            'voc_created', 'voc_description_edited',
+            'managed_system_registered'
+          )
+          and subject_id in (
+            select id from voc.vocs
+             where primary_managed_system_id in (
+               select id from core.managed_systems where slug like 'it-pd-%'
+             )
+            union
+            select id from core.managed_systems where slug like 'it-pd-%'
+          )`,
+      );
+    } finally {
+      await ops.close();
+    }
+  }
+
+  beforeAll(async () => {
+    process.env.NODE_ENV = 'test';
+    dbHandle = createDb(APP_URL);
+    app = await buildServer({ config: loadConfig(), dbHandle });
+    await app.ready();
+
+    const r = await dbHandle.pool.query<{ id: string }>(
+      `select id from core.actors where external_id = 'mock-admin-1' and workspace_id = $1`,
+      [WORKSPACE_ID],
+    );
+    const id = r.rows[0]?.id;
+    if (!id) throw new Error(`mock-admin-1 in ${WORKSPACE_ID} not found`);
+    adminActorId = id;
+  });
+
+  afterAll(async () => {
+    await cleanupAuditLog();
+    await cleanupProductTables();
+    await app?.close();
+    await dbHandle?.close();
+  });
+
+  beforeEach(async () => {
+    await cleanupAuditLog();
+    await cleanupProductTables();
+  });
+
+  // ── Happy paths ──────────────────────────────────────────────────────────
+
+  // Case 1: all 3 fields
+  it('case 1: Reporter edits own untriaged VOC with all 3 fields → 200, audit row with full diff', async () => {
+    const admin = await loginAs(app, 'mock-admin-1');
+    const msId = await createMs(app, admin, 'it-pd-happy-all', 'Happy All');
+    const reporter = await loginAs(app, 'mock-user-1');
+    const voc = await postVoc(app, reporter, {
+      primary_managed_system_id: msId,
+      title: 'original title',
+      description_rich_content: paragraphDoc('original'),
+    }, randomUUID());
+
+    const res = await patchDescription(app, reporter, voc.id, {
+      title: 'updated title',
+      description_rich_content: paragraphDoc('updated content'),
+      attachments: [],
+    }, { idempotencyKey: randomUUID(), ifMatch: voc.updated_at });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.title).toBe('updated title');
+    expect(body.updated_at).not.toBe(voc.updated_at);
+
+    if (MIGRATE_URL) {
+      const detail = await getAuditDetail(voc.id, 'voc_description_edited');
+      expect(detail).not.toBeNull();
+      expect(detail?.changes).toMatchObject({
+        title: { from: 'original title', to: 'updated title' },
+      });
+      expect((detail?.changes as Record<string, unknown>).description_rich_content).toBeDefined();
+    }
+  });
+
+  // Case 2: title-only
+  it('case 2: title-only edit → 200; audit changes carries only title', async () => {
+    const admin = await loginAs(app, 'mock-admin-1');
+    const msId = await createMs(app, admin, 'it-pd-title-only', 'Title Only');
+    const reporter = await loginAs(app, 'mock-user-1');
+    const voc = await postVoc(app, reporter, {
+      primary_managed_system_id: msId,
+      title: 'old title',
+      description_rich_content: paragraphDoc('body'),
+    }, randomUUID());
+
+    const res = await patchDescription(app, reporter, voc.id, {
+      title: 'new title',
+    }, { idempotencyKey: randomUUID(), ifMatch: voc.updated_at });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().title).toBe('new title');
+
+    if (MIGRATE_URL) {
+      const detail = await getAuditDetail(voc.id, 'voc_description_edited');
+      expect(detail?.changes).toMatchObject({ title: { from: 'old title', to: 'new title' } });
+      expect((detail?.changes as Record<string, unknown>).description_rich_content).toBeUndefined();
+    }
+  });
+
+  // Case 3: description-only
+  it('case 3: description_rich_content-only edit → 200; audit carries from_hash/to_hash', async () => {
+    const admin = await loginAs(app, 'mock-admin-1');
+    const msId = await createMs(app, admin, 'it-pd-desc-only', 'Desc Only');
+    const reporter = await loginAs(app, 'mock-user-1');
+    const voc = await postVoc(app, reporter, {
+      primary_managed_system_id: msId,
+      title: 'title stays',
+      description_rich_content: paragraphDoc('original body'),
+    }, randomUUID());
+
+    const res = await patchDescription(app, reporter, voc.id, {
+      description_rich_content: paragraphDoc('updated body'),
+    }, { idempotencyKey: randomUUID(), ifMatch: voc.updated_at });
+
+    expect(res.statusCode).toBe(200);
+
+    if (MIGRATE_URL) {
+      const detail = await getAuditDetail(voc.id, 'voc_description_edited');
+      const changes = detail?.changes as Record<string, unknown> | undefined;
+      expect(changes?.description_rich_content).toBeDefined();
+      const hashChange = changes?.description_rich_content as { from_hash: string; to_hash: string };
+      expect(hashChange.from_hash).toHaveLength(64);
+      expect(hashChange.to_hash).toHaveLength(64);
+      expect(hashChange.from_hash).not.toBe(hashChange.to_hash);
+      expect(changes?.title).toBeUndefined();
+    }
+  });
+
+  // Case 4: empty attachments when current is also empty — no diff
+  it('case 4: attachments: [] when current is [] → no attachments diff; if title unchanged → no audit', async () => {
+    const admin = await loginAs(app, 'mock-admin-1');
+    const msId = await createMs(app, admin, 'it-pd-attach-noop', 'Attach Noop');
+    const reporter = await loginAs(app, 'mock-user-1');
+    const voc = await postVoc(app, reporter, {
+      primary_managed_system_id: msId,
+      title: 'same title',
+      description_rich_content: paragraphDoc('same body'),
+    }, randomUUID());
+
+    // Send title same value + attachments: [] — only attachments in body
+    // but title is unchanged and description is unchanged, so empty diff.
+    const res = await patchDescription(app, reporter, voc.id, {
+      attachments: [],
+    }, { idempotencyKey: randomUUID(), ifMatch: voc.updated_at });
+
+    expect(res.statusCode).toBe(200);
+    // updated_at should NOT change — empty diff
+    expect(res.json().updated_at).toBe(voc.updated_at);
+
+    if (MIGRATE_URL) {
+      const count = await countAuditRows(voc.id, 'voc_description_edited');
+      expect(count).toBe(0);
+    }
+  });
+
+  // ── Permission ──────────────────────────────────────────────────────────
+
+  // Case 5: other reporter
+  it('case 5: other Reporter on someone else\'s VOC → 403 permission.denied', async () => {
+    const admin = await loginAs(app, 'mock-admin-1');
+    const msId = await createMs(app, admin, 'it-pd-other-reporter', 'Other Reporter');
+    const reporter1 = await loginAs(app, 'mock-user-1');
+    const voc = await postVoc(app, reporter1, {
+      primary_managed_system_id: msId,
+      title: 'reporter1 voc',
+      description_rich_content: paragraphDoc('body'),
+    }, randomUUID());
+
+    // Create a second reporter
+    const { externalId: r2ExternalId } = await insertReporterActor(
+      dbHandle, WORKSPACE_ID, `5-${randomUUID().slice(0, 8)}`,
+    );
+    const reporter2 = await loginAs(app, r2ExternalId);
+
+    const res = await patchDescription(app, reporter2, voc.id, {
+      title: 'hacked title',
+    }, { idempotencyKey: randomUUID(), ifMatch: voc.updated_at });
+
+    expect(res.statusCode).toBe(403);
+    expect(res.json().code).toBe('permission.denied');
+  });
+
+  // Case 6: workspace admin
+  it('case 6: Workspace Admin on reporter\'s VOC → 403 permission.denied (no admin elevation)', async () => {
+    const admin = await loginAs(app, 'mock-admin-1');
+    const msId = await createMs(app, admin, 'it-pd-admin-denied', 'Admin Denied');
+    const reporter = await loginAs(app, 'mock-user-1');
+    const voc = await postVoc(app, reporter, {
+      primary_managed_system_id: msId,
+      title: 'reporter voc',
+      description_rich_content: paragraphDoc('body'),
+    }, randomUUID());
+
+    const res = await patchDescription(app, admin, voc.id, {
+      title: 'admin edited',
+    }, { idempotencyKey: randomUUID(), ifMatch: voc.updated_at });
+
+    expect(res.statusCode).toBe(403);
+    expect(res.json().code).toBe('permission.denied');
+  });
+
+  // Case 7: developer with voc.triage capability
+  it('case 7: Developer with voc.triage capability → 403 permission.denied', async () => {
+    const admin = await loginAs(app, 'mock-admin-1');
+    const msId = await createMs(app, admin, 'it-pd-dev-denied', 'Dev Denied');
+    const reporter = await loginAs(app, 'mock-user-1');
+    const voc = await postVoc(app, reporter, {
+      primary_managed_system_id: msId,
+      title: 'reporter voc',
+      description_rich_content: paragraphDoc('body'),
+    }, randomUUID());
+
+    const { id: devId, externalId: devExtId } = await insertDevActor(
+      dbHandle, WORKSPACE_ID, `7-${randomUUID().slice(0, 8)}`,
+    );
+    await grantVocTriage(dbHandle, WORKSPACE_ID, devId, msId, adminActorId);
+    const dev = await loginAs(app, devExtId);
+
+    const res = await patchDescription(app, dev, voc.id, {
+      title: 'dev hacked',
+    }, { idempotencyKey: randomUUID(), ifMatch: voc.updated_at });
+
+    expect(res.statusCode).toBe(403);
+    expect(res.json().code).toBe('permission.denied');
+  });
+
+  // ── State ───────────────────────────────────────────────────────────────
+
+  // Case 8: triaged VOC
+  it('case 8: triaged VOC (triage_state=triaged) → 409 conflict.triage_already_committed', async () => {
+    const admin = await loginAs(app, 'mock-admin-1');
+    const msId = await createMs(app, admin, 'it-pd-triaged', 'Triaged');
+    const reporter = await loginAs(app, 'mock-user-1');
+    const voc = await postVoc(app, reporter, {
+      primary_managed_system_id: msId,
+      title: 'to be triaged',
+      description_rich_content: paragraphDoc('body'),
+    }, randomUUID());
+
+    // Force triage state via SQL
+    await forceTriageState(dbHandle, voc.id, 'triaged');
+
+    // Refresh updated_at
+    const fresh = await dbHandle.pool.query<{ updated_at: string }>(
+      `select updated_at::text as updated_at from voc.vocs where id = $1`,
+      [voc.id],
+    );
+    const freshAt = fresh.rows[0]?.updated_at ?? voc.updated_at;
+
+    const res = await patchDescription(app, reporter, voc.id, {
+      title: 'edit after triage',
+    }, { idempotencyKey: randomUUID(), ifMatch: freshAt });
+
+    expect(res.statusCode).toBe(409);
+    const body = res.json();
+    expect(body.code).toBe('conflict.triage_already_committed');
+    expect(body.detail?.current_triage_state).toBe('triaged');
+  });
+
+  // Case 9: archived VOC
+  it('case 9: archived VOC → 409 conflict.record_archived', async () => {
+    const admin = await loginAs(app, 'mock-admin-1');
+    const msId = await createMs(app, admin, 'it-pd-archived', 'Archived');
+    const reporter = await loginAs(app, 'mock-user-1');
+    const voc = await postVoc(app, reporter, {
+      primary_managed_system_id: msId,
+      title: 'to be archived',
+      description_rich_content: paragraphDoc('body'),
+    }, randomUUID());
+
+    await archiveVoc(dbHandle, voc.id);
+
+    const res = await patchDescription(app, reporter, voc.id, {
+      title: 'edit archived',
+    }, { idempotencyKey: randomUUID(), ifMatch: voc.updated_at });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json().code).toBe('conflict.record_archived');
+  });
+
+  // Case 10: archived parent MS
+  it('case 10: archived parent MS → 409 conflict.parent_archived', async () => {
+    const admin = await loginAs(app, 'mock-admin-1');
+    const msId = await createMs(app, admin, 'it-pd-parent-arch', 'Parent Archived');
+    const reporter = await loginAs(app, 'mock-user-1');
+    const voc = await postVoc(app, reporter, {
+      primary_managed_system_id: msId,
+      title: 'reporter voc',
+      description_rich_content: paragraphDoc('body'),
+    }, randomUUID());
+
+    await archiveMs(dbHandle, msId);
+
+    const res = await patchDescription(app, reporter, voc.id, {
+      title: 'edit with archived ms',
+    }, { idempotencyKey: randomUUID(), ifMatch: voc.updated_at });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json().code).toBe('conflict.parent_archived');
+  });
+
+  // ── Validation ───────────────────────────────────────────────────────────
+
+  // Case 11: empty body
+  it('case 11: empty body → 422 validation.failed', async () => {
+    const admin = await loginAs(app, 'mock-admin-1');
+    const msId = await createMs(app, admin, 'it-pd-empty-body', 'Empty Body');
+    const reporter = await loginAs(app, 'mock-user-1');
+    const voc = await postVoc(app, reporter, {
+      primary_managed_system_id: msId,
+      title: 'v',
+      description_rich_content: paragraphDoc('x'),
+    }, randomUUID());
+
+    const res = await patchDescription(app, reporter, voc.id, {}, {
+      idempotencyKey: randomUUID(), ifMatch: voc.updated_at,
+    });
+
+    expect(res.statusCode).toBe(422);
+    expect(res.json().code).toBe('validation.failed');
+  });
+
+  // Case 12: single forbidden field (severity)
+  it('case 12: forbidden field severity → 422 validation.unexpected_field with fields[0].path=[severity]', async () => {
+    const admin = await loginAs(app, 'mock-admin-1');
+    const msId = await createMs(app, admin, 'it-pd-forbidden-sev', 'Forbidden Sev');
+    const reporter = await loginAs(app, 'mock-user-1');
+    const voc = await postVoc(app, reporter, {
+      primary_managed_system_id: msId,
+      title: 'v',
+      description_rich_content: paragraphDoc('x'),
+    }, randomUUID());
+
+    const res = await patchDescription(app, reporter, voc.id, { severity: 'high' }, {
+      idempotencyKey: randomUUID(), ifMatch: voc.updated_at,
+    });
+
+    expect(res.statusCode).toBe(422);
+    const body = res.json();
+    expect(body.code).toBe('validation.unexpected_field');
+    expect(body.detail?.fields?.[0]?.path).toContain('severity');
+  });
+
+  // Case 13: multiple forbidden fields — fields[] carries each
+  it('case 13: multiple forbidden fields → 422; first forbidden field returned', async () => {
+    const admin = await loginAs(app, 'mock-admin-1');
+    const msId = await createMs(app, admin, 'it-pd-forbidden-multi', 'Forbidden Multi');
+    const reporter = await loginAs(app, 'mock-user-1');
+    const voc = await postVoc(app, reporter, {
+      primary_managed_system_id: msId,
+      title: 'v',
+      description_rich_content: paragraphDoc('x'),
+    }, randomUUID());
+
+    // Route pre-checks one at a time in FORBIDDEN list order; first match fires
+    const res = await patchDescription(app, reporter, voc.id, {
+      severity: 'low',
+      triage_state: 'triaged',
+    }, { idempotencyKey: randomUUID(), ifMatch: voc.updated_at });
+
+    expect(res.statusCode).toBe(422);
+    expect(res.json().code).toBe('validation.unexpected_field');
+  });
+
+  // Case 14: bad title (201 chars)
+  it('case 14: title 201 chars → 422 validation.failed', async () => {
+    const admin = await loginAs(app, 'mock-admin-1');
+    const msId = await createMs(app, admin, 'it-pd-bad-title', 'Bad Title');
+    const reporter = await loginAs(app, 'mock-user-1');
+    const voc = await postVoc(app, reporter, {
+      primary_managed_system_id: msId,
+      title: 'v',
+      description_rich_content: paragraphDoc('x'),
+    }, randomUUID());
+
+    const res = await patchDescription(app, reporter, voc.id, {
+      title: 'a'.repeat(201),
+    }, { idempotencyKey: randomUUID(), ifMatch: voc.updated_at });
+
+    expect(res.statusCode).toBe(422);
+    expect(res.json().code).toBe('validation.failed');
+  });
+
+  // Case 15: non-empty attachments
+  it('case 15: non-empty attachments → 422 attachment.unsupported_pending_storage_slice', async () => {
+    const admin = await loginAs(app, 'mock-admin-1');
+    const msId = await createMs(app, admin, 'it-pd-attach-unsup', 'Attach Unsupported');
+    const reporter = await loginAs(app, 'mock-user-1');
+    const voc = await postVoc(app, reporter, {
+      primary_managed_system_id: msId,
+      title: 'v',
+      description_rich_content: paragraphDoc('x'),
+    }, randomUUID());
+
+    const res = await patchDescription(app, reporter, voc.id, {
+      attachments: [{
+        id: randomUUID(),
+        name: 'file.txt',
+        size_bytes: 100,
+        mime_type: 'text/plain',
+        storage_uri: 'gs://bucket/file.txt',
+      }],
+    }, { idempotencyKey: randomUUID(), ifMatch: voc.updated_at });
+
+    expect(res.statusCode).toBe(422);
+    expect(res.json().code).toBe('attachment.unsupported_pending_storage_slice');
+  });
+
+  // ── Sanitizer ───────────────────────────────────────────────────────────
+
+  // Case 16: image node rejected
+  it('case 16: description_rich_content with image node → 422 rich_content.external_image_forbidden', async () => {
+    const admin = await loginAs(app, 'mock-admin-1');
+    const msId = await createMs(app, admin, 'it-pd-img-forbidden', 'Img Forbidden');
+    const reporter = await loginAs(app, 'mock-user-1');
+    const voc = await postVoc(app, reporter, {
+      primary_managed_system_id: msId,
+      title: 'v',
+      description_rich_content: paragraphDoc('x'),
+    }, randomUUID());
+
+    const docWithImage = {
+      type: 'doc',
+      content: [
+        {
+          type: 'image',
+          attrs: { src: 'https://example.com/img.png', alt: 'img' },
+        },
+      ],
+    };
+
+    const res = await patchDescription(app, reporter, voc.id, {
+      description_rich_content: docWithImage,
+    }, { idempotencyKey: randomUUID(), ifMatch: voc.updated_at });
+
+    expect(res.statusCode).toBe(422);
+    expect(res.json().code).toBe('rich_content.external_image_forbidden');
+  });
+
+  // Case 17: javascript link rejected
+  it('case 17: description_rich_content with javascript: href → 422 rich_content.disallowed_node', async () => {
+    const admin = await loginAs(app, 'mock-admin-1');
+    const msId = await createMs(app, admin, 'it-pd-js-link', 'JS Link');
+    const reporter = await loginAs(app, 'mock-user-1');
+    const voc = await postVoc(app, reporter, {
+      primary_managed_system_id: msId,
+      title: 'v',
+      description_rich_content: paragraphDoc('x'),
+    }, randomUUID());
+
+    const docWithJsLink = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'click me',
+              marks: [{ type: 'link', attrs: { href: 'javascript:alert(1)' } }],
+            },
+          ],
+        },
+      ],
+    };
+
+    const res = await patchDescription(app, reporter, voc.id, {
+      description_rich_content: docWithJsLink,
+    }, { idempotencyKey: randomUUID(), ifMatch: voc.updated_at });
+
+    expect(res.statusCode).toBe(422);
+    const body = res.json();
+    expect(body.code).toBe('rich_content.disallowed_node');
+    // post-#23: fields_code differentiates value-failure from key-failure
+    expect(body.detail?.fields?.[0]?.code).toBe('invalid_attr_value');
+  });
+
+  // ── Headers ──────────────────────────────────────────────────────────────
+
+  // Case 18: missing If-Match
+  it('case 18: missing If-Match → 422 validation.failed with fields[0].path=[headers,if-match]', async () => {
+    const admin = await loginAs(app, 'mock-admin-1');
+    const msId = await createMs(app, admin, 'it-pd-no-ifmatch', 'No IfMatch');
+    const reporter = await loginAs(app, 'mock-user-1');
+    const voc = await postVoc(app, reporter, {
+      primary_managed_system_id: msId,
+      title: 'v',
+      description_rich_content: paragraphDoc('x'),
+    }, randomUUID());
+
+    const res = await patchDescription(app, reporter, voc.id, { title: 'new' }, {
+      idempotencyKey: randomUUID(),
+      // no ifMatch
+    });
+
+    expect(res.statusCode).toBe(422);
+    const body = res.json();
+    expect(body.code).toBe('validation.failed');
+    expect(body.detail?.fields?.[0]?.path).toEqual(['headers', 'if-match']);
+  });
+
+  // Case 19: If-Match mismatch
+  it('case 19: If-Match mismatch → 409 conflict.stale_write with detail.current_updated_at', async () => {
+    const admin = await loginAs(app, 'mock-admin-1');
+    const msId = await createMs(app, admin, 'it-pd-stale', 'Stale');
+    const reporter = await loginAs(app, 'mock-user-1');
+    const voc = await postVoc(app, reporter, {
+      primary_managed_system_id: msId,
+      title: 'v',
+      description_rich_content: paragraphDoc('x'),
+    }, randomUUID());
+
+    const bogus = '1970-01-01T00:00:00.000Z';
+    const res = await patchDescription(app, reporter, voc.id, { title: 'new' }, {
+      idempotencyKey: randomUUID(),
+      ifMatch: bogus,
+    });
+
+    expect(res.statusCode).toBe(409);
+    const body = res.json();
+    expect(body.code).toBe('conflict.stale_write');
+    expect(body.detail?.current_updated_at).toBeDefined();
+    expect(body.detail?.current_updated_at).not.toBe(bogus);
+  });
+
+  // ── Concurrency ──────────────────────────────────────────────────────────
+
+  // Case 20: Reporter starts edit; admin commits triage first
+  it('case 20: admin commits triage between Reporter\'s lock and edit → 409 conflict.triage_already_committed', async () => {
+    const admin = await loginAs(app, 'mock-admin-1');
+    const msId = await createMs(app, admin, 'it-pd-race-triage', 'Race Triage');
+    const reporter = await loginAs(app, 'mock-user-1');
+    const voc = await postVoc(app, reporter, {
+      primary_managed_system_id: msId,
+      title: 'race voc',
+      description_rich_content: paragraphDoc('body'),
+    }, randomUUID());
+
+    // Admin commits triage directly via SQL (simulates concurrent admin PATCH)
+    await forceTriageState(dbHandle, voc.id, 'triaged');
+
+    // Reporter now tries to edit description with original If-Match
+    const res = await patchDescription(app, reporter, voc.id, { title: 'new title' }, {
+      idempotencyKey: randomUUID(),
+      ifMatch: voc.updated_at,
+    });
+
+    // State check fires (triage_already_committed) before If-Match comparison
+    expect(res.statusCode).toBe(409);
+    expect(res.json().code).toBe('conflict.triage_already_committed');
+  });
+
+  // Case 21: stale If-Match race (sequential simulation)
+  it('case 21: second PATCH with stale If-Match → 409 conflict.stale_write', async () => {
+    const admin = await loginAs(app, 'mock-admin-1');
+    const msId = await createMs(app, admin, 'it-pd-race-stale', 'Race Stale');
+    const reporter = await loginAs(app, 'mock-user-1');
+    const voc = await postVoc(app, reporter, {
+      primary_managed_system_id: msId,
+      title: 'race voc 2',
+      description_rich_content: paragraphDoc('body'),
+    }, randomUUID());
+
+    // First edit succeeds
+    const res1 = await patchDescription(app, reporter, voc.id, { title: 'first edit' }, {
+      idempotencyKey: randomUUID(),
+      ifMatch: voc.updated_at,
+    });
+    expect(res1.statusCode).toBe(200);
+
+    // Second edit with original (now stale) If-Match
+    const res2 = await patchDescription(app, reporter, voc.id, { title: 'second edit' }, {
+      idempotencyKey: randomUUID(),
+      ifMatch: voc.updated_at, // stale
+    });
+    expect(res2.statusCode).toBe(409);
+    expect(res2.json().code).toBe('conflict.stale_write');
+  });
+
+  // ── Idempotency ──────────────────────────────────────────────────────────
+
+  // Case 22: replay same key
+  it('case 22: same Idempotency-Key + body + If-Match replay → cached 200', async () => {
+    const admin = await loginAs(app, 'mock-admin-1');
+    const msId = await createMs(app, admin, 'it-pd-idem-replay', 'Idem Replay');
+    const reporter = await loginAs(app, 'mock-user-1');
+    const voc = await postVoc(app, reporter, {
+      primary_managed_system_id: msId,
+      title: 'v',
+      description_rich_content: paragraphDoc('x'),
+    }, randomUUID());
+
+    const key = randomUUID();
+    const body = { title: 'idempotent title' };
+
+    const res1 = await patchDescription(app, reporter, voc.id, body, {
+      idempotencyKey: key, ifMatch: voc.updated_at,
+    });
+    expect(res1.statusCode).toBe(200);
+    const firstBody = res1.json();
+
+    // Replay — deep-equal envelope. Byte-equal not enforced because the
+    // idempotency cache stores the parsed object then re-serializes on replay;
+    // V8 key order from cache differs from initial response order. Deep-equal
+    // (vitest .toEqual) locks the *content* invariant which is what
+    // idempotency semantics require.
+    const res2 = await patchDescription(app, reporter, voc.id, body, {
+      idempotencyKey: key, ifMatch: voc.updated_at,
+    });
+    expect(res2.statusCode).toBe(200);
+    expect(res2.json()).toEqual(firstBody);
+  });
+
+  // Case 23: same key, different body → 409 idempotency_key_reuse
+  it('case 23: same Idempotency-Key, different body → 409 conflict.idempotency_key_reuse', async () => {
+    const admin = await loginAs(app, 'mock-admin-1');
+    const msId = await createMs(app, admin, 'it-pd-idem-mismatch', 'Idem Mismatch');
+    const reporter = await loginAs(app, 'mock-user-1');
+    const voc = await postVoc(app, reporter, {
+      primary_managed_system_id: msId,
+      title: 'v',
+      description_rich_content: paragraphDoc('x'),
+    }, randomUUID());
+
+    const key = randomUUID();
+    const res1 = await patchDescription(app, reporter, voc.id, { title: 'body A' }, {
+      idempotencyKey: key, ifMatch: voc.updated_at,
+    });
+    expect(res1.statusCode).toBe(200);
+
+    // Different body, same key
+    const res2 = await patchDescription(app, reporter, voc.id, { title: 'body B' }, {
+      idempotencyKey: key, ifMatch: voc.updated_at,
+    });
+    expect(res2.statusCode).toBe(409);
+    expect(res2.json().code).toBe('conflict.idempotency_key_reuse');
+  });
+
+  // Case 24: same key + body, refreshed If-Match → 409 (hash includes If-Match)
+  it('case 24: same key, different If-Match → 409 conflict.idempotency_key_reuse', async () => {
+    const admin = await loginAs(app, 'mock-admin-1');
+    const msId = await createMs(app, admin, 'it-pd-idem-ifmatch', 'Idem IfMatch');
+    const reporter = await loginAs(app, 'mock-user-1');
+    const voc = await postVoc(app, reporter, {
+      primary_managed_system_id: msId,
+      title: 'v',
+      description_rich_content: paragraphDoc('x'),
+    }, randomUUID());
+
+    const key = randomUUID();
+    const res1 = await patchDescription(app, reporter, voc.id, { title: 'same body' }, {
+      idempotencyKey: key, ifMatch: voc.updated_at,
+    });
+    expect(res1.statusCode).toBe(200);
+    const freshAt = res1.json().updated_at as string;
+
+    // Same key, same body, but fresh If-Match → different hash → mismatch
+    const res2 = await patchDescription(app, reporter, voc.id, { title: 'same body' }, {
+      idempotencyKey: key, ifMatch: freshAt,
+    });
+    expect(res2.statusCode).toBe(409);
+    expect(res2.json().code).toBe('conflict.idempotency_key_reuse');
+  });
+
+  // ── Rate limit ───────────────────────────────────────────────────────────
+
+  // Case 25: 30 PATCHes succeed; 31st → 429 rate_limited.actor.
+  // Locks the dedicated reporterEdit bucket (30/min), not the shared mutation
+  // bucket (which would fire at the 11th). Cycle-1 codex MAJOR fix.
+  it('case 25: 30 PATCHes succeed, 31st → 429 rate_limited.actor', async () => {
+    const admin = await loginAs(app, 'mock-admin-1');
+    const msId = await createMs(app, admin, 'it-pd-ratelimit', 'Rate Limit');
+    const reporter = await loginAs(app, 'mock-user-1');
+    const voc = await postVoc(app, reporter, {
+      primary_managed_system_id: msId,
+      title: 'v',
+      description_rich_content: paragraphDoc('x'),
+    }, randomUUID());
+
+    // clear rate limits before test
+    await dbHandle.pool.query('delete from core.rate_limits');
+
+    let updatedAt = voc.updated_at;
+    const statuses: number[] = [];
+
+    for (let i = 0; i < 31; i++) {
+      const res = await patchDescription(
+        app, reporter, voc.id,
+        { title: `edit ${i}` },
+        { idempotencyKey: randomUUID(), ifMatch: updatedAt },
+      );
+      statuses.push(res.statusCode);
+      if (res.statusCode === 200) {
+        updatedAt = (res.json() as { updated_at: string }).updated_at;
+      }
+    }
+
+    // First 30 should succeed, 31st should be 429.
+    expect(statuses.slice(0, 30).every(s => s === 200)).toBe(true);
+    expect(statuses[30]).toBe(429);
+  });
+
+  // ── NewCoverage (cases 26-28) ─────────────────────────────────────────────
+
+  // Case 26: Reporter + stale If-Match + already-triaged → state check fires first
+  it('case 26: Reporter + stale If-Match + triaged VOC → 409 conflict.triage_already_committed (state before If-Match)', async () => {
+    const admin = await loginAs(app, 'mock-admin-1');
+    const msId = await createMs(app, admin, 'it-pd-order-26', 'Order 26');
+    const reporter = await loginAs(app, 'mock-user-1');
+    const voc = await postVoc(app, reporter, {
+      primary_managed_system_id: msId,
+      title: 'v',
+      description_rich_content: paragraphDoc('x'),
+    }, randomUUID());
+
+    await forceTriageState(dbHandle, voc.id, 'triaged');
+    const bogus = '1970-01-01T00:00:00.000Z';
+
+    const res = await patchDescription(app, reporter, voc.id, { title: 'new' }, {
+      idempotencyKey: randomUUID(),
+      ifMatch: bogus, // stale
+    });
+
+    // triage_already_committed fires before stale_write (per plan §ordering)
+    expect(res.statusCode).toBe(409);
+    expect(res.json().code).toBe('conflict.triage_already_committed');
+  });
+
+  // Case 27: unknown field not on forbidden list → validation.failed (zod unrecognized_keys)
+  it('case 27: body with unknown field (foobar) not on forbidden list → 422 validation.failed', async () => {
+    const admin = await loginAs(app, 'mock-admin-1');
+    const msId = await createMs(app, admin, 'it-pd-unknown-27', 'Unknown 27');
+    const reporter = await loginAs(app, 'mock-user-1');
+    const voc = await postVoc(app, reporter, {
+      primary_managed_system_id: msId,
+      title: 'v',
+      description_rich_content: paragraphDoc('x'),
+    }, randomUUID());
+
+    const res = await patchDescription(app, reporter, voc.id, {
+      title: 'ok',
+      foobar: 'unknown key',
+    }, { idempotencyKey: randomUUID(), ifMatch: voc.updated_at });
+
+    expect(res.statusCode).toBe(422);
+    expect(res.json().code).toBe('validation.failed');
+  });
+
+  // Case 28: stable-stringify regression. voc-description surface allows attrs only on
+  // attachmentRef (single key 'id') — no multi-key attr to shuffle within. So we exercise
+  // the diff-via-hash path by re-submitting a structurally equivalent doc and asserting
+  // no audit row. Multi-key attr-order invariance is covered directly by the unit test
+  // suite for stableStringify (apps/backend/src/lib/json/__tests__/stable-stringify.test.ts).
+  it('case 28: re-submitting structurally-equal description → empty diff, no audit', async () => {
+    const admin = await loginAs(app, 'mock-admin-1');
+    const msId = await createMs(app, admin, 'it-pd-stable-28', 'Stable 28');
+    const reporter = await loginAs(app, 'mock-user-1');
+
+    const docOriginal = {
+      type: 'doc',
+      content: [
+        { type: 'paragraph', content: [{ type: 'text', text: 'stable diff test' }] },
+      ],
+    };
+
+    const voc = await postVoc(app, reporter, {
+      primary_managed_system_id: msId,
+      title: 'v',
+      description_rich_content: docOriginal,
+    }, randomUUID());
+
+    // Re-submit a freshly-built doc that is structurally identical. Sanitizer's
+    // canonical rebuild on both sides produces identical canonical JSON →
+    // identical SHA-256 → empty diff → 200 with no audit row.
+    const docResubmit = {
+      type: 'doc',
+      content: [
+        { type: 'paragraph', content: [{ type: 'text', text: 'stable diff test' }] },
+      ],
+    };
+
+    const res = await patchDescription(app, reporter, voc.id, {
+      description_rich_content: docResubmit,
+    }, { idempotencyKey: randomUUID(), ifMatch: voc.updated_at });
+
+    expect(res.statusCode).toBe(200);
+
+    if (MIGRATE_URL) {
+      const count = await countAuditRows(voc.id, 'voc_description_edited');
+      expect(count).toBe(0);
+    }
+  });
+});

--- a/apps/backend/src/modules/voc/repo.ts
+++ b/apps/backend/src/modules/voc/repo.ts
@@ -286,6 +286,102 @@ export async function updateVocReporterStatus(
   `);
 }
 
+// ── updateVocDescriptionFields ─────────────────────────────────────────────
+// Applies a non-empty set of description field changes to a voc row within
+// the calling transaction. Caller MUST NOT invoke this if all 3 fields are
+// absent (defensive throw enforces the invariant).
+// workspace_id filter is defense-in-depth (cycle-2 B2 — guards cross-ws).
+
+export interface UpdateVocDescriptionFieldsInput {
+  tx: Tx;
+  vocId: string;
+  workspaceId: string;
+  title: string | undefined;
+  descriptionRichContent: unknown;
+}
+
+export async function updateVocDescriptionFields(
+  input: UpdateVocDescriptionFieldsInput,
+): Promise<LockedVoc> {
+  const { tx, vocId, workspaceId, title, descriptionRichContent } = input;
+
+  if (title === undefined && descriptionRichContent === undefined) {
+    throw new Error(
+      'updateVocDescriptionFields: called with empty diff — caller must not invoke on no-op',
+    );
+  }
+
+  // Build SET clause for non-undefined fields only.
+  const setClauses: ReturnType<typeof sql>[] = [sql`updated_at = now()`];
+  if (title !== undefined) {
+    setClauses.push(sql`title = ${title}`);
+  }
+  if (descriptionRichContent !== undefined) {
+    setClauses.push(sql`description_rich_content = ${descriptionRichContent as object}::jsonb`);
+  }
+
+  // Combine SET clauses
+  const setClause = sql.join(setClauses, sql`, `);
+
+  const rows = await tx.execute<{
+    id: string;
+    workspace_id: string;
+    primary_managed_system_id: string;
+    analytics_area_id: string | null;
+    reporter_id: string;
+    display_id: string;
+    title: string;
+    description_rich_content: unknown;
+    severity: string | null;
+    reporter_facing_status: string;
+    triage_state: string;
+    triage_state_review_postponed_at: Date | string | null;
+    owner_user_id: string | null;
+    owner_team_id: string | null;
+    source_context: string;
+    archived_at: Date | string | null;
+    created_at: Date | string;
+    updated_at: Date | string;
+  }>(sql`
+    UPDATE ${vocs}
+    SET ${setClause}
+    WHERE id = ${vocId}
+      AND workspace_id = ${workspaceId}
+    RETURNING
+      id, workspace_id, primary_managed_system_id, analytics_area_id, reporter_id,
+      display_id, title, description_rich_content, severity, reporter_facing_status,
+      triage_state, triage_state_review_postponed_at,
+      owner_user_id, owner_team_id, source_context,
+      archived_at, created_at, updated_at
+  `);
+
+  const row = rows.rows[0];
+  if (!row) {
+    throw new Error('updateVocDescriptionFields: UPDATE returned no row');
+  }
+
+  return {
+    id: row.id,
+    workspaceId: row.workspace_id,
+    primaryManagedSystemId: row.primary_managed_system_id,
+    analyticsAreaId: row.analytics_area_id,
+    reporterId: row.reporter_id,
+    displayId: row.display_id,
+    title: row.title,
+    descriptionRichContent: row.description_rich_content,
+    severity: row.severity as LockedVoc['severity'],
+    reporterFacingStatus: row.reporter_facing_status,
+    triageState: row.triage_state as LockedVoc['triageState'],
+    triageStateReviewPostponedAt: toDateOrNull(row.triage_state_review_postponed_at),
+    ownerUserId: row.owner_user_id,
+    ownerTeamId: row.owner_team_id,
+    sourceContext: row.source_context,
+    archivedAt: toDateOrNull(row.archived_at),
+    createdAt: toDate(row.created_at),
+    updatedAt: toDate(row.updated_at),
+  };
+}
+
 export async function insertVoc(tx: Tx, input: InsertVocInput) {
   // next_voc_display_id is a SECURITY DEFINER function from migration 0010
   // (#12). It assigns the next VOC-#### slug for the workspace under an

--- a/apps/backend/src/modules/voc/routes.ts
+++ b/apps/backend/src/modules/voc/routes.ts
@@ -7,9 +7,12 @@ import { sql } from 'drizzle-orm';
 
 import {
   FORBIDDEN_CREATE_FIELDS,
+  FORBIDDEN_EDIT_DESCRIPTION_FIELDS,
+  FORBIDDEN_EDIT_DESCRIPTION_FIELD_ERROR_CODES,
   FORBIDDEN_PATCH_FIELDS,
   FORBIDDEN_PATCH_FIELD_ERROR_CODES,
   createVocRequestSchema,
+  editDescriptionRequestSchema,
   getConversationQuerySchema,
   internalCommentRequestSchema,
   listVocsQuerySchema,
@@ -47,6 +50,7 @@ export interface VocRoutesOptions {
   rateLimitConfig?: {
     mutation: Record<string, unknown>;
     read?: Record<string, unknown>;
+    reporterEdit?: Record<string, unknown>;
   };
 }
 
@@ -241,6 +245,98 @@ export const vocRoutes: FastifyPluginAsync<VocRoutesOptions> = async (app, opts)
             actor_id: sess.actor_id,
             workspace_id: sess.workspace_id,
             role_level: sess.role_level,
+          },
+          vocId,
+          ifMatch,
+          input: parsed.data,
+        });
+
+        // 7. Record idempotency result and return 200.
+        await idempotencyService.record(tx, sess.actor_id, idempotencyKey, hash, 200, envelope);
+        return { status: 200, body: envelope };
+      });
+      return reply.code(result.status).send(result.body);
+    },
+  });
+
+  // ── PATCH /vocs/:id/description — Slice 3 #17 Reporter pre-triage edit ───
+  // Reporter-only endpoint. No admin elevation. Requires untriaged VOC.
+  // Rate limit: 30/min per actor (reporterEdit bucket — separate from the
+  // 10/min mutation bucket so a single edit session can fan out several saves
+  // without throttling a triaging admin's separate bucket). Falls back to
+  // shared mutation bucket only if the dedicated bucket isn't configured.
+  app.route({
+    method: 'PATCH',
+    url: '/vocs/:id/description',
+    preHandler: [requireSession(sessionService), requireWorkspace(workspaceId)],
+    ...(rateLimitConfig
+      ? { config: { rateLimit: (rateLimitConfig.reporterEdit ?? rateLimitConfig.mutation) as never } }
+      : {}),
+    handler: async (req, reply) => {
+      const sess = req.session;
+      if (!sess) throw new HttpError('internal.unexpected', 'session missing after middleware');
+
+      // 1. Idempotency-Key header.
+      const idempotencyKey = requireIdempotencyKey(req.headers as Record<string, unknown>);
+
+      // 2. If-Match header (optimistic concurrency).
+      const ifMatch = requireIfMatch(req.headers as Record<string, unknown>);
+
+      const params = req.params as { id: string };
+      const vocId = params.id;
+
+      if (!UUID_REGEX.test(vocId)) {
+        return sendError(reply, 'validation.failed', 'id must be a valid UUID', {
+          fields: [{ path: ['id'], code: 'invalid' }],
+        });
+      }
+
+      const rawBody = (req.body ?? {}) as Record<string, unknown>;
+
+      // 3. Strip forbidden fields before Zod parse for precise per-field errors.
+      // See C10 note on PATCH /vocs/:id — case-sensitive; .strict() catches
+      // any case variants as validation.failed (unrecognized_keys).
+      for (const f of FORBIDDEN_EDIT_DESCRIPTION_FIELDS) {
+        if (f in rawBody) {
+          const code = FORBIDDEN_EDIT_DESCRIPTION_FIELD_ERROR_CODES[f];
+          return sendError(reply, code, `${f} cannot be set via PATCH /vocs/:id/description`, {
+            fields: [{ path: [f], code: 'unexpected_field' }],
+          });
+        }
+      }
+
+      // 4. Schema validation.
+      const parsed = editDescriptionRequestSchema.safeParse(rawBody);
+      if (!parsed.success) {
+        return sendError(reply, 'validation.failed', 'invalid request body', {
+          fields: fieldsFromZodIssues(parsed.error.issues),
+        });
+      }
+
+      // 5. Idempotency frame (same pattern as PATCH /vocs/:id).
+      // ifMatch included in hash — different If-Match = different intent.
+      const hash = hashRequestBody({ vocId, ifMatch, route: 'voc.description_edit', ...rawBody });
+      const result = await db.transaction(async (tx) => {
+        await tx.execute(
+          sql`SELECT pg_advisory_xact_lock(hashtext(${sess.actor_id}), hashtext(${idempotencyKey}))`,
+        );
+        const hit = await idempotencyService.lookup(tx, sess.actor_id, idempotencyKey, hash);
+        if (hit.kind === 'match') {
+          return { status: hit.status, body: hit.body };
+        }
+        if (hit.kind === 'mismatch') {
+          throw new HttpError(
+            'conflict.idempotency_key_reuse',
+            'Idempotency-Key reused with different request body',
+          );
+        }
+
+        // 6. Delegate to service.
+        const envelope = await vocService.editVocDescription({
+          tx,
+          actor: {
+            actor_id: sess.actor_id,
+            workspace_id: sess.workspace_id,
           },
           vocId,
           ifMatch,

--- a/apps/backend/src/modules/voc/service.ts
+++ b/apps/backend/src/modules/voc/service.ts
@@ -5,19 +5,22 @@
 // API accepts a `Tx` so the controller's idempotency frame can own the
 // transaction.
 
+import { createHash } from 'node:crypto';
+
 import { and, eq, sql } from 'drizzle-orm';
 
 import type { Db } from '../../db/client.js';
 import type { Tx } from '../../db/tx.js';
 import { vocs } from '../../db/schema/voc.js';
 import { HttpError } from '../../lib/errors.js';
+import { stableStringify } from '../../lib/json/stable-stringify.js';
 import { sanitizeTipTap } from '../../lib/rich-content/sanitize.js';
 import { nextReporterStates, type ReporterFacingStatus } from './transitions.js';
-import { insertVoc, lockAnalyticsArea, lockManagedSystem, selectVocForUpdate } from './repo.js';
+import { insertVoc, lockAnalyticsArea, lockManagedSystem, selectVocForUpdate, updateVocDescriptionFields } from './repo.js';
 import type { AuditService } from '../core/audit/audit-service.js';
 import type { CheckService } from '../permissions/check-service.js';
 import type { RoleLevel } from '../auth/session-service.js';
-import type { CreateVocRequest, PatchVocRequest } from '@fops/shared';
+import type { CreateVocRequest, EditDescriptionRequest, PatchVocRequest } from '@fops/shared';
 
 export interface CreateVocActor {
   actor_id: string;
@@ -648,7 +651,184 @@ export function createVocService(deps: VocServiceDeps) {
     };
   }
 
-  return { createVoc, updateVoc };
+  // ── editVocDescription ────────────────────────────────────────────────────
+  // PATCH /vocs/:id/description — Reporter-only, pre-triage-only edit.
+  // Service-layer ordering (locked per plan §17):
+  //   1. selectVocForUpdate → 404 / archived
+  //   2. Actor must equal voc.reporter_id → 403 permission.denied
+  //   3. triage_state must be 'untriaged' → 409 conflict.triage_already_committed
+  //   4. If-Match compare → 409 conflict.stale_write
+  //   5. Lock parent MS → archived → 409 conflict.parent_archived
+  //   6. Sanitize description_rich_content
+  //   7. Reject non-empty attachments → 422
+  //   8. Diff computation
+  //   9. Empty diff → return existing envelope, no UPDATE, no audit
+  //  10. Non-empty diff → updateVocDescriptionFields + audit + return envelope
+  async function editVocDescription(args: {
+    tx: Tx;
+    actor: { actor_id: string; workspace_id: string };
+    vocId: string;
+    ifMatch: string;
+    input: EditDescriptionRequest;
+  }): Promise<VocEnvelope> {
+    const { tx, actor, vocId, ifMatch, input } = args;
+    const workspaceId = actor.workspace_id;
+
+    // 1. FOR UPDATE lock on the VOC row.
+    const row = await selectVocForUpdate(tx, workspaceId, vocId);
+    if (!row) throw new HttpError('not_found.record', 'voc not found');
+    if (row.archivedAt !== null) {
+      throw new HttpError('conflict.record_archived', 'voc is archived');
+    }
+
+    // 2. Reporter-only: actor must equal voc.reporter_id — no admin elevation.
+    if (actor.actor_id !== row.reporterId) {
+      throw new HttpError(
+        'permission.denied',
+        'only the original reporter may edit voc description',
+        { fields: [{ path: ['actor_id'], code: 'not_reporter' }] },
+      );
+    }
+
+    // 3. Triage state gate: only untriaged VOCs can have description edited.
+    if (row.triageState !== 'untriaged') {
+      throw new HttpError(
+        'conflict.triage_already_committed',
+        'voc triage has already been committed; description can no longer be edited',
+        { current_triage_state: row.triageState },
+      );
+    }
+
+    // 4. Optimistic concurrency check (after permission and state checks).
+    if (row.updatedAt.toISOString() !== ifMatch) {
+      throw new HttpError('conflict.stale_write', 'voc updated_at does not match If-Match', {
+        current_updated_at: row.updatedAt.toISOString(),
+      });
+    }
+
+    // 5. FOR UPDATE lock on parent Managed System.
+    const ms = await lockManagedSystem(tx, workspaceId, row.primaryManagedSystemId);
+    if (!ms) throw new HttpError('not_found.record', 'managed system not found');
+    if (ms.archived_at !== null) {
+      throw new HttpError('conflict.parent_archived', 'parent managed system is archived', {
+        fields: [{ path: ['primary_managed_system_id'], code: 'parent_archived' }],
+      });
+    }
+
+    // 6. Sanitize description_rich_content when present.
+    let sanitizedDoc: ReturnType<typeof sanitizeTipTap> | null = null;
+    if (input.description_rich_content !== undefined) {
+      sanitizedDoc = sanitizeTipTap({
+        surface: 'voc-description',
+        doc: input.description_rich_content,
+      });
+      if (!sanitizedDoc.ok) {
+        throw new HttpError(sanitizedDoc.error.code, sanitizedDoc.error.reason, {
+          fields: [
+            {
+              path: ['description_rich_content'],
+              code: sanitizedDoc.error.code === 'rich_content.external_image_forbidden'
+                ? 'external_image_forbidden'
+                : (sanitizedDoc.error.fields_code ?? 'disallowed_node'),
+            },
+          ],
+          hint: sanitizedDoc.error.path,
+        });
+      }
+    }
+
+    // 7. Reject non-empty attachments (storage slice not shipped yet).
+    if (input.attachments && input.attachments.length > 0) {
+      throw new HttpError(
+        'attachment.unsupported_pending_storage_slice',
+        'attachments are not supported until the storage slice ships (#22)',
+        {
+          fields: [{ path: ['attachments'], code: 'unsupported' }],
+        },
+      );
+    }
+
+    // 8. Diff computation.
+    type DescChanges = {
+      title?: { from: string; to: string };
+      description_rich_content?: { from_hash: string; to_hash: string };
+      attachments?: { from: unknown[]; to: unknown[] };
+    };
+    const changes: DescChanges = {};
+
+    // title diff
+    if (input.title !== undefined && input.title !== row.title) {
+      changes.title = { from: row.title, to: input.title };
+    }
+
+    // description_rich_content diff — compare via SHA-256 of stableStringify
+    if (input.description_rich_content !== undefined && sanitizedDoc?.ok) {
+      const fromHash = createHash('sha256')
+        .update(stableStringify(row.descriptionRichContent))
+        .digest('hex');
+      const toHash = createHash('sha256')
+        .update(stableStringify(sanitizedDoc.doc))
+        .digest('hex');
+      if (fromHash !== toHash) {
+        changes.description_rich_content = { from_hash: fromHash, to_hash: toHash };
+      }
+    }
+
+    // attachments diff — in Slice 3 always [] vs [] (non-empty rejected above)
+    if (input.attachments !== undefined) {
+      const fromStr = stableStringify([]); // current always [] in Slice 3
+      const toStr = stableStringify(input.attachments);
+      if (fromStr !== toStr) {
+        changes.attachments = { from: [], to: input.attachments };
+      }
+    }
+
+    // 9. Empty diff — return current envelope without any writes.
+    if (Object.keys(changes).length === 0) {
+      // Breadcrumb: no-op edit, idempotency will cache the result.
+      const nextStates = await nextReporterStates(
+        row.reporterFacingStatus as ReporterFacingStatus,
+        tx,
+      );
+      return composeEnvelope(row, nextStates);
+    }
+
+    // 10. Non-empty diff — UPDATE + audit + return refreshed envelope.
+    // Only pass fields that actually changed to updateVocDescriptionFields.
+    // The repo guard throws if both are undefined, which cannot happen here
+    // because we checked Object.keys(changes).length > 0 above.
+    const updatedRow = await updateVocDescriptionFields({
+      tx,
+      vocId,
+      workspaceId,
+      title: changes.title !== undefined ? changes.title.to : undefined,
+      descriptionRichContent:
+        changes.description_rich_content !== undefined && sanitizedDoc !== null && sanitizedDoc.ok
+          ? sanitizedDoc.doc
+          : undefined,
+    });
+
+    await deps.auditService.record(tx, {
+      workspace_id: workspaceId,
+      actor_id: actor.actor_id,
+      event_type: 'voc_description_edited',
+      subject_type: 'voc',
+      subject_id: vocId,
+      summary: `VOC ${updatedRow.displayId} description edited by reporter`,
+      detail: {
+        voc_id: vocId,
+        changes,
+      },
+    });
+
+    const nextStates = await nextReporterStates(
+      updatedRow.reporterFacingStatus as ReporterFacingStatus,
+      tx,
+    );
+    return composeEnvelope(updatedRow, nextStates);
+  }
+
+  return { createVoc, updateVoc, editVocDescription };
 }
 
 export type VocService = ReturnType<typeof createVocService>;

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -214,6 +214,16 @@ export async function buildServer(opts: BuildServerOptions): Promise<FastifyInst
       keyGenerator: mutationKeyGenerator,
       store: createPgRateLimitStore(dbHandle.pool, 'read') as never,
     },
+    // Slice 3 #17 — Reporter pre-triage edit (PATCH /vocs/:id/description).
+    // 30/min per actor (more permissive than generic `mutation: 10/min` because
+    // a single edit session can produce several saves; less than read tier).
+    // Plan §spec issue #17.
+    reporterEdit: {
+      max: 30,
+      timeWindow: '1 minute',
+      keyGenerator: mutationKeyGenerator,
+      store: createPgRateLimitStore(dbHandle.pool, 'reporter_edit') as never,
+    },
   });
 
   // ── Error handler ─ ADR-0012 envelope ────────────────────────────────
@@ -382,6 +392,7 @@ export async function buildServer(opts: BuildServerOptions): Promise<FastifyInst
     rateLimitConfig: {
       mutation: app.rateLimitConfig.mutation,
       read: app.rateLimitConfig.read,
+      reporterEdit: app.rateLimitConfig.reporterEdit,
     },
   });
 

--- a/apps/backend/src/types/fastify.d.ts
+++ b/apps/backend/src/types/fastify.d.ts
@@ -29,6 +29,7 @@ declare module 'fastify' {
       mutation: Record<string, unknown>;
       sensitive: Record<string, unknown>;
       read: Record<string, unknown>;
+      reporterEdit: Record<string, unknown>;
     };
   }
 }

--- a/docs/adr/0012-error-code-contract.md
+++ b/docs/adr/0012-error-code-contract.md
@@ -48,6 +48,9 @@ A non-error 4xx with no domain meaning (e.g. malformed JSON before the handler r
 - `reporter_facing_status.invalid_transition` (422) — the requested `next_reporter_facing_status` is not reachable from the current status per the `reporter_facing_status_transitions` seed table. `detail.reason` carries the human-readable gate text.
 - `reporter_facing_status.gate_blocked` (422) — a linked-task gate prevents the transition. Reserved in Slice 3; emitted in Slice 6 when `evaluateReporterStatusGate` returns a block result.
 
+**Slice 3 #17 adds one code to the closed enum:**
+- `conflict.triage_already_committed` (409) — `PATCH /vocs/:id/description` was attempted on a VOC whose `triage_state` is not `untriaged`. Only the Reporter may edit the description, and only while the VOC is still pre-triage. `detail.current_triage_state` carries the VOC's current `triage_state` value so the client can display a contextual message.
+
 **Slice 3 #13 also extends the inner `detail.fields[].code` enum:**
 - `unexpected_field` — paired with `validation.unexpected_field` / `voc.severity_not_user_settable` when a server-resolved field appears in the request body.
 - `parent_archived` — paired with `conflict.parent_archived` when the referenced parent (MS or AA) is archived; carries the offending field path so the frontend can bind the message to the picker input.

--- a/docs/implementation/03-api-contracts.md
+++ b/docs/implementation/03-api-contracts.md
@@ -375,12 +375,31 @@ POST /vocs
 GET /vocs
 GET /vocs/:id
 PATCH /vocs/:id
+PATCH /vocs/:id/description
 POST /vocs/:id/create-finding
 POST /vocs/:id/request-task
 POST /vocs/:id/public-updates
 POST /vocs/:id/reporter-replies
 POST /vocs/:id/internal-comments
 ```
+
+### PATCH /vocs/:id/description — Reporter pre-triage edit (Slice 3 #17)
+
+| Aspect | Contract |
+|---|---|
+| Purpose | Reporter-only edit of `title` / `description_rich_content` / `attachments` while VOC is in `triage_state='untriaged'`. Closes Slice 3 BE exit criterion (`docs/implementation/08-mvp-slice-plan.md`). |
+| Headers | `Idempotency-Key: <uuidv4>` (required) · `If-Match: <updated_at ISO>` (required) · `Authorization: Bearer <session>` |
+| Body | `{ title?: 1..200, description_rich_content?: TipTapDoc, attachments?: AttachmentRef[] }` — at least one field; `.strict()` (zod) rejects unknown keys |
+| Forbidden fields (UX-named) | `severity`, `owner_user_id`, `owner_team_id`, `analytics_area_id`, `triage_state`, `cluster_decision`, `reporter_facing_status`, `source_context`, `primary_managed_system_id`, `reporter_id`, `archived_at`, `workspace_id`, `display_id`, `id`, `created_at`, `updated_at` → 422 `validation.unexpected_field` |
+| Permission | `actor.actor_id === voc.reporter_id` — exclusive. Admin / Developer (with capability) / any non-reporter → 403 `permission.denied`. No admin elevation on this endpoint. |
+| State gate | `voc.triage_state === 'untriaged'` — else 409 `conflict.triage_already_committed` with `detail.current_triage_state` |
+| Optimistic concurrency | `If-Match` compared against `voc.updated_at`; mismatch → 409 `conflict.stale_write` with `detail.current_updated_at` |
+| Service ordering | `SELECT FOR UPDATE voc → reporter check → state gate → If-Match → SELECT FOR UPDATE managed_system → sanitize description (surface `voc-description`) → attachments rejection (non-empty → 422 `attachment.unsupported_pending_storage_slice`) → diff → UPDATE (only when diff is non-empty) → audit emit → refresh envelope` |
+| Empty-diff semantics | If sanitizer normalizes input to match current row (per-field check; description hashed via `stableStringify` → SHA-256) → 200 returns current envelope without bumping `updated_at` and without emitting an audit row. Idempotency cache still records the 200 envelope so replay is byte-equal. |
+| Audit event | `voc_description_edited` with `changes: { title?: {from, to}, description_rich_content?: {from_hash, to_hash}, attachments?: {from, to} }` (per-field shape; non-empty required). |
+| Idempotency hash | Includes `vocId`, `ifMatch`, route, and request body — a retry with a refreshed `If-Match` (post-409 refetch) produces a new hash; client must mint a fresh `Idempotency-Key` for each distinct `If-Match` value (same caveat as `PATCH /vocs/:id`). |
+| Rate limit | 30/min per actor — dedicated `reporterEdit` bucket, separate from the 10/min `mutation` tier. |
+| Error codes | `validation.failed` · `validation.unexpected_field` · `permission.denied` · `not_found.record` · `conflict.triage_already_committed` (new in #17) · `conflict.stale_write` · `conflict.record_archived` · `conflict.parent_archived` · `conflict.idempotency_key_reuse` · `rich_content.disallowed_node` · `rich_content.external_image_forbidden` · `attachment.unsupported_pending_storage_slice` · `rate_limited.actor` |
 
 ### VOC Cluster
 

--- a/packages/shared/src/audit/__tests__/voc-audit-schemas.test.ts
+++ b/packages/shared/src/audit/__tests__/voc-audit-schemas.test.ts
@@ -13,6 +13,7 @@ import {
   reporterReplyCreatedDetailSchema,
   internalCommentCreatedDetailSchema,
   vocTriagePostponedDetailSchema,
+  vocDescriptionEditedDetailSchema,
 } from '../voc.js';
 import { AUDIT_EVENT_TYPES, AUDIT_EVENT_DETAIL_SCHEMAS } from '../../enums/audit-events.js';
 
@@ -389,6 +390,78 @@ describe('vocTriagePostponedDetailSchema', () => {
   });
 });
 
+describe('vocDescriptionEditedDetailSchema', () => {
+  const hash64 = 'a'.repeat(64);
+
+  it('accepts title-only changes', () => {
+    const result = vocDescriptionEditedDetailSchema.parse({
+      voc_id: U,
+      changes: { title: { from: 'Old title', to: 'New title' } },
+    });
+    expect(result.changes.title?.to).toBe('New title');
+  });
+
+  it('accepts description_rich_content-only changes', () => {
+    const result = vocDescriptionEditedDetailSchema.parse({
+      voc_id: U,
+      changes: { description_rich_content: { from_hash: hash64, to_hash: hash64 } },
+    });
+    expect(result.changes.description_rich_content?.from_hash).toBe(hash64);
+  });
+
+  it('accepts attachments-only changes', () => {
+    const result = vocDescriptionEditedDetailSchema.parse({
+      voc_id: U,
+      changes: { attachments: { from: [], to: [] } },
+    });
+    expect(result.changes.attachments?.from).toEqual([]);
+  });
+
+  it('accepts all 3 fields in changes', () => {
+    const result = vocDescriptionEditedDetailSchema.parse({
+      voc_id: U,
+      changes: {
+        title: { from: 'A', to: 'B' },
+        description_rich_content: { from_hash: hash64, to_hash: hash64 },
+        attachments: { from: [], to: [] },
+      },
+    });
+    expect(Object.keys(result.changes)).toHaveLength(3);
+  });
+
+  it('rejects empty changes object', () => {
+    expect(() =>
+      vocDescriptionEditedDetailSchema.parse({
+        voc_id: U,
+        changes: {},
+      }),
+    ).toThrow();
+  });
+
+  it('rejects from_hash that is not 64 chars', () => {
+    expect(() =>
+      vocDescriptionEditedDetailSchema.parse({
+        voc_id: U,
+        changes: { description_rich_content: { from_hash: 'short', to_hash: hash64 } },
+      }),
+    ).toThrow();
+  });
+
+  it('rejects to_hash that is not 64 chars', () => {
+    expect(() =>
+      vocDescriptionEditedDetailSchema.parse({
+        voc_id: U,
+        changes: { description_rich_content: { from_hash: hash64, to_hash: 'short' } },
+      }),
+    ).toThrow();
+  });
+
+  it('is registered in AUDIT_EVENT_DETAIL_SCHEMAS', () => {
+    expect(AUDIT_EVENT_TYPES).toContain('voc_description_edited');
+    expect(AUDIT_EVENT_DETAIL_SCHEMAS).toHaveProperty('voc_description_edited');
+  });
+});
+
 describe('AUDIT_EVENT_TYPES registry', () => {
   const VOC_EVENTS = [
     'voc_created',
@@ -402,6 +475,7 @@ describe('AUDIT_EVENT_TYPES registry', () => {
     'reporter_reply_created',
     'internal_comment_created',
     'voc_triage_postponed',
+    'voc_description_edited',
   ] as const;
 
   it.each(VOC_EVENTS)('%s is in AUDIT_EVENT_TYPES and has a detail schema', (event) => {

--- a/packages/shared/src/audit/voc.ts
+++ b/packages/shared/src/audit/voc.ts
@@ -4,6 +4,8 @@
 
 import { z } from 'zod';
 
+import { attachmentRefSchema } from '../vocs/create-request.js';
+
 // ── Helpers ────────────────────────────────────────────────────────────────
 const uuid = () => z.string().uuid();
 
@@ -163,3 +165,42 @@ export const vocTriagePostponedDetailSchema = z.object({
   actor_id: uuid(),
 });
 export type VocTriagePostponedDetail = z.infer<typeof vocTriagePostponedDetailSchema>;
+
+// ── voc_description_edited ─────────────────────────────────────────────────
+// Emitted by PATCH /vocs/:id/description (Slice 3 #17) when the Reporter
+// makes an actual diff (non-empty changes object). Per-key types are
+// semantically precise: title uses a string {from,to} pair; description
+// uses a {from_hash, to_hash} 64-char hex pair (SHA-256 of stableStringify
+// of the sanitized canonical doc); attachments uses an {from,to} array pair.
+// The `.refine` enforces at least one changed field so an audit row is never
+// written for an empty diff.
+const stringChangeSchema = z.object({
+  from: z.string(),
+  to: z.string(),
+});
+
+const richHashChangeSchema = z.object({
+  from_hash: z.string().length(64),
+  to_hash: z.string().length(64),
+});
+
+const attachmentsDeltaSchema = z.object({
+  from: z.array(attachmentRefSchema),
+  to: z.array(attachmentRefSchema),
+});
+
+export const vocDescriptionEditedDetailSchema = z
+  .object({
+    voc_id: uuid(),
+    changes: z
+      .object({
+        title: stringChangeSchema.optional(),
+        description_rich_content: richHashChangeSchema.optional(),
+        attachments: attachmentsDeltaSchema.optional(),
+      })
+      .refine(
+        (o) => Object.keys(o).length > 0,
+        { message: 'changes must be non-empty' },
+      ),
+  });
+export type VocDescriptionEditedDetail = z.infer<typeof vocDescriptionEditedDetailSchema>;

--- a/packages/shared/src/enums/audit-events.ts
+++ b/packages/shared/src/enums/audit-events.ts
@@ -27,6 +27,7 @@ import {
   reporterReplyCreatedDetailSchema,
   internalCommentCreatedDetailSchema,
   vocTriagePostponedDetailSchema,
+  vocDescriptionEditedDetailSchema,
 } from '../audit/voc.js';
 
 export const AUDIT_EVENT_TYPES = [
@@ -52,6 +53,8 @@ export const AUDIT_EVENT_TYPES = [
   'internal_comment_created',
   // Slice 3 #14: 보류 path audit event.
   'voc_triage_postponed',
+  // Slice 3 #17: Reporter pre-triage description edit.
+  'voc_description_edited',
 ] as const;
 export type AuditEventType = (typeof AUDIT_EVENT_TYPES)[number];
 
@@ -160,4 +163,6 @@ export const AUDIT_EVENT_DETAIL_SCHEMAS = {
   internal_comment_created: internalCommentCreatedDetailSchema,
   // Slice 3 #14: 보류 path audit event.
   voc_triage_postponed: vocTriagePostponedDetailSchema,
+  // Slice 3 #17: Reporter pre-triage description edit.
+  voc_description_edited: vocDescriptionEditedDetailSchema,
 } as const satisfies Record<AuditEventType, z.ZodTypeAny>;

--- a/packages/shared/src/errors/__tests__/codes.test.ts
+++ b/packages/shared/src/errors/__tests__/codes.test.ts
@@ -12,3 +12,15 @@ describe('errorCodeSchema — Slice 3 #13 codes', () => {
     expect(errorCodeSchema.parse(code)).toBe(code);
   });
 });
+
+describe('errorCodeSchema — Slice 3 #17 codes', () => {
+  it('parses conflict.triage_already_committed', () => {
+    expect(errorCodeSchema.parse('conflict.triage_already_committed')).toBe(
+      'conflict.triage_already_committed',
+    );
+  });
+
+  it('rejects unknown code', () => {
+    expect(() => errorCodeSchema.parse('conflict.unknown_code')).toThrow();
+  });
+});

--- a/packages/shared/src/errors/codes.ts
+++ b/packages/shared/src/errors/codes.ts
@@ -54,6 +54,8 @@ export const ERROR_CODES = [
   // reporter_facing_status.* → 422 (Slice 3 #16 — transition validation + gate)
   'reporter_facing_status.invalid_transition',
   'reporter_facing_status.gate_blocked',
+  // conflict.* → 409 (Slice 3 #17 — Reporter edit blocked by committed triage)
+  'conflict.triage_already_committed',
 ] as const;
 
 export const errorCodeSchema = z.enum(ERROR_CODES);

--- a/packages/shared/src/vocs/__tests__/edit-description-request.test.ts
+++ b/packages/shared/src/vocs/__tests__/edit-description-request.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+
+import { editDescriptionRequestSchema } from '../edit-description-request.js';
+
+const validDoc = {
+  type: 'doc' as const,
+  content: [{ type: 'paragraph', content: [{ type: 'text', text: 'hello' }] }],
+};
+
+describe('editDescriptionRequestSchema', () => {
+  it('accepts all 3 fields', () => {
+    const result = editDescriptionRequestSchema.parse({
+      title: 'New title',
+      description_rich_content: validDoc,
+      attachments: [],
+    });
+    expect(result.title).toBe('New title');
+  });
+
+  it('accepts title-only (single field)', () => {
+    const result = editDescriptionRequestSchema.parse({ title: 'Only title' });
+    expect(result.title).toBe('Only title');
+  });
+
+  it('accepts description_rich_content only', () => {
+    const result = editDescriptionRequestSchema.parse({
+      description_rich_content: validDoc,
+    });
+    expect(result.description_rich_content).toEqual(validDoc);
+  });
+
+  it('accepts attachments only', () => {
+    const result = editDescriptionRequestSchema.parse({ attachments: [] });
+    expect(result.attachments).toEqual([]);
+  });
+
+  it('rejects empty body (non-empty refinement)', () => {
+    expect(() => editDescriptionRequestSchema.parse({})).toThrow();
+  });
+
+  it('rejects unknown key (strict mode)', () => {
+    expect(() =>
+      editDescriptionRequestSchema.parse({ title: 'ok', foobar: 'extra' }),
+    ).toThrow(z.ZodError);
+  });
+
+  it('rejects __proto__ key via Object.create (strict mode catches extra keys)', () => {
+    // Note: `{ title: 'ok', __proto__: 'x' }` in a JS object literal sets the
+    // prototype, not a real enumerable key, so Object.keys() doesn't surface it
+    // and Zod .strict() cannot catch it via that path. The actual __proto__ XSS
+    // surface is defense-in-depth handled by JSON schema validation upstream.
+    // We verify that a real unknown key (e.g. 'proto') is caught instead.
+    expect(() =>
+      editDescriptionRequestSchema.parse({ title: 'ok', proto: 'x' }),
+    ).toThrow(z.ZodError);
+  });
+
+  it('rejects title too short (empty string)', () => {
+    expect(() =>
+      editDescriptionRequestSchema.parse({ title: '' }),
+    ).toThrow(z.ZodError);
+  });
+
+  it('rejects title too long (201 chars)', () => {
+    expect(() =>
+      editDescriptionRequestSchema.parse({ title: 'a'.repeat(201) }),
+    ).toThrow(z.ZodError);
+  });
+
+  it('accepts title at max length (200 chars)', () => {
+    const result = editDescriptionRequestSchema.parse({ title: 'a'.repeat(200) });
+    expect(result.title?.length).toBe(200);
+  });
+
+  it('rejects malformed uuid in attachments', () => {
+    expect(() =>
+      editDescriptionRequestSchema.parse({
+        attachments: [{
+          id: 'not-a-uuid',
+          name: 'file.txt',
+          size_bytes: 100,
+          mime_type: 'text/plain',
+          storage_uri: 'gs://bucket/file',
+        }],
+      }),
+    ).toThrow(z.ZodError);
+  });
+
+  it('rejects id field (forbidden, strict mode catches it)', () => {
+    expect(() =>
+      editDescriptionRequestSchema.parse({ title: 'ok', id: 'some-id' }),
+    ).toThrow(z.ZodError);
+  });
+
+  it('rejects created_at field (strict mode)', () => {
+    expect(() =>
+      editDescriptionRequestSchema.parse({ title: 'ok', created_at: 'now' }),
+    ).toThrow(z.ZodError);
+  });
+});

--- a/packages/shared/src/vocs/edit-description-request.ts
+++ b/packages/shared/src/vocs/edit-description-request.ts
@@ -1,0 +1,72 @@
+import { z } from 'zod';
+
+import type { ErrorCode } from '../errors/codes.js';
+import { attachmentRefSchema, tipTapDocSchema } from './create-request.js';
+
+// ── editDescriptionRequestSchema ───────────────────────────────────────────
+// Used by PATCH /vocs/:id/description (Slice 3 #17). Strict so that any
+// field outside the allowlist is rejected as `unrecognized_keys` by Zod —
+// the schema's `.strict()` is the security boundary, not the forbidden-field
+// pre-check below. The pre-check exists only for UX precision on known named
+// server fields.
+export const editDescriptionRequestSchema = z
+  .object({
+    title: z.string().min(1).max(200).optional(),
+    description_rich_content: tipTapDocSchema.optional(),
+    attachments: z.array(attachmentRefSchema).optional(),
+  })
+  .strict()
+  .refine(
+    (o) => Object.keys(o).length > 0,
+    { message: 'at least one field required' },
+  );
+
+export type EditDescriptionRequest = z.infer<typeof editDescriptionRequestSchema>;
+
+// ── FORBIDDEN_EDIT_DESCRIPTION_FIELDS ─────────────────────────────────────
+// UX-only: known server-managed fields that a reporter might accidentally
+// send. Each maps to `validation.unexpected_field` so the response carries
+// a precise per-field path. `.strict()` catches anything else not on this
+// list as generic `validation.failed` with Zod `unrecognized_keys`.
+export const FORBIDDEN_EDIT_DESCRIPTION_FIELDS = [
+  'severity',
+  'owner_user_id',
+  'owner_team_id',
+  'analytics_area_id',
+  'triage_state',
+  'cluster_decision',
+  'reporter_facing_status',
+  'source_context',
+  'primary_managed_system_id',
+  'reporter_id',
+  'archived_at',
+  'workspace_id',
+  'display_id',
+  'id',
+  'created_at',
+  'updated_at',
+] as const;
+
+export type ForbiddenEditDescriptionField =
+  (typeof FORBIDDEN_EDIT_DESCRIPTION_FIELDS)[number];
+
+export const FORBIDDEN_EDIT_DESCRIPTION_FIELD_ERROR_CODES: Readonly<
+  Record<ForbiddenEditDescriptionField, ErrorCode>
+> = {
+  severity: 'validation.unexpected_field',
+  owner_user_id: 'validation.unexpected_field',
+  owner_team_id: 'validation.unexpected_field',
+  analytics_area_id: 'validation.unexpected_field',
+  triage_state: 'validation.unexpected_field',
+  cluster_decision: 'validation.unexpected_field',
+  reporter_facing_status: 'validation.unexpected_field',
+  source_context: 'validation.unexpected_field',
+  primary_managed_system_id: 'validation.unexpected_field',
+  reporter_id: 'validation.unexpected_field',
+  archived_at: 'validation.unexpected_field',
+  workspace_id: 'validation.unexpected_field',
+  display_id: 'validation.unexpected_field',
+  id: 'validation.unexpected_field',
+  created_at: 'validation.unexpected_field',
+  updated_at: 'validation.unexpected_field',
+};

--- a/packages/shared/src/vocs/index.ts
+++ b/packages/shared/src/vocs/index.ts
@@ -2,6 +2,7 @@ export * from './conversation-query.js';
 export * from './conversation.js';
 export * from './create-request.js';
 export * from './detail.js';
+export * from './edit-description-request.js';
 export * from './internal-comment-request.js';
 export * from './list-item.js';
 export * from './list-query.js';


### PR DESCRIPTION
Closes #17.

**Slice 3 BE exit criterion fully closed.** `docs/implementation/08-mvp-slice-plan.md` "Reporter can edit title, description, and attachments only before triage" is the last open BE item; this PR ships it.

## Summary
- Reporter-only `PATCH /vocs/:id/description` (no admin elevation). Pre-triage only.
- Fields: `title` / `description_rich_content` / `attachments` (≥1, `.strict()`).
- Service order: lock VOC → reporter check → triage gate → If-Match → MS lock → sanitize → diff → UPDATE → audit. Empty diff = 200 no UPDATE no audit.
- New ADR-0012 code `conflict.triage_already_committed` (409, `detail.current_triage_state`).
- New audit event `voc_description_edited` (per-key shape, description hashed via `stableStringify` + SHA-256).
- New `reporterEdit: 30/min` rate-limit bucket.
- API contracts doc updated.

## Verify
- `pnpm -w typecheck` — pass.
- `pnpm --filter @fops/backend test` — **558/558** live Postgres (+39 from 519 baseline).
- 2-cycle review (codex CLI + Opus subagent) — 0 unresolved BLOCKER/MAJOR.

## Out of scope (documented)
- Attachment storage (#22) — sanitizer accepts the schema field; service rejects non-empty.
- Two-tx concurrency fixture — current race tests use sequential SQL injection (same caveat as #14); follow-up across the codebase.

Refs: `.review/SLICE-3-17-PLAN.md`, `REVIEW-CYCLE-{1,2}.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)