### PR TITLE
feat(slice3 #22 C10, closes #42): decorate external anchors with rel/target

### DIFF
--- a/.review/CHUNK-22-C10-DEVIATIONS.md
+++ b/.review/CHUNK-22-C10-DEVIATIONS.md
@@ -1,0 +1,68 @@
+# PLAN-22 Chunk C10 — Deviations
+
+**Closes:** #42
+**Branch (worktree-native):** `worktree-agent-a832bf5547b275bba`
+**Remote feature branch:** `feature/22-c10-external-link-rel-target`
+**Base:** `develop` @ `1a5776a` (post-C9)
+
+## Plan vs. delivered
+
+| Plan item                                                                 | Delivered | Notes |
+| ------------------------------------------------------------------------- | --------- | ----- |
+| `isExternal(href)` helper                                                 | Yes       | Named `isExternalHref`. http(s) prefix + cross-origin check; SSR → http(s)=external. |
+| External anchors get `rel="noopener noreferrer" target="_blank"`          | Yes       | Via `Link.extend({ renderHTML })`. |
+| Internal anchors unchanged                                                | Yes       | `HTMLAttributes` defaults overridden to `{ target: null, rel: null }` so neither attr is emitted. |
+| Test: external https, http, root-relative, hash, same-origin, javascript: | Yes       | 6/6 green in `externalLink.test.tsx`. |
+
+## Deviations
+
+1. **`rel` value does NOT include `nofollow`.** Upstream `@tiptap/extension-link` default is
+   `noopener noreferrer nofollow`. The plan and #42 spec specify
+   `noopener noreferrer` only. We matched the plan exactly. `nofollow` would
+   suppress SEO link equity for legitimate external destinations agents link
+   to (vendor docs, status pages); the security-relevant tokens are
+   `noopener` (no `window.opener` handle leak) and `noreferrer` (no
+   `Referer` header leak). If a future requirement reintroduces `nofollow`
+   it can be added to the `extra` object in `RichContentRenderer.tsx`
+   without touching tests for the existing cases.
+
+2. **Implementation site: `Link.extend(...)` rather than monkey-patching
+   `renderHTML` on the imported extension.** TipTap's idiomatic override
+   path is `extend`. Same code path; cleaner.
+
+3. **`HTMLAttributes: { target: null, rel: null, class: null }` defaults
+   wiped.** Without this, TipTap merges the upstream `{ target: '_blank',
+   rel: 'noopener noreferrer nofollow' }` defaults underneath our
+   per-render overrides and internal anchors keep emitting them. Setting
+   them to `null` is the documented way to suppress an HTMLAttribute in
+   `mergeAttributes`.
+
+## Out of scope (not touched)
+
+- `sanitizeClient.ts` (C9) — confirmed renderer still consumes its output.
+- `RichEditor` (compose/draft surface) — #42 is about *rendered* anchors.
+- Backend sanitizer — server is authoritative per ADR-0011; this is
+  defence-in-depth on the renderer.
+
+## Verification
+
+- `pnpm --filter @fops/ui test` → 39 files, 445 tests, all pass.
+- `pnpm --filter @fops/ui typecheck` → clean.
+- New file: `packages/ui/src/rich-content/__tests__/externalLink.test.tsx` (6 tests).
+
+## LOC budget
+
+| File                                                                         | Lines |
+| ---------------------------------------------------------------------------- | ----- |
+| `packages/ui/src/rich-content/RichContentRenderer.tsx` (delta)               | +36   |
+| `packages/ui/src/rich-content/__tests__/externalLink.test.tsx` (new)         | +90   |
+| **Total**                                                                    | **+126** |
+
+Budget was ~105; +21 lines over. Driver: the SSR-safe `try/catch` and
+explicit `HTMLAttributes` reset comments + the javascript: belt-and-suspenders
+test case made the file marginally longer. No behavioral expansion.
+
+## Commits
+
+- `1db7b62` test(slice3 #22 C10, #42): RED — external anchors must get rel/target, internal must not
+- `a6298e9` feat(slice3 #22 C10, closes #42): decorate external anchors with rel/target only

--- a/packages/ui/src/rich-content/RichContentRenderer.tsx
+++ b/packages/ui/src/rich-content/RichContentRenderer.tsx
@@ -1,4 +1,4 @@
-import type { JSONContent } from '@tiptap/core';
+import { mergeAttributes, type JSONContent } from '@tiptap/core';
 import Link from '@tiptap/extension-link';
 import Underline from '@tiptap/extension-underline';
 import { generateHTML } from '@tiptap/html';
@@ -9,6 +9,42 @@ import type { TipTapDoc } from './RichEditor';
 import { AttachmentRef } from './extensions/attachmentRef';
 import { Mention } from './extensions/mention';
 import { sanitizeClient, type ClientSanitizeSurface } from './sanitizeClient';
+
+// PLAN-22 C10 (closes #42) — only cross-origin http(s) URLs are "external".
+// Relative paths ('/foo'), hash fragments ('#anchor'), same-origin absolute
+// URLs, and the empty href produced by the C9 sanitizer for hostile schemes
+// all stay internal: no target, no rel injection.
+//
+// SSR / non-browser render contexts have no `window`; we conservatively treat
+// any http(s)://-prefixed href as external in that case. The sanitizer is the
+// authoritative gate for hostile schemes (javascript:, data:, etc.) — they
+// arrive here as '' and short-circuit to internal.
+function isExternalHref(href: unknown): boolean {
+  if (typeof href !== 'string' || href === '') return false;
+  if (!/^https?:\/\//i.test(href)) return false;
+  if (typeof window === 'undefined' || !window.location?.origin) return true;
+  try {
+    return new URL(href).origin !== window.location.origin;
+  } catch {
+    return false;
+  }
+}
+
+// Disable Link's default target/rel injection (which fires on *every* link)
+// and substitute a renderHTML that only decorates external anchors.
+const ExternalAwareLink = Link.extend({
+  renderHTML({ HTMLAttributes }) {
+    const isExternal = isExternalHref(HTMLAttributes.href);
+    const extra = isExternal
+      ? { rel: 'noopener noreferrer', target: '_blank' }
+      : { rel: null, target: null };
+    return ['a', mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, extra), 0];
+  },
+}).configure({
+  openOnClick: false,
+  // Wipe the upstream defaults so internal links inherit neither target nor rel.
+  HTMLAttributes: { target: null, rel: null, class: null },
+});
 
 export type RichContentMode = 'reporter_visible' | 'internal';
 
@@ -56,7 +92,7 @@ export function RichContentRenderer({ doc, mode, surface, className }: RichConte
         link: false,
         underline: false,
       }),
-      Link.configure({ openOnClick: false }),
+      ExternalAwareLink,
       Underline,
       AttachmentRef,
       Mention,

--- a/packages/ui/src/rich-content/__tests__/externalLink.test.tsx
+++ b/packages/ui/src/rich-content/__tests__/externalLink.test.tsx
@@ -1,0 +1,90 @@
+// PLAN-22 C10 (closes #42) — RichContentRenderer external-link rel/target.
+//
+// External anchors (cross-origin http/https) MUST carry
+//   rel="noopener noreferrer" target="_blank"
+// so reporter-visible content cannot tabnap or leak the opener handle.
+// Internal anchors (relative paths, hash fragments, same-origin absolute)
+// stay unchanged — no rel, no target — so in-app navigation still flows
+// through TanStack Router naturally.
+//
+// The sanitizer (PLAN-22 C9) is authoritative for href safety: javascript:,
+// data:, and other hostile schemes are coerced to '' before they reach the
+// renderer. This file does *not* re-test that — it only asserts the renderer
+// decorates external anchors and leaves internal ones alone.
+
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { RichContentRenderer } from '../RichContentRenderer';
+import type { TipTapDoc } from '../RichEditor';
+
+const docWithLink = (href: string): TipTapDoc =>
+  ({
+    type: 'doc',
+    content: [
+      {
+        type: 'paragraph',
+        content: [
+          {
+            type: 'text',
+            text: 'link',
+            marks: [{ type: 'link', attrs: { href } }],
+          },
+        ],
+      },
+    ],
+  }) as unknown as TipTapDoc;
+
+function renderDoc(href: string): HTMLAnchorElement {
+  const { container } = render(
+    <RichContentRenderer doc={docWithLink(href)} mode="internal" />,
+  );
+  const a = container.querySelector('a');
+  if (!a) throw new Error(`no anchor rendered for href=${href}`);
+  return a as HTMLAnchorElement;
+}
+
+describe('RichContentRenderer — external link decoration (PLAN-22 C10, #42)', () => {
+  // jsdom default origin is http://localhost:3000 unless overridden.
+  // External = any http(s) URL whose origin differs from window.location.origin.
+
+  it('external https → rel="noopener noreferrer" and target="_blank"', () => {
+    const a = renderDoc('https://example.com/path');
+    expect(a.getAttribute('rel')).toBe('noopener noreferrer');
+    expect(a.getAttribute('target')).toBe('_blank');
+  });
+
+  it('external http → rel + target set', () => {
+    const a = renderDoc('http://example.com/');
+    expect(a.getAttribute('rel')).toBe('noopener noreferrer');
+    expect(a.getAttribute('target')).toBe('_blank');
+  });
+
+  it('root-relative "/foo" → no rel, no target', () => {
+    const a = renderDoc('/foo');
+    expect(a.getAttribute('rel')).toBeNull();
+    expect(a.getAttribute('target')).toBeNull();
+  });
+
+  it('hash "#anchor" → no rel, no target', () => {
+    const a = renderDoc('#anchor');
+    expect(a.getAttribute('rel')).toBeNull();
+    expect(a.getAttribute('target')).toBeNull();
+  });
+
+  it('same-origin absolute → no rel, no target', () => {
+    // jsdom default origin is http://localhost:3000 (see vitest config).
+    const sameOrigin = `${window.location.origin}/inbox`;
+    const a = renderDoc(sameOrigin);
+    expect(a.getAttribute('rel')).toBeNull();
+    expect(a.getAttribute('target')).toBeNull();
+  });
+
+  it('javascript: href → sanitizer (C9) coerces to "" and renderer adds no target', () => {
+    // Belt-and-suspenders: sanitizeClient blanks the hostile href, so by the
+    // time renderHTML runs href is '' which is not external. No target leak.
+    const a = renderDoc('javascript:alert(1)');
+    expect(a.getAttribute('href') ?? '').not.toMatch(/javascript:/i);
+    expect(a.getAttribute('target')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
Closes #42.

- `RichContentRenderer.tsx`: extracted `isExternalHref()` (http(s) prefix + cross-origin via `window.location.origin`; SSR-safe try/catch)
- `Link.extend({ renderHTML })` injects `rel="noopener noreferrer" target="_blank"` only for external hrefs; internal links emit neither attribute (HTMLAttributes defaults reset to null to avoid upstream `nofollow`)
- Belt-and-suspenders: `javascript:` href → blanked by C9 sanitizer → renderer sees `''` → no `target` leak

Plan: `.review/PLAN-22.md` §C10. Deviations: `.review/CHUNK-22-C10-DEVIATIONS.md`.

## Test plan
- [x] +6 externalLink tests (https, http, root-relative, hash, same-origin absolute, javascript:)
- [x] UI suite 39 files / 445 tests pass
- [x] typecheck clean

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>