### PR TITLE
fix(slice3 #22 C9): packages/ui boundary violation — duplicate allowlist locally

### DIFF
--- a/packages/ui/src/rich-content/__tests__/allowlist-drift.test.ts
+++ b/packages/ui/src/rich-content/__tests__/allowlist-drift.test.ts
@@ -1,0 +1,136 @@
+// PLAN-22 C9 fix — UI-side drift assertion for `allowlist-local.ts`.
+//
+// ADR-0016 forbids @fops/ui from importing @fops/shared, so this test cannot
+// import the shared allowlist directly. Instead it carries an inline fixture
+// describing the **shape** of the canonical shared allowlist; if the UI-local
+// copy drifts (extra/missing surfaces, nodes, marks, attr keys, attr kinds,
+// or DoS caps), this test fails.
+//
+// The companion `apps/backend/src/lib/rich-content/__tests__/drift-vs-shared
+// .test.ts` enforces backend↔shared parity. Together the two tests pin all
+// three copies (backend, shared, UI) in lockstep.
+//
+// If you change the canonical shared allowlist, update:
+//   1. packages/shared/src/rich-content/allowlist.ts (canonical)
+//   2. apps/backend/src/lib/rich-content/surface-allowlists.ts
+//   3. packages/ui/src/rich-content/allowlist-local.ts
+//   4. The EXPECTED fixture in this file.
+
+import { describe, expect, it } from 'vitest';
+
+import { UI_ALLOWLISTS, UI_SURFACES, type UISurface } from '../allowlist-local';
+
+// ── Inline fixture mirroring canonical shared allowlist ──────────────────────
+
+type AttrKind = 'uuid' | 'url' | 'string';
+
+interface ExpectedSurface {
+  nodes: string[];
+  marks: string[];
+  nodeAttrs: Record<string, Record<string, AttrKind>>;
+  markAttrs: Record<string, Record<string, AttrKind>>;
+  maxTextBytes: number;
+  maxDepth: number;
+  maxNodes: number;
+  maxMarks: number;
+}
+
+const EXPECTED_SURFACES: readonly UISurface[] = [
+  'voc-description',
+  'reporter-reply',
+  'public-update',
+  'internal-comment',
+];
+
+const EXPECTED: Record<UISurface, ExpectedSurface> = {
+  'voc-description': {
+    nodes: ['doc', 'paragraph', 'text', 'bulletList', 'orderedList', 'listItem', 'attachmentRef'],
+    marks: ['bold', 'italic', 'underline', 'code', 'link'],
+    nodeAttrs: { attachmentRef: { id: 'uuid' } },
+    markAttrs: { link: { href: 'url' } },
+    maxTextBytes: 50 * 1024,
+    maxDepth: 32,
+    maxNodes: 5000,
+    maxMarks: 1000,
+  },
+  'public-update': {
+    nodes: ['doc', 'paragraph', 'text', 'bulletList', 'orderedList', 'listItem'],
+    marks: ['bold', 'italic'],
+    nodeAttrs: {},
+    markAttrs: {},
+    maxTextBytes: 50 * 1024,
+    maxDepth: 32,
+    maxNodes: 5000,
+    maxMarks: 1000,
+  },
+  'reporter-reply': {
+    nodes: ['doc', 'paragraph', 'text', 'bulletList', 'orderedList', 'listItem', 'attachmentRef'],
+    marks: ['bold', 'italic', 'code', 'link'],
+    nodeAttrs: { attachmentRef: { id: 'uuid' } },
+    markAttrs: { link: { href: 'url' } },
+    maxTextBytes: 50 * 1024,
+    maxDepth: 32,
+    maxNodes: 5000,
+    maxMarks: 1000,
+  },
+  'internal-comment': {
+    nodes: [
+      'doc', 'paragraph', 'text', 'codeBlock',
+      'bulletList', 'orderedList', 'listItem',
+      'mention', 'attachmentRef',
+    ],
+    marks: ['bold', 'italic', 'code', 'link'],
+    nodeAttrs: {
+      attachmentRef: { id: 'uuid' },
+      mention: { actor_id: 'uuid' },
+      codeBlock: { language: 'string' },
+    },
+    markAttrs: { link: { href: 'url' } },
+    maxTextBytes: 50 * 1024,
+    maxDepth: 32,
+    maxNodes: 5000,
+    maxMarks: 1000,
+  },
+};
+
+describe('UI allowlist-local ↔ shared canonical fixture drift', () => {
+  it('UI_SURFACES tuple matches expected surfaces (set equality)', () => {
+    expect(new Set(UI_SURFACES)).toEqual(new Set(EXPECTED_SURFACES));
+  });
+
+  it.each(EXPECTED_SURFACES)(
+    '%s — node names, mark names, attr key shape, and DoS caps match expected',
+    (surface) => {
+      const ui = UI_ALLOWLISTS[surface];
+      const ex = EXPECTED[surface];
+
+      expect([...ui.nodes].sort()).toEqual([...ex.nodes].sort());
+      expect([...ui.marks].sort()).toEqual([...ex.marks].sort());
+
+      expect(Object.keys(ui.nodeAttrs).sort()).toEqual(Object.keys(ex.nodeAttrs).sort());
+      expect(Object.keys(ui.markAttrs).sort()).toEqual(Object.keys(ex.markAttrs).sort());
+
+      for (const nodeType of Object.keys(ex.nodeAttrs)) {
+        const eNode = ex.nodeAttrs[nodeType]!;
+        const uNode = ui.nodeAttrs[nodeType]!;
+        expect(Object.keys(uNode).sort()).toEqual(Object.keys(eNode).sort());
+        for (const k of Object.keys(eNode)) {
+          expect(uNode[k]!.kind).toBe(eNode[k]);
+        }
+      }
+      for (const markType of Object.keys(ex.markAttrs)) {
+        const eMark = ex.markAttrs[markType]!;
+        const uMark = ui.markAttrs[markType]!;
+        expect(Object.keys(uMark).sort()).toEqual(Object.keys(eMark).sort());
+        for (const k of Object.keys(eMark)) {
+          expect(uMark[k]!.kind).toBe(eMark[k]);
+        }
+      }
+
+      expect(ui.maxTextBytes).toBe(ex.maxTextBytes);
+      expect(ui.maxDepth).toBe(ex.maxDepth);
+      expect(ui.maxNodes).toBe(ex.maxNodes);
+      expect(ui.maxMarks).toBe(ex.maxMarks);
+    },
+  );
+});

--- a/packages/ui/src/rich-content/allowlist-local.ts
+++ b/packages/ui/src/rich-content/allowlist-local.ts
@@ -1,0 +1,136 @@
+// PLAN-22 C9 fix — UI-local copy of the shared rich-content allowlist.
+//
+// ADR-0016 forbids `@fops/ui` from importing `@fops/shared`. The shared
+// allowlist (`packages/shared/src/rich-content/allowlist.ts`) is therefore
+// duplicated here verbatim so the FE render-time defence-in-depth sanitizer
+// can run without crossing the boundary.
+//
+// Parity with `@fops/shared` is enforced by:
+//   - `apps/backend/src/lib/rich-content/__tests__/drift-vs-shared.test.ts`
+//     (backend ↔ shared)
+//   - `packages/ui/src/rich-content/__tests__/allowlist-drift.test.ts`
+//     (UI ↔ inline fixture mirroring shared)
+//
+// If you change values in either side, update both and rerun both drift tests.
+// Do NOT add an import of @fops/shared to this package — the boundary script
+// (`scripts/check-boundaries.mjs`) walks `*.ts` and `*.test.ts` and will fail.
+
+// ── Surface enum ─────────────────────────────────────────────────────────────
+
+export const UI_SURFACES = [
+  'voc-description',
+  'reporter-reply',
+  'public-update',
+  'internal-comment',
+] as const;
+export type UISurface = (typeof UI_SURFACES)[number];
+
+// ── AttrSchema ───────────────────────────────────────────────────────────────
+
+export type AttrSchema =
+  | { kind: 'uuid'; required: boolean }
+  | { kind: 'url'; schemes: ReadonlySet<string>; maxLen: number; required: boolean }
+  | { kind: 'string'; maxLen: number; nullable: boolean; required: boolean };
+
+// ── SurfaceAllowlist ─────────────────────────────────────────────────────────
+
+export interface UISurfaceAllowlist {
+  nodes: ReadonlySet<string>;
+  marks: ReadonlySet<string>;
+  nodeAttrs: Readonly<Record<string, Readonly<Record<string, AttrSchema>>>>;
+  markAttrs: Readonly<Record<string, Readonly<Record<string, AttrSchema>>>>;
+  allowedLinkSchemes: ReadonlySet<string>;
+  maxTextBytes: number;
+  maxDepth: number;
+  maxNodes: number;
+  maxMarks: number;
+}
+
+export type UIAllowlists = Readonly<Record<UISurface, UISurfaceAllowlist>>;
+
+// ── Shared scheme sets ───────────────────────────────────────────────────────
+
+const HTTP_ONLY = new Set(['http:', 'https:']);
+
+// ── Shared attr schemas ──────────────────────────────────────────────────────
+
+const uuidRequired: AttrSchema = { kind: 'uuid', required: true };
+
+const attachmentRefAttrs: Readonly<Record<string, AttrSchema>> = {
+  id: uuidRequired,
+};
+
+const linkMarkAttrs: Readonly<Record<string, AttrSchema>> = {
+  href: { kind: 'url', schemes: HTTP_ONLY, maxLen: 2048, required: true },
+};
+
+// ── Surface definitions ──────────────────────────────────────────────────────
+
+export const UI_ALLOWLISTS: UIAllowlists = {
+  'voc-description': {
+    nodes: new Set([
+      'doc', 'paragraph', 'text',
+      'bulletList', 'orderedList', 'listItem',
+      'attachmentRef',
+    ]),
+    marks: new Set(['bold', 'italic', 'underline', 'code', 'link']),
+    nodeAttrs: { attachmentRef: attachmentRefAttrs },
+    markAttrs: { link: linkMarkAttrs },
+    allowedLinkSchemes: HTTP_ONLY,
+    maxTextBytes: 50 * 1024,
+    maxDepth: 32,
+    maxNodes: 5000,
+    maxMarks: 1000,
+  },
+
+  'public-update': {
+    nodes: new Set(['doc', 'paragraph', 'text', 'bulletList', 'orderedList', 'listItem']),
+    marks: new Set(['bold', 'italic']),
+    nodeAttrs: {},
+    markAttrs: {},
+    allowedLinkSchemes: new Set<string>(),
+    maxTextBytes: 50 * 1024,
+    maxDepth: 32,
+    maxNodes: 5000,
+    maxMarks: 1000,
+  },
+
+  'reporter-reply': {
+    nodes: new Set([
+      'doc', 'paragraph', 'text',
+      'bulletList', 'orderedList', 'listItem',
+      'attachmentRef',
+    ]),
+    marks: new Set(['bold', 'italic', 'code', 'link']),
+    nodeAttrs: { attachmentRef: attachmentRefAttrs },
+    markAttrs: { link: linkMarkAttrs },
+    allowedLinkSchemes: HTTP_ONLY,
+    maxTextBytes: 50 * 1024,
+    maxDepth: 32,
+    maxNodes: 5000,
+    maxMarks: 1000,
+  },
+
+  'internal-comment': {
+    nodes: new Set([
+      'doc', 'paragraph', 'text',
+      'codeBlock',
+      'bulletList', 'orderedList', 'listItem',
+      'mention', 'attachmentRef',
+    ]),
+    marks: new Set(['bold', 'italic', 'code', 'link']),
+    nodeAttrs: {
+      attachmentRef: attachmentRefAttrs,
+      mention: { actor_id: uuidRequired },
+      codeBlock: {
+        language: { kind: 'string', maxLen: 32, nullable: true, required: false },
+      },
+    },
+    markAttrs: { link: linkMarkAttrs },
+    allowedLinkSchemes: HTTP_ONLY,
+    maxTextBytes: 50 * 1024,
+    maxDepth: 32,
+    maxNodes: 5000,
+    maxMarks: 1000,
+  },
+};

--- a/packages/ui/src/rich-content/sanitizeClient.ts
+++ b/packages/ui/src/rich-content/sanitizeClient.ts
@@ -21,17 +21,20 @@
 // on serialized HTML so we would re-render + re-parse, (c) the test surface is
 // the JSON we already validate on the server.
 
+// ADR-0016: @fops/ui MUST NOT import @fops/shared. The allowlist values are
+// duplicated locally and kept in lockstep via drift tests on both sides
+// (backend↔shared and ui↔inline-fixture).
 import {
-  SHARED_ALLOWLISTS,
+  UI_ALLOWLISTS,
   type AttrSchema,
-  type SharedSurface,
-} from '@fops/shared';
+  type UISurface,
+} from './allowlist-local';
 
 import type { TipTapDoc } from './RichEditor';
 
 // ── Public types ─────────────────────────────────────────────────────────────
 
