### PR TITLE
test(slice3 #22): integration-glue drift tests (vite proxy + .env.example + DB grants)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,12 +2,28 @@
 # Real `.env*` files are gitignored.
 
 # --- Server runtime ---
+# 'development' | 'test' | 'production'. Defaults to 'development'.
+NODE_ENV=development
 # Backend HTTP port. Vite dev proxy expects 3011 (see vite.config.ts).
 PORT=3011
+# Bind host for Fastify. 0.0.0.0 listens on all interfaces (dev/docker).
+HOST=0.0.0.0
 # ADR-0006: single seeded workspace. UUID of the dev workspace (matches seed CLI output).
 WORKSPACE_ID=00000000-0000-0000-0000-000000000001
+# Display name for the seeded workspace.
+WORKSPACE_NAME=FeedbackOps
 # 'mock' = local dev session shim; 'oidc' = real provider (production-only).
 AUTH_PROVIDER=mock
+# Slice 1 seed scope. Only 'core' is supported today.
+SEED_MODE=core
+# CSP `img-src` origin for public attachment URLs. `'self'` keeps everything
+# same-origin; switch to a CDN origin (quoted) in prod if attachments are
+# served from a different host.
+PUBLIC_ATTACHMENT_ORIGIN='self'
+# Number of trusted proxy hops in front of Fastify (X-Forwarded-For chain
+# depth). 0 outside production = trust nothing. Set to 1 in prod when a
+# single ingress terminates TLS. See Review HTTP-H-2 / ADR-0015.
+TRUSTED_PROXY_HOPS=0
 
 # --- Postgres (matches docker-compose.dev.yml :5434) ---
 DATABASE_URL=postgres://fops_app:fops_app@localhost:5434/feedbackops

--- a/apps/backend/src/__tests__/env-example-completeness.test.ts
+++ b/apps/backend/src/__tests__/env-example-completeness.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Slice 3 #22 — .env.example completeness check.
+ *
+ * Every key in the backend `envSchema` (apps/backend/src/config.ts) MUST appear
+ * in the repo-root `.env.example`. Keys with `.optional()` and/or `.default(...)`
+ * are documented in `.env.example` so a fresh clone knows the full surface.
+ * Keys without a default AND without `.optional()` are REQUIRED — failure to
+ * list them in `.env.example` is a drift bug.
+ *
+ * Catches the class of bug where a new env key ships in `config.ts` but
+ * `.env.example` is left stale, breaking `pnpm dev` for anyone who copies
+ * the file. The latest occurrence was missing `PORT` / `WORKSPACE_ID` /
+ * `AUTH_PROVIDER` (PR #99bdb5e).
+ *
+ * Pure file-read assertion. No DB, no env mutation. Always runs.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+// Re-import the schema in a way that doesn't require running loadConfig().
+// envSchema is module-private; we re-derive the key set by parsing the same
+// source file. (Alternative: export envSchema. We deliberately avoid that
+// to keep config.ts API surface unchanged.)
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const CONFIG_TS = path.join(REPO_ROOT, 'apps/backend/src/config.ts');
+const ENV_EXAMPLE = path.join(REPO_ROOT, '.env.example');
+
+interface SchemaKey {
+  name: string;
+  required: boolean; // true = no .optional() AND no .default(...)
+}
+
+function parseEnvSchemaKeys(source: string): SchemaKey[] {
+  // Locate the envSchema z.object({ ... }) block. Use the first
+  // `z.object({` that follows `const envSchema`.
+  const start = source.search(/const\s+envSchema\s*=\s*z\.object\(\{/);
+  expect(start, 'could not locate envSchema in config.ts').toBeGreaterThanOrEqual(0);
+  // Walk braces from the first '{' after `z.object(`.
+  const objOpenRel = source.slice(start).search(/\{/);
+  const objStart = start + objOpenRel;
+  let depth = 0;
+  let objEnd = -1;
+  for (let i = objStart; i < source.length; i += 1) {
+    const ch = source[i];
+    if (ch === '{') depth += 1;
+    else if (ch === '}') {
+      depth -= 1;
+      if (depth === 0) {
+        objEnd = i;
+        break;
+      }
+    }
+  }
+  expect(objEnd, 'could not find end of envSchema object literal').toBeGreaterThan(objStart);
+  const body = source.slice(objStart + 1, objEnd);
+
+  // For each top-level KEY: z.<...>, capture the KEY and the rest of its
+  // chained call so we can scan for `.optional(` and `.default(`.
+  // Top-level entries: a line starting with WORD: at depth 1.
+  const keys: SchemaKey[] = [];
+  // Split entries by scanning for `KEY:` at depth 0 within `body`.
+  let i = 0;
+  while (i < body.length) {
+    // Skip whitespace + comment lines.
+    while (i < body.length && /\s/.test(body[i] ?? '')) i += 1;
+    if (i < body.length && body[i] === '/' && body[i + 1] === '/') {
+      // line comment: skip to end of line
+      while (i < body.length && body[i] !== '\n') i += 1;
+      continue;
+    }
+    // Match KEY:
+    const rest = body.slice(i);
+    const m = rest.match(/^([A-Z_][A-Z0-9_]*)\s*:/);
+    if (!m) {
+      // Advance one char to keep scanning; this catches stray punctuation.
+      i += 1;
+      continue;
+    }
+    const name = m[1] ?? '';
+    // Find end of this entry: scan to next top-level `,` at our current depth.
+    let j = i + m[0].length;
+    let d = 0;
+    let inStr: '"' | "'" | null = null;
+    while (j < body.length) {
+      const ch = body[j] ?? '';
+      if (inStr) {
+        if (ch === '\\') {
+          j += 2;
+          continue;
+        }
+        if (ch === inStr) inStr = null;
+        j += 1;
+        continue;
+      }
+      if (ch === '"' || ch === "'") {
+        inStr = ch;
+        j += 1;
+        continue;
+      }
+      if (ch === '(' || ch === '{' || ch === '[') d += 1;
+      else if (ch === ')' || ch === '}' || ch === ']') d -= 1;
+      else if (ch === ',' && d === 0) break;
+      j += 1;
+    }
+    const entry = body.slice(i + m[0].length, j);
+    const hasOptional = /\.optional\s*\(/.test(entry);
+    const hasDefault = /\.default\s*\(/.test(entry);
+    keys.push({ name, required: !hasOptional && !hasDefault });
+    i = j + 1;
+  }
+  return keys;
+}
+
+function parseEnvExampleKeys(source: string): Set<string> {
+  const keys = new Set<string>();
+  for (const raw of source.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line || line.startsWith('#')) continue;
+    const eq = line.indexOf('=');
+    if (eq <= 0) continue;
+    keys.add(line.slice(0, eq).trim());
+  }
+  return keys;
+}
+
+describe('.env.example completeness (Slice 3 #22)', () => {
+  it('every envSchema key is documented in .env.example', () => {
+    const schemaKeys = parseEnvSchemaKeys(fs.readFileSync(CONFIG_TS, 'utf8'));
+    expect(schemaKeys.length, 'should discover at least one schema key').toBeGreaterThan(0);
+
+    const exampleKeys = parseEnvExampleKeys(fs.readFileSync(ENV_EXAMPLE, 'utf8'));
+
+    const missingRequired: string[] = [];
+    const missingOptional: string[] = [];
+    for (const k of schemaKeys) {
+      if (exampleKeys.has(k.name)) continue;
+      if (k.required) missingRequired.push(k.name);
+      else missingOptional.push(k.name);
+    }
+
+    // Required keys MUST be in .env.example. Optional/defaulted keys SHOULD
+    // be there too — they're the documentation surface. Both fail.
+    const all = [...missingRequired, ...missingOptional];
+    expect(
+      all,
+      `add the following key(s) to .env.example (required first, then optional/defaulted): ` +
+        `required=[${missingRequired.join(', ')}] optional=[${missingOptional.join(', ')}]`,
+    ).toEqual([]);
+  });
+});

--- a/apps/backend/src/db/__tests__/role-grants-product-tables.integration.test.ts
+++ b/apps/backend/src/db/__tests__/role-grants-product-tables.integration.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Slice 3 #22 — DB role grants drift check for product tables.
+ *
+ * Asserts that `fops_app` retains SELECT + INSERT + UPDATE + DELETE on every
+ * base table in the `voc` schema after migrations apply. ADR-0008 exempts
+ * `core.audit_log` (INSERT + SELECT only) but every product table is full-DML
+ * for fops_app.
+ *
+ * Catches the class of drift bug where a migration `RENAME` / `CREATE` /
+ * `REVOKE` drops a previously-granted privilege without a paired re-GRANT.
+ * The latest occurrence was the missing DELETE on `voc.voc_attachments`
+ * after migration 0014's rename, fixed by migration 0016.
+ *
+ * Skipped without DATABASE_URL / DATABASE_URL_MIGRATE / WORKSPACE_ID,
+ * matching the existing role-grants integration test.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { type DbHandle, createDb } from '../client.js';
+
+const APP_URL = process.env.DATABASE_URL ?? '';
+const MIGRATE_URL = process.env.DATABASE_URL_MIGRATE ?? '';
+const WORKSPACE_ID = process.env.WORKSPACE_ID ?? '';
+
+const runIntegration = Boolean(APP_URL && MIGRATE_URL && WORKSPACE_ID);
+
+const PRODUCT_SCHEMAS = ['voc'] as const;
+const REQUIRED_PRIVILEGES = ['SELECT', 'INSERT', 'UPDATE', 'DELETE'] as const;
+
+// ADR-0008: core.audit_log is INSERT + SELECT only by design. No other
+// product-table exceptions today.
+const KNOWN_LIMITED_GRANTS = new Set<string>([
+  // 'core.audit_log' — not iterated because PRODUCT_SCHEMAS=['voc'] only.
+]);
+
+describe.skipIf(!runIntegration)(
+  'ADR-0008 role grants — product tables (Slice 3 #22)',
+  () => {
+    let migrateHandle: DbHandle;
+
+    beforeAll(() => {
+      migrateHandle = createDb(MIGRATE_URL);
+    });
+
+    afterAll(async () => {
+      await migrateHandle?.close();
+    });
+
+    it('fops_app has SELECT + INSERT + UPDATE + DELETE on every voc.* base table', async () => {
+      const { rows: tables } = await migrateHandle.pool.query<{
+        table_schema: string;
+        table_name: string;
+      }>(
+        `select table_schema, table_name
+           from information_schema.tables
+          where table_schema = ANY($1::text[])
+            and table_type = 'BASE TABLE'
+          order by table_schema, table_name`,
+        [PRODUCT_SCHEMAS as unknown as string[]],
+      );
+      expect(tables.length, 'should discover at least one product table').toBeGreaterThan(0);
+
+      const failures: string[] = [];
+      for (const t of tables) {
+        const fq = `${t.table_schema}.${t.table_name}`;
+        if (KNOWN_LIMITED_GRANTS.has(fq)) continue;
+
+        const { rows: grants } = await migrateHandle.pool.query<{ privilege_type: string }>(
+          `select privilege_type
+             from information_schema.role_table_grants
+            where grantee = 'fops_app'
+              and table_schema = $1
+              and table_name = $2`,
+          [t.table_schema, t.table_name],
+        );
+        const got = new Set(grants.map((g) => g.privilege_type));
+        for (const priv of REQUIRED_PRIVILEGES) {
+          if (!got.has(priv)) {
+            failures.push(`fops_app missing GRANT ${priv} ON ${fq}; add to a new migration`);
+          }
+        }
+      }
+
+      expect(failures, failures.join('\n')).toEqual([]);
+    });
+  },
+);

--- a/apps/frontend/src/__tests__/vite-proxy-completeness.test.ts
+++ b/apps/frontend/src/__tests__/vite-proxy-completeness.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Slice 3 #22 — Vite proxy completeness check.
+ *
+ * Every root prefix served by the backend MUST be either:
+ *   (a) registered in `apps/frontend/vite.config.ts` under `server.proxy`, OR
+ *   (b) listed in `KNOWN_FE_ONLY` as a deliberately FE-only route that
+ *       collides with a BE prefix by name (none today).
+ *
+ * Catches the class of drift bug where a new BE route ships without a
+ * matching dev-proxy entry, breaking `pnpm dev` smoke without breaking
+ * any unit test. The latest occurrence was `/attachments` (PR #75 hotfix).
+ *
+ * Implementation:
+ *   - Parse `apps/backend/src/server.ts` for top-level `app.route({ url: '/x' })`.
+ *   - Parse every `apps/backend/src/modules/<name>/routes.ts` for the same.
+ *   - Reduce to unique root prefixes (`/foo/bar` → `/foo`).
+ *   - Assert each is a proxy key in `vite.config.ts` (or in KNOWN_FE_ONLY).
+ *
+ * Pure file-read assertion. No DB, no server boot. Always runs.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+// FE routes that intentionally collide with BE prefix names AND are served
+// by the SPA on document loads (proxy entries already bypass HTML in that
+// case). Start empty; add only when a real collision surfaces.
+const KNOWN_FE_ONLY = new Set<string>([]);
+
+// Root of the monorepo, derived from this file's location.
+// __dirname = apps/frontend/src/__tests__  →  repoRoot = ../../../..
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+
+const SERVER_TS = path.join(REPO_ROOT, 'apps/backend/src/server.ts');
+const VITE_CONFIG = path.join(REPO_ROOT, 'apps/frontend/vite.config.ts');
+const MODULES_DIR = path.join(REPO_ROOT, 'apps/backend/src/modules');
+
+function extractRouteUrls(source: string): string[] {
+  // Match `url: '/...'` or `url: "/..."` inside `app.route({ ... })` /
+  // `fastify.route({ ... })`. Quote-aware, single-line.
+  const re = /url:\s*['"](\/[A-Za-z0-9/_\-:]*)['"]/g;
+  const out: string[] = [];
+  for (const m of source.matchAll(re)) {
+    if (m[1]) out.push(m[1]);
+  }
+  return out;
+}
+
+function collectBackendRoutes(): string[] {
+  const urls: string[] = [];
+  urls.push(...extractRouteUrls(fs.readFileSync(SERVER_TS, 'utf8')));
+  // Walk apps/backend/src/modules/*/routes.ts
+  for (const entry of fs.readdirSync(MODULES_DIR, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const candidate = path.join(MODULES_DIR, entry.name, 'routes.ts');
+    if (fs.existsSync(candidate)) {
+      urls.push(...extractRouteUrls(fs.readFileSync(candidate, 'utf8')));
+    }
+  }
+  return urls;
+}
+
+function rootPrefix(url: string): string {
+  // '/vocs/:id/conversation' → '/vocs'   '/me' → '/me'   '/me/permissions/check' → '/me'
+  const seg = url.split('/').filter(Boolean)[0];
+  return seg ? `/${seg}` : '/';
+}
+
+function parseProxyKeys(viteConfig: string): Set<string> {
+  // Find the `proxy: { ... }` block (single occurrence) and pull every
+  // top-level string-quoted key. Robust against per-entry object/string
+  // values because we only consume keys.
+  const blockMatch = viteConfig.match(/proxy:\s*{([\s\S]*?)},\s*}/);
+  expect(blockMatch, 'could not find server.proxy block in vite.config.ts').toBeTruthy();
+  const block = blockMatch?.[1] ?? '';
+  const keys = new Set<string>();
+  // Keys at the start of a line (after whitespace), quoted.
+  for (const m of block.matchAll(/^\s*['"](\/[A-Za-z0-9/_\-:]*)['"]\s*:/gm)) {
+    if (m[1]) keys.add(m[1]);
+  }
+  return keys;
+}
+
+describe('Vite dev proxy completeness (Slice 3 #22)', () => {
+  it('every BE root prefix has a matching vite proxy entry (or is in KNOWN_FE_ONLY)', () => {
+    const backendUrls = collectBackendRoutes();
+    expect(backendUrls.length, 'should discover at least one BE route').toBeGreaterThan(0);
+
+    const backendPrefixes = new Set(backendUrls.map(rootPrefix));
+    const proxyKeys = parseProxyKeys(fs.readFileSync(VITE_CONFIG, 'utf8'));
+
+    const missing: string[] = [];
+    for (const prefix of backendPrefixes) {
+      if (proxyKeys.has(prefix)) continue;
+      if (KNOWN_FE_ONLY.has(prefix)) continue;
+      missing.push(prefix);
+    }
+
+    expect(
+      missing,
+      `add the following prefix(es) to apps/frontend/vite.config.ts server.proxy ` +
+        `or KNOWN_FE_ONLY: ${missing.join(', ')}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Why
3 #22 chunks shipped with broken integration glue that all unit tests passed:
- Vite proxy missing `/attachments` → browser 404 on first PNG drop
- `.env.example` missing `WORKSPACE_ID` / `PORT` / `AUTH_PROVIDER` → fresh boot crash
- `voc.voc_attachments` missing `fops_app.DELETE` grant after migration 0014 RENAME

All three caught only during live UI smoke. This PR adds tests that would have failed in CI before any of those bugs reached develop.

## Tests

1. **`apps/frontend/src/__tests__/vite-proxy-completeness.test.ts`** — parses BE route registrations + asserts every root prefix is in `vite.config.ts` proxy table (or explicit `KNOWN_FE_ONLY` allow-list). Failure msg: `add the following prefix(es) to apps/frontend/vite.config.ts server.proxy or KNOWN_FE_ONLY: /foo`.

2. **`apps/backend/src/__tests__/env-example-completeness.test.ts`** — reads `envSchema` from `config.ts`, asserts every key present in `.env.example` (required first, optional/defaulted next). Failure msg: `add the following key(s) to .env.example: required=[...] optional=[...]`.
   - **Surfaced its own gap**: 6 more schema keys missing (`NODE_ENV`, `HOST`, `WORKSPACE_NAME`, `SEED_MODE`, `PUBLIC_ATTACHMENT_ORIGIN`, `TRUSTED_PROXY_HOPS`) → added with sensible defaults.

3. **`apps/backend/src/db/__tests__/role-grants-product-tables.integration.test.ts`** — for every `voc.*` BASE TABLE, asserts `fops_app` holds SELECT+INSERT+UPDATE+DELETE (excludes `core.audit_log` per ADR-0008). Failure msg: `fops_app missing GRANT <PRIV> ON voc.<table>; add to a new migration`.

## Test plan
- [x] BE 229 passed / 419 skipped (DB-gated)
- [x] FE 427/427 pass
- [x] check:boundaries OK
- [x] Each test verified by temporarily reverting the corresponding fix — all three caught the bug with the documented failure message
- [x] `.env.example` updated with 6 newly-surfaced missing keys (Test 2 meta-validation)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>