### PR TITLE
feat(slice3 #22 C9, closes #41): client render-time sanitizer + shared allowlist

### DIFF
--- a/.review/CHUNK-22-C9-DEVIATIONS.md
+++ b/.review/CHUNK-22-C9-DEVIATIONS.md
@@ -1,0 +1,90 @@
+# PLAN-22 Chunk C9 — Deviations
+
+**Branch:** `feature/22-c9-client-sanitizer-shared-allowlist`
+**Scope:** Issue #41 — client render-time sanitizer + shared allowlist constant.
+
+## Summary of deltas vs. plan
+
+The chunk shipped as planned. Three notable adjustments:
+
+### 1. Backend allowlist refactor: re-export shape, not adapter shape
+
+The plan suggested "an adapter layer if BE has internal zod schemas built atop
+the data." Inspection showed the BE `surface-allowlists.ts` is **pure data**
+(`Set<string>`, plain attr maps, no zod). The cleanest refactor was therefore
+a direct re-export from `@fops/shared`:
+
+```ts
+export const SURFACES = SHARED_SURFACES;
+export const SURFACE_ALLOWLISTS: SharedAllowlists = SHARED_ALLOWLISTS;
+```
+
+This keeps every BE import path (`SURFACES`, `SURFACE_ALLOWLISTS`, `Surface`,
+`SurfaceAllowlist`, `AttrSchema`) byte-stable. The existing 237-line
+`surface-allowlists.test.ts` and the 609-line `sanitize.test.ts` both passed
+without modification.
+
+### 2. Surface enum: dashed (`voc-description`) not underscored (`voc_description`)
+
+The plan suggested underscored surface names (e.g. `voc_description`). The
+existing BE module already shipped dashed names, and `RichEditor.tsx`,
+service code, and ADR-0011 all use the dashed convention. AGENTS.md root rule:
+"Match existing docs and implementation patterns before inventing new
+structure." Surface tuple kept as `'voc-description' | 'reporter-reply' |
+'public-update' | 'internal-comment'`.
+
+### 3. Existing UI test fixtures updated to real UUIDs (Rule 1: bug)
+
+`packages/ui/__tests__/rich-content.test.tsx` used `'u1'` and `'a1'` as
+mention/attachment ids. The C9 sanitizer (mirroring the server's
+authoritative validator) drops nodes whose required `uuid` attrs do not match
+the UUID regex. Without the sanitizer these strings rendered through, but
+they never could have round-tripped from the API — the server would already
+have rejected them. Updated the fixtures to `11111111-…` style UUIDs, which
+restores test intent and matches production data shape. The assertions that
+read `@u1` text were re-pointed at the `[data-type="mention"]` element since
+the visible label comes from the actor registry, not the attr.
+
+This is the kind of fixture drift the FE sanitizer is designed to surface.
+
+## Behavioral notes (intentional, not deviations)
+
+- **Sanitizer never throws.** Server sanitizer returns a typed error union;
+  FE sanitizer silently drops invalid nodes and coerces hostile hrefs to `''`.
+  Rationale: a renderer should always have *something* to render. The server
+  pass is the source of validation errors; the FE pass is purely defensive
+  against cached or stored XSS.
+
+- **Coerce-to-`''` only for `href`.** Other URL attrs (none currently allowlisted)
+  would be DROPped rather than coerced. The coerce-to-empty pattern is
+  link-specific because dropping the `href` attr would leave a required-attr
+  hole and cause the whole link mark to fall away; coercing keeps the surrounding
+  text intact while neutralising the URL.
+
+- **Default surface mapping.** `RichContentRenderer` accepts a new optional
+  `surface` prop. When absent, `mode="reporter_visible"` → `public-update`,
+  `mode="internal"` → `internal-comment`. Existing call sites do not need to
+  change; they pick up the safest reader by default.
+
+## Verification
+
+- `pnpm --filter @fops/shared test`: 258 passed (17 files).
+- `pnpm --filter @fops/ui test`: 439 passed (38 files).
+- `pnpm --filter @fops/backend test`: 219 passed, 403 skipped (DB-gated).
+- `pnpm --filter @fops/{shared,ui,backend} typecheck`: clean.
+
+## Files touched
+
+| File | New / Modified | LOC |
+|---|---|---|
+| `packages/shared/src/rich-content/allowlist.ts` | new | ~125 |
+| `packages/shared/src/rich-content/index.ts` | new | 1 |
+| `packages/shared/src/rich-content/__tests__/allowlist.test.ts` | new | ~60 |
+| `packages/shared/src/index.ts` | +1 line | — |
+| `apps/backend/src/lib/rich-content/surface-allowlists.ts` | reduced from 165 → ~30 (re-export) | -135 |
+| `apps/backend/src/lib/rich-content/__tests__/drift-vs-shared.test.ts` | new | ~45 |
+| `packages/ui/src/rich-content/sanitizeClient.ts` | new | ~210 |
+| `packages/ui/src/rich-content/RichContentRenderer.tsx` | +sanitize call, new `surface` prop | ~15 |
+| `packages/ui/src/rich-content/__tests__/sanitizeClient.test.ts` | new | ~115 |
+| `packages/ui/__tests__/rich-content.test.tsx` | fixture UUIDs (Rule 1) | ~10 |
+| `packages/ui/package.json` | + `@fops/shared` workspace dep | 1 |

--- a/apps/backend/src/lib/rich-content/__tests__/drift-vs-shared.test.ts
+++ b/apps/backend/src/lib/rich-content/__tests__/drift-vs-shared.test.ts
@@ -1,0 +1,51 @@
+// PLAN-22 C9 — drift assertion between backend SURFACE_ALLOWLISTS and the
+// shared @fops/shared SHARED_ALLOWLISTS. If this test fails, someone changed
+// one side without the other; align them before merging.
+
+import { describe, expect, it } from 'vitest';
+import { SHARED_ALLOWLISTS, SHARED_SURFACES } from '@fops/shared';
+
+import { SURFACE_ALLOWLISTS, SURFACES } from '../surface-allowlists.js';
+
+describe('backend ↔ shared allowlist drift', () => {
+  it('SURFACES tuple matches SHARED_SURFACES (set equality)', () => {
+    expect(new Set(SURFACES)).toEqual(new Set(SHARED_SURFACES));
+  });
+
+  it.each(['voc-description', 'reporter-reply', 'public-update', 'internal-comment'] as const)(
+    '%s — node names, mark names, and attr key shape match shared',
+    (surface) => {
+      const be = SURFACE_ALLOWLISTS[surface];
+      const sh = SHARED_ALLOWLISTS[surface];
+
+      expect([...be.nodes].sort()).toEqual([...sh.nodes].sort());
+      expect([...be.marks].sort()).toEqual([...sh.marks].sort());
+      expect(Object.keys(be.nodeAttrs).sort()).toEqual(Object.keys(sh.nodeAttrs).sort());
+      expect(Object.keys(be.markAttrs).sort()).toEqual(Object.keys(sh.markAttrs).sort());
+
+      // Per-node attr key sets and AttrSchema.kind must match (deep enough to
+      // catch a typo'd attr name on one side).
+      for (const nodeType of Object.keys(sh.nodeAttrs)) {
+        const sNode = sh.nodeAttrs[nodeType]!;
+        const bNode = be.nodeAttrs[nodeType]!;
+        expect(Object.keys(bNode).sort()).toEqual(Object.keys(sNode).sort());
+        for (const k of Object.keys(sNode)) {
+          expect(bNode[k]!.kind).toBe(sNode[k]!.kind);
+        }
+      }
+      for (const markType of Object.keys(sh.markAttrs)) {
+        const sMark = sh.markAttrs[markType]!;
+        const bMark = be.markAttrs[markType]!;
+        expect(Object.keys(bMark).sort()).toEqual(Object.keys(sMark).sort());
+        for (const k of Object.keys(sMark)) {
+          expect(bMark[k]!.kind).toBe(sMark[k]!.kind);
+        }
+      }
+
+      expect(be.maxTextBytes).toBe(sh.maxTextBytes);
+      expect(be.maxDepth).toBe(sh.maxDepth);
+      expect(be.maxNodes).toBe(sh.maxNodes);
+      expect(be.maxMarks).toBe(sh.maxMarks);
+    },
+  );
+});

--- a/apps/backend/src/lib/rich-content/surface-allowlists.ts
+++ b/apps/backend/src/lib/rich-content/surface-allowlists.ts
@@ -1,164 +1,35 @@
 // apps/backend/src/lib/rich-content/surface-allowlists.ts
+//
 // Per-surface node + mark allowlists with per-attr value schemas.
 // Spec: docs/frontend/specs/voc.md §5.7. ADR-0011 names this layer authoritative.
 //
-// Layering note: the sanitizer enforces attr *shape* here (type, format, length).
-// Service-layer business rules (e.g. rejecting non-empty attachments[] until the
-// storage slice ships) are enforced separately in conversation-service.ts. These
-// two gates are intentionally distinct; do not collapse them.
-
-export const SURFACES = [
-  'voc-description',
-  'reporter-reply',
-  'public-update',
-  'internal-comment',
-] as const;
-export type Surface = (typeof SURFACES)[number];
-
-// ── AttrSchema ────────────────────────────────────────────────────────────────
-
-export type AttrSchema =
-  | { kind: 'uuid'; required: boolean }
-  | { kind: 'url'; schemes: ReadonlySet<string>; maxLen: number; required: boolean }
-  | { kind: 'string'; maxLen: number; nullable: boolean; required: boolean };
-
-// ── SurfaceAllowlist ──────────────────────────────────────────────────────────
-
-// DoS caps — these are hard structural limits, NOT UX allowances.
-// They exist to prevent adversarial payloads from exhausting the V8 call stack
-// (deep nesting) or burning CPU (extremely wide / mark-heavy documents).
+// PLAN-22 C9: the canonical data now lives in `@fops/shared/rich-content/
+// allowlist.ts` so the FE render-time sanitizer (packages/ui/src/rich-content/
+// sanitizeClient.ts) can apply the same allowlist without re-declaring it. This
+// file is a thin re-export so existing backend callers (sanitize.ts and tests)
+// keep their import paths and behavior. A `drift-vs-shared.test.ts` proves the
+// two layers stay in lockstep.
 //
-// Depth counts edges from the root doc node (depth 0) to the deepest descendant.
-// A typical rich TipTap document with ~6 list levels and inline structure reaches
-// depth ~12; cap at 32 gives ~2.5× safety margin with zero impact on real content.
-//
-// Node and mark counts are cumulative over the whole document (not per-level).
-// Real internal-comment threads rarely exceed a few hundred nodes; 5 000 / 1 000
-// provide ~10× headroom while hard-capping adversarial fan-out.
-//
-// Per-surface override is reserved for future tuning; all surfaces share these
-// defaults as locked in the cycle-1 plan review for issue #24.
-export interface SurfaceAllowlist {
-  nodes: ReadonlySet<string>;
-  marks: ReadonlySet<string>;
-  // nodeAttrs: node type → allowed attr key → value schema.
-  // A node type NOT present here means attrs must be absent or empty {}.
-  nodeAttrs: Readonly<Record<string, Readonly<Record<string, AttrSchema>>>>;
-  // markAttrs: mark type → allowed attr key → value schema.
-  // A mark type NOT present here means attrs must be absent or empty {}.
-  markAttrs: Readonly<Record<string, Readonly<Record<string, AttrSchema>>>>;
-  // Retained for back-compat reads in tests; sanitizer now uses link's AttrSchema.
-  allowedLinkSchemes: ReadonlySet<string>;
-  // hard cap on total text content (chars). Spec: 50 KB.
-  maxTextBytes: number;
-  // DoS structural caps (see header comment above).
-  maxDepth: number;
-  maxNodes: number;
-  maxMarks: number;
-}
+// Layering note unchanged: the sanitizer enforces attr *shape* here (type,
+// format, length). Service-layer business rules (e.g. rejecting non-empty
+// attachments[] until the storage slice ships) are enforced separately in
+// conversation-service.ts.
 
-// ── Shared scheme sets ────────────────────────────────────────────────────────
+import {
+  SHARED_ALLOWLISTS,
+  SHARED_SURFACES,
+  type SharedAllowlists,
+  type SharedSurface,
+  type SharedSurfaceAllowlist,
+  type AttrSchema as SharedAttrSchema,
+} from '@fops/shared';
 
-const HTTP_ONLY = new Set(['http:', 'https:']);
+// ── Re-exported public surface ───────────────────────────────────────────────
 
-// ── Shared attr schemas ───────────────────────────────────────────────────────
+export const SURFACES = SHARED_SURFACES;
+export type Surface = SharedSurface;
 
-const uuidRequired: AttrSchema = { kind: 'uuid', required: true };
+export type AttrSchema = SharedAttrSchema;
+export type SurfaceAllowlist = SharedSurfaceAllowlist;
 
-const attachmentRefAttrs: Readonly<Record<string, AttrSchema>> = {
-  id: uuidRequired,
-};
-
-const linkMarkAttrs: Readonly<Record<string, AttrSchema>> = {
-  href: { kind: 'url', schemes: HTTP_ONLY, maxLen: 2048, required: true },
-};
-
-// ── Surface definitions ───────────────────────────────────────────────────────
-
-export const SURFACE_ALLOWLISTS: Readonly<Record<Surface, SurfaceAllowlist>> = {
-  'voc-description': {
-    nodes: new Set([
-      'doc', 'paragraph', 'text',
-      'bulletList', 'orderedList', 'listItem',
-      'attachmentRef',
-    ]),
-    marks: new Set(['bold', 'italic', 'underline', 'code', 'link']),
-    nodeAttrs: {
-      attachmentRef: attachmentRefAttrs,
-    },
-    markAttrs: {
-      link: linkMarkAttrs,
-    },
-    allowedLinkSchemes: HTTP_ONLY,
-    maxTextBytes: 50 * 1024,
-    maxDepth: 32,
-    maxNodes: 5000,
-    maxMarks: 1000,
-  },
-
-  // public-update: no links, no attachments, no mentions, no images.
-  // No nodeAttrs or markAttrs entries: all attrs must be absent or empty.
-  'public-update': {
-    nodes: new Set(['doc', 'paragraph', 'text', 'bulletList', 'orderedList', 'listItem']),
-    marks: new Set(['bold', 'italic']),
-    nodeAttrs: {},
-    markAttrs: {},
-    allowedLinkSchemes: new Set<string>(),
-    maxTextBytes: 50 * 1024,
-    maxDepth: 32,
-    maxNodes: 5000,
-    maxMarks: 1000,
-  },
-
-  // reporter-reply: attachmentRef node allowed (value layer rejects non-empty
-  // attachments[] until storage slice ships); link mark allowed http/https.
-  'reporter-reply': {
-    nodes: new Set([
-      'doc', 'paragraph', 'text',
-      'bulletList', 'orderedList', 'listItem',
-      'attachmentRef',
-    ]),
-    marks: new Set(['bold', 'italic', 'code', 'link']),
-    nodeAttrs: {
-      attachmentRef: attachmentRefAttrs,
-    },
-    markAttrs: {
-      link: linkMarkAttrs,
-    },
-    allowedLinkSchemes: HTTP_ONLY,
-    maxTextBytes: 50 * 1024,
-    maxDepth: 32,
-    maxNodes: 5000,
-    maxMarks: 1000,
-  },
-
-  // internal-comment: full feature set — codeBlock, mention, attachmentRef,
-  // bold, italic, code, link.
-  'internal-comment': {
-    nodes: new Set([
-      'doc', 'paragraph', 'text',
-      'codeBlock',
-      'bulletList', 'orderedList', 'listItem',
-      'mention', 'attachmentRef',
-    ]),
-    marks: new Set(['bold', 'italic', 'code', 'link']),
-    nodeAttrs: {
-      attachmentRef: attachmentRefAttrs,
-      mention: {
-        // Canonical attr name per conversation-service.ts:517 (codex major finding).
-        actor_id: uuidRequired,
-      },
-      codeBlock: {
-        language: { kind: 'string', maxLen: 32, nullable: true, required: false },
-      },
-    },
-    markAttrs: {
-      link: linkMarkAttrs,
-    },
-    allowedLinkSchemes: HTTP_ONLY,
-    maxTextBytes: 50 * 1024,
-    maxDepth: 32,
-    maxNodes: 5000,
-    maxMarks: 1000,
-  },
-};
+export const SURFACE_ALLOWLISTS: SharedAllowlists = SHARED_ALLOWLISTS;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -9,3 +9,4 @@ export * from './permissions/index.js';
 export * from './audit/voc.js';
 export * from './audit/attachments.js';
 export * from './vocs/index.js';
+export * from './rich-content/index.js';

--- a/packages/shared/src/rich-content/__tests__/allowlist.test.ts
+++ b/packages/shared/src/rich-content/__tests__/allowlist.test.ts
@@ -1,0 +1,60 @@
+// PLAN-22 C9 RED — shared allowlist constants.
+// The shared layer is the single source of truth for per-surface node/mark/attr
+// allowlists. The backend imports and adapts it; the FE sanitizer also imports
+// it. Drift between the two would re-open the XSS hole this chunk closes.
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  SHARED_ALLOWLISTS,
+  SHARED_SURFACES,
+  type SharedAllowlists,
+  type SharedSurface,
+} from '../allowlist.js';
+
+describe('shared rich-content allowlist', () => {
+  it('SHARED_SURFACES tuple has 4 entries', () => {
+    expect(SHARED_SURFACES).toHaveLength(4);
+    expect(SHARED_SURFACES).toContain('voc-description');
+    expect(SHARED_SURFACES).toContain('reporter-reply');
+    expect(SHARED_SURFACES).toContain('public-update');
+    expect(SHARED_SURFACES).toContain('internal-comment');
+  });
+
+  it('each surface defines nodes, marks, nodeAttrs, markAttrs maps', () => {
+    for (const surface of SHARED_SURFACES) {
+      const a = SHARED_ALLOWLISTS[surface];
+      expect(a).toBeDefined();
+      expect(a.nodes instanceof Set).toBe(true);
+      expect(a.marks instanceof Set).toBe(true);
+      expect(typeof a.nodeAttrs).toBe('object');
+      expect(typeof a.markAttrs).toBe('object');
+      expect(a.allowedLinkSchemes instanceof Set).toBe(true);
+      expect(typeof a.maxTextBytes).toBe('number');
+      expect(typeof a.maxDepth).toBe('number');
+      expect(typeof a.maxNodes).toBe('number');
+      expect(typeof a.maxMarks).toBe('number');
+    }
+  });
+
+  it('AttrSchema variants cover uuid, url, string', () => {
+    // attachmentRef.id is uuid; link.href is url; codeBlock.language is string-nullable.
+    const ic = SHARED_ALLOWLISTS['internal-comment'];
+    expect(ic.nodeAttrs.attachmentRef?.id?.kind).toBe('uuid');
+    expect(ic.markAttrs.link?.href?.kind).toBe('url');
+    expect(ic.nodeAttrs.codeBlock?.language?.kind).toBe('string');
+  });
+
+  it('public-update has no link mark and no attachmentRef node', () => {
+    const pu = SHARED_ALLOWLISTS['public-update'];
+    expect(pu.marks.has('link')).toBe(false);
+    expect(pu.nodes.has('attachmentRef')).toBe(false);
+    expect(pu.allowedLinkSchemes.size).toBe(0);
+  });
+
+  it('SharedAllowlists type accepts the exported map', () => {
+    const x: SharedAllowlists = SHARED_ALLOWLISTS;
+    const s: SharedSurface = 'voc-description';
+    expect(x[s]).toBeDefined();
+  });
+});

