### PR TITLE
feat(workflow): v0.3 sandbox containment finding + VERIFIER hardening

### DIFF
--- a/.review/schemas/verify.schema.json
+++ b/.review/schemas/verify.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Verify Result Artifact",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "artifact_type", "producer_role", "issue", "branch", "head_sha", "cwd", "verify_cmd", "db_target", "verdict", "classifier", "created_at"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "artifact_type": { "const": "verify_result" },
+    "producer_role": { "const": "VERIFIER" },
+    "producer_version": { "type": "string", "description": "optional: agent CLI version (e.g. 'codex/0.133.0') for debugging provenance" },
+    "issue": { "type": "integer" },
+    "branch": { "type": "string" },
+    "head_sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+    "cwd": { "type": "string" },
+    "verify_cmd": { "type": "string" },
+    "env_profile": { "type": "string", "description": "optional: verifier environment profile (e.g. 'scrubbed')" },
+    "db_target": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["host", "database", "role"],
+      "properties": {
+        "host": { "type": "string" },
+        "database": { "type": "string" },
+        "role": { "type": "string" }
+      }
+    },
+    "verdict": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["passed", "failed", "pending", "exit_code"],
+      "properties": {
+        "passed": { "type": "integer", "minimum": 0 },
+        "failed": { "type": "integer", "minimum": 0 },
+        "pending": { "type": "integer", "minimum": 0 },
+        "exit_code": { "type": "integer" }
+      }
+    },
+    "classifier": { "enum": ["PASS", "FAIL"] },
+    "created_at": { "type": "string", "description": "ISO-8601 timestamp" }
+  }
+}

--- a/docs/agents/multi-agent-workflow.md
+++ b/docs/agents/multi-agent-workflow.md
@@ -72,6 +72,20 @@ All `codex exec` invocations MUST go through `scripts/codex-safe.sh`, which enfo
 
 Direct `codex exec` invocations are forbidden in this workflow.
 
