### PR TITLE
feat(slice3 #50): apiClient rate-limit headers + errorMapper inline wait

### DIFF
--- a/apps/frontend/src/lib/api/__tests__/client.test.ts
+++ b/apps/frontend/src/lib/api/__tests__/client.test.ts
@@ -106,4 +106,67 @@ describe('apiClient', () => {
     const init = getCallInit(fetchMock);
     expect(init.credentials).toBe('include');
   });
+
+  it('429 ApiError populates rateLimit + retryAfterSeconds from headers', async () => {
+    const resetEpoch = Math.floor(Date.now() / 1000) + 30;
+    global.fetch = mockFetch({
+      ok: false,
+      status: 429,
+      headers: {
+        'x-ratelimit-limit': '100',
+        'x-ratelimit-remaining': '0',
+        'x-ratelimit-reset': String(resetEpoch),
+        'retry-after': '30',
+      },
+      jsonBody: {
+        code: 'rate_limited.actor',
+        message: 'rate limit exceeded',
+        detail: { retry_after_seconds: 30 },
+      },
+    });
+    try {
+      await apiClient('POST', '/x', { body: {} });
+      throw new Error('should have thrown');
+    } catch (e) {
+      const err = e as ApiError;
+      expect(err).toBeInstanceOf(ApiError);
+      expect(err.code).toBe('rate_limited.actor');
+      expect(err.retryAfterSeconds).toBe(30);
+      expect(err.rateLimit).toEqual({
+        limit: 100,
+        remaining: 0,
+        resetAt: new Date(resetEpoch * 1000),
+      });
+    }
+  });
+
+  it('200 ApiResponse exposes rateLimit when headers present', async () => {
+    const resetEpoch = Math.floor(Date.now() / 1000) + 60;
+    global.fetch = mockFetch({
+      status: 200,
+      jsonBody: { ok: true },
+      headers: {
+        'x-ratelimit-limit': '50',
+        'x-ratelimit-remaining': '49',
+        'x-ratelimit-reset': String(resetEpoch),
+      },
+    });
+    const res = await apiClient('GET', '/x');
+    expect(res.rateLimit).toEqual({
+      limit: 50,
+      remaining: 49,
+      resetAt: new Date(resetEpoch * 1000),
+    });
+    expect(res.retryAfterSeconds).toBeUndefined();
+  });
+
+  it('omits rateLimit when any ratelimit header missing', async () => {
+    global.fetch = mockFetch({
+      status: 200,
+      jsonBody: {},
+      headers: { 'x-ratelimit-limit': '50' },
+    });
+    const res = await apiClient('GET', '/x');
+    expect(res.rateLimit).toBeUndefined();
+  });
 });

--- a/apps/frontend/src/lib/api/__tests__/errorMapper.test.ts
+++ b/apps/frontend/src/lib/api/__tests__/errorMapper.test.ts
@@ -63,6 +63,30 @@ describe('errorMapper — ERROR_CODES coverage', () => {
     expect(called).toBe(true);
   });
 
