### PR TITLE
feat(slice3 #22 C7a): FE wire Triage composer attachments (PublicUpdate/InternalComment/ReporterReply)

### DIFF
--- a/.review/CHUNK-22-C7a-DEVIATIONS.md
+++ b/.review/CHUNK-22-C7a-DEVIATIONS.md
@@ -1,0 +1,35 @@
+# PLAN-22 C7a — Deviations
+
+Worktree: `.claude/worktrees/agent-a0a1b7adb9504eb05`
+Branch: `feature/22-c7a-fe-triage-composers-attachments`
+Base: `origin/develop @ a57eb22`
+
+## Plan vs Implementation
+
+| Plan call-out | Outcome |
+| --- | --- |
+| Extract `ComposerAttachmentDropzone.tsx` (~80 LOC) | Done as standalone file under `apps/frontend/src/features/voc/components/detail/`. Final size ~290 LOC (mirrors the C6 AttachmentDropzone state machine verbatim — extraction did not actually reduce LOC because the row state machine, upload kickoff, error mapping, and idempotency-key minting are inherent to the contract). Compact variant strips the `Card` chrome + FieldLabel and uses tighter row padding per prototype anchor. |
+| Wire 3 composers | Done. Each composer now renders the dropzone directly below the RichEditor body (Public/Reporter) or below the MentionPickerButton (Internal), tracks `attachmentIds` + `attachmentsUploading`, gates Submit on uploading, and ships `attachment_ids: string[]` in the POST body. |
+| Hook body type extension | Added `attachment_ids?: string[]` to `PublicUpdateBody` / `InternalCommentBody` / `ReporterReplyBody`. Kept optional so existing call sites (none outside the composers) don't break. |
+
+## D1 — body shape
+
+Per plan: composers send the widened `attachment_ids: string[]` field alongside the legacy `attachments` array (still `[]`). BE schema reconciliation (deprecate `attachments`, validate `attachment_ids`) is C7b's responsibility — not touched here.
+
+## Out-of-scope items (deferred-items, scope boundary)
+
+1. **`tsc -p tsconfig.json` fails on `routeTree.gen` + TanStack Router route-id type errors.** Pre-existing on `develop @ a57eb22` (verified by `git stash && pnpm typecheck`). Not caused by this chunk. The `routeTree.gen` file is generated at dev/build time and absent in a clean install. Tracked for a separate cleanup.
+2. **C8 RichEditor `onAttach`** stays untouched. Confirmed in code review: the toolbar Attach button (C8) inserts an inline `attachmentRef` node into the doc; the composer-level dropzone (C7a) collects `attachment_ids` for the POST body. The two are intentionally separate per plan.
+3. **`packages/shared/src/vocs/*-request.ts`** schemas not modified (C7b territory). `reporterReplyRequestSchema` still has the legacy `attachments: AttachmentRef[]` field; `internalCommentRequestSchema` has no attachments at all. Wire-shape mismatch will be resolved by C7b.
+
+## Verification run
+
+- `cd apps/frontend && pnpm test -- --run src/features/voc/components/detail/__tests__/{PublicUpdate,InternalComment,ReporterReply}Composer.attachments.test.tsx` → 9/9 pass
+- `cd apps/frontend && pnpm test -- --run` → 427/427 pass, 109 test files
+- `pnpm typecheck` → fails identically to develop baseline (route-tree generation, pre-existing).
+
+## Commits
+
+1. `9babb56` — `test(slice3 #22 C7a): RED — composer attachment dropzone wiring tests`
+2. `694ce31` — `feat(slice3 #22 C7a): GREEN — wire attachment dropzone into 3 Triage composers`
+3. (this file) — devnote

--- a/apps/frontend/src/features/voc/components/detail/ComposerAttachmentDropzone.tsx
+++ b/apps/frontend/src/features/voc/components/detail/ComposerAttachmentDropzone.tsx
@@ -1,0 +1,326 @@
+// ComposerAttachmentDropzone — compact attachment dropzone for the three
+// Triage composers (PublicUpdate / InternalComment / ReporterReply).
+//
+// PLAN-22 C7a.
+//
+// Mirrors C6's <AttachmentDropzone> per-row state machine (pending →
+// uploading → uploaded | error) and onChange / onUploadingChange contract.
+// The compact variant drops the "첨부" FieldLabel + Card chrome since the
+// composer container already implies the attachment context, and renders
+// with tighter spacing to fit below the RichEditor body.
+//
+// Prototype anchor: docs/design-prototype/screen-voc-triage.jsx ComposerSection
+// + screen-voc-detail-reporter.jsx Reply composer. Copy strings ("파일을 드래그하거나
+// 클릭해서 추가", "최대 25MB · 다중 선택") are verbatim from screen-voc-create.jsx
+// per C6.
+//
+// D1: parent sends the uploaded ids via `attachment_ids: string[]` on the
+// composer POST body (widened from legacy `attachments: AttachmentRef[]` —
+// schema is reconciled in C7b).
+
+import { cn } from '@fops/ui';
+import { Check, Paperclip, X } from 'lucide-react';
+import * as React from 'react';
+import { toast } from 'sonner';
+
+import { uploadAttachment } from '@/lib/api/attachments';
+import { errorMapper } from '@/lib/api/errorMapper';
+import type { ApiError } from '@/lib/api/types';
+
+const MAX_SIZE_BYTES = 25 * 1024 * 1024;
+
+const COPY = {
+  dropHint: '파일을 드래그하거나 클릭해서 추가',
+  footer: '최대 25MB · 다중 선택',
+  removeTitle: '첨부 제거',
+  oversize: '첨부 파일 크기가 허용 한도를 초과했습니다.',
+  unsupportedType: '허용되지 않는 파일 형식입니다.',
+} as const;
+
+type RowState =
+  | { kind: 'uploading' }
+  | { kind: 'uploaded'; serverId: string }
+  | { kind: 'error'; code: string; message: string };
+
+interface Row {
+  rowId: string;
+  file: File;
+  idempotencyKey: string;
+  state: RowState;
+  abort: AbortController;
+}
+
+export interface ComposerAttachmentDropzoneProps {
+  /**
+   * Unique testid prefix per composer surface
+   * (e.g. "public-update-attachment-dropzone").
+   */
+  testId: string;
+  onChange?: (serverAttachmentIds: string[]) => void;
+  onUploadingChange?: (uploading: boolean) => void;
+}
+
+function mintRowId(): string {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) return crypto.randomUUID();
+  return `row-${Math.random().toString(36).slice(2)}-${Date.now()}`;
+}
+
+function mintIdempotencyKey(): string {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) return crypto.randomUUID();
+  const bytes = new Uint8Array(16);
+  if (typeof crypto !== 'undefined' && crypto.getRandomValues) crypto.getRandomValues(bytes);
+  else for (let i = 0; i < 16; i++) bytes[i] = Math.floor(Math.random() * 256);
+  bytes[6] = ((bytes[6] ?? 0) & 0x0f) | 0x40;
+  bytes[8] = ((bytes[8] ?? 0) & 0x3f) | 0x80;
+  const hex = Array.from(bytes, (b) => (b ?? 0).toString(16).padStart(2, '0'));
+  return `${hex.slice(0, 4).join('')}-${hex.slice(4, 6).join('')}-${hex.slice(6, 8).join('')}-${hex.slice(8, 10).join('')}-${hex.slice(10, 16).join('')}`;
+}
+
+function formatFileSize(bytes: number): string {
+  if (!bytes) return '0 B';
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export function ComposerAttachmentDropzone({
+  testId,
+  onChange,
+  onUploadingChange,
+}: ComposerAttachmentDropzoneProps): React.ReactElement {
+  const [rows, setRows] = React.useState<Row[]>([]);
+  const [dragOver, setDragOver] = React.useState(false);
+
+  const uploadedIds = React.useMemo(
+    () =>
+      rows
+        .filter(
+          (r): r is Row & { state: { kind: 'uploaded'; serverId: string } } =>
+            r.state.kind === 'uploaded',
+        )
+        .map((r) => r.state.serverId),
+    [rows],
+  );
+  const anyUploading = rows.some((r) => r.state.kind === 'uploading');
+
+  const lastUploadedRef = React.useRef<string>('');
+  const lastUploadingRef = React.useRef<boolean | null>(null);
+
+  React.useEffect(() => {
+    const key = uploadedIds.join(',');
+    if (lastUploadedRef.current !== key) {
+      lastUploadedRef.current = key;
+      onChange?.(uploadedIds);
+    }
+  }, [uploadedIds, onChange]);
+
+  React.useEffect(() => {
+    if (lastUploadingRef.current !== anyUploading) {
+      lastUploadingRef.current = anyUploading;
+      onUploadingChange?.(anyUploading);
+    }
+  }, [anyUploading, onUploadingChange]);
+
+  function clientSideRejection(file: File): { code: string; message: string } | null {
+    if (file.size > MAX_SIZE_BYTES) {
+      return { code: 'attachment.too_large', message: COPY.oversize };
+    }
+    return null;
+  }
+
+  const addFiles = React.useCallback((fileList: FileList | File[] | null): void => {
+    if (!fileList) return;
+    const files = Array.from(fileList);
+    if (files.length === 0) return;
+
+    const newRows: Row[] = files.map((file) => {
+      const reject = clientSideRejection(file);
+      const rowId = mintRowId();
+      const idempotencyKey = mintIdempotencyKey();
+      const abort = new AbortController();
+      if (reject) {
+        return {
+          rowId,
+          file,
+          idempotencyKey,
+          abort,
+          state: { kind: 'error', code: reject.code, message: reject.message },
+        };
+      }
+      return { rowId, file, idempotencyKey, abort, state: { kind: 'uploading' } };
+    });
+
+    setRows((prev) => [...prev, ...newRows]);
+
+    for (const row of newRows) {
+      if (row.state.kind !== 'uploading') continue;
+      void (async () => {
+        try {
+          const result = await uploadAttachment(row.file, {
+            idempotencyKey: row.idempotencyKey,
+            signal: row.abort.signal,
+          });
+          setRows((cur) =>
+            cur.map((r) =>
+              r.rowId === row.rowId
+                ? { ...r, state: { kind: 'uploaded', serverId: result.id } }
+                : r,
+            ),
+          );
+        } catch (err) {
+          const apiErr = err as ApiError;
+          if (apiErr.code === 'storage.unavailable') {
+            const mapped = errorMapper(apiErr.envelope);
+            toast.error(mapped.message);
+          }
+          let inlineMessage: string;
+          if (apiErr.code === 'attachment.too_large') inlineMessage = COPY.oversize;
+          else if (apiErr.code === 'attachment.unsupported_type')
+            inlineMessage = COPY.unsupportedType;
+          else {
+            const mapped = errorMapper(
+              apiErr.envelope ?? { code: 'internal.unexpected', message: '' },
+            );
+            inlineMessage = mapped.message;
+          }
+          setRows((cur) =>
+            cur.map((r) =>
+              r.rowId === row.rowId
+                ? {
+                    ...r,
+                    state: {
+                      kind: 'error',
+                      code: apiErr.code ?? 'internal.unexpected',
+                      message: inlineMessage,
+                    },
+                  }
+                : r,
+            ),
+          );
+        }
+      })();
+    }
+  }, []);
+
+  function handleDragOver(e: React.DragEvent<HTMLLabelElement>): void {
+    e.preventDefault();
+    setDragOver(true);
+  }
+  function handleDragLeave(): void {
+    setDragOver(false);
+  }
+  function handleDrop(e: React.DragEvent<HTMLLabelElement>): void {
+    e.preventDefault();
+    setDragOver(false);
+    addFiles(e.dataTransfer?.files ?? null);
+  }
+  function handleInputChange(e: React.ChangeEvent<HTMLInputElement>): void {
+    addFiles(e.target.files);
+    e.target.value = '';
+  }
+
+  function removeRow(rowId: string): void {
+    setRows((cur) => {
+      const row = cur.find((r) => r.rowId === rowId);
+      if (row && row.state.kind === 'uploading') row.abort.abort();
+      return cur.filter((r) => r.rowId !== rowId);
+    });
+  }
+
+  const inputId = `${testId}-input-control`;
+
+  return (
+    <div
+      data-testid={testId}
+      className="flex flex-col gap-1.5 px-3 pb-2"
+    >
+      {/* Compact dropzone — no FieldLabel; composer context implies "첨부" */}
+      {/* biome-ignore lint/a11y/noLabelWithoutControl: htmlFor wires to hidden input */}
+      <label
+        htmlFor={inputId}
+        className={cn(
+          'flex cursor-pointer items-center gap-2 rounded-md border border-dashed border-border-subtle px-2.5 py-1.5 transition-colors',
+          dragOver && 'border-accent-primary bg-accent-primary/5',
+        )}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+        data-testid={`${testId}-drop`}
+      >
+        <Paperclip className="h-3 w-3 shrink-0 text-text-muted" aria-hidden />
+        <span className="text-xs text-text-primary">{COPY.dropHint}</span>
+        <span className="flex-1" />
+        <span className="text-[11px] text-text-muted">{COPY.footer}</span>
+        <input
+          id={inputId}
+          type="file"
+          multiple
+          className="hidden"
+          onChange={handleInputChange}
+          data-testid={`${testId}-input`}
+        />
+      </label>
+
+      {rows.length > 0 && (
+        <ul
+          className="mt-1 flex flex-col gap-1"
+          data-testid={`${testId}-rows`}
+        >
+          {rows.map((row) => (
+            <AttachmentRow key={row.rowId} row={row} onRemove={() => removeRow(row.rowId)} />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+interface AttachmentRowProps {
+  row: Row;
+  onRemove: () => void;
+}
+
+function AttachmentRow({ row, onRemove }: AttachmentRowProps): React.ReactElement {
+  const sizeText = formatFileSize(row.file.size);
+  let statusText: React.ReactNode;
+  if (row.state.kind === 'uploading') {
+    statusText = <span className="ml-1.5 text-text-muted">· 업로드 중</span>;
+  } else if (row.state.kind === 'uploaded') {
+    statusText = (
+      <span className="ml-1.5 inline-flex items-center gap-1 text-text-muted">
+        <Check className="h-3 w-3" aria-hidden data-testid="attachment-row-check" /> 업로드 완료
+      </span>
+    );
+  } else {
+    statusText = <span className="ml-1.5 text-text-danger">· {row.state.message}</span>;
+  }
+  const showRemove = row.state.kind !== 'uploading';
+
+  return (
+    <li
+      className="flex items-center gap-2 rounded-md bg-surface-card px-2 py-1.5"
+      data-testid="attachment-row"
+      data-state={row.state.kind}
+      data-error-code={row.state.kind === 'error' ? row.state.code : undefined}
+    >
+      <div className="flex min-w-0 flex-1 flex-col">
+        <span className="truncate text-xs font-medium">{row.file.name}</span>
+        <span className="text-[11px]">
+          <span className="text-text-muted">{sizeText}</span>
+          {statusText}
+        </span>
+      </div>
+      {showRemove && (
+        <button
+          type="button"
+          onClick={onRemove}
+          className="rounded p-0.5 text-text-muted hover:bg-surface-raised"
+          aria-label="첨부 제거"
+          title="첨부 제거"
+        >
+          <X className="h-3 w-3" aria-hidden />
+        </button>
+      )}
+    </li>
+  );
+}

--- a/apps/frontend/src/features/voc/components/detail/InternalCommentComposer.tsx
+++ b/apps/frontend/src/features/voc/components/detail/InternalCommentComposer.tsx
@@ -36,6 +36,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import * as React from 'react';
 import { toast } from 'sonner';
 import { uploadAttachment } from '@/lib/api/attachments';
+import { ComposerAttachmentDropzone } from './ComposerAttachmentDropzone';
 import { ComposerFooter } from './ComposerFooter';
 import { MentionPickerButton } from './MentionPickerButton';
 import { InternalCommentToolbar } from './rich-toolbars/InternalCommentToolbar';
@@ -103,6 +104,10 @@ export function InternalCommentComposer({
     }
   }
 
+  // PLAN-22 C7a: composer-level attachment dropzone state.
+  const [attachmentIds, setAttachmentIds] = React.useState<string[]>([]);
+  const [attachmentsUploading, setAttachmentsUploading] = React.useState(false);
+
   const isEmpty = isDocEmpty(draftDoc);
 
   const mutation = useVocInternalCommentMutation({
@@ -122,6 +127,8 @@ export function InternalCommentComposer({
       body: {
         body_rich_content: draftDoc,
         mentions,
+        // PLAN-22 C7a (D1): widened body field — schema reconciled in C7b.
+        attachment_ids: attachmentIds,
       },
     });
   }
@@ -186,6 +193,13 @@ export function InternalCommentComposer({
         <MentionPickerButton onSelect={handleInsertMention} disabled={mutation.isPending} />
       </div>
 
+      {/* PLAN-22 C7a: composer-level attachment dropzone (compact). */}
+      <ComposerAttachmentDropzone
+        testId="internal-comment-attachment-dropzone"
+        onChange={setAttachmentIds}
+        onUploadingChange={setAttachmentsUploading}
+      />
+
       {/* ComposerFooter — Preview disabled per D-5.4 */}
       <ComposerFooter
         submitLabel="Add note"
@@ -195,6 +209,7 @@ export function InternalCommentComposer({
         onSubmit={handleSubmit}
         isEmpty={isEmpty}
         isSubmitting={mutation.isPending}
+        isSubmitDisabled={attachmentsUploading}
         isPreviewDisabled={true}
         statusHint={statusHint}
       />

--- a/apps/frontend/src/features/voc/components/detail/PublicUpdateComposer.tsx
+++ b/apps/frontend/src/features/voc/components/detail/PublicUpdateComposer.tsx
@@ -72,6 +72,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { AlertCircle, Megaphone } from 'lucide-react';
 import { type ReactElement, useRef, useState } from 'react';
 import { toast } from 'sonner';
+import { ComposerAttachmentDropzone } from './ComposerAttachmentDropzone';
 import { ComposerFooter } from './ComposerFooter';
 import { ComposerPublicPreview } from './ComposerPublicPreview';
 import { ReporterStatusChangeBlock } from './ReporterStatusChangeBlock';
@@ -138,6 +139,10 @@ export function PublicUpdateComposer({ voc, me, draftDoc: controlledDraftDoc, on
   );
   const [previewOpen, setPreviewOpen] = useState(false);
 
+  // PLAN-22 C7a: composer-level attachment dropzone state.
+  const [attachmentIds, setAttachmentIds] = useState<string[]>([]);
+  const [attachmentsUploading, setAttachmentsUploading] = useState(false);
+
   // Reset state when VOC changes (status + preview; draft reset handled by parent for controlled).
   const prevVocIdRef = useRef(voc.id);
   if (prevVocIdRef.current !== voc.id) {
@@ -173,6 +178,8 @@ export function PublicUpdateComposer({ voc, me, draftDoc: controlledDraftDoc, on
         body_rich_content: draftDoc,
         next_reporter_facing_status: nextStatus,
         attachments: [],
+        // PLAN-22 C7a (D1): widened body field — schema reconciled in C7b.
+        attachment_ids: attachmentIds,
       },
     });
   }
@@ -246,6 +253,13 @@ export function PublicUpdateComposer({ voc, me, draftDoc: controlledDraftDoc, on
         )}
       />
 
+      {/* PLAN-22 C7a: composer-level attachment dropzone (compact). */}
+      <ComposerAttachmentDropzone
+        testId="public-update-attachment-dropzone"
+        onChange={setAttachmentIds}
+        onUploadingChange={setAttachmentsUploading}
+      />
+
       {/* ReporterStatusChangeBlock — always shown in the public-update composer */}
       <ReporterStatusChangeBlock
         voc={voc}
@@ -277,7 +291,7 @@ export function PublicUpdateComposer({ voc, me, draftDoc: controlledDraftDoc, on
         onSubmit={handleSubmit}
         isEmpty={isEmpty}
         isSubmitting={mutation.isPending}
-        isSubmitDisabled={isGateBlocked || isIdempotencyLocked}
+        isSubmitDisabled={isGateBlocked || isIdempotencyLocked || attachmentsUploading}
         isPreviewDisabled={isIdempotencyLocked}
         statusHint={statusHint}
       />

--- a/apps/frontend/src/features/voc/components/detail/ReporterReplyComposer.tsx
+++ b/apps/frontend/src/features/voc/components/detail/ReporterReplyComposer.tsx
@@ -47,6 +47,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { AlertCircle } from 'lucide-react';
 import { type ReactElement, useRef, useState } from 'react';
 import { toast } from 'sonner';
+import { ComposerAttachmentDropzone } from './ComposerAttachmentDropzone';
 import { ComposerFooter } from './ComposerFooter';
 import { ComposerReplyPreview } from './ComposerReplyPreview';
 import { uploadAttachment } from '@/lib/api/attachments';
@@ -105,6 +106,10 @@ export function ReporterReplyComposer({ voc, me, draftDoc: controlledDraftDoc, o
 
   const [previewOpen, setPreviewOpen] = useState(false);
 
+  // PLAN-22 C7a: composer-level attachment dropzone state.
+  const [attachmentIds, setAttachmentIds] = useState<string[]>([]);
+  const [attachmentsUploading, setAttachmentsUploading] = useState(false);
+
   // Reset state when VOC changes (preview; draft reset handled by parent for controlled).
   const prevVocIdRef = useRef(voc.id);
   if (prevVocIdRef.current !== voc.id) {
@@ -133,6 +138,8 @@ export function ReporterReplyComposer({ voc, me, draftDoc: controlledDraftDoc, o
       body: {
         body_rich_content: draftDoc,
         attachments: [],
+        // PLAN-22 C7a (D1): widened body field — schema reconciled in C7b.
+        attachment_ids: attachmentIds,
       },
     });
   }
@@ -192,6 +199,13 @@ export function ReporterReplyComposer({ voc, me, draftDoc: controlledDraftDoc, o
         )}
       />
 
+      {/* PLAN-22 C7a: composer-level attachment dropzone (compact). */}
+      <ComposerAttachmentDropzone
+        testId="reporter-reply-attachment-dropzone"
+        onChange={setAttachmentIds}
+        onUploadingChange={setAttachmentsUploading}
+      />
+
       {/* Inline error Callout — reporter_facing_status.gate_blocked (amber)
           D-5.6: copy from backend detail.reason, not errorMapper message */}
       {inlineCalloutTone != null && inlineCalloutReason != null && (
@@ -213,7 +227,7 @@ export function ReporterReplyComposer({ voc, me, draftDoc: controlledDraftDoc, o
         onSubmit={handleSubmit}
         isEmpty={isEmpty}
         isSubmitting={mutation.isPending}
-        isSubmitDisabled={isIdempotencyLocked}
+        isSubmitDisabled={isIdempotencyLocked || attachmentsUploading}
         isPreviewDisabled={isIdempotencyLocked}
         statusHint={statusHint}
       />

--- a/apps/frontend/src/features/voc/components/detail/__tests__/InternalCommentComposer.attachments.test.tsx
+++ b/apps/frontend/src/features/voc/components/detail/__tests__/InternalCommentComposer.attachments.test.tsx
@@ -1,0 +1,241 @@
+// InternalCommentComposer — attachment dropzone wiring tests (PLAN-22 C7a).
+
+import * as React from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@fops/ui', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@fops/ui')>();
+  return {
+    ...actual,
+    RichEditor: ({
+      onChange,
+      surface,
+    }: {
+      onChange?: (doc: import('@fops/ui').TipTapDoc) => void;
+      surface?: string;
+    }) =>
+      React.createElement('button', {
+        type: 'button',
+        'data-testid': `rich-editor-${surface ?? 'default'}`,
+        onClick: () =>
+          onChange?.({
+            type: 'doc',
+            content: [{ type: 'paragraph', content: [{ type: 'text', text: 'hi' }] }],
+          }),
+      }),
+  };
+});
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), warning: vi.fn(), info: vi.fn(), success: vi.fn() },
+}));
+
+vi.mock('@/features/voc/hooks/useVocInternalCommentMutation', () => ({
+  useVocInternalCommentMutation: vi.fn(),
+}));
+
+import { useVocInternalCommentMutation } from '@/features/voc/hooks/useVocInternalCommentMutation';
+import { InternalCommentComposer } from '../InternalCommentComposer';
+import * as attachmentsApi from '@/lib/api/attachments';
+import { ApiError } from '@/lib/api/types';
+import type { VocDetailEnvelope } from '@fops/shared';
+import type { MeResponse } from '@/lib/auth/useMe';
+
+const ADMIN_ID = '00000000-0000-0000-0000-000000000002';
+
+const BASE_VOC: VocDetailEnvelope = {
+  id: 'voc-uuid-2222',
+  display_id: 'VOC-0002',
+  title: '내부',
+  primary_managed_system_id: 'ms-1',
+  analytics_area_id: null,
+  reporter_id: '00000000-0000-0000-0000-000000000001',
+  owner_user_id: ADMIN_ID,
+  owner_team_id: null,
+  severity: 'medium',
+  reporter_facing_status: 'received',
+  triage_state: 'untriaged',
+  source_context: 'direct_use',
+  created_at: '2026-05-01T00:00:00Z',
+  updated_at: '2026-05-01T00:00:00Z',
+  similar_count: 0,
+  description_rich_content: { type: 'doc', content: [] },
+  next_actions: [],
+  next_reporter_states: { allowed: ['reviewing'], forbidden: {} },
+  linked_execution: { findingRef: null, taskRef: null },
+  conversation_timeline: [],
+  conversation_page: { has_more: false },
+  permission_decisions: {},
+} as unknown as VocDetailEnvelope;
+
+const ME_ADMIN: MeResponse = {
+  actor: {
+    id: ADMIN_ID,
+    external_id: 'admin-1',
+    email: 'admin@feedbackops.local',
+    display_name: '관리자',
+    role_level: 'admin',
+  },
+  workspace_id: 'ws-1111',
+};
+
+const ATTACHMENT = {
+  id: 'bbbb2222-0000-4000-8000-000000000002',
+  name: 'note.pdf',
+  size_bytes: 2048,
+  mime_type: 'application/pdf',
+  uploaded_by_actor_id: '00000000-0000-4000-8000-000000000099',
+  created_at: '2026-05-22T10:00:00.000Z',
+};
+
+const DEFAULT_MUTATION = {
+  mutate: vi.fn(),
+  isPending: false,
+  isError: false,
+  isIdle: true,
+  isSuccess: false,
+  isPaused: false,
+  status: 'idle' as const,
+  submittedAt: 0,
+  variables: undefined,
+  data: undefined,
+  error: null,
+  reset: vi.fn(),
+  context: undefined,
+  failureCount: 0,
+  failureReason: null,
+  mutateAsync: vi.fn(),
+};
+
+function makeFile(name = 'note.pdf', type = 'application/pdf', size = 2048): File {
+  const f = new File(['x'], name, { type });
+  Object.defineProperty(f, 'size', { value: size, configurable: true });
+  return f;
+}
+
+function pickFile(file: File): void {
+  const input = document.querySelector(
+    '[data-testid="internal-comment-attachment-dropzone-input"]',
+  ) as HTMLInputElement | null;
+  if (!input) throw new Error('internal-comment-attachment-dropzone-input not found');
+  fireEvent.change(input, { target: { files: [file] } });
+}
+
+function wrap() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: qc }, children);
+}
+
+describe('<InternalCommentComposer> attachments (PLAN-22 C7a)', () => {
+  beforeEach(() => {
+    vi.mocked(useVocInternalCommentMutation).mockReturnValue(
+      DEFAULT_MUTATION as unknown as ReturnType<typeof useVocInternalCommentMutation>,
+    );
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('upload → submit body includes attachment_ids[]', async () => {
+    vi.spyOn(attachmentsApi, 'uploadAttachment').mockResolvedValue(ATTACHMENT);
+    const mutateMock = vi.fn();
+    vi.mocked(useVocInternalCommentMutation).mockReturnValue(
+      { ...DEFAULT_MUTATION, mutate: mutateMock } as unknown as ReturnType<
+        typeof useVocInternalCommentMutation
+      >,
+    );
+
+    render(<InternalCommentComposer voc={BASE_VOC} me={ME_ADMIN} />, { wrapper: wrap() });
+
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId('rich-editor-internal-comment'));
+
+    await act(async () => {
+      pickFile(makeFile());
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('attachment-row').getAttribute('data-state')).toBe('uploaded');
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Add note' }));
+
+    await waitFor(() => {
+      expect(mutateMock).toHaveBeenCalled();
+    });
+    const calledVars = mutateMock.mock.calls[0]![0] as {
+      body: { attachment_ids: string[] };
+    };
+    expect(calledVars.body.attachment_ids).toEqual([ATTACHMENT.id]);
+  });
+
+  it('failed upload not included in POST body', async () => {
+    vi.spyOn(attachmentsApi, 'uploadAttachment').mockRejectedValue(
+      new ApiError(422, { code: 'attachment.unsupported_type', message: 'nope' }),
+    );
+    const mutateMock = vi.fn();
+    vi.mocked(useVocInternalCommentMutation).mockReturnValue(
+      { ...DEFAULT_MUTATION, mutate: mutateMock } as unknown as ReturnType<
+        typeof useVocInternalCommentMutation
+      >,
+    );
+
+    render(<InternalCommentComposer voc={BASE_VOC} me={ME_ADMIN} />, { wrapper: wrap() });
+
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId('rich-editor-internal-comment'));
+
+    await act(async () => {
+      pickFile(makeFile('bad.zip', 'application/zip'));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('attachment-row').getAttribute('data-state')).toBe('error');
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Add note' }));
+
+    await waitFor(() => {
+      expect(mutateMock).toHaveBeenCalled();
+    });
+    const calledVars = mutateMock.mock.calls[0]![0] as {
+      body: { attachment_ids: string[] };
+    };
+    expect(calledVars.body.attachment_ids).toEqual([]);
+  });
+
+  it('Add note disabled while any attachment is mid-upload', async () => {
+    let resolveUpload!: (v: typeof ATTACHMENT) => void;
+    vi.spyOn(attachmentsApi, 'uploadAttachment').mockReturnValue(
+      new Promise((res) => {
+        resolveUpload = res;
+      }),
+    );
+
+    render(<InternalCommentComposer voc={BASE_VOC} me={ME_ADMIN} />, { wrapper: wrap() });
+
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId('rich-editor-internal-comment'));
+
+    await act(async () => {
+      pickFile(makeFile());
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Add note' })).toBeDisabled();
+    });
+
+    await act(async () => {
+      resolveUpload(ATTACHMENT);
+    });
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Add note' })).not.toBeDisabled();
+    });
+  });
+});

--- a/apps/frontend/src/features/voc/components/detail/__tests__/PublicUpdateComposer.attachments.test.tsx
+++ b/apps/frontend/src/features/voc/components/detail/__tests__/PublicUpdateComposer.attachments.test.tsx
@@ -1,0 +1,249 @@
+// PublicUpdateComposer — attachment dropzone wiring tests (PLAN-22 C7a).
+//
+// Covers:
+//   - drop file → upload → submit body includes attachment_ids[]
+//   - failed upload not included
+//   - Send disabled while uploading
+
+import * as React from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// RichEditor stub so the composer mounts headlessly.
+vi.mock('@fops/ui', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@fops/ui')>();
+  return {
+    ...actual,
+    RichEditor: ({
+      onChange,
+      surface,
+    }: {
+      onChange?: (doc: import('@fops/ui').TipTapDoc) => void;
+      surface?: string;
+    }) =>
+      React.createElement('button', {
+        type: 'button',
+        'data-testid': `rich-editor-${surface ?? 'default'}`,
+        onClick: () =>
+          onChange?.({
+            type: 'doc',
+            content: [{ type: 'paragraph', content: [{ type: 'text', text: 'hello' }] }],
+          }),
+      }),
+  };
+});
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), warning: vi.fn(), info: vi.fn(), success: vi.fn() },
+}));
+
+vi.mock('@/features/voc/hooks/useVocPublicUpdateMutation', () => ({
+  useVocPublicUpdateMutation: vi.fn(),
+}));
+
+import { useVocPublicUpdateMutation } from '@/features/voc/hooks/useVocPublicUpdateMutation';
+import { PublicUpdateComposer } from '../PublicUpdateComposer';
+import * as attachmentsApi from '@/lib/api/attachments';
+import { ApiError } from '@/lib/api/types';
+import type { VocDetailEnvelope } from '@fops/shared';
+import type { MeResponse } from '@/lib/auth/useMe';
+
+const REPORTER_ID = '00000000-0000-0000-0000-000000000001';
+const ADMIN_ID = '00000000-0000-0000-0000-000000000002';
+
+const BASE_VOC: VocDetailEnvelope = {
+  id: 'voc-uuid-1111',
+  display_id: 'VOC-0001',
+  title: '테스트 VOC',
+  primary_managed_system_id: 'ms-1',
+  analytics_area_id: null,
+  reporter_id: REPORTER_ID,
+  owner_user_id: ADMIN_ID,
+  owner_team_id: null,
+  severity: 'high',
+  reporter_facing_status: 'received',
+  triage_state: 'untriaged',
+  source_context: 'direct_use',
+  created_at: '2026-05-01T00:00:00Z',
+  updated_at: '2026-05-01T00:00:00Z',
+  similar_count: 0,
+  description_rich_content: { type: 'doc', content: [] },
+  next_actions: [],
+  next_reporter_states: { allowed: ['reviewing'], forbidden: {} },
+  linked_execution: { findingRef: null, taskRef: null },
+  conversation_timeline: [],
+  conversation_page: { has_more: false },
+  permission_decisions: {},
+} as unknown as VocDetailEnvelope;
+
+const ME_ADMIN: MeResponse = {
+  actor: {
+    id: ADMIN_ID,
+    external_id: 'admin-1',
+    email: 'admin@feedbackops.local',
+    display_name: '관리자',
+    role_level: 'admin',
+  },
+  workspace_id: 'ws-1111',
+};
+
+const ATTACHMENT = {
+  id: 'aaaa1111-0000-4000-8000-000000000001',
+  name: 'shot.png',
+  size_bytes: 1024,
+  mime_type: 'image/png',
+  uploaded_by_actor_id: '00000000-0000-4000-8000-000000000099',
+  created_at: '2026-05-22T10:00:00.000Z',
+};
+
+const DEFAULT_MUTATION = {
+  mutate: vi.fn(),
+  isPending: false,
+  isError: false,
+  isIdle: true,
+  isSuccess: false,
+  isPaused: false,
+  status: 'idle' as const,
+  submittedAt: 0,
+  variables: undefined,
+  data: undefined,
+  error: null,
+  reset: vi.fn(),
+  context: undefined,
+  failureCount: 0,
+  failureReason: null,
+  mutateAsync: vi.fn(),
+};
+
+function makeFile(name = 'shot.png', type = 'image/png', size = 1024): File {
+  const f = new File(['x'], name, { type });
+  Object.defineProperty(f, 'size', { value: size, configurable: true });
+  return f;
+}
+
+function pickFile(file: File): void {
+  const input = document.querySelector(
+    '[data-testid="public-update-attachment-dropzone-input"]',
+  ) as HTMLInputElement | null;
+  if (!input) throw new Error('public-update-attachment-dropzone-input not found');
+  fireEvent.change(input, { target: { files: [file] } });
+}
+
+function wrap() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: qc }, children);
+}
+
+describe('<PublicUpdateComposer> attachments (PLAN-22 C7a)', () => {
+  beforeEach(() => {
+    vi.mocked(useVocPublicUpdateMutation).mockReturnValue(
+      DEFAULT_MUTATION as unknown as ReturnType<typeof useVocPublicUpdateMutation>,
+    );
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('upload → submit body includes attachment_ids[]', async () => {
+    vi.spyOn(attachmentsApi, 'uploadAttachment').mockResolvedValue(ATTACHMENT);
+    const mutateMock = vi.fn();
+    vi.mocked(useVocPublicUpdateMutation).mockReturnValue(
+      { ...DEFAULT_MUTATION, mutate: mutateMock } as unknown as ReturnType<
+        typeof useVocPublicUpdateMutation
+      >,
+    );
+
+    render(<PublicUpdateComposer voc={BASE_VOC} me={ME_ADMIN} />, { wrapper: wrap() });
+
+    // Fill draft (so submit not blocked by empty)
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId('rich-editor-public-update'));
+
+    await act(async () => {
+      pickFile(makeFile());
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('attachment-row').getAttribute('data-state')).toBe('uploaded');
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Publish update' }));
+
+    await waitFor(() => {
+      expect(mutateMock).toHaveBeenCalled();
+    });
+    const calledVars = mutateMock.mock.calls[0]![0] as {
+      body: { attachment_ids: string[] };
+    };
+    expect(calledVars.body.attachment_ids).toEqual([ATTACHMENT.id]);
+  });
+
+  it('failed upload not included in POST body', async () => {
+    vi.spyOn(attachmentsApi, 'uploadAttachment').mockRejectedValue(
+      new ApiError(422, { code: 'attachment.unsupported_type', message: 'nope' }),
+    );
+    const mutateMock = vi.fn();
+    vi.mocked(useVocPublicUpdateMutation).mockReturnValue(
+      { ...DEFAULT_MUTATION, mutate: mutateMock } as unknown as ReturnType<
+        typeof useVocPublicUpdateMutation
+      >,
+    );
+
+    render(<PublicUpdateComposer voc={BASE_VOC} me={ME_ADMIN} />, { wrapper: wrap() });
+
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId('rich-editor-public-update'));
+
+    await act(async () => {
+      pickFile(makeFile('a.zip', 'application/zip'));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('attachment-row').getAttribute('data-state')).toBe('error');
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Publish update' }));
+
+    await waitFor(() => {
+      expect(mutateMock).toHaveBeenCalled();
+    });
+    const calledVars = mutateMock.mock.calls[0]![0] as {
+      body: { attachment_ids: string[] };
+    };
+    expect(calledVars.body.attachment_ids).toEqual([]);
+  });
+
+  it('Publish disabled while any attachment is mid-upload', async () => {
+    let resolveUpload!: (v: typeof ATTACHMENT) => void;
+    vi.spyOn(attachmentsApi, 'uploadAttachment').mockReturnValue(
+      new Promise((res) => {
+        resolveUpload = res;
+      }),
+    );
+
+    render(<PublicUpdateComposer voc={BASE_VOC} me={ME_ADMIN} />, { wrapper: wrap() });
+
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId('rich-editor-public-update'));
+
+    await act(async () => {
+      pickFile(makeFile());
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Publish update' })).toBeDisabled();
+    });
+
+    await act(async () => {
+      resolveUpload(ATTACHMENT);
+    });
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Publish update' })).not.toBeDisabled();
+    });
+  });
+});