+### Sandbox network containment — why the worker can't self-verify DB tests (v0.3)
+
+`workspace-write` blocks **all** network egress, including **loopback**. A v0.3 spike proved this is total: a probe run inside the sandbox cannot `connect()` even to `127.0.0.1` (TCP) **nor** to a Unix-domain socket placed inside the writable root — both fail with `EPERM`. (Repro: host-side relay `scripts/uds-pg-relay.mjs` + in-sandbox `scripts/__tests__/uds-sandbox-probe.mjs`; the TCP-loopback case is the live layer of the network-deny smoke below.) So there is **no containment-preserving way** to give a sandboxed worker access to the local Postgres on current codex (0.133.0):
+
+- A loopback-only network allowance is **not shipped** (codex issue #6737 open; #6807 closed-folded). `network_access` is all-or-nothing.
+- The "UDS proxy" idea (front Postgres with a socket in a writable root) was **rejected** — Seatbelt denies AF_UNIX `connect()` too.
+- A full-egress `dbtest` profile (`network_access=true`) was **rejected** as a standing workflow: with the principled UDS fallback dead, it is a pure risk-trade (tests run arbitrary dep/app code → exfil surface), and VERIFIER already runs the same tests cleanly outside the sandbox.
+
+**Decision: status-quo.** The worker stays network-denied; the **VERIFIER runs DB tests outside the sandbox** (see VERIFIER protocol). Revisit only when (a) codex ships loopback-only network (#6737), or (b) data shows DB-test verifier churn is a real throughput bottleneck.
+
+Hardening shipped alongside this decision:
+- Global `~/.codex/config.toml` default lowered `danger-full-access` → `workspace-write` (defense-in-depth for bare `codex`; the wrapper already forces `--sandbox workspace-write` explicitly).
+- `scripts/__tests__/sandbox-network-deny.smoke.sh` guards against regression: Layer 1 (offline) asserts `codex-safe.sh` still pins `--sandbox workspace-write` and grants no `danger-full-access`/`network_access`; Layer 2 (opt-in, `RUN_LIVE_SANDBOX_PROBE=1`) runs `scripts/__tests__/net-deny-probe.mjs` inside the sandbox and asserts loopback is `BLOCKED`.
+
 ## Worktree Prep
 
 A fresh `git worktree` is **NOT dispatch-ready**: it has no `node_modules` and no gitignored `.env`. Because the codex sandbox blocks network, deps and env cannot self-provision inside it — provisioning MUST happen host-side, **outside the sandbox**, before dispatch.
@@ -111,6 +125,15 @@ The `<filter>` arg is a **Vitest test name/path filter scoped to the backend pac
 - a missing, empty, or unparseable report (fail closed).
 
 A PASS is reported only when none of the above trip.
+
+### Verifier hardening (v0.3)
+
+Because the VERIFIER runs tests **outside** the sandbox (full host access), the filter-mode run is hardened:
+
+- **Local-DB guard (fail closed).** `verify.sh` extracts the `DATABASE_URL` host and **refuses with `exit 3`** if it is not local (`localhost`/`127.0.0.1`/`::1`/`[::1]`/empty unix-socket form). The verifier must never run against a remote/staging/prod DB.
+- **Least-privilege role.** Set `VERIFY_DATABASE_URL` (and optionally `VERIFY_DATABASE_URL_MIGRATE`) to point the run at a low-privilege role; it overrides `DATABASE_URL` for the run only. If the effective role is the superuser `postgres`, `verify.sh` prints a `WARN` recommending `fops_app`. Pair with an **ephemeral per-issue DB** (see Parallel-cluster DB isolation) so a verifier run can never mutate shared state.
+- **Env scrub (default-deny allowlist).** The vitest child runs under `env -i` with only an allowlist passed through (`PATH HOME SHELL TERM LANG LC_ALL TMPDIR TMP USER LOGNAME PWD NODE_OPTIONS NODE_ENV DATABASE_URL DATABASE_URL_MIGRATE WORKSPACE_ID CI`, plus `PNPM_*`/`npm_config_*`, plus any names in `VERIFY_ENV_ALLOW`). Arbitrary host secrets (tokens/keys) do **not** leak into test/app code.
+- **Canonical provenance artifact.** When `VERIFY_ISSUE=<n>` is set, `verify.sh` writes `.review/ISSUE-<n>-VERIFY.json` (schema `.review/schemas/verify.schema.json`, `artifact_type: "verify_result"`, `producer_role: "VERIFIER"`): branch, `head_sha`, cwd, `verify_cmd`, `env_profile`, `db_target` (host/database/role — **never a password**), `verdict` (passed/failed/pending/exit_code), `classifier` (PASS/FAIL), `created_at`. This makes verifier output the canonical readiness signal, not worker prose. Artifact-write failure is non-fatal and never flips the run's exit code. With `VERIFY_ISSUE` unset, behavior is unchanged (no artifact).
 
 ### Baseline-aware typecheck
 

--- a/scripts/__tests__/net-deny-probe.mjs
+++ b/scripts/__tests__/net-deny-probe.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+// Probe whether a sandboxed worker can open a TCP connection.
+import fs from 'fs';
+import net from 'net';
+import process from 'process';
+
+const host = process.argv[2];
+const port = Number(process.argv[3]);
+const outPath = process.argv[4];
+let wrote = false;
+
+function ensureParentDir(filePath) {
+  const index = filePath.lastIndexOf('/');
+  if (index === -1) return;
+  const dir = index === 0 ? '/' : filePath.slice(0, index);
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+function finish(verdict, code) {
+  if (wrote) return;
+  wrote = true;
+  ensureParentDir(outPath);
+  fs.writeFileSync(outPath, verdict);
+  process.exit(code);
+}
+
+const socket = net.connect(port, host);
+socket.setTimeout(3000);
+
+socket.on('connect', () => {
+  socket.destroy();
+  finish('CONNECTED\n', 0);
+});
+
+socket.on('error', (err) => {
+  finish(`BLOCKED code=${err.code}\n`, 1);
+});
+
+socket.on('timeout', () => {
+  socket.destroy();
+  finish('BLOCKED timeout\n', 1);
+});

--- a/scripts/__tests__/sandbox-network-deny.smoke.sh
+++ b/scripts/__tests__/sandbox-network-deny.smoke.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Smoke test that the codex worker wrapper preserves sandbox network denial.
+set -u
+
+repo_root="$(git rev-parse --show-toplevel)"
+SCRIPT="$repo_root/scripts/codex-safe.sh"
+FAILURES=0
+
+run_case() {
+  name="$1"; expected="$2"; command="$3"
+  if eval "$command"; then actual="PASS"; else actual="FAIL"; fi
+  if [ "$actual" = "$expected" ]; then
+    echo "ok - $name (expected $expected, got $actual)"
+  else
+    echo "NOT OK - $name (expected $expected, got $actual)"
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+run_live_probe() {
+  out=".review/netdeny-probe.$$"
+  trap 'rm -f "$repo_root/$out"' EXIT
+  rm -f "$repo_root/$out"
+
+  (
+    cd "$repo_root" &&
+      codex exec --sandbox workspace-write --cd "$repo_root" "Run exactly this one command from the repo root and nothing else: node scripts/__tests__/net-deny-probe.mjs 127.0.0.1 5434 $out"
+  ) >/dev/null 2>&1
+
+  if [ ! -s "$repo_root/$out" ]; then
+    echo "NOT OK - loopback blocked in sandbox (probe output missing)"
+    FAILURES=$((FAILURES + 1))
+  elif grep -q "BLOCKED" "$repo_root/$out"; then
+    echo "ok - loopback blocked in sandbox"
+  else
+    echo "NOT OK - loopback blocked in sandbox ($(cat "$repo_root/$out"))"
+    FAILURES=$((FAILURES + 1))
+  fi
+
+  rm -f "$repo_root/$out"
+}
+
+run_case "wrapper pins workspace-write" PASS "grep -q -- '--sandbox workspace-write' \"\$SCRIPT\""
+run_case "wrapper has no danger-full-access" PASS "! grep -q -- 'danger-full-access' \"\$SCRIPT\""
+run_case "wrapper grants no network_access" PASS "! grep -q -- 'network_access' \"\$SCRIPT\""
+
+if [ "${RUN_LIVE_SANDBOX_PROBE:-}" = "1" ] && command -v codex >/dev/null 2>&1; then
+  run_live_probe
+else
+  echo "ok - SKIP live in-sandbox probe (set RUN_LIVE_SANDBOX_PROBE=1 and ensure codex on PATH)"
+fi
+
+echo "---"
+if [ "$FAILURES" -eq 0 ]; then
+  echo "ALL CASES PASS"
+  exit 0
+else
+  echo "$FAILURES CASE(S) FAILED"
+  exit 1
+fi

--- a/scripts/__tests__/uds-sandbox-probe.mjs
+++ b/scripts/__tests__/uds-sandbox-probe.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+// Sandbox-side UDS Postgres reachability probe.
+import net from "net";
+import process from "process";
+
+const socketPath = process.argv[2] || process.env.UDS_PATH || ".review/pg.sock";
+const timeoutMs = 4000;
+let done = false;
+
+const failReason = (error) => {
+  if (error === "timeout") return "ETIMEDOUT no response";
+  if (error === "no-data") return "no data";
+  if (error?.code === "ENOENT") return "ENOENT socket missing";
+  if (error?.code === "EACCES" || error?.code === "EPERM") return `${error.code} sandbox blocked connect`;
+  if (error?.code === "ECONNREFUSED") return "ECONNREFUSED relay down";
+  if (error?.code === "ETIMEDOUT") return "ETIMEDOUT no response";
+  return error?.message || String(error);
+};
+
+const finish = (ok, text) => {
+  if (done) return;
+  done = true;
+  clearTimeout(timer);
+  socket.destroy();
+  console.log(ok ? `UDS-PROBE-OK byte=${text}` : `UDS-PROBE-FAIL reason=${text}`);
+  process.exit(ok ? 0 : 1);
+};
+
+const packet = Buffer.alloc(8);
+packet.writeInt32BE(8, 0);
+packet.writeInt32BE(80877103, 4);
+
+const socket = net.connect(socketPath, () => {
+  socket.write(packet);
+});
+
+const timer = setTimeout(() => finish(false, failReason("timeout")), timeoutMs);
+
+socket.once("data", (chunk) => {
+  if (!chunk.length) finish(false, failReason("no-data"));
+  else finish(true, String.fromCharCode(chunk[0]));
+});
+
+socket.once("error", (error) => finish(false, failReason(error)));
+socket.once("close", () => finish(false, failReason("no-data")));

--- a/scripts/uds-pg-relay.mjs
+++ b/scripts/uds-pg-relay.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+// Host-side UDS-to-TCP Postgres relay.
+import fs from "fs";
+import net from "net";
+import process from "process";
+
+const socketPath = process.argv[2] || process.env.UDS_PATH || ".review/pg.sock";
+const host = process.env.PG_HOST || "127.0.0.1";
+const port = Number(process.env.PG_PORT || "5434");
+const absPath = fs.realpathSync(process.cwd()) + "/" + socketPath;
+
+try {
+  fs.unlinkSync(socketPath);
+} catch (error) {
+  if (error?.code !== "ENOENT") throw error;
+}
+
+const server = net.createServer((client) => {
+  console.log("relay: conn open");
+  const upstream = net.connect({ host, port });
+  let closed = false;
+
+  const closeBoth = () => {
+    if (!closed) {
+      closed = true;
+      console.log("relay: conn close");
+    }
+    client.destroy();
+    upstream.destroy();
+  };
+
+  client.pipe(upstream);
+  upstream.pipe(client);
+  client.on("error", closeBoth);
+  upstream.on("error", closeBoth);
+  client.on("close", closeBoth);
+  upstream.on("close", closeBoth);
+});
+
+const shutdown = () => {
+  server.close(() => {
+    try {
+      fs.unlinkSync(socketPath);
+    } catch (error) {
+      if (error?.code !== "ENOENT") throw error;
+    }
+    process.exit(0);
+  });
+};
+
+process.on("SIGINT", shutdown);
+process.on("SIGTERM", shutdown);
+
+server.listen(socketPath, () => {
+  console.log(`relay: listening on ${absPath} -> ${host}:${port}`);
+});

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -166,6 +166,119 @@ classify_json() {
   return $?
 }
 
+emit_verify_artifact() {
+  issue="$1"
+  filter="$2"
+  report="$3"
+  vitest_ec="$4"
+  classifier="$5"
+
+  case "$issue" in
+    ""|*[!0-9]*)
+      echo "WARN: VERIFY_ISSUE must be a non-empty integer; skipping verify artifact" >&2
+      return 0
+      ;;
+  esac
+
+  artifact_path=".review/ISSUE-${issue}-VERIFY.json"
+  mkdir -p .review || {
+    echo "WARN: unable to create .review directory; skipping verify artifact" >&2
+    return 0
+  }
+
+  db_host=""
+  db_database=""
+  db_role=""
+  if [ -n "${DATABASE_URL+x}" ] && [ -n "$DATABASE_URL" ]; then
+    db_after_scheme="$(printf '%s\n' "$DATABASE_URL" | sed 's,^[^:][^:]*://,,')"
+    db_role=""
+    case "$db_after_scheme" in
+      *@*) db_role="$(printf '%s\n' "$db_after_scheme" | sed 's/[:@].*//')" ;;
+    esac
+
+    db_authority="$db_after_scheme"
+    case "$db_authority" in
+      *@*) db_authority="${db_authority#*@}" ;;
+    esac
+    db_host="$(printf '%s\n' "$db_authority" | sed 's/[/:].*//')"
+    case "$db_authority" in
+      \[*\]*) db_host="$(printf '%s\n' "$db_authority" | sed 's/^\(\[[^]]*\]\).*/\1/')" ;;
+      "::1"|::1/*|::1:*) db_host="::1" ;;
+    esac
+    case "$db_after_scheme" in
+      */*) db_database="$(printf '%s\n' "$db_after_scheme" | sed 's/[?].*$//; s,.*/,,')" ;;
+    esac
+  fi
+
+  head_sha="$(git rev-parse HEAD 2>/dev/null || printf '')"
+  branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || printf '')"
+  cwd="$(pwd)"
+  verify_cmd="verify.sh $filter"
+  created_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+  VERIFY_ARTIFACT_PATH="$artifact_path" \
+  VERIFY_ARTIFACT_ISSUE="$issue" \
+  VERIFY_ARTIFACT_BRANCH="$branch" \
+  VERIFY_ARTIFACT_HEAD_SHA="$head_sha" \
+  VERIFY_ARTIFACT_CWD="$cwd" \
+  VERIFY_ARTIFACT_CMD="$verify_cmd" \
+  VERIFY_ARTIFACT_DB_HOST="$db_host" \
+  VERIFY_ARTIFACT_DB_DATABASE="$db_database" \
+  VERIFY_ARTIFACT_DB_ROLE="$db_role" \
+  VERIFY_ARTIFACT_EXIT_CODE="$vitest_ec" \
+  VERIFY_ARTIFACT_CLASSIFIER="$classifier" \
+  VERIFY_ARTIFACT_CREATED_AT="$created_at" \
+  VERIFY_ARTIFACT_REPORT="$report" \
+  node -e '
+    var fs = require("fs");
+    function count(data, key) {
+      var value = data && data[key];
+      return (typeof value === "number" && isFinite(value)) ? value : 0;
+    }
+
+    var data = {};
+    try {
+      data = JSON.parse(fs.readFileSync(process.env.VERIFY_ARTIFACT_REPORT, "utf8"));
+    } catch (e) {
+      data = {};
+    }
+
+    var artifact = {
+      schema_version: "1",
+      artifact_type: "verify_result",
+      producer_role: "VERIFIER",
+      issue: parseInt(process.env.VERIFY_ARTIFACT_ISSUE, 10),
+      branch: process.env.VERIFY_ARTIFACT_BRANCH || "",
+      head_sha: process.env.VERIFY_ARTIFACT_HEAD_SHA || "",
+      cwd: process.env.VERIFY_ARTIFACT_CWD || "",
+      verify_cmd: process.env.VERIFY_ARTIFACT_CMD || "",
+      env_profile: "scrubbed",
+      db_target: {
+        host: process.env.VERIFY_ARTIFACT_DB_HOST || "",
+        database: process.env.VERIFY_ARTIFACT_DB_DATABASE || "",
+        role: process.env.VERIFY_ARTIFACT_DB_ROLE || ""
+      },
+      verdict: {
+        passed: count(data, "numPassedTests"),
+        failed: count(data, "numFailedTests"),
+        pending: count(data, "numPendingTests"),
+        exit_code: parseInt(process.env.VERIFY_ARTIFACT_EXIT_CODE, 10) || 0
+      },
+      classifier: process.env.VERIFY_ARTIFACT_CLASSIFIER === "PASS" ? "PASS" : "FAIL",
+      created_at: process.env.VERIFY_ARTIFACT_CREATED_AT || ""
+    };
+
+    if (process.env.CODEX_VERSION) {
+      artifact.producer_version = "codex/" + process.env.CODEX_VERSION;
+    }
+
+    fs.writeFileSync(process.env.VERIFY_ARTIFACT_PATH, JSON.stringify(artifact, null, 2) + "\n");
+  ' || {
+    echo "WARN: unable to write verify artifact: $artifact_path" >&2
+    return 0
+  }
+}
+
 main() {
   if [ "$#" -lt 1 ]; then
     usage
@@ -221,14 +334,70 @@ main() {
     set +a
   fi
 
+  if [ -n "${VERIFY_DATABASE_URL+x}" ] && [ -n "$VERIFY_DATABASE_URL" ]; then
+    export DATABASE_URL="$VERIFY_DATABASE_URL"
+    export DATABASE_URL_MIGRATE="${VERIFY_DATABASE_URL_MIGRATE:-$VERIFY_DATABASE_URL}"
+  fi
+
+  if [ -n "${DATABASE_URL+x}" ] && [ -n "$DATABASE_URL" ]; then
+    db_after_scheme="$(printf '%s\n' "$DATABASE_URL" | sed 's,^[^:][^:]*://,,')"
+    db_user="$(printf '%s\n' "$db_after_scheme" | sed 's/[:@].*//')"
+    if [ "$db_user" = "postgres" ]; then
+      echo "WARN: verifier running as superuser role 'postgres' — prefer a low-privilege role (e.g. fops_app) via VERIFY_DATABASE_URL" >&2
+    fi
+
+    db_authority="$db_after_scheme"
+    case "$db_authority" in
+      *@*) db_authority="${db_authority#*@}" ;;
+    esac
+    db_host="$(printf '%s\n' "$db_authority" | sed 's/[/:].*//')"
+    case "$db_authority" in
+      \[*\]*) db_host="$(printf '%s\n' "$db_authority" | sed 's/^\(\[[^]]*\]\).*/\1/')" ;;
+      "::1"|::1/*|::1:*) db_host="::1" ;;
+    esac
+    case "$db_host" in
+      ""|"localhost"|"127.0.0.1"|"::1"|"[::1]") ;;
+      *)
+        echo "FAIL: refusing to verify against non-local DATABASE_URL host '$db_host' (fail closed — verifier must run against a local/ephemeral DB)" >&2
+        exit 3
+        ;;
+    esac
+  fi
+
   tmp_report="$(mktemp -t verify-vitest.XXXXXX)"
   trap 'rm -f "$tmp_report"' EXIT
 
-  pnpm --filter backend exec vitest run "$filter" --reporter=json --outputFile="$tmp_report"
+  set -- env -i
+  for env_name in PATH HOME SHELL TERM LANG LC_ALL TMPDIR TMP USER LOGNAME PWD NODE_OPTIONS NODE_ENV DATABASE_URL DATABASE_URL_MIGRATE WORKSPACE_ID CI; do
+    eval 'if [ -n "${'"$env_name"'+x}" ]; then env_value=$'"$env_name"'; set -- "$@" "'"$env_name"'=$env_value"; fi'
+  done
+  for env_name in $(env | sed -n 's/^\(PNPM_[A-Za-z0-9_]*\)=.*/\1/p; s/^\(npm_config_[A-Za-z0-9_]*\)=.*/\1/p' | sort -u); do
+    eval 'if [ -n "${'"$env_name"'+x}" ]; then env_value=$'"$env_name"'; set -- "$@" "'"$env_name"'=$env_value"; fi'
+  done
+  for env_name in ${VERIFY_ENV_ALLOW:-}; do
+    case "$env_name" in
+      [A-Za-z_][A-Za-z0-9_]*)
+        eval 'if [ -n "${'"$env_name"'+x}" ]; then env_value=$'"$env_name"'; set -- "$@" "'"$env_name"'=$env_value"; fi'
+        ;;
+    esac
+  done
+
+  "$@" pnpm --filter backend exec vitest run "$filter" --reporter=json --outputFile="$tmp_report"
   vitest_ec=$?
 
   classify_json "$tmp_report" "$vitest_ec"