+  it('rate_limited.actor renders retry_after_seconds inline (<60s → 초)', () => {
+    const mapped = errorMapper({
+      code: 'rate_limited.actor',
+      message: 'rate limit exceeded',
+      detail: { retry_after_seconds: 30 },
+    });
+    expect(mapped.tone).toBe('warning');
+    expect(mapped.message).toContain('30초');
+  });
+
+  it('rate_limited.ip renders retry_after_seconds inline (≥60s → 분, ceil)', () => {
+    const mapped = errorMapper({
+      code: 'rate_limited.ip',
+      message: 'rate limit exceeded',
+      detail: { retry_after_seconds: 75 },
+    });
+    expect(mapped.message).toContain('2분');
+  });
+
+  it('rate_limited.actor falls back to generic wait copy without detail', () => {
+    const mapped = errorMapper({ code: 'rate_limited.actor', message: '' });
+    expect(mapped.message).toBe('요청이 너무 많습니다. 잠시 후 다시 시도해 주세요.');
+  });
+
   it('unknown code falls back to generic error', () => {
     const mapped = errorMapper({ code: 'made.up.code' as ErrorCode, message: '' });
     expect(mapped.message).toBe(GENERIC_ERROR_MESSAGE);

--- a/apps/frontend/src/lib/api/client.ts
+++ b/apps/frontend/src/lib/api/client.ts
@@ -1,4 +1,4 @@
-import { ApiError, type ApiErrorEnvelope } from './types';
+import { ApiError, type ApiErrorEnvelope, type RateLimitInfo } from './types';
 
 export interface ApiClientOptions {
   body?: unknown;
@@ -14,6 +14,8 @@ export interface ApiResponse<T> {
   data: T;
   etag: string | undefined;
   requestId: string | undefined;
+  rateLimit?: RateLimitInfo;
+  retryAfterSeconds?: number;
 }
 
 // PUT is intentionally excluded: the locked API contract auto-mints Idempotency-Key
@@ -49,9 +51,13 @@ export async function apiClient<T = unknown>(
 
   const etag = res.headers.get('etag') ?? undefined;
   const requestId = res.headers.get('x-request-id') ?? undefined;
+  const { rateLimit, retryAfterSeconds } = parseRateLimitHeaders(res.headers);
 
   if (res.status === 304) {
-    return { status: 304, data: undefined as T, etag, requestId };
+    const base: ApiResponse<T> = { status: 304, data: undefined as T, etag, requestId };
+    if (rateLimit) base.rateLimit = rateLimit;
+    if (retryAfterSeconds !== undefined) base.retryAfterSeconds = retryAfterSeconds;
+    return base;
   }
 
   const text = await res.text();
@@ -62,13 +68,45 @@ export async function apiClient<T = unknown>(
       data && typeof data === 'object' && 'code' in data
         ? (data as ApiErrorEnvelope)
         : { code: 'internal.unexpected', message: `HTTP ${res.status}` };
-    throw new ApiError(res.status, envelope, requestId);
+    throw new ApiError(res.status, envelope, requestId, rateLimit, retryAfterSeconds);
   }
 
-  return { status: res.status, data: data as T, etag, requestId };
+  const base: ApiResponse<T> = { status: res.status, data: data as T, etag, requestId };
+  if (rateLimit) base.rateLimit = rateLimit;
+  if (retryAfterSeconds !== undefined) base.retryAfterSeconds = retryAfterSeconds;
+  return base;
 }
 
 function mintInlineKey(): string {
   if (typeof crypto !== 'undefined' && crypto.randomUUID) return crypto.randomUUID();
   return Math.random().toString(36).slice(2) + Date.now().toString(36);
+}
+
+// Parses fastify @fastify/rate-limit response headers.
+// `x-ratelimit-reset` is unix epoch seconds; `retry-after` is delta-seconds.
+// All four headers must be present and integer-parseable for rateLimit to be populated;
+// otherwise the field is omitted (callers fall back to generic copy).
+function parseRateLimitHeaders(
+  headers: Headers,
+): { rateLimit?: RateLimitInfo; retryAfterSeconds?: number } {
+  const limit = parseIntHeader(headers.get('x-ratelimit-limit'));
+  const remaining = parseIntHeader(headers.get('x-ratelimit-remaining'));
+  const reset = parseIntHeader(headers.get('x-ratelimit-reset'));
+  const retryAfter = parseIntHeader(headers.get('retry-after'));
+
+  const rateLimit: RateLimitInfo | undefined =
+    limit !== undefined && remaining !== undefined && reset !== undefined
+      ? { limit, remaining, resetAt: new Date(reset * 1000) }
+      : undefined;
+
+  const result: { rateLimit?: RateLimitInfo; retryAfterSeconds?: number } = {};
+  if (rateLimit) result.rateLimit = rateLimit;
+  if (retryAfter !== undefined) result.retryAfterSeconds = retryAfter;
+  return result;
+}
+
+function parseIntHeader(raw: string | null): number | undefined {
+  if (raw == null) return undefined;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) ? n : undefined;
 }

--- a/apps/frontend/src/lib/api/errorMapper.ts
+++ b/apps/frontend/src/lib/api/errorMapper.ts
@@ -20,8 +20,24 @@ const CATALOG: Partial<Record<ErrorCode, CatalogEntry>> = {
   'permission.scope_required': { tone: 'error', message: '해당 Managed System에 대한 권한이 없습니다.' },
 
   // rate_limited.*
-  'rate_limited.actor': { tone: 'warning', message: '요청이 너무 많습니다. 잠시 후 다시 시도해 주세요.' },
-  'rate_limited.ip':    { tone: 'warning', message: '동일 IP에서의 요청이 너무 많습니다. 잠시 후 다시 시도해 주세요.' },
+  'rate_limited.actor': {
+    tone: 'warning',
+    message: (detail) => {
+      const wait = formatRetryAfter(detail);
+      return wait
+        ? `요청이 너무 많습니다. ${wait} 후 다시 시도해 주세요.`
+        : '요청이 너무 많습니다. 잠시 후 다시 시도해 주세요.';
+    },
+  },
+  'rate_limited.ip': {
+    tone: 'warning',
+    message: (detail) => {
+      const wait = formatRetryAfter(detail);
+      return wait
+        ? `동일 IP에서의 요청이 너무 많습니다. ${wait} 후 다시 시도해 주세요.`
+        : '동일 IP에서의 요청이 너무 많습니다. 잠시 후 다시 시도해 주세요.';
+    },
+  },
 
   // validation.*
   'validation.failed':                    { tone: 'error', message: '입력값이 올바르지 않습니다.' },
@@ -63,6 +79,14 @@ const CATALOG: Partial<Record<ErrorCode, CatalogEntry>> = {
   'reporter_facing_status.invalid_transition': { tone: 'warning', message: '허용되지 않는 상태 전환입니다.' },
   'reporter_facing_status.gate_blocked':       { tone: 'warning', message: '권한 게이트로 상태를 변경할 수 없습니다.' },
 };
+
+function formatRetryAfter(detail?: Record<string, unknown>): string | undefined {
+  const raw = detail?.['retry_after_seconds'];
+  const secs = typeof raw === 'number' && Number.isFinite(raw) ? raw : undefined;
+  if (secs === undefined || secs <= 0) return undefined;
+  if (secs < 60) return `${secs}초`;
+  return `${Math.ceil(secs / 60)}분`;
+}
 
 export function errorMapper(envelope: ApiErrorEnvelope, opts?: { onRetry?: () => void }): MappedError {
   const entry = CATALOG[envelope.code];

--- a/apps/frontend/src/lib/api/types.ts
+++ b/apps/frontend/src/lib/api/types.ts
@@ -5,11 +5,19 @@ import type { ErrorCode, ErrorEnvelope } from '@fops/shared';
 // (packages/shared/src/errors/codes.ts); do NOT duplicate it here.
 export type { ErrorEnvelope as ApiErrorEnvelope } from '@fops/shared';
 
+export interface RateLimitInfo {
+  limit: number;
+  remaining: number;
+  resetAt: Date;
+}
+
 export class ApiError extends Error {
   constructor(
     public readonly status: number,
     public readonly envelope: ErrorEnvelope,
     public readonly requestId?: string,
+    public readonly rateLimit?: RateLimitInfo,
+    public readonly retryAfterSeconds?: number,
   ) {
     super(envelope.message);
     this.name = 'ApiError';


### PR DESCRIPTION
## Summary

Closes #50. apiClient now parses BE rate-limit response headers (`apps/backend/src/server.ts:156-166`) and exposes them on success and failure paths. errorMapper renders Korean wait time inline.

- `ApiResponse<T>` + `ApiError`: `rateLimit?: { limit, remaining, resetAt: Date }`, `retryAfterSeconds?: number`
- Header conventions: `x-ratelimit-reset` = unix epoch seconds; `retry-after` = delta-seconds
- Conservative: all three `x-ratelimit-*` headers must be present + parseable; otherwise `rateLimit` is omitted
- errorMapper `rate_limited.actor` / `rate_limited.ip` switched to function-form catalog entries reading `envelope.detail.retry_after_seconds`; <60s → "N초", ≥60s → "N분" (`Math.ceil`)

## Test plan

- [x] `pnpm -F @fops/frontend typecheck` — pass
- [x] `pnpm -F @fops/frontend test` — 81 tests pass (75 → 81)
- [ ] Manual: trigger 429 on a mutation route in dev → toast shows inline wait copy

## Unblocks

#19 / #21 toasts on `rate_limited.*` now render precise retry timing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)