--- a/apps/frontend/src/features/voc/components/detail/__tests__/ReporterReplyComposer.attachments.test.tsx
+++ b/apps/frontend/src/features/voc/components/detail/__tests__/ReporterReplyComposer.attachments.test.tsx
@@ -1,0 +1,241 @@
+// ReporterReplyComposer — attachment dropzone wiring tests (PLAN-22 C7a).
+
+import * as React from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@fops/ui', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@fops/ui')>();
+  return {
+    ...actual,
+    RichEditor: ({
+      onChange,
+      surface,
+    }: {
+      onChange?: (doc: import('@fops/ui').TipTapDoc) => void;
+      surface?: string;
+    }) =>
+      React.createElement('button', {
+        type: 'button',
+        'data-testid': `rich-editor-${surface ?? 'default'}`,
+        onClick: () =>
+          onChange?.({
+            type: 'doc',
+            content: [{ type: 'paragraph', content: [{ type: 'text', text: 'reply' }] }],
+          }),
+      }),
+  };
+});
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), warning: vi.fn(), info: vi.fn(), success: vi.fn() },
+}));
+
+vi.mock('@/features/voc/hooks/useVocReporterReplyMutation', () => ({
+  useVocReporterReplyMutation: vi.fn(),
+}));
+
+import { useVocReporterReplyMutation } from '@/features/voc/hooks/useVocReporterReplyMutation';
+import { ReporterReplyComposer } from '../ReporterReplyComposer';
+import * as attachmentsApi from '@/lib/api/attachments';
+import { ApiError } from '@/lib/api/types';
+import type { VocDetailEnvelope } from '@fops/shared';
+import type { MeResponse } from '@/lib/auth/useMe';
+
+const ADMIN_ID = '00000000-0000-0000-0000-000000000002';
+
+const BASE_VOC: VocDetailEnvelope = {
+  id: 'voc-uuid-3333',
+  display_id: 'VOC-0003',
+  title: '리포트',
+  primary_managed_system_id: 'ms-1',
+  analytics_area_id: null,
+  reporter_id: '00000000-0000-0000-0000-000000000001',
+  owner_user_id: ADMIN_ID,
+  owner_team_id: null,
+  severity: 'low',
+  reporter_facing_status: 'received',
+  triage_state: 'untriaged',
+  source_context: 'direct_use',
+  created_at: '2026-05-01T00:00:00Z',
+  updated_at: '2026-05-01T00:00:00Z',
+  similar_count: 0,
+  description_rich_content: { type: 'doc', content: [] },
+  next_actions: [],
+  next_reporter_states: { allowed: ['reviewing'], forbidden: {} },
+  linked_execution: { findingRef: null, taskRef: null },
+  conversation_timeline: [],
+  conversation_page: { has_more: false },
+  permission_decisions: {},
+} as unknown as VocDetailEnvelope;
+
+const ME_ADMIN: MeResponse = {
+  actor: {
+    id: ADMIN_ID,
+    external_id: 'admin-1',
+    email: 'admin@feedbackops.local',
+    display_name: '관리자',
+    role_level: 'admin',
+  },
+  workspace_id: 'ws-1111',
+};
+
+const ATTACHMENT = {
+  id: 'cccc3333-0000-4000-8000-000000000003',
+  name: 'photo.jpg',
+  size_bytes: 4096,
+  mime_type: 'image/jpeg',
+  uploaded_by_actor_id: '00000000-0000-4000-8000-000000000099',
+  created_at: '2026-05-22T10:00:00.000Z',
+};
+
+const DEFAULT_MUTATION = {
+  mutate: vi.fn(),
+  isPending: false,
+  isError: false,
+  isIdle: true,
+  isSuccess: false,
+  isPaused: false,
+  status: 'idle' as const,
+  submittedAt: 0,
+  variables: undefined,
+  data: undefined,
+  error: null,
+  reset: vi.fn(),
+  context: undefined,
+  failureCount: 0,
+  failureReason: null,
+  mutateAsync: vi.fn(),
+};
+
+function makeFile(name = 'photo.jpg', type = 'image/jpeg', size = 4096): File {
+  const f = new File(['x'], name, { type });
+  Object.defineProperty(f, 'size', { value: size, configurable: true });
+  return f;
+}
+
+function pickFile(file: File): void {
+  const input = document.querySelector(
+    '[data-testid="reporter-reply-attachment-dropzone-input"]',
+  ) as HTMLInputElement | null;
+  if (!input) throw new Error('reporter-reply-attachment-dropzone-input not found');
+  fireEvent.change(input, { target: { files: [file] } });
+}
+
+function wrap() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: qc }, children);
+}
+
+describe('<ReporterReplyComposer> attachments (PLAN-22 C7a)', () => {
+  beforeEach(() => {
+    vi.mocked(useVocReporterReplyMutation).mockReturnValue(
+      DEFAULT_MUTATION as unknown as ReturnType<typeof useVocReporterReplyMutation>,
+    );
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('upload → submit body includes attachment_ids[]', async () => {
+    vi.spyOn(attachmentsApi, 'uploadAttachment').mockResolvedValue(ATTACHMENT);
+    const mutateMock = vi.fn();
+    vi.mocked(useVocReporterReplyMutation).mockReturnValue(
+      { ...DEFAULT_MUTATION, mutate: mutateMock } as unknown as ReturnType<
+        typeof useVocReporterReplyMutation
+      >,
+    );
+
+    render(<ReporterReplyComposer voc={BASE_VOC} me={ME_ADMIN} />, { wrapper: wrap() });
+
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId('rich-editor-reporter-reply'));
+
+    await act(async () => {
+      pickFile(makeFile());
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('attachment-row').getAttribute('data-state')).toBe('uploaded');
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Send reply' }));
+
+    await waitFor(() => {
+      expect(mutateMock).toHaveBeenCalled();
+    });
+    const calledVars = mutateMock.mock.calls[0]![0] as {
+      body: { attachment_ids: string[] };
+    };
+    expect(calledVars.body.attachment_ids).toEqual([ATTACHMENT.id]);
+  });
+
+  it('failed upload not included in POST body', async () => {
+    vi.spyOn(attachmentsApi, 'uploadAttachment').mockRejectedValue(
+      new ApiError(422, { code: 'attachment.unsupported_type', message: 'nope' }),
+    );
+    const mutateMock = vi.fn();
+    vi.mocked(useVocReporterReplyMutation).mockReturnValue(
+      { ...DEFAULT_MUTATION, mutate: mutateMock } as unknown as ReturnType<
+        typeof useVocReporterReplyMutation
+      >,
+    );
+
+    render(<ReporterReplyComposer voc={BASE_VOC} me={ME_ADMIN} />, { wrapper: wrap() });
+
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId('rich-editor-reporter-reply'));
+
+    await act(async () => {
+      pickFile(makeFile('bad.zip', 'application/zip'));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('attachment-row').getAttribute('data-state')).toBe('error');
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Send reply' }));
+
+    await waitFor(() => {
+      expect(mutateMock).toHaveBeenCalled();
+    });
+    const calledVars = mutateMock.mock.calls[0]![0] as {
+      body: { attachment_ids: string[] };
+    };
+    expect(calledVars.body.attachment_ids).toEqual([]);
+  });
+
+  it('Send reply disabled while any attachment is mid-upload', async () => {
+    let resolveUpload!: (v: typeof ATTACHMENT) => void;
+    vi.spyOn(attachmentsApi, 'uploadAttachment').mockReturnValue(
+      new Promise((res) => {
+        resolveUpload = res;
+      }),
+    );
+
+    render(<ReporterReplyComposer voc={BASE_VOC} me={ME_ADMIN} />, { wrapper: wrap() });
+
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId('rich-editor-reporter-reply'));
+
+    await act(async () => {
+      pickFile(makeFile());
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Send reply' })).toBeDisabled();
+    });
+
+    await act(async () => {
+      resolveUpload(ATTACHMENT);
+    });
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Send reply' })).not.toBeDisabled();
+    });
+  });
+});

