### PR TITLE
fix(voc): extract runIdempotent helper (#30)

### DIFF
--- a/apps/backend/src/modules/analytics-areas/analytics-area-service.ts
+++ b/apps/backend/src/modules/analytics-areas/analytics-area-service.ts
@@ -15,7 +15,7 @@
 // check + idempotency lookup because the outer service already performed
 // both for the parent operation.
 
-import { and, asc, count, eq, isNull, sql } from 'drizzle-orm';
+import { and, asc, count, eq, isNull } from 'drizzle-orm';
 import type { DatabaseError } from 'pg';
 
 import type { AuditEventType } from '@fops/shared';
@@ -224,118 +224,101 @@ export function createAnalyticsAreaService(deps: AnalyticsAreaServiceDeps) {
 
     return await db.transaction(async (tx) => {
       if (options.idempotencyKey) {
-        // S-001: serialise concurrent first-time retries with the same
-        // (actor_id, key) so the loser blocks until the winner commits and
-        // then replays the stored response instead of colliding on the
-        // domain unique constraint. See ADR-0015 "Race surface" amendment.
-        await tx.execute(
-          sql`SELECT pg_advisory_xact_lock(hashtext(${actor.actor_id}), hashtext(${options.idempotencyKey}))`,
-        );
-        const hit = await idempotencyService.lookup(
+        return idempotencyService.runIdempotent(
           tx,
           actor.actor_id,
           options.idempotencyKey,
           requestHash,
-        );
-        if (hit.kind === 'match') {
-          return { status: hit.status, body: hit.body as AnalyticsAreaDto };
-        }
-        if (hit.kind === 'mismatch') {
-          throw new HttpError(
-            'conflict.idempotency_key_reuse',
-            'Idempotency-Key reused with a different request body',
-          );
-        }
-      }
-
-      await requireWorkspaceAdmin(checkService, actor, tx);
-
-      // Parent MS must exist, share the workspace, and not be archived.
-      // ADR-0019 Section E: lock the parent MS row inside this tx so a
-      // concurrent `archiveManagedSystem` (which also UPDATEs this row
-      // and runs the cascade) serialises against us. Without the lock,
-      // `READ COMMITTED` lets the archive tx commit between our parent
-      // read and our AA INSERT, leaving an active AA under an archived
-      // parent — the exact state Section B Q1/Q2 has to clean up.
-      const msRows = await tx
-        .select({
-          id: managedSystems.id,
-          workspaceId: managedSystems.workspaceId,
-          archivedAt: managedSystems.archivedAt,
-        })
-        .from(managedSystems)
-        .where(eq(managedSystems.id, body.managed_system_id))
-        .for('update')
-        .limit(1);
-      const ms = msRows[0];
-      if (!ms || ms.workspaceId !== actor.workspace_id) {
-        throw new HttpError('not_found.record', 'managed_system not found in workspace');
-      }
-      if (ms.archivedAt !== null) {
-        throw new HttpError(
-          'conflict.parent_archived',
-          'cannot register an Analytics Area under an archived Managed System',
-          { managed_system_id: body.managed_system_id },
+          () => registerAnalyticsAreaOnce(tx, actor, body),
         );
       }
 
-      let inserted: Row;
-      try {
-        const rows = await tx
-          .insert(analyticsAreas)
-          .values({
-            workspaceId: actor.workspace_id,
-            managedSystemId: body.managed_system_id,
-            slug: body.slug,
-            name: body.name,
-            ownerTeamId: body.owner_team_id ?? null,
-          })
-          .returning();
-        const row = rows[0];
-        if (!row) {
-          throw new HttpError('internal.unexpected', 'analytics_areas insert returned no row');
-        }
-        inserted = row;
-      } catch (err) {
-        const pgErr = err as DatabaseError;
-        if (pgErr?.code === '23505') {
-          throw new HttpError('conflict.duplicate_slug', 'slug already in use under this MS', {
-            slug: body.slug,
-            managed_system_id: body.managed_system_id,
-          });
-        }
-        throw err;
-      }
-
-      await auditService.record(tx, {
-        workspace_id: actor.workspace_id,
-        actor_id: actor.actor_id,
-        event_type: REGISTERED,
-        subject_type: 'analytics_area',
-        subject_id: inserted.id,
-        summary: `Analytics Area registered: ${inserted.slug}`,
-        detail: {
-          workspace_id: actor.workspace_id,
-          managed_system_id: inserted.managedSystemId,
-          slug: inserted.slug,
-          name: inserted.name,
-          owner_team_id: inserted.ownerTeamId,
-        },
-      });
-
-      const dto = toDto(inserted);
-      if (options.idempotencyKey) {
-        await idempotencyService.record(
-          tx,
-          actor.actor_id,
-          options.idempotencyKey,
-          requestHash,
-          201,
-          dto,
-        );
-      }
-      return { status: 201, body: dto };
+      return registerAnalyticsAreaOnce(tx, actor, body);
     });
+  }
+
+  async function registerAnalyticsAreaOnce(
+    tx: Tx,
+    actor: ActorContext,
+    body: RegisterAnalyticsAreaBody,
+  ): Promise<ServiceResult<AnalyticsAreaDto>> {
+    await requireWorkspaceAdmin(checkService, actor, tx);
+
+    // Parent MS must exist, share the workspace, and not be archived.
+    // ADR-0019 Section E: lock the parent MS row inside this tx so a
+    // concurrent `archiveManagedSystem` (which also UPDATEs this row
+    // and runs the cascade) serialises against us. Without the lock,
+    // `READ COMMITTED` lets the archive tx commit between our parent
+    // read and our AA INSERT, leaving an active AA under an archived
+    // parent — the exact state Section B Q1/Q2 has to clean up.
+    const msRows = await tx
+      .select({
+        id: managedSystems.id,
+        workspaceId: managedSystems.workspaceId,
+        archivedAt: managedSystems.archivedAt,
+      })
+      .from(managedSystems)
+      .where(eq(managedSystems.id, body.managed_system_id))
+      .for('update')
+      .limit(1);
+    const ms = msRows[0];
+    if (!ms || ms.workspaceId !== actor.workspace_id) {
+      throw new HttpError('not_found.record', 'managed_system not found in workspace');
+    }
+    if (ms.archivedAt !== null) {
+      throw new HttpError(
+        'conflict.parent_archived',
+        'cannot register an Analytics Area under an archived Managed System',
+        { managed_system_id: body.managed_system_id },
+      );
+    }
+
+    let inserted: Row;
+    try {
+      const rows = await tx
+        .insert(analyticsAreas)
+        .values({
+          workspaceId: actor.workspace_id,
+          managedSystemId: body.managed_system_id,
+          slug: body.slug,
+          name: body.name,
+          ownerTeamId: body.owner_team_id ?? null,
+        })
+        .returning();
+      const row = rows[0];
+      if (!row) {
+        throw new HttpError('internal.unexpected', 'analytics_areas insert returned no row');
+      }
+      inserted = row;
+    } catch (err) {
+      const pgErr = err as DatabaseError;
+      if (pgErr?.code === '23505') {
+        throw new HttpError('conflict.duplicate_slug', 'slug already in use under this MS', {
+          slug: body.slug,
+          managed_system_id: body.managed_system_id,
+        });
+      }
+      throw err;
+    }
+
+    await auditService.record(tx, {
+      workspace_id: actor.workspace_id,
+      actor_id: actor.actor_id,
+      event_type: REGISTERED,
+      subject_type: 'analytics_area',
+      subject_id: inserted.id,
+      summary: `Analytics Area registered: ${inserted.slug}`,
+      detail: {
+        workspace_id: actor.workspace_id,
+        managed_system_id: inserted.managedSystemId,
+        slug: inserted.slug,
+        name: inserted.name,
+        owner_team_id: inserted.ownerTeamId,
+      },
+    });
+
+    const dto = toDto(inserted);
+    return { status: 201, body: dto };
   }
 
   async function updateAnalyticsArea(

--- a/apps/backend/src/modules/core/idempotency/__tests__/run-idempotent.integration.test.ts
+++ b/apps/backend/src/modules/core/idempotency/__tests__/run-idempotent.integration.test.ts
@@ -1,0 +1,86 @@
+import { randomUUID } from 'node:crypto';
+
+import { sql } from 'drizzle-orm';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { type DbHandle, createDb } from '../../../../db/client.js';
+import { HttpError } from '../../../../lib/errors.js';
+import { createIdempotencyService } from '../idempotency-service.js';
+
+const APP_URL = process.env.DATABASE_URL ?? '';
+const WORKSPACE_ID = process.env.WORKSPACE_ID ?? '';
+const runIntegration = Boolean(APP_URL && WORKSPACE_ID);
+
+describe.skipIf(!runIntegration)('idempotencyService.runIdempotent', () => {
+  let handle: DbHandle;
+  let actorId: string;
+
+  beforeAll(async () => {
+    handle = createDb(APP_URL);
+
+    const actorRows = await handle.db.execute<{ id: string }>(sql`
+      SELECT id FROM core.actors
+      WHERE workspace_id = ${WORKSPACE_ID}
+        AND external_id = 'mock-admin-1'
+    `);
+    actorId = (actorRows as unknown as { rows: { id: string }[] }).rows[0]?.id ?? '';
+    expect(actorId).toBeTruthy();
+  });
+
+  afterAll(async () => {
+    await handle.close();
+  });
+
+  it('runs the handler once, records the response, and replays matching retries', async () => {
+    const svc = createIdempotencyService();
+    const key = randomUUID();
+    const requestHash = 'run-idempotent-hash';
+    const body = { ok: true, id: randomUUID() };
+    const handler = vi.fn(async () => ({ status: 201, body }));
+    const replayHandler = vi.fn(async () => ({ status: 201, body: { ok: false } }));
+
+    try {
+      const first = await handle.db.transaction((tx) =>
+        svc.runIdempotent(tx, actorId, key, requestHash, handler),
+      );
+      const replay = await handle.db.transaction((tx) =>
+        svc.runIdempotent(tx, actorId, key, requestHash, replayHandler),
+      );
+
+      expect(first).toEqual({ status: 201, body });
+      expect(replay).toEqual({ status: 201, body });
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(replayHandler).not.toHaveBeenCalled();
+    } finally {
+      await handle.db.execute(sql`
+        DELETE FROM core.idempotency_keys WHERE actor_id = ${actorId} AND key = ${key}
+      `);
+    }
+  });
+
+  it('rejects reused keys with a different request hash before running the handler', async () => {
+    const svc = createIdempotencyService();
+    const key = randomUUID();
+    const handler = vi.fn(async () => ({ status: 201, body: { ok: true } }));
+
+    try {
+      await handle.db.transaction((tx) =>
+        svc.runIdempotent(tx, actorId, key, 'original-hash', handler),
+      );
+
+      await expect(
+        handle.db.transaction((tx) =>
+          svc.runIdempotent(tx, actorId, key, 'changed-hash', handler),
+        ),
+      ).rejects.toMatchObject({
+        code: 'conflict.idempotency_key_reuse',
+      } satisfies Partial<HttpError>);
+
+      expect(handler).toHaveBeenCalledTimes(1);
+    } finally {
+      await handle.db.execute(sql`
+        DELETE FROM core.idempotency_keys WHERE actor_id = ${actorId} AND key = ${key}
+      `);
+    }
+  });
+});

--- a/apps/backend/src/modules/core/idempotency/idempotency-service.ts
+++ b/apps/backend/src/modules/core/idempotency/idempotency-service.ts
@@ -8,23 +8,18 @@
 //   4. Miss                         → caller executes the handler, then calls
 //                                     `record` inside the SAME transaction.
 //
-// The service exposes two methods rather than one combined "lookupOrReserve"
-// because the response body is only known AFTER the application service runs
-// the mutation. The middleware sequence is therefore:
+// Callers that need the full ADR-0015 frame should prefer `runIdempotent` so
+// the advisory lock, lookup, handler execution, and record stay together:
 //
 //   tx.transaction(async (tx) => {
-//     const hit = await idempotencyService.lookup(tx, actor_id, key, hash);
-//     if (hit.kind === 'match') return hit.response;
-//     if (hit.kind === 'mismatch') throw new HttpError('conflict.idempotency_key_reuse', ...);
-//     const response = await runHandler();
-//     await idempotencyService.record(tx, actor_id, key, hash, status, body);
-//     return response;
+//     return idempotencyService.runIdempotent(tx, actor_id, key, hash, runHandler);
 //   });
 
-import { and, eq } from 'drizzle-orm';
+import { and, eq, sql } from 'drizzle-orm';
 
 import type { Tx } from '../../../db/tx.js';
 import { idempotencyKeys } from '../../../db/schema/core.js';
+import { HttpError } from '../../../lib/errors.js';
 
 export type { Tx };
 
@@ -32,6 +27,11 @@ export type IdempotencyLookupResult =
   | { kind: 'miss' }
   | { kind: 'match'; status: number; body: unknown }
   | { kind: 'mismatch' };
+
+export interface IdempotentResult<TBody = unknown> {
+  status: number;
+  body: TBody;
+}
 
 export function createIdempotencyService() {
   async function lookup(
@@ -87,7 +87,35 @@ export function createIdempotencyService() {
       });
   }
 
-  return { lookup, record };
+  async function runIdempotent<TBody>(
+    tx: Tx,
+    actorId: string,
+    key: string,
+    requestHash: string,
+    handler: () => Promise<IdempotentResult<TBody>>,
+  ): Promise<IdempotentResult<TBody>> {
+    // ADR-0015 race-surface amendment: serialise first-time retries with the
+    // same (actor_id, key) before lookup so only one handler can produce
+    // side effects; followers replay the stored response.
+    await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${actorId}), hashtext(${key}))`);
+
+    const hit = await lookup(tx, actorId, key, requestHash);
+    if (hit.kind === 'match') {
+      return { status: hit.status, body: hit.body as TBody };
+    }
+    if (hit.kind === 'mismatch') {
+      throw new HttpError(
+        'conflict.idempotency_key_reuse',
+        'Idempotency-Key reused with a different request body',
+      );
+    }
+
+    const response = await handler();
+    await record(tx, actorId, key, requestHash, response.status, response.body);
+    return response;
+  }
+
+  return { lookup, record, runIdempotent };
 }
 
 export type IdempotencyService = ReturnType<typeof createIdempotencyService>;

--- a/apps/backend/src/modules/voc/routes.ts
+++ b/apps/backend/src/modules/voc/routes.ts
@@ -126,34 +126,14 @@ export const vocRoutes: FastifyPluginAsync<VocRoutesOptions> = async (app, opts)
       // 4. Idempotency + service in one transaction (ADR-0015 protocol).
       const hash = hashRequestBody(rawBody);
       const result = await db.transaction(async (tx) => {
-        // S-001 / ADR-0015 "Race surface" amendment: serialise concurrent
-        // first-time retries with the same (actor_id, key) so the loser
-        // blocks until the winner commits and then replays the stored
-        // response. Without this lock, two concurrent same-key requests
-        // both see `miss` at lookup, both run createVoc, and both produce
-        // a VOC row + audit row (the loser's idempotency INSERT is
-        // swallowed by ON CONFLICT DO NOTHING). Mirrors the AA service
-        // pattern (analytics-area-service.ts:230-233).
-        await tx.execute(
-          sql`SELECT pg_advisory_xact_lock(hashtext(${sess.actor_id}), hashtext(${idempotencyKey}))`,
-        );
-        const hit = await idempotencyService.lookup(tx, sess.actor_id, idempotencyKey, hash);
-        if (hit.kind === 'match') {
-          return { status: hit.status, body: hit.body };
-        }
-        if (hit.kind === 'mismatch') {
-          throw new HttpError(
-            'conflict.idempotency_key_reuse',
-            'Idempotency-Key reused with different request body',
-          );
-        }
-        const envelope = await vocService.createVoc({
-          tx,
-          actor: { actor_id: sess.actor_id, workspace_id: sess.workspace_id },
-          input,
+        return idempotencyService.runIdempotent(tx, sess.actor_id, idempotencyKey, hash, async () => {
+          const envelope = await vocService.createVoc({
+            tx,
+            actor: { actor_id: sess.actor_id, workspace_id: sess.workspace_id },
+            input,
+          });
+          return { status: 201, body: envelope };
         });
-        await idempotencyService.record(tx, sess.actor_id, idempotencyKey, hash, 201, envelope);
-        return { status: 201, body: envelope };
       });
       return reply.code(result.status).send(result.body);
     },


### PR DESCRIPTION
## Summary
- Extracts a shared `runIdempotent` helper in the idempotency service; voc routes + analytics-area service consume it instead of inlining the replay/store dance.
- Behavior-preserving refactor (no contract change).

Closes #30.

## Test plan
- [ ] `run-idempotent.integration.test.ts` green
- [ ] voc create replay path unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)