### PR TITLE
fix(#94): PageShell fills viewport (constrained 1600 / fluid)

### DIFF
--- a/apps/frontend/src/routes/_authed/admin/analytics-areas.tsx
+++ b/apps/frontend/src/routes/_authed/admin/analytics-areas.tsx
@@ -112,11 +112,9 @@ export function AnalyticsAreasAdminPage() {
         ),
       }}
     >
-      <div className="mx-auto max-w-5xl p-8">
-        <PermissionGate capability="workspace.admin">
-          <AnalyticsAreasBody registerCtx={registerCtx} setRegisterCtx={setRegisterCtx} />
-        </PermissionGate>
-      </div>
+      <PermissionGate capability="workspace.admin">
+        <AnalyticsAreasBody registerCtx={registerCtx} setRegisterCtx={setRegisterCtx} />
+      </PermissionGate>
     </PageShell>
   );
 }

--- a/apps/frontend/src/routes/_authed/admin/managed-systems.tsx
+++ b/apps/frontend/src/routes/_authed/admin/managed-systems.tsx
@@ -89,11 +89,9 @@ export function ManagedSystemsAdminPage() {
         ),
       }}
     >
-      <div className="mx-auto max-w-5xl p-8">
-        <PermissionGate capability="workspace.admin">
-          <ManagedSystemsBody registerOpen={registerOpen} setRegisterOpen={setRegisterOpen} />
-        </PermissionGate>
-      </div>
+      <PermissionGate capability="workspace.admin">
+        <ManagedSystemsBody registerOpen={registerOpen} setRegisterOpen={setRegisterOpen} />
+      </PermissionGate>
     </PageShell>
   );
 }

--- a/packages/ui/src/layout/PageShell.tsx
+++ b/packages/ui/src/layout/PageShell.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type * as React from 'react';
 import { cn } from '../utils/cn';
 import { ShellHeader, type ShellHeaderProps } from './ShellHeader';
 import { useDetailPanelSlot } from './useDetailPanelSlot';
@@ -10,6 +10,12 @@ export interface PageShellProps {
   children: React.ReactNode;
   /** Optional detail-panel intent. Forwarded to AppFrame's global slot via useDetailPanelSlot. */
   detailPanel?: React.ReactNode;
+  /**
+   * Full-bleed content. When false (default) the content column is centered and
+   * capped at 1600px (prototype `.main-padded.constrained`); when true it spans
+   * the full available width (prototype `page-shell--fluid`).
+   */
+  fluid?: boolean;
   className?: string;
   contentClassName?: string;
 }
@@ -17,14 +23,36 @@ export interface PageShellProps {
 /**
  * PageShell — full-page content (Home, Settings, New VOC, Roadmap, Survey list).
  * Layout: 50px header + scrollable content. NO list rail. detailPanel forwards to AppFrame slot.
+ *
+ * The scroll region fills the available height; the inner padded column mirrors
+ * the prototype's `.main-padded` (28px 32px 36px) and, when not `fluid`, caps at
+ * 1600px centered so huge monitors stay readable without leaving a 1024px gutter.
  */
-export function PageShell({ header, children, detailPanel, className, contentClassName }: PageShellProps) {
+export function PageShell({
+  header,
+  children,
+  detailPanel,
+  fluid = false,
+  className,
+  contentClassName,
+}: PageShellProps) {
   useDetailPanelSlot(detailPanel);
   return (
-    <div className={cn('flex flex-col flex-1 min-h-0 bg-surface-canvas', className)} data-shell="page">
+    <div
+      className={cn('flex flex-col flex-1 min-h-0 bg-surface-canvas', className)}
+      data-shell="page"
+    >
       {header && <ShellHeader {...header} />}
-      <div className={cn('flex-1 min-h-0 overflow-y-auto', contentClassName)}>
-        {children}
+      <div className="flex-1 min-h-0 overflow-y-auto">
+        <div
+          className={cn(
+            'px-8 pt-7 pb-9',
+            fluid ? 'w-full' : 'mx-auto w-full max-w-[1600px]',
+            contentClassName,
+          )}
+        >
+          {children}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
Closes #94.

## Root cause
PageShell content was capped at `max-w-5xl` (1024px) centered via per-route `mx-auto max-w-5xl p-8` wrappers. On a 1680px viewport the content column was only 1024px → ~182px gutters each side (the reported right whitespace); the prototype's constrained width is actually **1600px**.

## Fix
- `PageShell` now mirrors the prototype `.main-padded`: padding `28/32/36`, default **constrained** = `mx-auto max-w-[1600px]`, plus a `fluid` prop for full-bleed (prototype `page-shell--fluid`).
- Removed the redundant `mx-auto max-w-5xl p-8` wrappers from `managed-systems.tsx` + `analytics-areas.tsx`; they inherit PageShell padding/width. VOC create (also PageShell) now gets consistent padding.

## Verification
- Browser (Playwright, 1680×1050): content column now spans full main width (1387px here, caps at 1600 on wider) right-edge 1679 — gutter gone. Padding 28/32/36 confirmed.
- `@fops/ui` typecheck clean; biome clean on touched files.
- Admin route tests: 8/8 pass.

## Note (pre-existing, not from this PR)
`analytics-areas.tsx` has a pre-existing biome `useSemanticElements` hit on the catalog row (confirmed present on `develop` from #88) — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)