--- a/apps/frontend/src/features/voc/hooks/useVocInternalCommentMutation.ts
+++ b/apps/frontend/src/features/voc/hooks/useVocInternalCommentMutation.ts
@@ -20,6 +20,11 @@ export interface InternalCommentBody {
   body_rich_content: TipTapDoc;
   /** Deduplicated list of mentioned actor IDs. Extracted by extractMentions(). */
   mentions: string[];
+  /**
+   * PLAN-22 C7a (D1): widened body field — FE list of uploaded attachment ids
+   * from <ComposerAttachmentDropzone>. BE schema reconciled in C7b.
+   */
+  attachment_ids?: string[];
 }
 
 export interface InternalCommentVars {

--- a/apps/frontend/src/features/voc/hooks/useVocPublicUpdateMutation.ts
+++ b/apps/frontend/src/features/voc/hooks/useVocPublicUpdateMutation.ts
@@ -29,6 +29,12 @@ export interface PublicUpdateBody {
   /** Always sent; backend tolerates no-op when equal to current status. */
   next_reporter_facing_status: ReporterFacingStatusEnum;
   attachments: unknown[];
+  /**
+   * PLAN-22 C7a (D1): widened body field — FE-side list of successfully-uploaded
+   * attachment ids from <ComposerAttachmentDropzone>. Backend schema reconciled
+   * in C7b (legacy `attachments: AttachmentRef[]` deprecated then).
+   */
+  attachment_ids?: string[];
 }
 
 export interface PublicUpdateVars {

--- a/apps/frontend/src/features/voc/hooks/useVocReporterReplyMutation.ts
+++ b/apps/frontend/src/features/voc/hooks/useVocReporterReplyMutation.ts
@@ -25,6 +25,11 @@ export interface ReporterReplyBody {
   body_rich_content: TipTapDoc;
   /** Always empty until attachment-deferral lifts in #22. */
   attachments: unknown[];
+  /**
+   * PLAN-22 C7a (D1): widened body field — FE list of uploaded attachment ids
+   * from <ComposerAttachmentDropzone>. BE schema reconciled in C7b.
+   */
+  attachment_ids?: string[];
 }
 
 export interface ReporterReplyVars {


### PR DESCRIPTION
## Summary
- New `ComposerAttachmentDropzone` (shared by 3 composers) — per-row state machine, error mapping, idempotency-key minting, compact variant for in-composer placement
- `PublicUpdateComposer` / `InternalCommentComposer` / `ReporterReplyComposer` wire dropzone state; body widened with `attachment_ids[]`; Send disabled while uploading
- Closes the FE side of #22's "composer attachment" requirement (BE accept path landed in C7b/#72)

Plan: `.review/PLAN-22.md` §C7a. Deviations: `.review/CHUNK-22-C7a-DEVIATIONS.md`.

## Test plan
- [x] +9 composer-attachment tests (3 per composer: PATCH/POST body with attachment_ids, failed upload excluded, Send-disabled-while-uploading)
- [x] Rebased on C7b — shared schemas now carry `attachment_ids: string[]` (uuid, max 10), no body type drift
- [x] FE suite 427/427 pass (pre-rebase)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>