-  exit $?
+  cls_ec=$?
+  if [ "$cls_ec" -eq 0 ]; then
+    classifier="PASS"
+  else
+    classifier="FAIL"
+  fi
+
+  if [ -n "${VERIFY_ISSUE+x}" ] && [ -n "$VERIFY_ISSUE" ]; then
+    emit_verify_artifact "$VERIFY_ISSUE" "$filter" "$tmp_report" "$vitest_ec" "$classifier"
+  fi
+
+  exit "$cls_ec"
 }
 
 main "$@"


### PR DESCRIPTION
**Stacked on #83** (base = `feature/agent-workflow-trial`). v0.3 modifies `verify.sh`, which only exists on the v0.2 branch — basing on #83 keeps this diff to v0.3-only. Retarget to `develop` after #83 merges.

## The finding
A self-verify spike proved codex `workspace-write` (Seatbelt, codex 0.133.0) blocks **all** egress including **loopback**: an in-sandbox probe cannot `connect()` to `127.0.0.1` (TCP) **nor** to an AF_UNIX socket in a writable root — both `EPERM`. So:
- loopback-only allowance is unshipped (codex #6737 open),
- the "UDS proxy" fallback is **dead**,
- a full-egress `dbtest` profile is a pure risk-trade (VERIFIER already runs the same tests cleanly outside).

**Decision: status-quo** — worker stays network-denied; VERIFIER runs DB tests outside the sandbox. Revisit when #6737 lands or churn data justifies.

## Changes
- **verify.sh hardening** (filter mode): local-DB guard (`exit 3` on non-local host); `VERIFY_DATABASE_URL` least-priv override + superuser WARN; `env -i` default-deny allowlist scrub (`VERIFY_ENV_ALLOW` for extras).
- **Provenance**: `VERIFY_ISSUE=<n>` emits `.review/ISSUE-<n>-VERIFY.json` (new `verify.schema.json`; `db_target` = host/db/role, never a password). Non-fatal; never flips exit code.
- **Regression guard**: `sandbox-network-deny.smoke.sh` — L1 offline (wrapper pins workspace-write, no danger-full-access/network_access), L2 opt-in live (in-sandbox loopback `BLOCKED`).
- **Repro scripts**: `net-deny-probe.mjs`, `uds-pg-relay.mjs`, `uds-sandbox-probe.mjs`.
- **Doc-sync**: `multi-agent-workflow.md` sandbox rule + VERIFIER protocol.
- **Out-of-repo**: global `~/.codex/config.toml` default lowered `danger-full-access` → `workspace-write`.

## Test plan
- [x] `verify.smoke.sh` all pass
- [x] `sandbox-network-deny.smoke.sh` L1 + live L2 (`loopback blocked`)
- [x] real `VERIFY_ISSUE=… verify.sh create-voc` → artifact ajv-valid, `PASS 31`
- [ ] reviewer: confirm env scrub doesn't starve any other DB-backed suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)