### PR TITLE
fix(auth): rate-limit bucket keyed by workspace_id (#32)

### DIFF
--- a/apps/backend/src/modules/auth/__tests__/session-summary.test.ts
+++ b/apps/backend/src/modules/auth/__tests__/session-summary.test.ts
@@ -4,7 +4,8 @@
 
 import { describe, expect, test } from 'vitest';
 
-import { summarizeIp, summarizeUserAgent } from '../session-service.js';
+import type { Db } from '../../../db/client.js';
+import { createSessionService, summarizeIp, summarizeUserAgent } from '../session-service.js';
 
 describe('summarizeIp', () => {
   test('IPv4 → 16-char hash of /24 prefix', () => {
@@ -69,5 +70,24 @@ describe('summarizeUserAgent', () => {
     const out = summarizeUserAgent('x'.repeat(200));
     expect(out).not.toBeNull();
     expect((out ?? '').length).toBeLessThanOrEqual(64);
+  });
+});
+
+describe('lookupActorIdByToken', () => {
+  test('returns actor and workspace identifiers for an active session', async () => {
+    const service = createSessionService({
+      db: {
+        execute: async () => ({
+          rows: [{ actor_id: 'actor-1', workspace_id: 'workspace-1' }],
+        }),
+      } as unknown as Db,
+      workspaceId: 'workspace-1',
+      now: () => new Date('2026-01-01T00:00:00.000Z'),
+    });
+
+    await expect(service.lookupActorIdByToken('session-1')).resolves.toEqual({
+      actor_id: 'actor-1',
+      workspace_id: 'workspace-1',
+    });
   });
 });

--- a/apps/backend/src/modules/auth/session-service.ts
+++ b/apps/backend/src/modules/auth/session-service.ts
@@ -38,6 +38,11 @@ export interface SessionRecord {
   roleLevel: RoleLevel;
 }
 
+export type RateLimitActorIdentity = {
+  actor_id: string;
+  workspace_id: string;
+};
+
 /** ADR-0006:23-26 — 12h TTL on issue. `last_seen_at` updated per request. */
 export const SESSION_TTL_MS = 12 * 60 * 60 * 1000;
 
@@ -293,8 +298,8 @@ export function createSessionService(deps: SessionServiceDeps) {
     },
 
     /**
-     * Read-only lookup of the actor_id for an active session token. Does NOT
-     * touch `last_seen_at`. Intended for the `@fastify/rate-limit`
+     * Read-only lookup of actor/workspace identifiers for an active session
+     * token. Does NOT touch `last_seen_at`. Intended for the `@fastify/rate-limit`
      * keyGenerator which runs in the `onRequest` hook (before the
      * `requireSession` preHandler) and needs the actor identity without
      * paying for a second `loadAndTouch` write. Returns null when the row
@@ -302,17 +307,18 @@ export function createSessionService(deps: SessionServiceDeps) {
      *
      * Adversarial review API-C-2.
      */
-    async lookupActorIdByToken(sessionId: string): Promise<string | null> {
+    async lookupActorIdByToken(sessionId: string): Promise<RateLimitActorIdentity | null> {
       const rightNow = now();
-      const result = await deps.db.execute<{ actor_id: string }>(sql`
-        SELECT actor_id
+      const result = await deps.db.execute<RateLimitActorIdentity>(sql`
+        SELECT actor_id,
+               workspace_id
           FROM core.sessions
          WHERE id = ${sessionId}
            AND revoked_at IS NULL
            AND expires_at > ${rightNow}
          LIMIT 1
       `);
-      return result.rows[0]?.actor_id ?? null;
+      return result.rows[0] ?? null;
     },
 
     /** Revoke immediately. Idempotent: revoking an already-revoked row is a no-op. */

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -168,7 +168,8 @@ export async function buildServer(opts: BuildServerOptions): Promise<FastifyInst
     max: (req) => (req.session?.actor_id ? 100 : 50),
     timeWindow: '1 minute',
     allowList: (req) => req.url === '/health',
-    keyGenerator: (req) => req.session?.actor_id ?? req.ip,
+    keyGenerator: (req) =>
+      req.session ? `${req.session.workspace_id}:${req.session.actor_id}` : req.ip,
     store: createPgRateLimitStore(dbHandle.pool, 'global') as never,
     errorResponseBuilder: (_req, ctx) => ({
       code: 'rate_limited.actor',
@@ -199,15 +200,15 @@ export async function buildServer(opts: BuildServerOptions): Promise<FastifyInst
   // observed `undefined` and fell back to `req.ip`, collapsing all users
   // behind a shared NAT into one bucket. We resolve the session cookie
   // inline (one DB lookup per mutation) so the per-actor bucket is the
-  // actor's actor_id when a valid session cookie is present, and `req.ip`
-  // only for unauthenticated traffic.
+  // workspace+actor identity when a valid session cookie is present, and
+  // `req.ip` only for unauthenticated traffic.
   const mutationKeyGenerator = async (req: FastifyRequest): Promise<string> => {
     const raw = req.cookies?.[SESSION_COOKIE_NAME];
     const token = typeof raw === 'string' ? raw : undefined;
     if (token) {
       try {
-        const actorId = await sessionService.lookupActorIdByToken(token);
-        if (actorId) return actorId;
+        const identity = await sessionService.lookupActorIdByToken(token);
+        if (identity) return `${identity.workspace_id}:${identity.actor_id}`;
       } catch (err) {
         req.log?.warn?.({ err }, 'rate-limit actor lookup failed; falling back to ip');
       }


### PR DESCRIPTION
## Summary
- Rate-limit bucket key now uses `workspace_id` so tenants don't share/contend a global bucket.
- session-service + server wiring updated; session-summary test extended.

Closes #32.

## Test plan
- [ ] `session-summary.test.ts` green
- [ ] per-workspace isolation verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)