### PR TITLE
feat(slice3 #22 C5): shared AttachmentCreated schema + FE attachments api client

### DIFF
--- a/.review/CHUNK-22-C5-DEVIATIONS.md
+++ b/.review/CHUNK-22-C5-DEVIATIONS.md
@@ -1,0 +1,88 @@
+# PLAN-22 C5 — Deviations
+
+Branch: `feature/22-c5-shared-attachment-schema-fe-api`
+
+## Scope-Aligned Decisions
+
+1. **`AttachmentRef` not re-exported.** The existing `AttachmentRef` (in
+   `packages/shared/src/vocs/create-request.ts`) carries `storage_uri`, which
+   `AttachmentCreated` intentionally drops. They are distinct contracts:
+   - `AttachmentRef` — VOC create/edit request payload (legacy shape; will
+     be reconciled in a later chunk).
+   - `AttachmentCreated` — strict POST /attachments 201 envelope; what the
+     FE upload helper returns.
+   Re-exporting would imply structural compatibility that does not exist.
+   Plan said "if exists, re-export only" — the safer call is to keep them
+   separate. No FE consumer in this chunk needs `AttachmentRef`.
+
+2. **`apiClient` extended to accept `FormData`.** The plan listed
+   `apiClient.post('/attachments', formData, ...)` but `apiClient` did not
+   support multipart (always JSON-stringified `body` and set
+   `Content-Type: application/json`). Added an `opts.formData?: FormData`
+   field — when present, `body` is ignored and `Content-Type` is left for
+   the browser to set with the multipart boundary. This is a minimal,
+   composable change (~5 LOC in `client.ts`) and keeps `ApiError` /
+   rate-limit handling consistent with every other call site (Rule 3 —
+   blocking issue for the task; resolved in-place).
+
+3. **`attachment.unsupported_pending_storage_slice` left in `ERROR_CODES`.**
+   Plan said to retire the FE mapping row. The shared `ERROR_CODES` enum
+   still includes the code because BE (`apps/backend/src/modules/voc/*`)
+   actively emits it from `service.ts`, `conversation-service.ts`, and
+   reporter-reply / patch-description / create-voc integration paths.
+   Removing the code from `ERROR_CODES` would break BE compilation, and
+   the plan said "DO NOT touch BE — C4a/b parallel." Resolution:
+   - FE `errorMapper` CATALOG row REMOVED (the retiring action).
+   - `errorMapper.test.ts` adds a `RETIRING_CODES` exemption so the
+     Slice-3-owner non-fallback invariant skips this code (it now falls
+     back to the generic envelope copy by design, with a new explicit
+     test asserting that fallback).
+   - When C4a/C4b lands and BE stops emitting the code, a later chunk
+     can also remove it from `ERROR_CODES` in `packages/shared` (and the
+     RETIRING_CODES exemption).
+
+4. **Test framework — `vi.fn(fetch)`, not msw.** Plan suggested msw-based
+   tests; the FE house style (per `client.test.ts`,
+   `VocCreateScreen.integration.test.tsx` comment header) is to mock
+   `global.fetch` with `vi.fn`. Adopted the house style — no msw dependency
+   was added.
+
+5. **Idempotency-Key is opt-in via `opts.idempotencyKey`, not a hook.**
+   `useIdempotencyKey()` is a React hook and `uploadAttachment` is a plain
+   async function callable from non-hook contexts (event handlers, queries,
+   workers). Callers pass `opts.idempotencyKey` from a hook-derived value
+   in their component; if absent, `apiClient` auto-mints a UUID via its
+   existing fallback. Matches the existing pattern in
+   `auth.ts` / `analytics-areas.ts`.
+
+## Out-Of-Scope Untouched
+
+- BE `attachments` module — C4a/b owns.
+- FE components / dropzone — C6 owns.
+- `attachment.unsupported_pending_storage_slice` references in BE — C4
+  owns the BE retirement.
+
+## Verification
+
+- `pnpm --filter @fops/shared test` — 253/253 pass (+6 new in
+  `vocs/__tests__/attachment.test.ts`).
+- `pnpm --filter @fops/frontend test` — 406/406 pass (+6 new in
+  `lib/api/__tests__/attachments.test.ts`, +4 new in
+  `lib/api/__tests__/errorMapper.test.ts`).
+- Both packages typecheck clean.
+
+## Commits
+
+1. `c60d94d feat(22-c5): add AttachmentCreated shared schema`
+2. `d942514 feat(22-c5): wire attachment.js into shared vocs barrel + FE api client`
+
+## Branch Hygiene Note
+
+During execution, the repository working tree had branch state mutate
+externally (likely a parallel agent on a sibling worktree or shared CLI
+context — `feature/22-c4a-get-download` and `feature/22-c4b-purge-unlinked-attachments`
+were live in this same working directory). Two of my commits landed on
+the wrong branch tip mid-flow; both were cherry-picked back onto
+`feature/22-c5-shared-attachment-schema-fe-api` and the sibling branches
+were reset to their pre-C5 tips (`a3ceea9` and `9078e6c` respectively).
+Final state on C5 branch is correct and verified via `git log --oneline`.

--- a/apps/frontend/src/lib/api/__tests__/attachments.test.ts
+++ b/apps/frontend/src/lib/api/__tests__/attachments.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { uploadAttachment } from '../attachments';
+import { ApiError } from '../types';
+
+const originalFetch = global.fetch;
+afterEach(() => {
+  global.fetch = originalFetch;
+});
+
+const UUID = '00000000-0000-4000-8000-000000000001';
+const UUID2 = '00000000-0000-4000-8000-000000000002';
+const VALID_201 = {
+  id: UUID,
+  name: 'screenshot.png',
+  size_bytes: 1024,
+  mime_type: 'image/png',
+  uploaded_by_actor_id: UUID2,
+  created_at: '2026-05-22T10:00:00.000Z',
+};
+
+type MockArgs = {
+  ok?: boolean;
+  status?: number;
+  headers?: Record<string, string>;
+  jsonBody?: unknown;
+};
+
+function mockFetch(response: MockArgs): typeof fetch {
+  const headers = new Headers(response.headers);
+  return vi.fn(async () =>
+    ({
+      ok: response.ok ?? true,
+      status: response.status ?? 200,
+      headers,
+      text: async () =>
+        response.jsonBody !== undefined ? JSON.stringify(response.jsonBody) : '',
+    } as Response),
+  ) as unknown as typeof fetch;
+}
+
+function getCallArgs(fetchMock: typeof fetch): [string, RequestInit] {
+  const calls = (fetchMock as unknown as ReturnType<typeof vi.fn>).mock.calls as [
+    string,
+    RequestInit,
+  ][];
+  const first = calls[0];
+  if (!first) throw new Error('fetch was not called');
+  return first;
+}
+
+function makeFile(name = 'screenshot.png', type = 'image/png'): File {
+  return new File(['hello'], name, { type });
+}
+
+describe('uploadAttachment', () => {
+  it('POSTs multipart with Idempotency-Key header (no Content-Type)', async () => {
+    const fetchMock = mockFetch({ status: 201, jsonBody: VALID_201 });
+    global.fetch = fetchMock;
+    await uploadAttachment(makeFile(), { idempotencyKey: 'key-abc' });
+    const [url, init] = getCallArgs(fetchMock);
+    expect(url).toBe('/attachments');
+    expect(init.method).toBe('POST');
+    const headers = init.headers as Record<string, string>;
+    expect(headers['Idempotency-Key']).toBe('key-abc');
+    // Browser sets multipart boundary — we must NOT set Content-Type ourselves.
+    expect(headers['Content-Type']).toBeUndefined();
+    expect(init.body).toBeInstanceOf(FormData);
+    const fd = init.body as FormData;
+    expect(fd.get('file')).toBeInstanceOf(File);
+  });
+
+  it('returns parsed AttachmentCreated on 201', async () => {
+    global.fetch = mockFetch({ status: 201, jsonBody: VALID_201 });
+    const result = await uploadAttachment(makeFile());
+    expect(result.id).toBe(UUID);
+    expect(result.name).toBe('screenshot.png');
+    expect(result.size_bytes).toBe(1024);
+    expect(result.uploaded_by_actor_id).toBe(UUID2);
+  });
+
+  it('maps 422 attachment.too_large to typed ApiError', async () => {
+    global.fetch = mockFetch({
+      ok: false,
+      status: 422,
+      jsonBody: { code: 'attachment.too_large', message: 'too big' },
+    });
+    await expect(uploadAttachment(makeFile())).rejects.toBeInstanceOf(ApiError);
+    global.fetch = mockFetch({
+      ok: false,
+      status: 422,
+      jsonBody: { code: 'attachment.too_large', message: 'too big' },
+    });
+    try {
+      await uploadAttachment(makeFile());
+    } catch (e) {
+      expect((e as ApiError).code).toBe('attachment.too_large');
+      expect((e as ApiError).status).toBe(422);
+    }
+  });
+
+  it('maps 422 attachment.unsupported_type to typed ApiError', async () => {
+    global.fetch = mockFetch({
+      ok: false,
+      status: 422,
+      jsonBody: { code: 'attachment.unsupported_type', message: 'nope' },
+    });
+    try {
+      await uploadAttachment(makeFile());
+    } catch (e) {
+      expect((e as ApiError).code).toBe('attachment.unsupported_type');
+    }
+  });
+
+  it('maps 502 storage.unavailable to typed ApiError', async () => {
+    global.fetch = mockFetch({
+      ok: false,
+      status: 502,
+      jsonBody: { code: 'storage.unavailable', message: 'down' },
+    });
+    try {
+      await uploadAttachment(makeFile());
+    } catch (e) {
+      expect((e as ApiError).code).toBe('storage.unavailable');
+      expect((e as ApiError).status).toBe(502);
+    }
+  });
+
+  it('maps 429 rate_limited.actor with retry-after', async () => {
+    const reset = Math.floor(Date.now() / 1000) + 30;
+    global.fetch = mockFetch({
+      ok: false,
+      status: 429,
+      headers: {
+        'x-ratelimit-limit': '100',
+        'x-ratelimit-remaining': '0',
+        'x-ratelimit-reset': String(reset),
+        'retry-after': '30',
+      },
+      jsonBody: {
+        code: 'rate_limited.actor',
+        message: 'too many',
+        detail: { retry_after_seconds: 30 },
+      },
+    });
+    try {
+      await uploadAttachment(makeFile());
+    } catch (e) {
+      const err = e as ApiError;
+      expect(err.code).toBe('rate_limited.actor');
+      expect(err.retryAfterSeconds).toBe(30);
+    }
+  });
+});

--- a/apps/frontend/src/lib/api/__tests__/errorMapper.test.ts
+++ b/apps/frontend/src/lib/api/__tests__/errorMapper.test.ts
@@ -14,9 +14,18 @@ const SLICE_3_OWNER_CODES_EXACT: ReadonlyArray<ErrorCode> = [
   'conflict.stale_write',
   'conflict.triage_already_committed',
   'conflict.idempotency_key_reuse',
+  'storage.unavailable',
+];
+
+// Codes whose FE mapping is being retired (PLAN-22 C5). BE may still emit
+// them transiently while C4a/C4b lands; mapping rows are intentionally
+// removed so a retiring code falls back to the generic envelope copy.
+const RETIRING_CODES: ReadonlyArray<ErrorCode> = [
+  'attachment.unsupported_pending_storage_slice',
 ];
 
 function isSlice3OwnerCode(code: ErrorCode): boolean {
+  if (RETIRING_CODES.includes(code)) return false;
   return (
     SLICE_3_OWNER_PREFIXES.some((p) => code.startsWith(p)) ||
     SLICE_3_OWNER_CODES_EXACT.includes(code)
@@ -85,6 +94,31 @@ describe('errorMapper — ERROR_CODES coverage', () => {
   it('rate_limited.actor falls back to generic wait copy without detail', () => {
     const mapped = errorMapper({ code: 'rate_limited.actor', message: '' });
     expect(mapped.message).toBe('요청이 너무 많습니다. 잠시 후 다시 시도해 주세요.');
+  });
+
+  it('storage.unavailable maps to error tone with Korean copy', () => {
+    const mapped = errorMapper({ code: 'storage.unavailable', message: '' });
+    expect(mapped.tone).toBe('error');
+    expect(mapped.message).not.toBe(GENERIC_ERROR_MESSAGE);
+    expect(mapped.message.length).toBeGreaterThan(0);
+  });
+
+  it('attachment.too_large maps to non-generic Korean copy', () => {
+    const mapped = errorMapper({ code: 'attachment.too_large', message: '' });
+    expect(mapped.message).not.toBe(GENERIC_ERROR_MESSAGE);
+  });
+
+  it('attachment.unsupported_type maps to non-generic Korean copy', () => {
+    const mapped = errorMapper({ code: 'attachment.unsupported_type', message: '' });
+    expect(mapped.message).not.toBe(GENERIC_ERROR_MESSAGE);
+  });
+
+  it('attachment.unsupported_pending_storage_slice is retired — falls back to generic', () => {
+    const mapped = errorMapper({
+      code: 'attachment.unsupported_pending_storage_slice',
+      message: '',
+    });
+    expect(mapped.message).toBe(GENERIC_ERROR_MESSAGE);
   });
 
   it('unknown code falls back to generic error', () => {

--- a/apps/frontend/src/lib/api/attachments.ts
+++ b/apps/frontend/src/lib/api/attachments.ts
@@ -1,0 +1,39 @@
+import { AttachmentCreatedSchema, type AttachmentCreated } from '@fops/shared';
+import { apiClient } from './client';
+
+export interface UploadAttachmentOpts {
+  /**
+   * Caller-supplied Idempotency-Key. Components should source this from
+   * `useIdempotencyKey()` so per-call-site stability is preserved.
+   * If omitted, apiClient auto-mints a UUID (acceptable for one-shot uploads
+   * not bound to a parent mutation).
+   */
+  idempotencyKey?: string;
+  signal?: AbortSignal;
+}
+
+/**
+ * POST /attachments — multipart upload (PLAN-22 C3b/C5).
+ *
+ * Browser sets `multipart/form-data; boundary=...` automatically when
+ * the body is a FormData instance; do NOT set Content-Type explicitly
+ * or the boundary parameter will be missing and the BE multipart parser
+ * will reject the request.
+ *
+ * Throws `ApiError` on non-2xx (mapped error codes: `attachment.too_large`,
+ * `attachment.unsupported_type`, `storage.unavailable`, `rate_limited.actor`).
+ */
+export async function uploadAttachment(
+  file: File,
+  opts: UploadAttachmentOpts = {},
+): Promise<AttachmentCreated> {
+  const formData = new FormData();
+  formData.append('file', file);
+
+  const clientOpts: Parameters<typeof apiClient>[2] = { formData };
+  if (opts.idempotencyKey !== undefined) clientOpts.idempotencyKey = opts.idempotencyKey;
+  if (opts.signal !== undefined) clientOpts.signal = opts.signal;
+
+  const res = await apiClient<unknown>('POST', '/attachments', clientOpts);
+  return AttachmentCreatedSchema.parse(res.data);
+}

--- a/apps/frontend/src/lib/api/client.ts
+++ b/apps/frontend/src/lib/api/client.ts
@@ -2,6 +2,12 @@ import { ApiError, type ApiErrorEnvelope, type RateLimitInfo } from './types';
 
 export interface ApiClientOptions {
   body?: unknown;
+  /**
+   * Multipart body. When set, `body` is ignored and Content-Type is NOT set
+   * (browser fills in `multipart/form-data; boundary=...`). Used by
+   * POST /attachments (PLAN-22 C5).
+   */
+  formData?: FormData;
   idempotencyKey?: string;
   ifMatch?: string;
   ifNoneMatch?: string;
@@ -30,7 +36,11 @@ export async function apiClient<T = unknown>(
   const upper = method.toUpperCase();
   const headers: Record<string, string> = { Accept: 'application/json', ...opts.headers };
 
-  if (opts.body !== undefined) headers['Content-Type'] = 'application/json';
+  // Only JSON bodies set Content-Type; multipart leaves it to the browser
+  // so it can append the boundary parameter.
+  if (opts.formData === undefined && opts.body !== undefined) {
+    headers['Content-Type'] = 'application/json';
+  }
 
   if (MUTATION_METHODS.has(upper)) {
     headers['Idempotency-Key'] = opts.idempotencyKey ?? mintInlineKey();
@@ -44,7 +54,9 @@ export async function apiClient<T = unknown>(
     credentials: 'include',
   };
   if (opts.signal != null) fetchInit.signal = opts.signal;
-  if (opts.body !== undefined) {
+  if (opts.formData !== undefined) {
+    fetchInit.body = opts.formData;
+  } else if (opts.body !== undefined) {
     fetchInit.body = JSON.stringify(opts.body);
   }
   const res = await fetch(path, fetchInit);

--- a/apps/frontend/src/lib/api/errorMapper.ts
+++ b/apps/frontend/src/lib/api/errorMapper.ts
@@ -72,8 +72,13 @@ const CATALOG: Partial<Record<ErrorCode, CatalogEntry>> = {
   'rich_content.disallowed_node':          { tone: 'error', message: '허용되지 않는 콘텐츠 요소가 포함되어 있습니다.' },
   'rich_content.external_image_forbidden': { tone: 'error', message: '외부 이미지 링크는 허용되지 않습니다.' },
 
-  // attachment.*
-  'attachment.unsupported_pending_storage_slice': { tone: 'warning', message: '첨부 파일은 다음 단계에서 지원됩니다.' },
+  // attachment.* (PLAN-22 C5 — pending_storage_slice row retired; BE may still emit it
+  // transiently while C4 lands and it falls back to the generic envelope copy by design).
+  'attachment.too_large':        { tone: 'error', message: '첨부 파일 크기가 허용 한도를 초과했습니다.' },
+  'attachment.unsupported_type': { tone: 'error', message: '허용되지 않는 파일 형식입니다.' },
+
+  // storage.*
+  'storage.unavailable': { tone: 'error', message: '파일 저장소에 접근할 수 없습니다. 잠시 후 다시 시도해 주세요.' },
 
   // reporter_facing_status.*
   'reporter_facing_status.invalid_transition': { tone: 'warning', message: '허용되지 않는 상태 전환입니다.' },

--- a/apps/frontend/src/lib/api/index.ts
+++ b/apps/frontend/src/lib/api/index.ts
@@ -6,3 +6,4 @@ export * from './auth';
 export * from './permissions';
 export * from './managed-systems';
 export * from './analytics-areas';
+export * from './attachments';

--- a/packages/shared/src/vocs/__tests__/attachment.test.ts
+++ b/packages/shared/src/vocs/__tests__/attachment.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { AttachmentCreatedSchema } from '../attachment.js';
+
+const UUID = '00000000-0000-4000-8000-000000000001';
+const UUID2 = '00000000-0000-4000-8000-000000000002';
+const VALID = {
+  id: UUID,
+  name: 'screenshot.png',
+  size_bytes: 12345,
+  mime_type: 'image/png',
+  uploaded_by_actor_id: UUID2,
+  created_at: '2026-05-22T10:00:00.000Z',
+};
+
+describe('AttachmentCreatedSchema', () => {
+  it('parses 201 envelope', () => {
+    const parsed = AttachmentCreatedSchema.parse(VALID);
+    expect(parsed.id).toBe(UUID);
+    expect(parsed.size_bytes).toBe(12345);
+    expect(parsed.mime_type).toBe('image/png');
+    expect(parsed.uploaded_by_actor_id).toBe(UUID2);
+  });
+
+  it('rejects extra fields (.strict)', () => {
+    expect(() =>
+      AttachmentCreatedSchema.parse({ ...VALID, storage_uri: 's3://...' }),
+    ).toThrow();
+  });
+
+  it('rejects negative size_bytes', () => {
+    expect(() => AttachmentCreatedSchema.parse({ ...VALID, size_bytes: -1 })).toThrow();
+  });
+
+  it('requires uuid id', () => {
+    expect(() => AttachmentCreatedSchema.parse({ ...VALID, id: 'not-a-uuid' })).toThrow();
+  });
+
+  it('requires uuid uploaded_by_actor_id', () => {
+    expect(() =>
+      AttachmentCreatedSchema.parse({ ...VALID, uploaded_by_actor_id: 'not-a-uuid' }),
+    ).toThrow();
+  });
+
+  it('created_at parses as ISO 8601 datetime string', () => {
+    const parsed = AttachmentCreatedSchema.parse(VALID);
+    expect(parsed.created_at).toBe('2026-05-22T10:00:00.000Z');
+    expect(() => AttachmentCreatedSchema.parse({ ...VALID, created_at: 'not-a-date' })).toThrow();
+  });
+});

--- a/packages/shared/src/vocs/attachment.ts
+++ b/packages/shared/src/vocs/attachment.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+
+/**
+ * POST /attachments 201 envelope (Slice 3 #22 / PLAN-22 C3b).
+ *
+ * Strict shape: backend returns exactly these fields after a successful
+ * multipart upload. `storage_uri` is intentionally NOT exposed to the
+ * frontend — clients reference attachments by `id` only and resolve
+ * downloads through the GET attachment endpoint (C4a).
+ *
+ * Distinct from `AttachmentRef` (vocs/create-request.ts) which is the
+ * VOC-create request payload shape (includes `storage_uri` server-side
+ * before C3b landed; will be reconciled in a later chunk).
+ */
+export const AttachmentCreatedSchema = z
+  .object({
+    id: z.string().uuid(),
+    name: z.string().min(1),
+    size_bytes: z.number().int().nonnegative(),
+    mime_type: z.string().min(1),
+    uploaded_by_actor_id: z.string().uuid(),
+    created_at: z.string().datetime({ offset: true }),
+  })
+  .strict();
+
+export type AttachmentCreated = z.infer<typeof AttachmentCreatedSchema>;

--- a/packages/shared/src/vocs/index.ts
+++ b/packages/shared/src/vocs/index.ts
@@ -1,3 +1,4 @@
+export * from './attachment.js';
 export * from './conversation-query.js';
 export * from './conversation.js';
 export * from './create-request.js';


### PR DESCRIPTION
## Summary
- `packages/shared/src/vocs/attachment.ts` — `AttachmentCreatedSchema` zod + type
- `apps/frontend/src/lib/api/attachments.ts` — `uploadAttachment(file, opts)` multipart + Idempotency-Key
- `apiClient` extended with optional `formData` to keep multipart inside ApiError/rate-limit pipeline (D2)
- errorMapper: + `storage.unavailable` Korean toast; removed `attachment.unsupported_pending_storage_slice` row (BE still emits — retires in C7b)

Plan: `.review/PLAN-22.md` §C5. Deviations: `.review/CHUNK-22-C5-DEVIATIONS.md`.

## Test plan
- [x] +6 shared schema tests
- [x] +6 FE attachments api tests (multipart + idempotency header + 422/502/429 mapping)
- [x] +4 errorMapper tests (storage.unavailable + retired-code fallback)
- [x] typecheck clean both packages

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>