-export type ClientSanitizeSurface = SharedSurface;
+export type ClientSanitizeSurface = UISurface;
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
@@ -168,7 +171,7 @@ interface WalkCtx {
 const EMPTY_DOC: TipTapDoc = { type: 'doc', content: [] } as unknown as TipTapDoc;
 
 function cleanNode(raw: unknown, depth: number, ctx: WalkCtx): CleanNode | null {
-  const allow = SHARED_ALLOWLISTS[ctx.surface];
+  const allow = UI_ALLOWLISTS[ctx.surface];
 
   if (depth > allow.maxDepth) return null;
   if (!isPlainObject(raw)) return null;
@@ -240,7 +243,7 @@ function cleanNode(raw: unknown, depth: number, ctx: WalkCtx): CleanNode | null 
  * Unrecognised input shapes coerce to an empty `doc`.
  */
 export function sanitizeClient(doc: TipTapDoc, surface: ClientSanitizeSurface): TipTapDoc {
-  if (!SHARED_ALLOWLISTS[surface]) return EMPTY_DOC;
+  if (!UI_ALLOWLISTS[surface]) return EMPTY_DOC;
   if (!isPlainObject(doc as unknown)) return EMPTY_DOC;
 
   const ctx: WalkCtx = { surface, nodeCount: 0, markCount: 0, textBytes: 0 };


### PR DESCRIPTION
## Summary
ADR-0016 boundary fix. C9 (PR #68) introduced `packages/ui/src/rich-content/sanitizeClient.ts` import from `@fops/shared` which violates the leaf-UI rule.

- `packages/ui/src/rich-content/allowlist-local.ts` — local copy of allowlist values (verbatim from shared)
- `sanitizeClient.ts` now imports `./allowlist-local` instead of `@fops/shared`
- `packages/ui/src/rich-content/__tests__/allowlist-drift.test.ts` — UI-local vs inline fixture parity (5 cases)
- Shared canonical export untouched; BE↔shared drift test untouched

`pnpm check:boundaries` → `boundaries: OK`.

## Test plan
- [x] check:boundaries clean
- [x] UI 466 pass
- [x] BE drift-vs-shared still 5/5
- [x] typecheck clean

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>