### PR TITLE
fix(slice3 #22): render attachments in detail panel + timeline + EditDescriptionModal

### DIFF
--- a/.review/CHUNK-22-C6-DEVIATIONS.md
+++ b/.review/CHUNK-22-C6-DEVIATIONS.md
@@ -79,3 +79,56 @@ against the `uploadAttachment` client landed in C5.
 - `tsc -p tsconfig.json --noEmit` clean for our touched files (the only
   errors are pre-existing `routeTree.gen` codegen issues that vite generates
   at dev/build time — unchanged by this chunk).
+
+---
+
+## 2026-05-22 amendment — EditDescriptionModal GET-side attachment hydration (PLAN-22 §Bug-3)
+
+Live Playwright verification after PR #77 surfaced a hydration gap that this
+chunk's C6 work missed: the modal opens on a VOC whose `voc.attachments[]`
+already carries one or more linked rows (e.g. reporter uploaded a file, saved,
+reopened the modal), but the modal initialized only `attachment_ids: []` and
+showed no chips for the existing rows. The user saw the file silently
+disappear from the edit surface.
+
+**Fix landed on `fix/22-fe-render-attachments-in-detail`:**
+
+- `EditDescriptionModalVoc` now optionally accepts `attachments?: LinkedAttachment[]`.
+- When the prop is non-empty, render a `기존 첨부` label + `<AttachmentChipList>`
+  above the active `<AttachmentDropzone>`. Chips are read-only — no remove
+  affordance this slice (see PATCH-semantics note below).
+- PATCH body shape unchanged: `attachment_ids: string[]` carries only the
+  **newly uploaded** ids; pre-existing rows are NOT re-sent.
+
+**PATCH semantic decision — ADDITIVE (not full-set):**
+
+Audited `apps/backend/src/modules/voc/service.ts:editVocDescription` (and the
+`linkAttachments` repo it delegates to). The BE only **adds** unlinked rows;
+re-sending an already-linked id throws `LinkAttachmentsRejected`, which the
+service translates to `validation.failed` and rolls the entire PATCH tx back.
+There is no unlink path on `editVocDescription` — the audit diff comment in
+the service literally says *"Future chunks that support remove/replace will
+populate `from` from a prior SELECT."*
+
+So the only safe wire shape today is **additive**: send the new ids only.
+Tests assert `attachment_ids` excludes the pre-existing row id (see
+`EditDescriptionModal.attachments.test.tsx` → `existing attachments
+(GET-side hydration)` describe block).
+
+**Companion fixes in the same branch:**
+
+- `<DescriptionSection>` renders `voc.attachments[]` as chips below the BODY
+  card (PLAN-22 §Bug-1).
+- `<TimelineEntry>` renders `entry.attachments[]` for every kind
+  (`public_update` / `reporter_reply` / `internal_comment`) (PLAN-22 §Bug-2).
+- Added `apps/frontend/src/features/voc/lib/format-file-size.ts` and pointed
+  the two pre-existing private `formatFileSize` definitions
+  (`<AttachmentDropzone>`, `<ComposerAttachmentDropzone>`) at it — single
+  source of truth, zero behavior change.
+- Test fixtures (`_fixtures.ts`, `ConversationTimeline.test.tsx`,
+  `TimelineEntry.test.tsx`) updated to include the now-required `attachments`
+  and `attachment_count` fields introduced by PR #77.
+
+**Remove / replace semantics — deferred:** when the BE adds an unlink path on
+`editVocDescription`, the chip's read-only state will gain a remove button
+and the modal will switch to full-set PATCH. Not in this slice.

--- a/apps/frontend/src/features/voc/components/create/AttachmentDropzone.tsx
+++ b/apps/frontend/src/features/voc/components/create/AttachmentDropzone.tsx
@@ -20,6 +20,7 @@ import { toast } from 'sonner';
 import { uploadAttachment } from '@/lib/api/attachments';
 import { errorMapper } from '@/lib/api/errorMapper';
 import type { ApiError } from '@/lib/api/types';
+import { formatFileSize } from '@/features/voc/lib/format-file-size';
 
 const MAX_SIZE_BYTES = 25 * 1024 * 1024;
 
@@ -81,12 +82,8 @@ function mintIdempotencyKey(): string {
   return `${hex.slice(0, 4).join('')}-${hex.slice(4, 6).join('')}-${hex.slice(6, 8).join('')}-${hex.slice(8, 10).join('')}-${hex.slice(10, 16).join('')}`;
 }
 
-function formatFileSize(bytes: number): string {
-  if (!bytes) return '0 B';
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-}
+// formatFileSize moved to lib/format-file-size.ts (PLAN-22 §Bug-1, 2026-05-22)
+// so the detail-panel AttachmentChip can reuse the same B/KB/MB rendering.
 
 export function AttachmentDropzone({
   testId,

--- a/apps/frontend/src/features/voc/components/detail/AttachmentChip.tsx
+++ b/apps/frontend/src/features/voc/components/detail/AttachmentChip.tsx
@@ -1,0 +1,66 @@
+// AttachmentChip — compact horizontal pill rendering a linked attachment
+// on the VOC body or a conversation entry. Paperclip icon + filename + size,
+// click → download via GET /attachments/:id/download (browser handles
+// Content-Disposition).
+//
+// Prototype shape: see screen-voc-create.jsx:285-340 (file icon + name + size)
+// — compacted to a single-line chip for the read-side detail panel.
+// PLAN-22 §Bug-1 (2026-05-22).
+
+import { Paperclip } from 'lucide-react';
+import * as React from 'react';
+
+import type { LinkedAttachment } from '@fops/shared';
+
+import { formatFileSize } from '../../lib/format-file-size';
+
+export interface AttachmentChipProps {
+  attachment: Pick<LinkedAttachment, 'id' | 'name' | 'size_bytes'>;
+}
+
+export function AttachmentChip({ attachment }: AttachmentChipProps): React.ReactElement {
+  // Anchor with href triggers a same-origin GET that carries the session
+  // cookie; Content-Disposition: attachment makes the browser download
+  // instead of navigate. download attr is a hint; the server header wins.
+  const href = `/attachments/${attachment.id}/download`;
+  return (
+    <a
+      data-testid="attachment-chip"
+      data-attachment-id={attachment.id}
+      href={href}
+      // Same-tab navigation is fine — Content-Disposition: attachment makes
+      // the browser save instead of replacing the page. Explicit download
+      // attribute is a hint to the UA.
+      download={attachment.name}
+      className="inline-flex items-center gap-1.5 px-2 py-1 rounded-md border border-border-subtle bg-surface-card text-xs text-text-secondary hover:bg-surface-card-elevated transition-colors max-w-[240px]"
+    >
+      <Paperclip className="h-3 w-3 shrink-0 text-text-muted" aria-hidden />
+      <span className="truncate" title={attachment.name}>
+        {attachment.name}
+      </span>
+      <span className="text-text-muted shrink-0">{formatFileSize(attachment.size_bytes)}</span>
+    </a>
+  );
+}
+
+export interface AttachmentChipListProps {
+  // Tolerate undefined for legacy fixtures/test envelopes built before the
+  // schema gained `attachments[]`. BE always sends `[]` when none.
+  attachments: ReadonlyArray<Pick<LinkedAttachment, 'id' | 'name' | 'size_bytes'>> | undefined;
+}
+
+export function AttachmentChipList({
+  attachments,
+}: AttachmentChipListProps): React.ReactElement | null {
+  if (!attachments || attachments.length === 0) return null;
+  return (
+    <div
+      data-testid="attachment-chip-list"
+      className="flex flex-wrap gap-2 mt-2"
+    >
+      {attachments.map((a) => (
+        <AttachmentChip key={a.id} attachment={a} />
+      ))}
+    </div>
+  );
+}

--- a/apps/frontend/src/features/voc/components/detail/ComposerAttachmentDropzone.tsx
+++ b/apps/frontend/src/features/voc/components/detail/ComposerAttachmentDropzone.tsx
@@ -26,6 +26,7 @@ import { toast } from 'sonner';
 import { uploadAttachment } from '@/lib/api/attachments';
 import { errorMapper } from '@/lib/api/errorMapper';
 import type { ApiError } from '@/lib/api/types';
+import { formatFileSize } from '@/features/voc/lib/format-file-size';
 
 const MAX_SIZE_BYTES = 25 * 1024 * 1024;
 
@@ -76,12 +77,7 @@ function mintIdempotencyKey(): string {
   return `${hex.slice(0, 4).join('')}-${hex.slice(4, 6).join('')}-${hex.slice(6, 8).join('')}-${hex.slice(8, 10).join('')}-${hex.slice(10, 16).join('')}`;
 }
 
-function formatFileSize(bytes: number): string {
-  if (!bytes) return '0 B';
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-}
+// formatFileSize moved to lib/format-file-size.ts (PLAN-22 §Bug-1, 2026-05-22).
 
 export function ComposerAttachmentDropzone({
   testId,

--- a/apps/frontend/src/features/voc/components/detail/DescriptionSection.tsx
+++ b/apps/frontend/src/features/voc/components/detail/DescriptionSection.tsx
@@ -7,6 +7,7 @@
 import type { VocDetailEnvelope } from '@fops/shared';
 import { RichContentRenderer, type TipTapDoc } from '@fops/ui';
 import * as React from 'react';
+import { AttachmentChipList } from './AttachmentChip';
 import { EditDescriptionModal } from './EditDescriptionModal';
 
 export interface DescriptionSectionProps {
@@ -54,6 +55,10 @@ export function DescriptionSection({
           <RichContentRenderer doc={voc.description_rich_content as TipTapDoc} mode="internal" />
         )}
       </div>
+      {/* PLAN-22 §Bug-1 (2026-05-22): linked attachments on the VOC body.
+          BE GET /vocs/:id returns these in voc.attachments[]; clicking a
+          chip downloads via GET /attachments/:id/download. */}
+      <AttachmentChipList attachments={voc.attachments} />
       {isReporterOnOwnVoc && (
         <>
           <button

--- a/apps/frontend/src/features/voc/components/detail/EditDescriptionModal.tsx
+++ b/apps/frontend/src/features/voc/components/detail/EditDescriptionModal.tsx
@@ -19,6 +19,7 @@ import { toast } from 'sonner';
 import {
   type EditDescriptionRequest,
   type ErrorEnvelope,
+  type LinkedAttachment,
   editDescriptionRequestSchema,
 } from '@fops/shared';
 import {
@@ -40,6 +41,7 @@ import { errorMapper } from '@/lib/api';
 import { useVocEditDescriptionMutation } from '../../hooks/useVocEditDescriptionMutation';
 import { AttachmentDropzone } from '../create/AttachmentDropzone';
 import { VocDescriptionToolbar } from '../create/VocDescriptionToolbar';
+import { AttachmentChipList } from './AttachmentChip';
 
 // ── Props ──────────────────────────────────────────────────────────────────
 
@@ -49,6 +51,19 @@ export interface EditDescriptionModalVoc {
   title: string;
   updated_at: string;
   description_rich_content?: unknown;
+  /**
+   * PLAN-22 §Bug-3 (2026-05-22): existing linked attachments on the VOC body.
+   * Hydrated from `GET /vocs/:id` (PR #77). Rendered as read-only chips above
+   * the upload dropzone. Optional for backward-compat with callers that build
+   * the prop from a narrower shape; treat undefined as empty.
+   *
+   * PATCH semantics — ADDITIVE: the BE `editVocDescription` calls
+   * `linkAttachments(attachment_ids)` which rejects already-linked ids, so the
+   * modal MUST send only NEW uploads in `attachment_ids[]`. Removing or
+   * replacing existing rows is not supported in this slice; the chips render
+   * without an X affordance.
+   */
+  attachments?: ReadonlyArray<Pick<LinkedAttachment, 'id' | 'name' | 'size_bytes'>>;
 }
 
 export interface EditDescriptionModalProps {
@@ -323,6 +338,17 @@ export function EditDescriptionModal({
                 </p>
               )}
             </div>
+
+            {/* Existing attachments (read-only) — PLAN-22 §Bug-3 (2026-05-22).
+                Hydrated from voc.attachments[] so reopening the modal shows
+                previously-uploaded files. PATCH is additive (see prop docs);
+                rows render without remove affordance. */}
+            {voc.attachments && voc.attachments.length > 0 && (
+              <div className="flex flex-col gap-1.5">
+                <FieldLabel>기존 첨부</FieldLabel>
+                <AttachmentChipList attachments={voc.attachments} />
+              </div>
+            )}
 
             {/* Attachments — active upload (C6). ───────────── */}
             <AttachmentDropzone

--- a/apps/frontend/src/features/voc/components/detail/TimelineEntry.tsx
+++ b/apps/frontend/src/features/voc/components/detail/TimelineEntry.tsx
@@ -12,6 +12,7 @@ import {
 } from '@fops/ui';
 import { useMe } from '@/lib/auth/useMe';
 import { formatVocCreatedAt } from '@/features/voc/components/list/VocRow';
+import { AttachmentChipList } from './AttachmentChip';
 
 // ── Korean labels ────────────────────────────────────────────────────────────
 
@@ -60,6 +61,8 @@ export function TimelineEntry({ entry }: TimelineEntryProps): React.ReactElement
       {/* Rich body */}
       <div className="pl-8">
         <RichContentRenderer doc={entry.body_rich_content as TipTapDoc} mode={rendererMode} />
+        {/* PLAN-22 §Bug-2 (2026-05-22): per-entry linked attachments. */}
+        <AttachmentChipList attachments={entry.attachments} />
       </div>
 
       {/* Status transition pair (public_update only) */}

--- a/apps/frontend/src/features/voc/components/detail/__tests__/ConversationTimeline.test.tsx
+++ b/apps/frontend/src/features/voc/components/detail/__tests__/ConversationTimeline.test.tsx
@@ -29,6 +29,7 @@ const PUBLIC_ENTRY: ConversationEntry = {
   body_rich_content: {},
   created_at: '2026-05-01T00:00:00Z',
   visibility: 'public',
+  attachments: [],
 };
 
 const REPORTER_REPLY_ENTRY: ConversationEntry = {
@@ -38,6 +39,7 @@ const REPORTER_REPLY_ENTRY: ConversationEntry = {
   body_rich_content: {},
   created_at: '2026-05-01T01:00:00Z',
   visibility: 'reporter',
+  attachments: [],
 };
 
 const INTERNAL_ENTRY: ConversationEntry = {
@@ -47,6 +49,7 @@ const INTERNAL_ENTRY: ConversationEntry = {
   body_rich_content: {},
   created_at: '2026-05-01T02:00:00Z',
   visibility: 'internal',
+  attachments: [],
 };
 
 beforeEach(() => {

--- a/apps/frontend/src/features/voc/components/detail/__tests__/DescriptionSection.test.tsx
+++ b/apps/frontend/src/features/voc/components/detail/__tests__/DescriptionSection.test.tsx
@@ -80,4 +80,58 @@ describe('<DescriptionSection>', () => {
     render(<DescriptionSection voc={DETAIL_ENVELOPE} isReporterOnOwnVoc={false} />);
     expect(screen.queryByRole('button', { name: '설명 수정' })).not.toBeInTheDocument();
   });
+
+  // ── PLAN-22 §Bug-1 (2026-05-22): attachment chip rendering ─────────────────
+  describe('attachment chips', () => {
+    const ATTACHMENT_A = {
+      id: 'aaaa1111-0000-4000-8000-000000000001',
+      name: 'test.png',
+      size_bytes: 2048,
+      mime_type: 'image/png',
+      uploaded_by_actor_id: '00000000-0000-4000-8000-000000000099',
+      created_at: '2026-05-22T10:00:00.000Z',
+      linked_at: '2026-05-22T10:00:00.000Z',
+    };
+    const ATTACHMENT_B = {
+      id: 'aaaa1111-0000-4000-8000-000000000002',
+      name: 'spec.pdf',
+      size_bytes: 12345,
+      mime_type: 'application/pdf',
+      uploaded_by_actor_id: '00000000-0000-4000-8000-000000000099',
+      created_at: '2026-05-22T10:01:00.000Z',
+      linked_at: '2026-05-22T10:01:00.000Z',
+    };
+
+    it('renders an AttachmentChip per item in voc.attachments', () => {
+      const envelope = {
+        ...DETAIL_ENVELOPE,
+        attachments: [ATTACHMENT_A, ATTACHMENT_B],
+      };
+      render(<DescriptionSection voc={envelope} isReporterOnOwnVoc={false} />);
+      const chips = screen.getAllByTestId('attachment-chip');
+      expect(chips).toHaveLength(2);
+      expect(screen.getByText('test.png')).toBeInTheDocument();
+      expect(screen.getByText('spec.pdf')).toBeInTheDocument();
+    });
+
+    it('renders no chip list when attachments is empty', () => {
+      render(<DescriptionSection voc={DETAIL_ENVELOPE} isReporterOnOwnVoc={false} />);
+      expect(screen.queryByTestId('attachment-chip-list')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('attachment-chip')).not.toBeInTheDocument();
+    });
+
+    it('chip is an anchor whose href targets GET /attachments/:id/download', () => {
+      const envelope = {
+        ...DETAIL_ENVELOPE,
+        attachments: [ATTACHMENT_A],
+      };
+      render(<DescriptionSection voc={envelope} isReporterOnOwnVoc={false} />);
+      const chip = screen.getByTestId('attachment-chip') as HTMLAnchorElement;
+      expect(chip.tagName).toBe('A');
+      // jsdom resolves relative href against document base; assert via getAttribute
+      // to compare the literal route the BE expects.
+      expect(chip.getAttribute('href')).toBe(`/attachments/${ATTACHMENT_A.id}/download`);
+      expect(chip.getAttribute('download')).toBe(ATTACHMENT_A.name);
+    });
+  });
 });

--- a/apps/frontend/src/features/voc/components/detail/__tests__/EditDescriptionModal.attachments.test.tsx
+++ b/apps/frontend/src/features/voc/components/detail/__tests__/EditDescriptionModal.attachments.test.tsx
@@ -180,6 +180,72 @@ describe('<EditDescriptionModal> attachments (C6)', () => {
     expect(calledVars.body.attachment_ids).toEqual([]);
   });
 
+  // ── PLAN-22 §Bug-3 (2026-05-22): existing-attachment hydration on reopen ───
+  describe('existing attachments (GET-side hydration)', () => {
+    const EXISTING_A = {
+      id: 'cccc3333-0000-4000-8000-000000000001',
+      name: 'previously-uploaded.png',
+      size_bytes: 4096,
+      mime_type: 'image/png',
+      uploaded_by_actor_id: '00000000-0000-4000-8000-000000000099',
+      created_at: '2026-05-20T10:00:00.000Z',
+      linked_at: '2026-05-20T10:00:00.000Z',
+    };
+
+    it('renders existing attachments[] when opened on a VOC with attachments', () => {
+      const vocWithExisting = { ...VOC, attachments: [EXISTING_A] };
+      render(
+        <EditDescriptionModal voc={vocWithExisting} open={true} onClose={vi.fn()} />,
+        { wrapper: wrap() },
+      );
+      // The existing-attachment list is portaled to the dialog; query the
+      // document for the chip.
+      const chip = document.querySelector('[data-testid="attachment-chip"]');
+      expect(chip).not.toBeNull();
+      expect(chip?.getAttribute('data-attachment-id')).toBe(EXISTING_A.id);
+      expect(document.body.textContent).toContain('previously-uploaded.png');
+      expect(document.body.textContent).toContain('기존 첨부');
+    });
+
+    it('PATCH body only includes NEW upload ids — additive semantics (BE rejects re-link)', async () => {
+      vi.spyOn(attachmentsApi, 'uploadAttachment').mockResolvedValue(ATTACHMENT);
+      const mutateMock = vi.fn();
+      vi.mocked(useVocEditDescriptionMutation).mockReturnValue(
+        { ...DEFAULT_MUTATION, mutate: mutateMock } as unknown as ReturnType<typeof useVocEditDescriptionMutation>,
+      );
+
+      const vocWithExisting = { ...VOC, attachments: [EXISTING_A] };
+      const { container } = render(
+        <EditDescriptionModal voc={vocWithExisting} open={true} onClose={vi.fn()} />,
+        { wrapper: wrap() },
+      );
+
+      await act(async () => {
+        pickFile(container, makeFile());
+      });
+      await waitFor(() => {
+        expect(screen.getByTestId('attachment-row').getAttribute('data-state')).toBe('uploaded');
+      });
+
+      const user = userEvent.setup();
+      const titleInput = screen.getByRole('textbox', { name: /제목/ });
+      await user.clear(titleInput);
+      await user.type(titleInput, '새 제목');
+      await user.click(screen.getByRole('button', { name: '수정 저장' }));
+
+      await waitFor(() => {
+        expect(mutateMock).toHaveBeenCalled();
+      });
+      const calledVars = mutateMock.mock.calls[0]![0] as {
+        body: { attachment_ids: string[] };
+      };
+      // Additive: only NEW upload id, NOT the pre-existing EXISTING_A.id
+      // (BE linkAttachments rejects already-linked rows).
+      expect(calledVars.body.attachment_ids).toEqual([ATTACHMENT.id]);
+      expect(calledVars.body.attachment_ids).not.toContain(EXISTING_A.id);
+    });
+  });
+
   it('submit disabled while any attachment is mid-upload', async () => {
     let resolveUpload!: (v: typeof ATTACHMENT) => void;
     vi.spyOn(attachmentsApi, 'uploadAttachment').mockReturnValue(

--- a/apps/frontend/src/features/voc/components/detail/__tests__/TimelineEntry.test.tsx
+++ b/apps/frontend/src/features/voc/components/detail/__tests__/TimelineEntry.test.tsx
@@ -27,6 +27,8 @@ const BASE: Omit<ConversationEntry, 'kind' | 'visibility'> = {
   actor_id: 'actor-99',
   body_rich_content: {},
   created_at: '2026-05-01T00:00:00Z',
+  // PLAN-22 §Bug-2 (2026-05-22): per-entry linked attachments — default empty.
+  attachments: [],
 };
 
 describe('<TimelineEntry>', () => {
@@ -68,5 +70,63 @@ describe('<TimelineEntry>', () => {
     const entry: ConversationEntry = { ...BASE, kind: 'public_update', visibility: 'public' };
     render(<TimelineEntry entry={entry} />);
     expect(screen.queryByText('→')).not.toBeInTheDocument();
+  });
+
+  // ── PLAN-22 §Bug-2 (2026-05-22): per-entry attachment chips ────────────────
+  describe('attachment chips', () => {
+    const ATT = {
+      id: 'bbbb2222-0000-4000-8000-000000000001',
+      name: 'log.txt',
+      size_bytes: 512,
+      mime_type: 'text/plain',
+      uploaded_by_actor_id: '00000000-0000-4000-8000-000000000099',
+      created_at: '2026-05-22T10:00:00.000Z',
+      linked_at: '2026-05-22T10:00:00.000Z',
+    };
+
+    it('public_update entry with linked attachments renders chip(s)', () => {
+      const entry: ConversationEntry = {
+        ...BASE,
+        kind: 'public_update',
+        visibility: 'public',
+        attachments: [ATT],
+      };
+      render(<TimelineEntry entry={entry} />);
+      expect(screen.getByTestId('attachment-chip')).toBeInTheDocument();
+      expect(screen.getByText('log.txt')).toBeInTheDocument();
+    });
+
+    it('internal_comment entry renders chips', () => {
+      const entry: ConversationEntry = {
+        ...BASE,
+        kind: 'internal_comment',
+        visibility: 'internal',
+        attachments: [ATT],
+      };
+      render(<TimelineEntry entry={entry} />);
+      expect(screen.getByTestId('attachment-chip')).toBeInTheDocument();
+    });
+
+    it('reporter_reply entry renders chips', () => {
+      const entry: ConversationEntry = {
+        ...BASE,
+        kind: 'reporter_reply',
+        visibility: 'reporter',
+        attachments: [ATT],
+      };
+      render(<TimelineEntry entry={entry} />);
+      expect(screen.getByTestId('attachment-chip')).toBeInTheDocument();
+    });
+
+    it('entry with empty attachments[] renders no chips', () => {
+      const entry: ConversationEntry = {
+        ...BASE,
+        kind: 'public_update',
+        visibility: 'public',
+        attachments: [],
+      };
+      render(<TimelineEntry entry={entry} />);
+      expect(screen.queryByTestId('attachment-chip')).not.toBeInTheDocument();
+    });
   });
 });

--- a/apps/frontend/src/features/voc/components/detail/__tests__/_fixtures.ts
+++ b/apps/frontend/src/features/voc/components/detail/__tests__/_fixtures.ts
@@ -47,6 +47,11 @@ export const DETAIL_ENVELOPE: VocDetailEnvelope = {
   conversation_timeline: [],
   conversation_page: { has_more: false },
   permission_decisions: {},
+  // PLAN-22 §Bug-1 (2026-05-22): linked-attachment fields added to VocDetailEnvelope
+  // (and attachment_count to the list-item shape). Default to empty for fixtures that
+  // don't exercise attachments rendering.
+  attachments: [],
+  attachment_count: 0,
 };
 
 // ── Query result helpers ─────────────────────────────────────────────────────

--- a/apps/frontend/src/features/voc/lib/format-file-size.ts
+++ b/apps/frontend/src/features/voc/lib/format-file-size.ts
@@ -1,0 +1,14 @@
+// Shared byte → human-readable size formatter for attachment chips and
+// dropzone rows. Single source of truth — previously duplicated in
+// AttachmentDropzone.tsx and ComposerAttachmentDropzone.tsx.
+//
+// PLAN-22 §Bug-1 (2026-05-22): consolidated when wiring detail-panel and
+// timeline-entry attachment chips, which also need this same B/KB/MB
+// rendering. Keep the output stable — existing tests assert exact strings.
+
+export function formatFileSize(bytes: number): string {
+  if (!bytes) return '0 B';
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/docs/frontend/specs/voc.md
+++ b/docs/frontend/specs/voc.md
@@ -138,6 +138,16 @@ Production tree under `apps/frontend/src/features/voc/`. Shared primitives live 
 | `<ComposerReplyPreview>` (inside modal) | `<ComposerReplyPreview>` in `features/voc/components/detail/` | none | `voc`, `owner`, `reporter`, `draftDoc` | with-body · empty-body |
 | `<PreviewModal>` | `<PreviewModal>` in `packages/ui/src/feedback/` | shadcn `<Dialog>` (size `lg`) | `open`, `onClose`, `title`, `children` | open · closed |
 
+### 3.5b Detail panel body card + attachment chips (PLAN-22 §Bug-1/2/3, 2026-05-22)
+
+| Prototype surface | Production component | Composition | State variants |
+|---|---|---|---|
+| BODY card (description) | `<DescriptionSection>` in `features/voc/components/detail/` | BODY label + `bg-surface-card-elevated` rounded card · `<RichContentRenderer doc=voc.description_rich_content mode="internal">` · `<AttachmentChipList attachments=voc.attachments>` rendered below the card when non-empty · `<EditDescriptionModal>` opener (reporter-on-own-VOC only) | empty body → `설명 없음` · with body → rich render · attachments=[] → no chip list · attachments[].length>0 → horizontal chip row |
+| Conversation entry body | `<TimelineEntry>` in `features/voc/components/detail/` | actor `<UserChip>` + kind `<OutlineBadge>` · `<RichContentRenderer>` · `<AttachmentChipList attachments=entry.attachments>` below the body · optional status-transition pair | public/reporter_reply/internal_comment all read `entry.attachments[]` |
+| Attachment chip | `<AttachmentChip>` in `features/voc/components/detail/` | `<Paperclip>` icon + truncated filename + `formatFileSize(size_bytes)` rendered as `<a href="/attachments/:id/download" download={name}>`. Same-tab navigation; BE's `Content-Disposition: attachment` makes the browser save. | default · hover (`bg-surface-card-elevated`) |
+| Existing attachments in EditDescriptionModal | `<EditDescriptionModal>` `voc.attachments` slot | When `voc.attachments?.length > 0`, render `기존 첨부` label + `<AttachmentChipList>` above the active `<AttachmentDropzone>`. **PATCH is additive**: only NEW upload ids land in `attachment_ids[]`; existing rows are NOT re-sent (BE `linkAttachments` rejects already-linked ids). Remove affordance deferred — chips are read-only this slice. | hydrated (chips visible) · empty (dropzone-only) |
+| `formatFileSize(bytes)` util | `apps/frontend/src/features/voc/lib/format-file-size.ts` | Single source of truth — previously duplicated in `<AttachmentDropzone>` and `<ComposerAttachmentDropzone>`. Returns `0 B` · `<n> B` · `<n.n> KB` · `<n.n> MB`. | n/a |
+
 ### 3.6 Status + signal badges
 
 | Prototype surface | Production component | shadcn/ui base | Props | State variants |


### PR DESCRIPTION
## Why
Live Playwright smoke after PR #77 confirmed BE returns `attachments[]` but FE never renders them. User uploads a file → opens detail → no chip. Same for conversation entries + EditDescriptionModal reopen.

## Components
- `AttachmentChip.tsx` (new) — paperclip + name + size + download link
- `DescriptionSection.tsx` — renders `voc.attachments[]` below BODY card
- `TimelineEntry.tsx` — renders `entry.attachments[]` per kind
- `EditDescriptionModal.tsx` — hydrates `voc.attachments[]` as read-only chips above dropzone

PATCH semantic: **additive** (BE rejects already-linked ids; modal sends only new upload ids).

## Test plan
- [x] FE 439 pass (+9)
- [x] typecheck no new errors
- [x] check:boundaries OK

Doc sync: CHUNK-22-C6-DEVIATIONS.md amendment.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>