--- a/packages/shared/src/rich-content/allowlist.ts
+++ b/packages/shared/src/rich-content/allowlist.ts
@@ -1,7 +1,132 @@
-// PLAN-22 C9 RED scaffold — implementation arrives in GREEN.
-export const SHARED_SURFACES = [] as const;
-export type SharedSurface = string;
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const SHARED_ALLOWLISTS: any = {};
-export type SharedAllowlists = Record<string, unknown>;
-export type AttrSchema = unknown;
+// PLAN-22 C9 — shared per-surface rich-content allowlist.
+//
+// This module is the single source of truth for which TipTap nodes/marks/attrs
+// each surface accepts. Both the backend authoritative sanitizer
+// (apps/backend/src/lib/rich-content/sanitize.ts, ADR-0011) and the FE
+// render-time defence-in-depth sanitizer (packages/ui/src/rich-content/
+// sanitizeClient.ts) import these constants. A `drift-vs-shared` test on the
+// backend asserts the two stay in lockstep.
+//
+// Values copied verbatim from the original backend file as of PLAN-22 C9
+// extraction; the backend file now re-exports rather than re-defines.
+
+// ── Surface enum ─────────────────────────────────────────────────────────────
+
+export const SHARED_SURFACES = [
+  'voc-description',
+  'reporter-reply',
+  'public-update',
+  'internal-comment',
+] as const;
+export type SharedSurface = (typeof SHARED_SURFACES)[number];
+
+// ── AttrSchema ───────────────────────────────────────────────────────────────
+
+export type AttrSchema =
+  | { kind: 'uuid'; required: boolean }
+  | { kind: 'url'; schemes: ReadonlySet<string>; maxLen: number; required: boolean }
+  | { kind: 'string'; maxLen: number; nullable: boolean; required: boolean };
+
+// ── SurfaceAllowlist ─────────────────────────────────────────────────────────
+
+// DoS caps — see surface-allowlists.ts header for rationale.
+export interface SharedSurfaceAllowlist {
+  nodes: ReadonlySet<string>;
+  marks: ReadonlySet<string>;
+  nodeAttrs: Readonly<Record<string, Readonly<Record<string, AttrSchema>>>>;
+  markAttrs: Readonly<Record<string, Readonly<Record<string, AttrSchema>>>>;
+  allowedLinkSchemes: ReadonlySet<string>;
+  maxTextBytes: number;
+  maxDepth: number;
+  maxNodes: number;
+  maxMarks: number;
+}
+
+export type SharedAllowlists = Readonly<Record<SharedSurface, SharedSurfaceAllowlist>>;
+
+// ── Shared scheme sets ───────────────────────────────────────────────────────
+
+const HTTP_ONLY = new Set(['http:', 'https:']);
+
+// ── Shared attr schemas ──────────────────────────────────────────────────────
+
+const uuidRequired: AttrSchema = { kind: 'uuid', required: true };
+
+const attachmentRefAttrs: Readonly<Record<string, AttrSchema>> = {
+  id: uuidRequired,
+};
+
+const linkMarkAttrs: Readonly<Record<string, AttrSchema>> = {
+  href: { kind: 'url', schemes: HTTP_ONLY, maxLen: 2048, required: true },
+};
+
+// ── Surface definitions ──────────────────────────────────────────────────────
+
+export const SHARED_ALLOWLISTS: SharedAllowlists = {
+  'voc-description': {
+    nodes: new Set([
+      'doc', 'paragraph', 'text',
+      'bulletList', 'orderedList', 'listItem',
+      'attachmentRef',
+    ]),
+    marks: new Set(['bold', 'italic', 'underline', 'code', 'link']),
+    nodeAttrs: { attachmentRef: attachmentRefAttrs },
+    markAttrs: { link: linkMarkAttrs },
+    allowedLinkSchemes: HTTP_ONLY,
+    maxTextBytes: 50 * 1024,
+    maxDepth: 32,
+    maxNodes: 5000,
+    maxMarks: 1000,
+  },
+
+  'public-update': {
+    nodes: new Set(['doc', 'paragraph', 'text', 'bulletList', 'orderedList', 'listItem']),
+    marks: new Set(['bold', 'italic']),
+    nodeAttrs: {},
+    markAttrs: {},
+    allowedLinkSchemes: new Set<string>(),
+    maxTextBytes: 50 * 1024,
+    maxDepth: 32,
+    maxNodes: 5000,
+    maxMarks: 1000,
+  },
+
+  'reporter-reply': {
+    nodes: new Set([
+      'doc', 'paragraph', 'text',
+      'bulletList', 'orderedList', 'listItem',
+      'attachmentRef',
+    ]),
+    marks: new Set(['bold', 'italic', 'code', 'link']),
+    nodeAttrs: { attachmentRef: attachmentRefAttrs },
+    markAttrs: { link: linkMarkAttrs },
+    allowedLinkSchemes: HTTP_ONLY,
+    maxTextBytes: 50 * 1024,
+    maxDepth: 32,
+    maxNodes: 5000,
+    maxMarks: 1000,
+  },
+
+  'internal-comment': {
+    nodes: new Set([
+      'doc', 'paragraph', 'text',
+      'codeBlock',
+      'bulletList', 'orderedList', 'listItem',
+      'mention', 'attachmentRef',
+    ]),
+    marks: new Set(['bold', 'italic', 'code', 'link']),
+    nodeAttrs: {
+      attachmentRef: attachmentRefAttrs,
+      mention: { actor_id: uuidRequired },
+      codeBlock: {
+        language: { kind: 'string', maxLen: 32, nullable: true, required: false },
+      },
+    },
+    markAttrs: { link: linkMarkAttrs },
+    allowedLinkSchemes: HTTP_ONLY,
+    maxTextBytes: 50 * 1024,
+    maxDepth: 32,
+    maxNodes: 5000,
+    maxMarks: 1000,
+  },
+};

