### PR TITLE
fix(#98): lock all header/toolbar bars to 50px rhythm

### DIFF
--- a/.review/ISSUE-98-CODEX.json
+++ b/.review/ISSUE-98-CODEX.json
@@ -1,0 +1,66 @@
+{
+  "issue": 98,
+  "branch": "feature/98-header-row-parity",
+  "summary": "Unified route header and toolbar rows on the shared 50px h-toolbar token, and locked the triage queue row padding test to the prototype value.",
+  "files_changed": [
+    "packages/ui/src/toolbar/ListToolbar.tsx",
+    "packages/ui/src/toolbar/__tests__/ListToolbar.test.tsx",
+    "packages/ui/src/layout/ListShell.tsx",
+    "packages/ui/__tests__/shells.test.tsx",
+    "apps/frontend/src/features/voc/components/triage/VocTriageScreen.tsx",
+    "apps/frontend/src/features/voc/components/triage/__tests__/VocTriageScreen.kicker.test.tsx",
+    "apps/frontend/src/features/voc/components/triage/__tests__/TriageRow.test.tsx",
+    "docs/adr/0020-shell-taxonomy-three-route-shells-and-50px-header-rhythm.md",
+    ".review/ISSUE-98-CODEX.json"
+  ],
+  "bar_class_changes": [
+    {
+      "surface": "ListToolbar root",
+      "file": "packages/ui/src/toolbar/ListToolbar.tsx",
+      "before": "flex items-center justify-between gap-3 border-b border-border-subtle px-4 py-2 bg-surface-canvas sticky top-0 z-10",
+      "after": "flex h-toolbar items-center justify-between gap-3 border-b border-border-subtle px-4 bg-surface-canvas sticky top-0 z-10",
+      "marker_added": "data-toolbar-height=\"50\""
+    },
+    {
+      "surface": "ListShell tabs row",
+      "file": "packages/ui/src/layout/ListShell.tsx",
+      "before": "border-b border-border-subtle px-4 py-2 bg-surface-canvas",
+      "after": "flex h-toolbar items-center border-b border-border-subtle px-4 bg-surface-canvas",
+      "marker_added": "data-list-shell-tabs=\"\" data-toolbar-height=\"50\""
+    },
+    {
+      "surface": "VOC triage route-owned toolbar",
+      "file": "apps/frontend/src/features/voc/components/triage/VocTriageScreen.tsx",
+      "before": "flex items-center gap-2 px-5 h-[50px] border-b border-border-subtle bg-surface-detail shrink-0",
+      "after": "flex items-center gap-2 px-5 h-toolbar border-b border-border-subtle bg-surface-detail shrink-0",
+      "marker_added": "data-toolbar-height=\"50\""
+    }
+  ],
+  "triage_queue_row": {
+    "prototype_source": "docs/design-prototype/screen-voc-create.jsx TriageQueueRow + docs/design-prototype/styles.css .object-row.expanded",
+    "prototype_padding": "padding: 14px 20px",
+    "tailwind_value_mirrored": "py-3.5 px-5",
+    "min_height": "min-h-[96px]",
+    "production_change": "No content or column change; TriageRow already used the prototype padding, so a regression test now locks min-h-[96px] py-3.5 px-5."
+  },
+  "verification": [
+    {
+      "command": "pnpm --filter @fops/ui test",
+      "result": "passed",
+      "test_files": "44 passed",
+      "tests": "482 passed"
+    },
+    {
+      "command": "pnpm --filter @fops/frontend exec vitest run src/features/voc/components/triage/__tests__/TriageRow.test.tsx src/features/voc/components/triage/__tests__/VocTriageScreen.kicker.test.tsx",
+      "result": "passed",
+      "test_files": "2 passed",
+      "tests": "14 passed",
+      "note": "Existing stderr remains in VocTriageScreen.kicker.test.tsx for relative URL parsing during optimistic mutation failure path; tests pass."
+    },
+    {
+      "command": "pnpm exec biome check packages/ui/src/toolbar/ListToolbar.tsx packages/ui/src/layout/ListShell.tsx packages/ui/src/toolbar/__tests__/ListToolbar.test.tsx packages/ui/__tests__/shells.test.tsx apps/frontend/src/features/voc/components/triage/VocTriageScreen.tsx apps/frontend/src/features/voc/components/triage/__tests__/TriageRow.test.tsx apps/frontend/src/features/voc/components/triage/__tests__/VocTriageScreen.kicker.test.tsx docs/adr/0020-shell-taxonomy-three-route-shells-and-50px-header-rhythm.md",
+      "result": "passed",
+      "output": "Checked 7 files in 21ms. No fixes applied."
+    }
+  ]
+}

--- a/apps/frontend/src/features/voc/components/triage/VocTriageScreen.tsx
+++ b/apps/frontend/src/features/voc/components/triage/VocTriageScreen.tsx
@@ -67,7 +67,8 @@ export function VocTriageScreen({
       {/* V1: ShellHeader removed from WorkbenchShell; route identity lives here as a left-edge kicker. */}
       <div
         data-testid="triage-toolbar"
-        className="flex items-center gap-2 px-5 h-[50px] border-b border-border-subtle bg-surface-detail shrink-0"
+        className="flex items-center gap-2 px-5 h-toolbar border-b border-border-subtle bg-surface-detail shrink-0"
+        data-toolbar-height="50"
       >
         {/* Kicker: "Console · Triage" — absorbs route identity previously held by ShellHeader toolbar prop. */}
         <div

--- a/apps/frontend/src/features/voc/components/triage/__tests__/TriageRow.test.tsx
+++ b/apps/frontend/src/features/voc/components/triage/__tests__/TriageRow.test.tsx
@@ -1,12 +1,7 @@
-// TriageRow.test.tsx — RED tests for the 96px expanded triage queue row.
-// Prototype ref: screen-voc-create.jsx:367-389
-// TDD RED: these tests are written before the implementation file exists.
-
-import * as React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import type { VocListItem } from '@fops/shared';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { TriageRow } from '../TriageRow';
-import type { VocListItem } from '@fops/shared';
 
 const BASE_VOC: VocListItem = {
   id: '00000000-0000-0000-0000-000000000001',
@@ -27,6 +22,14 @@ const BASE_VOC: VocListItem = {
 };
 
 describe('TriageRow', () => {
+  it('mirrors prototype expanded row padding and min height', () => {
+    render(<TriageRow voc={BASE_VOC} selected={false} onSelect={vi.fn()} />);
+    const row = screen.getByRole('button');
+    expect(row.className).toContain('min-h-[96px]');
+    expect(row.className).toContain('py-3.5');
+    expect(row.className).toContain('px-5');
+  });
+
   it('renders the voc title and display_id', () => {
     render(<TriageRow voc={BASE_VOC} selected={false} onSelect={vi.fn()} />);
     expect(screen.getByText('Test VOC title')).toBeInTheDocument();

--- a/apps/frontend/src/features/voc/components/triage/__tests__/VocTriageScreen.kicker.test.tsx
+++ b/apps/frontend/src/features/voc/components/triage/__tests__/VocTriageScreen.kicker.test.tsx
@@ -52,6 +52,24 @@ function Wrapper({ children }: { children: React.ReactNode }) {
 }
 
 describe('VocTriageScreen — V1 inline kicker', () => {
+  it('locks the route-owned toolbar to the 50px h-toolbar rhythm', () => {
+    render(
+      <Wrapper>
+        <VocTriageScreen
+          items={[MOCK_VOC]}
+          selectedId={MOCK_VOC.id}
+          activeTab="untriaged"
+          onSelectVoc={vi.fn()}
+          onTabChange={vi.fn()}
+        />
+      </Wrapper>,
+    );
+
+    const toolbar = screen.getByTestId('triage-toolbar');
+    expect(toolbar.className).toContain('h-toolbar');
+    expect(toolbar).toHaveAttribute('data-toolbar-height', '50');
+  });
+
   it('renders "Console" kicker label in the toolbar', () => {
     render(
       <Wrapper>

--- a/docs/adr/0020-shell-taxonomy-three-route-shells-and-50px-header-rhythm.md
+++ b/docs/adr/0020-shell-taxonomy-three-route-shells-and-50px-header-rhythm.md
@@ -30,6 +30,8 @@ The following surfaces MUST share a single 50px height baseline:
 - Detail-panel drawer header (`<DetailPanelHeader>` and its analogues).
 - Survey preview drawer header.
 
+Production toolbar rows, including `ListToolbar`, `ListShell` extension rows, and route-owned inline toolbars, enforce this with the shared `h-toolbar` token.
+
 `PageShell` itself does not impose a 50px header — its layout is content-driven, not toolbar-driven — but any drawer or panel that opens on top of a `PageShell` MUST follow the 50px rule for its own header.
 
 ### 3. Source of truth: baseline screenshots + manifest

--- a/packages/ui/__tests__/shells.test.tsx
+++ b/packages/ui/__tests__/shells.test.tsx
@@ -1,6 +1,12 @@
-import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { PageShell, ListShell, WorkbenchShell, ShellHeader, DetailPanelSlotContext } from '../src/index';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  DetailPanelSlotContext,
+  ListShell,
+  PageShell,
+  ShellHeader,
+  WorkbenchShell,
+} from '../src/index';
 
 describe('Three-shell taxonomy (ADR-0020)', () => {
   it('PageShell renders with data-shell="page" and 50px header', () => {
@@ -14,15 +20,41 @@ describe('Three-shell taxonomy (ADR-0020)', () => {
 
   it('ListShell renders with data-shell="list" and tabs slot', () => {
     const { container } = render(
-      <ListShell toolbar={{ title: 'Inbox' }} tabs={<div data-testid="tabs">tabs</div>} list={<ul><li>row</li></ul>} />,
+      <ListShell
+        toolbar={{ title: 'Inbox' }}
+        tabs={<div data-testid="tabs">tabs</div>}
+        list={
+          <ul>
+            <li>row</li>
+          </ul>
+        }
+      />,
     );
     expect(container.querySelector('[data-shell="list"]')).toBeInTheDocument();
     expect(screen.getByTestId('tabs')).toBeInTheDocument();
     expect(screen.getByText('row')).toBeInTheDocument();
   });
 
+  it('ListShell tabs row locks to the 50px h-toolbar rhythm', () => {
+    const { container } = render(
+      <ListShell
+        tabs={<div data-testid="tabs">tabs</div>}
+        list={
+          <ul>
+            <li>row</li>
+          </ul>
+        }
+      />,
+    );
+    const tabsRow = container.querySelector('[data-list-shell-tabs]');
+    expect(tabsRow?.className).toContain('h-toolbar');
+    expect(tabsRow).toHaveAttribute('data-toolbar-height', '50');
+  });
+
   it('WorkbenchShell renders with data-shell="workbench"', () => {
-    const { container } = render(<WorkbenchShell toolbar={{ title: 'Triage' }}>workbench body</WorkbenchShell>);
+    const { container } = render(
+      <WorkbenchShell toolbar={{ title: 'Triage' }}>workbench body</WorkbenchShell>,
+    );
     expect(container.querySelector('[data-shell="workbench"]')).toBeInTheDocument();
     expect(screen.getByText(/workbench body/)).toBeInTheDocument();
   });
@@ -58,7 +90,9 @@ describe('useDetailPanelSlot forwarding', () => {
       </DetailPanelSlotContext.Provider>,
     );
     expect(setContent).toHaveBeenCalledTimes(1);
-    const [, node] = setContent.mock.calls[0]!;
+    const firstCall = setContent.mock.calls[0];
+    expect(firstCall).toBeDefined();
+    const [, node] = firstCall ?? [];
     expect(node).toBeDefined();
   });
 

--- a/packages/ui/src/layout/ListShell.tsx
+++ b/packages/ui/src/layout/ListShell.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type * as React from 'react';
 import { cn } from '../utils/cn';
 import { ShellHeader, type ShellHeaderProps } from './ShellHeader';
 import { useDetailPanelSlot } from './useDetailPanelSlot';
@@ -22,12 +22,21 @@ export interface ListShellProps {
 export function ListShell({ toolbar, list, tabs, detailPanel, className }: ListShellProps) {
   useDetailPanelSlot(detailPanel);
   return (
-    <div className={cn('flex flex-col flex-1 min-h-0 bg-surface-list', className)} data-shell="list">
+    <div
+      className={cn('flex flex-col flex-1 min-h-0 bg-surface-list', className)}
+      data-shell="list"
+    >
       {toolbar && <ShellHeader {...toolbar} variant="toolbar" />}
-      {tabs && <div className="border-b border-border-subtle px-4 py-2 bg-surface-canvas">{tabs}</div>}
-      <div className="flex-1 min-h-0 overflow-y-auto">
-        {list}
-      </div>
+      {tabs && (
+        <div
+          className="flex h-toolbar items-center border-b border-border-subtle px-4 bg-surface-canvas"
+          data-list-shell-tabs=""
+          data-toolbar-height="50"
+        >
+          {tabs}
+        </div>
+      )}
+      <div className="flex-1 min-h-0 overflow-y-auto">{list}</div>
     </div>
   );
 }

--- a/packages/ui/src/toolbar/ListToolbar.tsx
+++ b/packages/ui/src/toolbar/ListToolbar.tsx
@@ -36,9 +36,10 @@ export function ListToolbar({
   return (
     <div
       className={cn(
-        'flex items-center justify-between gap-3 border-b border-border-subtle px-4 py-2 bg-surface-canvas sticky top-0 z-10',
+        'flex h-toolbar items-center justify-between gap-3 border-b border-border-subtle px-4 bg-surface-canvas sticky top-0 z-10',
         className,
       )}
+      data-toolbar-height="50"
     >
       <div className="flex items-center min-w-0">
         {tabs !== undefined ? (

--- a/packages/ui/src/toolbar/__tests__/ListToolbar.test.tsx
+++ b/packages/ui/src/toolbar/__tests__/ListToolbar.test.tsx
@@ -11,6 +11,13 @@ const tabs: ListToolbarTab[] = [
 ];
 
 describe('ListToolbar — tabs mode', () => {
+  it('locks the toolbar row to the 50px h-toolbar rhythm', () => {
+    const { container } = render(<ListToolbar tabs={tabs} activeTab="untriaged" />);
+    const toolbar = container.firstElementChild;
+    expect(toolbar?.className).toContain('h-toolbar');
+    expect(toolbar).toHaveAttribute('data-toolbar-height', '50');
+  });
+
   it('renders all tab labels', () => {
     render(<ListToolbar tabs={tabs} activeTab="untriaged" />);
     expect(screen.getByText('미분류')).toBeInTheDocument();
@@ -56,7 +63,13 @@ describe('ListToolbar — tabs mode', () => {
   });
 
   it('renders action slot when provided', () => {
-    render(<ListToolbar tabs={tabs} activeTab="untriaged" action={<button>+ New VOC</button>} />);
+    render(
+      <ListToolbar
+        tabs={tabs}
+        activeTab="untriaged"
+        action={<button type="button">+ New VOC</button>}
+      />,
+    );
     expect(screen.getByText('+ New VOC')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Closes #98.

## Root cause (measured live at 1440)
VOC inbox `ListToolbar` rendered **57px** — it used `px-4 py-2` (content-driven) instead of the locked 50px rhythm. Triage toolbar + ShellHeader were already 50px.

## Fix
- `ListToolbar` + `ListShell` tabs row → `h-toolbar` (50px) + `items-center` (drop `py-2`).
- Triage toolbar hardcoded `h-[50px]` → `h-toolbar` token (same value, consistency).
- Triage queue row: already matches prototype `TriageQueueRow` = `object-row expanded` (96px, 14×20px). No change; locked with a regression test.
- Doc-sync: ADR-0020 note.

## Note on "rows too tall"
The triage rows (96px) are **prototype-faithful** — `screen-voc-create.jsx` TriageQueueRow uses `object-row expanded` (`--row-height-expanded: 96px`, padding 14/20). Matching the prototype 1:1 means keeping 96px. Going tighter would be a deliberate deviation from the prototype.

## Verification
- `verify.sh --typecheck`: PASS (no new errors beyond baseline — shared-UI blast radius clean).
- `@fops/ui` vitest: 482 pass; triage vitest: 14 pass; biome clean on touched files.
- Header height now 50px == triage == ShellHeader (deterministic via `h-toolbar` token + unit assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)