--- a/packages/shared/src/rich-content/allowlist.ts
+++ b/packages/shared/src/rich-content/allowlist.ts
@@ -1,0 +1,7 @@
+// PLAN-22 C9 RED scaffold — implementation arrives in GREEN.
+export const SHARED_SURFACES = [] as const;
+export type SharedSurface = string;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const SHARED_ALLOWLISTS: any = {};
+export type SharedAllowlists = Record<string, unknown>;
+export type AttrSchema = unknown;

--- a/packages/shared/src/rich-content/index.ts
+++ b/packages/shared/src/rich-content/index.ts
@@ -1,0 +1,1 @@
+export * from './allowlist.js';

--- a/packages/ui/__tests__/rich-content.test.tsx
+++ b/packages/ui/__tests__/rich-content.test.tsx
@@ -2,6 +2,12 @@ import { render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { RichContentRenderer, RichEditor, type TipTapDoc } from '../src/index';
 
+// UUIDs are required by the shared allowlist (PLAN-22 C9) — the FE sanitizer
+// drops mention/attachmentRef nodes whose required id attrs fail UUID shape,
+// matching the server contract. Test fixtures use real UUIDs accordingly.
+const ACTOR_UUID = '11111111-1111-1111-1111-111111111111';
+const ATTACHMENT_UUID = '22222222-2222-2222-2222-222222222222';
+
 const sampleDoc: TipTapDoc = {
   type: 'doc',
   content: [
@@ -9,7 +15,7 @@ const sampleDoc: TipTapDoc = {
       type: 'paragraph',
       content: [
         { type: 'text', text: 'Hello ' },
-        { type: 'mention', attrs: { actor_id: 'u1' } },
+        { type: 'mention', attrs: { actor_id: ACTOR_UUID } },
         { type: 'text', text: ' world.' },
       ],
     },
@@ -57,14 +63,15 @@ describe('RichEditor', () => {
 describe('RichContentRenderer mode handling', () => {
   it('mode="reporter_visible" strips mention nodes', () => {
     render(<RichContentRenderer doc={sampleDoc} mode="reporter_visible" />);
-    expect(screen.queryByText(/@u1/)).not.toBeInTheDocument();
+    // Strict mode strips the mention node entirely; only literal text survives.
+    expect(document.querySelector('[data-type="mention"]')).toBeNull();
     expect(screen.getByText(/Hello/)).toBeInTheDocument();
     expect(screen.getByText(/world/)).toBeInTheDocument();
   });
 
   it('mode="internal" preserves mention nodes', () => {
     render(<RichContentRenderer doc={sampleDoc} mode="internal" />);
-    expect(screen.getByText(/@u1/)).toBeInTheDocument();
+    expect(document.querySelector('[data-type="mention"]')).toBeInTheDocument();
   });
 });
 
@@ -75,7 +82,7 @@ describe('attachmentRef + mention extension round-trip', () => {
       content: [
         {
           type: 'attachmentRef',
-          attrs: { id: 'a1' },
+          attrs: { id: ATTACHMENT_UUID },
         },
       ],
     };
@@ -83,7 +90,7 @@ describe('attachmentRef + mention extension round-trip', () => {
     const el = document.querySelector('[data-type="attachment-ref"]');
     expect(el).toBeInTheDocument();
     // Canonical attrs: only id. No name, sizeBytes, mimeType (display via runtime registry #19+).
-    expect(el?.getAttribute('id')).toBe('a1');
+    expect(el?.getAttribute('id')).toBe(ATTACHMENT_UUID);
     expect(el?.getAttribute('data-size-bytes')).toBeNull();
     expect(el?.getAttribute('name')).toBeNull();
     expect(el?.getAttribute('mimetype')).toBeNull();
@@ -94,7 +101,7 @@ describe('attachmentRef + mention extension round-trip', () => {
     const el = document.querySelector('[data-type="mention"]');
     expect(el).toBeInTheDocument();
     // Canonical: actor_id only. Label comes from runtime user registry (#19+).
-    expect(el?.textContent).toContain('@u1');
+    expect(el?.getAttribute('actor_id')).toBe(ACTOR_UUID);
     expect(el?.getAttribute('label')).toBeNull();
   });
 });

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -18,6 +18,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@fops/shared": "workspace:*",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/packages/ui/src/rich-content/RichContentRenderer.tsx
+++ b/packages/ui/src/rich-content/RichContentRenderer.tsx
@@ -8,12 +8,21 @@ import { cn } from '../utils/cn';
 import type { TipTapDoc } from './RichEditor';
 import { AttachmentRef } from './extensions/attachmentRef';
 import { Mention } from './extensions/mention';
+import { sanitizeClient, type ClientSanitizeSurface } from './sanitizeClient';
 
 export type RichContentMode = 'reporter_visible' | 'internal';
 
 export interface RichContentRendererProps {
   doc: TipTapDoc;
   mode: RichContentMode;
+  /**
+   * Allowlist surface for the render-time defence-in-depth sanitizer (PLAN-22
+   * C9). Defaults to the safest reader for each `mode` when omitted, so
+   * existing call sites do not need to change. Callers SHOULD pass an explicit
+   * `surface` when they know it (e.g. `reporter-reply` rendering uses
+   * `reporter-reply`; internal-comment threads use `internal-comment`).
+   */
+  surface?: ClientSanitizeSurface;
   className?: string;
 }
 
@@ -29,11 +38,18 @@ function stripMentions(doc: TipTapDoc): TipTapDoc {
   return walk(doc) as TipTapDoc;
 }
 
-export function RichContentRenderer({ doc, mode, className }: RichContentRendererProps) {
+export function RichContentRenderer({ doc, mode, surface, className }: RichContentRendererProps) {
   const html = React.useMemo(() => {
+    // PLAN-22 C9: defence-in-depth client sanitize before TipTap render.
+    // Mode is the public/internal split (drives mention stripping); `surface`
+    // selects the allowlist. Default surface mirrors the safest reader for
+    // each mode so legacy call sites stay safe without code changes.
+    const effectiveSurface: ClientSanitizeSurface =
+      surface ?? (mode === 'reporter_visible' ? 'public-update' : 'internal-comment');
+    const sanitized = sanitizeClient(doc, effectiveSurface);
     // stripMentions is moved inside useMemo so generateHTML is only re-invoked
     // when doc or mode actually change — not on every parent render.
-    const safe = mode === 'reporter_visible' ? stripMentions(doc) : doc;
+    const safe = mode === 'reporter_visible' ? stripMentions(sanitized) : sanitized;
     return generateHTML(safe as JSONContent, [
       StarterKit.configure({
         // Disable built-ins that we configure separately below to avoid duplicate extension warnings.
@@ -45,7 +61,7 @@ export function RichContentRenderer({ doc, mode, className }: RichContentRendere
       AttachmentRef,
       Mention,
     ]);
-  }, [doc, mode]);
+  }, [doc, mode, surface]);
 
   return (
     <div

--- a/packages/ui/src/rich-content/__tests__/sanitizeClient.test.ts
+++ b/packages/ui/src/rich-content/__tests__/sanitizeClient.test.ts
@@ -1,0 +1,126 @@
+// PLAN-22 C9 — client render-time sanitizer.
+// The server is authoritative (ADR-0011), but a defence-in-depth FE pass
+// guards against:
+//   (a) hostile JSON cached in TanStack Query that the user later sees,
+//   (b) stored XSS that bypassed an older server version,
+//   (c) regressions in the BE pipeline.
+// Behaviour: silently drop disallowed nodes/marks/attrs; coerce hostile
+// hrefs to ''; never throw.
+
+import { describe, expect, it } from 'vitest';
+
+import { sanitizeClient, type ClientSanitizeSurface } from '../sanitizeClient';
+import type { TipTapDoc } from '../RichEditor';
+
+const wrap = (...content: unknown[]): TipTapDoc =>
+  ({ type: 'doc', content } as unknown as TipTapDoc);
+
+const text = (t: string, marks?: unknown[]) =>
+  marks ? { type: 'text', text: t, marks } : { type: 'text', text: t };
+
+const para = (...content: unknown[]) => ({ type: 'paragraph', content });
+
+describe('sanitizeClient', () => {
+  const surfaces: ClientSanitizeSurface[] = ['internal-comment', 'voc-description', 'reporter-reply', 'public-update'];
+
+  it('strips a script node', () => {
+    const doc = wrap(para({ type: 'script', text: 'alert(1)' } as unknown), para(text('safe')));
+    const out = sanitizeClient(doc, 'internal-comment');
+    const flat = JSON.stringify(out);
+    expect(flat).not.toContain('script');
+    expect(flat).toContain('safe');
+  });
+
+  it('rewrites javascript: href to empty string', () => {
+    const doc = wrap(para(text('click', [{ type: 'link', attrs: { href: 'javascript:alert(1)' } }])));
+    const out = sanitizeClient(doc, 'internal-comment');
+    const flat = JSON.stringify(out);
+    expect(flat).not.toContain('javascript:');
+    expect(flat).toContain('"href":""');
+  });
+
+  it('rewrites vbscript: href to empty string', () => {
+    const doc = wrap(para(text('x', [{ type: 'link', attrs: { href: 'vbscript:evil()' } }])));
+    const flat = JSON.stringify(sanitizeClient(doc, 'internal-comment'));
+    expect(flat).not.toContain('vbscript:');
+  });
+
+  it('strips data: href (not allowed on link surfaces)', () => {
+    const doc = wrap(para(text('x', [{ type: 'link', attrs: { href: 'data:text/html,<script>1</script>' } }])));
+    const flat = JSON.stringify(sanitizeClient(doc, 'internal-comment'));
+    expect(flat).not.toContain('data:');
+  });
+
+  it('strips on* attr keys from any node attrs (defence in depth)', () => {
+    const doc = wrap(
+      para({ type: 'image', attrs: { src: 'x', onerror: 'alert(1)', onclick: 'x' } } as unknown),
+    );
+    const out = sanitizeClient(doc, 'internal-comment');
+    const flat = JSON.stringify(out);
+    expect(flat).not.toContain('onerror');
+    expect(flat).not.toContain('onclick');
+  });
+
+  it('preserves valid headings, paragraphs, marks, and attachmentRef nodes', () => {
+    const doc = wrap(
+      para(text('hello', [{ type: 'bold' }])),
+      { type: 'attachmentRef', attrs: { id: '11111111-1111-1111-1111-111111111111' } },
+    );
+    const out = sanitizeClient(doc, 'voc-description') as unknown as { content: unknown[] };
+    expect(out.content).toHaveLength(2);
+    expect(JSON.stringify(out)).toContain('attachmentRef');
+    expect(JSON.stringify(out)).toContain('"type":"bold"');
+  });
+
+  it('drops disallowed mark (link on public-update)', () => {
+    const doc = wrap(para(text('x', [{ type: 'link', attrs: { href: 'https://ok.example' } }])));
+    const out = sanitizeClient(doc, 'public-update');
+    expect(JSON.stringify(out)).not.toContain('link');
+    expect(JSON.stringify(out)).toContain('"text":"x"');
+  });
+
+  it('drops unknown attr keys but keeps allowed ones', () => {
+    const doc = wrap(
+      para(text('x', [{ type: 'link', attrs: { href: 'https://ok.example', evil: 'yes' } }])),
+    );
+    const out = sanitizeClient(doc, 'internal-comment');
+    const flat = JSON.stringify(out);
+    expect(flat).toContain('https://ok.example');
+    expect(flat).not.toContain('evil');
+  });
+
+  it('ignores prototype-pollution-shaped keys like __proto__ and constructor', () => {
+    const hostile = wrap({
+      type: 'paragraph',
+      attrs: { __proto__: { polluted: true }, constructor: { x: 1 } },
+      content: [text('hi')],
+    } as unknown);
+    const out = sanitizeClient(hostile, 'internal-comment');
+    // Walker survived without polluting Object.prototype.
+    expect(({} as { polluted?: boolean }).polluted).toBeUndefined();
+    expect(JSON.stringify(out)).toContain('hi');
+  });
+
+  it('handles deep nesting without throwing (within cap)', () => {
+    // Build 20 levels of nested bulletList > listItem > paragraph > text.
+    let node: unknown = text('deep');
+    for (let i = 0; i < 20; i++) {
+      node = { type: 'listItem', content: [{ type: 'paragraph', content: [node] }] };
+      node = { type: 'bulletList', content: [node] };
+    }
+    const doc = wrap(node);
+    expect(() => sanitizeClient(doc, 'internal-comment')).not.toThrow();
+  });
+
+  it('coerces non-object input to empty doc rather than throwing', () => {
+    const out = sanitizeClient(null as unknown as TipTapDoc, 'internal-comment');
+    expect(out).toEqual({ type: 'doc', content: [] });
+    const out2 = sanitizeClient({ type: 'paragraph' } as unknown as TipTapDoc, 'internal-comment');
+    expect(out2.type).toBe('doc');
+  });
+
+  it.each(surfaces)('%s — empty doc round-trips to empty doc', (surface) => {
+    const out = sanitizeClient({ type: 'doc', content: [] } as unknown as TipTapDoc, surface);
+    expect(out.type).toBe('doc');
+  });
+});

--- a/packages/ui/src/rich-content/sanitizeClient.ts
+++ b/packages/ui/src/rich-content/sanitizeClient.ts
@@ -1,12 +1,250 @@
-// PLAN-22 C9 RED scaffold — replaced in GREEN.
+// PLAN-22 C9 — client render-time defence-in-depth sanitizer.
+//
+// The backend sanitizer (apps/backend/src/lib/rich-content/sanitize.ts) is
+// authoritative per ADR-0011 and rejects hostile payloads at the API boundary.
+// This module runs in the renderer as a belt-and-suspenders layer that guards
+// against:
+//   (a) hostile JSON cached client-side (TanStack Query) that bypasses a fresh
+//       server validation pass,
+//   (b) stored XSS that slipped through an older server version,
+//   (c) future regressions in the server pipeline.
+//
+// Differs from the server sanitizer in two important ways:
+//   1. NEVER throws and never returns an error union. Disallowed nodes/marks/
+//      attrs are silently dropped. Hostile hrefs are coerced to ''. The
+//      renderer should always have *something* to render, never an exception.
+//   2. Walks plain JSON only — no DOM access, no @tiptap deps required at
+//      import time. Pure function; safe under SSR.
+//
+// Decision (PLAN-22 §C9): hand-rolled walker rather than isomorphic-dompurify
+// because (a) we already own the JSON-shape allowlist, (b) DOMPurify operates
+// on serialized HTML so we would re-render + re-parse, (c) the test surface is
+// the JSON we already validate on the server.
+
+import {
+  SHARED_ALLOWLISTS,
+  type AttrSchema,
+  type SharedSurface,
+} from '@fops/shared';
+
 import type { TipTapDoc } from './RichEditor';
 
-export type ClientSanitizeSurface =
-  | 'voc-description'
-  | 'reporter-reply'
-  | 'public-update'
-  | 'internal-comment';
+// ── Public types ─────────────────────────────────────────────────────────────
 
-export function sanitizeClient(_doc: TipTapDoc, _surface: ClientSanitizeSurface): TipTapDoc {
-  throw new Error('not implemented (RED)');
+export type ClientSanitizeSurface = SharedSurface;
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// Keys that JS engines treat specially; if these appeared in attrs at all, we
+// refuse to copy them so we cannot accidentally write a polluted object.
+const FORBIDDEN_ATTR_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+// ── Internal types ───────────────────────────────────────────────────────────
+
+interface RawNode {
+  type?: unknown;
+  attrs?: unknown;
+  marks?: unknown;
+  text?: unknown;
+  content?: unknown;
+}
+
+interface CleanMark {
+  type: string;
+  attrs?: Record<string, unknown>;
+}
+
+interface CleanNode {
+  type: string;
+  attrs?: Record<string, unknown>;
+  text?: string;
+  marks?: CleanMark[];
+  content?: CleanNode[];
+}
+
+// ── Guards ───────────────────────────────────────────────────────────────────
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+// ── Attr validation (silent: returns the cleaned object) ─────────────────────
+
+function cleanAttrs(
+  attrSchemas: Readonly<Record<string, AttrSchema>> | undefined,
+  rawAttrs: unknown,
+): Record<string, unknown> {
+  if (!isPlainObject(rawAttrs)) return {};
+  if (!attrSchemas) return {};
+
+  const out: Record<string, unknown> = {};
+  for (const [key, schema] of Object.entries(attrSchemas)) {
+    if (FORBIDDEN_ATTR_KEYS.has(key)) continue;
+    // own-property only — defends against `__proto__` shenanigans.
+    if (!Object.prototype.hasOwnProperty.call(rawAttrs, key)) continue;
+
+    const value = rawAttrs[key];
+    const coerced = coerceAttrValue(schema, value, key);
+    if (coerced === DROP) continue;
+    out[key] = coerced;
+  }
+  return out;
+}
+
+const DROP = Symbol('drop');
+
+function coerceAttrValue(schema: AttrSchema, value: unknown, key: string): unknown {
+  if (schema.kind === 'uuid') {
+    if (typeof value === 'string' && UUID_RE.test(value)) return value;
+    return DROP;
+  }
+  if (schema.kind === 'url') {
+    // Defence-in-depth href coercion. The server already rejected hostile
+    // schemes; here we coerce-to-empty so the renderer never emits an
+    // executable URL even if cached JSON slipped past validation.
+    if (typeof value !== 'string') return key === 'href' ? '' : DROP;
+    if (value.length > schema.maxLen) return key === 'href' ? '' : DROP;
+    let parsed: URL;
+    try {
+      parsed = new URL(value);
+    } catch {
+      // Relative URLs and fragments are not full URLs but are safe to render.
+      // The link extension in our renderer accepts them. Allow through if
+      // they are clearly not script schemes.
+      const lower = value.trim().toLowerCase();
+      if (lower.startsWith('javascript:') || lower.startsWith('vbscript:') || lower.startsWith('data:')) {
+        return key === 'href' ? '' : DROP;
+      }
+      return value;
+    }
+    if (parsed.username !== '' || parsed.password !== '') {
+      return key === 'href' ? '' : DROP;
+    }
+    if (!schema.schemes.has(parsed.protocol)) {
+      return key === 'href' ? '' : DROP;
+    }
+    return value;
+  }
+  if (schema.kind === 'string') {
+    if (schema.nullable && value === null) return null;
+    if (typeof value !== 'string') return DROP;
+    if (value.length > schema.maxLen) return DROP;
+    return value;
+  }
+  return DROP;
+}
+
+// ── Mark walker ──────────────────────────────────────────────────────────────
+
+function cleanMark(
+  raw: unknown,
+  allowedMarks: ReadonlySet<string>,
+  markAttrSchemas: Readonly<Record<string, Readonly<Record<string, AttrSchema>>>>,
+): CleanMark | null {
+  if (!isPlainObject(raw)) return null;
+  if (typeof raw.type !== 'string') return null;
+  const markType = raw.type;
+  if (!allowedMarks.has(markType)) return null;
+
+  const schemas = markAttrSchemas[markType];
+  const attrs = cleanAttrs(schemas, raw.attrs);
+
+  const out: CleanMark = { type: markType };
+  if (Object.keys(attrs).length > 0) out.attrs = attrs;
+  return out;
+}
+
+// ── Node walker ──────────────────────────────────────────────────────────────
+
+interface WalkCtx {
+  surface: ClientSanitizeSurface;
+  nodeCount: number;
+  markCount: number;
+  textBytes: number;
+}
+
+const EMPTY_DOC: TipTapDoc = { type: 'doc', content: [] } as unknown as TipTapDoc;
+
+function cleanNode(raw: unknown, depth: number, ctx: WalkCtx): CleanNode | null {
+  const allow = SHARED_ALLOWLISTS[ctx.surface];
+
+  if (depth > allow.maxDepth) return null;
+  if (!isPlainObject(raw)) return null;
+
+  const node = raw as RawNode;
+  if (typeof node.type !== 'string') return null;
+
+  // image is always dropped — there is no allowed image node on any surface.
+  if (node.type === 'image') return null;
+  if (!allow.nodes.has(node.type)) return null;
+
+  ctx.nodeCount++;
+  if (ctx.nodeCount > allow.maxNodes) return null;
+
+  // text byte cap (defence-in-depth; truncate by dropping further text).
+  let text: string | undefined;
+  if (typeof node.text === 'string') {
+    const bytes = new TextEncoder().encode(node.text).length;
+    if (ctx.textBytes + bytes > allow.maxTextBytes) return null;
+    ctx.textBytes += bytes;
+    text = node.text;
+  }
+
+  const attrs = cleanAttrs(allow.nodeAttrs[node.type], node.attrs);
+
+  const marks: CleanMark[] = [];
+  if (Array.isArray(node.marks)) {
+    for (const rawMark of node.marks) {
+      if (ctx.markCount >= allow.maxMarks) break;
+      const m = cleanMark(rawMark, allow.marks, allow.markAttrs);
+      if (m) {
+        marks.push(m);
+        ctx.markCount++;
+      }
+    }
+  }
+
+  const content: CleanNode[] = [];
+  if (Array.isArray(node.content)) {
+    for (const child of node.content) {
+      const c = cleanNode(child, depth + 1, ctx);
+      if (c) content.push(c);
+    }
+  }
+
+  // Required-attr enforcement: drop the node if a required attr did not
+  // survive cleaning. Mirrors server behaviour and avoids rendering a node
+  // missing its key (e.g. attachmentRef without `id`).
+  const nodeAttrSchemas = allow.nodeAttrs[node.type];
+  if (nodeAttrSchemas) {
+    for (const [key, schema] of Object.entries(nodeAttrSchemas)) {
+      if (schema.required && !(key in attrs)) return null;
+    }
+  }
+
+  const out: CleanNode = { type: node.type };
+  if (Object.keys(attrs).length > 0) out.attrs = attrs;
+  if (text !== undefined) out.text = text;
+  if (marks.length > 0) out.marks = marks;
+  if (content.length > 0) out.content = content;
+  return out;
+}
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Walks a TipTap JSON document and returns a cleaned copy honoring the
+ * `surface` allowlist. Never throws. Hostile hrefs coerce to ''.
+ * Unrecognised input shapes coerce to an empty `doc`.
+ */
+export function sanitizeClient(doc: TipTapDoc, surface: ClientSanitizeSurface): TipTapDoc {
+  if (!SHARED_ALLOWLISTS[surface]) return EMPTY_DOC;
+  if (!isPlainObject(doc as unknown)) return EMPTY_DOC;
+
+  const ctx: WalkCtx = { surface, nodeCount: 0, markCount: 0, textBytes: 0 };
+  const cleaned = cleanNode(doc, 0, ctx);
+  if (!cleaned || cleaned.type !== 'doc') return EMPTY_DOC;
+  return cleaned as unknown as TipTapDoc;
 }

--- a/packages/ui/src/rich-content/sanitizeClient.ts
+++ b/packages/ui/src/rich-content/sanitizeClient.ts
@@ -1,0 +1,12 @@
+// PLAN-22 C9 RED scaffold — replaced in GREEN.
+import type { TipTapDoc } from './RichEditor';
+
+export type ClientSanitizeSurface =
+  | 'voc-description'
+  | 'reporter-reply'
+  | 'public-update'
+  | 'internal-comment';
+
+export function sanitizeClient(_doc: TipTapDoc, _surface: ClientSanitizeSurface): TipTapDoc {
+  throw new Error('not implemented (RED)');
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,6 +191,9 @@ importers:
 
   packages/ui:
     dependencies:
+      '@fops/shared':
+        specifier: workspace:*
+        version: link:../shared
       '@radix-ui/react-avatar':
         specifier: ^1.1.11
         version: 1.1.11(@types/react-dom@19.0.2(@types/react@19.0.2))(@types/react@19.0.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)


### PR DESCRIPTION
## Summary
Closes #41.

- `packages/shared/src/rich-content/allowlist.ts` — canonical per-surface allowlist (node types, mark types, AttrSchema)
- `packages/ui/src/rich-content/sanitizeClient.ts` — pure walker over TipTap JSON
  - Drops disallowed nodes/marks/attrs by allowlist
  - Rewrites `javascript:`/`vbscript:`/non-image `data:` hrefs to empty
  - Strips `on*` attrs
  - Handles deep nesting + prototype-pollution-shaped keys safely
- `RichContentRenderer` runs `sanitizeClient(doc, surface)` before TipTap render
- BE `surface-allowlists.ts` re-exports the shared constant (D1: pure re-export, BE data already plain)
- Drift test pins BE ↔ shared parity per surface

Plan: `.review/PLAN-22.md` §C9. Deviations: `.review/CHUNK-22-C9-DEVIATIONS.md`.

## Test plan
- [x] +4 shared allowlist tests
- [x] +11 sanitizeClient hostile-corpus tests (script nodes, javascript: hrefs, onerror img, data:, nesting, proto-pollution keys)
- [x] +5 BE drift-vs-shared parameterised
- [x] Existing `rich-content.test.tsx` fixtures updated to real UUIDs (sanitizer drops legacy 'u1'/'a1' — Rule 1)
- [x] Typecheck clean across shared/ui/backend

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>