### PR TITLE
feat(#95): sidebar prototype icons + collapsed icon rail

### DIFF
--- a/apps/frontend/src/lib/layout/AppSidebar.tsx
+++ b/apps/frontend/src/lib/layout/AppSidebar.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
-import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { cn } from '@fops/ui';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import * as React from 'react';
 
 export interface SidebarNavEntry {
   id: string;
@@ -23,7 +23,9 @@ const STORAGE_KEY = 'appSidebarCollapsed';
 function readInitialCollapsed(defaultValue: boolean): boolean {
   if (typeof window === 'undefined') return defaultValue;
   try {
-    return localStorage.getItem(STORAGE_KEY) === '1';
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored === null) return defaultValue;
+    return stored === '1';
   } catch {
     return defaultValue;
   }
@@ -76,11 +78,7 @@ export function AppSidebar({
           aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
           data-testid="sidebar-collapse-toggle"
         >
-          {collapsed ? (
-            <ChevronRight className="h-4 w-4" />
-          ) : (
-            <ChevronLeft className="h-4 w-4" />
-          )}
+          {collapsed ? <ChevronRight className="h-4 w-4" /> : <ChevronLeft className="h-4 w-4" />}
         </button>
       </div>
       <nav className="flex-1 overflow-y-auto py-2">
@@ -91,10 +89,13 @@ export function AppSidebar({
                 href={e.href}
                 className={cn(
                   'flex items-center gap-2 px-3 py-1.5 text-sm rounded-md mx-2 text-text-secondary hover:bg-surface-row-hover hover:text-text-primary',
+                  collapsed && 'justify-center px-0 mx-1',
                   e.active && 'bg-surface-row-selected text-text-primary',
                 )}
                 data-testid={`sidebar-nav-${e.id}`}
                 aria-current={e.active ? 'page' : undefined}
+                title={collapsed ? e.label : undefined}
+                aria-label={collapsed ? e.label : undefined}
               >
                 {e.icon && <span className="shrink-0">{e.icon}</span>}
                 {!collapsed && <span className="truncate">{e.label}</span>}

--- a/apps/frontend/src/lib/layout/__tests__/AppSidebar.test.tsx
+++ b/apps/frontend/src/lib/layout/__tests__/AppSidebar.test.tsx
@@ -1,9 +1,10 @@
-import { describe, it, expect, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { Inbox } from 'lucide-react';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { AppSidebar } from '../AppSidebar';
 
 const entries = [
-  { id: 'inbox', label: 'Inbox', href: '/inbox' },
+  { id: 'inbox', label: 'Inbox', href: '/inbox', icon: <Inbox className="h-4 w-4" /> },
   { id: 'my', label: 'My', href: '/my', active: true },
 ];
 
@@ -30,5 +31,61 @@ describe('AppSidebar', () => {
     localStorage.setItem('appSidebarCollapsed', '1');
     render(<AppSidebar entries={entries} />);
     expect(screen.getByTestId('app-sidebar').getAttribute('data-collapsed')).toBe('true');
+  });
+
+  it('renders icon when icon prop is provided (expanded)', () => {
+    render(<AppSidebar entries={entries} />);
+    // The svg inside the Inbox icon should be in the document
+    const navLink = screen.getByTestId('sidebar-nav-inbox');
+    expect(navLink.querySelector('svg')).not.toBeNull();
+  });
+
+  it('icon remains visible when sidebar is collapsed', () => {
+    render(<AppSidebar entries={entries} defaultCollapsed={true} />);
+    expect(screen.getByTestId('app-sidebar').getAttribute('data-collapsed')).toBe('true');
+    const navLink = screen.getByTestId('sidebar-nav-inbox');
+    // Icon (svg) is still rendered in collapsed state
+    expect(navLink.querySelector('svg')).not.toBeNull();
+  });
+
+  it('collapsed icon nav link has accessible title and aria-label', () => {
+    render(<AppSidebar entries={entries} defaultCollapsed={true} />);
+    const navLink = screen.getByTestId('sidebar-nav-inbox');
+    expect(navLink.getAttribute('title')).toBe('Inbox');
+    expect(navLink.getAttribute('aria-label')).toBe('Inbox');
+  });
+
+  it('collapsed icon nav link has correct href and is clickable', () => {
+    render(<AppSidebar entries={entries} defaultCollapsed={true} />);
+    const navLink = screen.getByTestId('sidebar-nav-inbox');
+    expect(navLink.getAttribute('href')).toBe('/inbox');
+    // Link is an <a> element and is present in the DOM — navigation works
+    expect(navLink.tagName).toBe('A');
+  });
+
+  it('hides label text in collapsed state', () => {
+    render(<AppSidebar entries={entries} defaultCollapsed={true} />);
+    // Label text element is not rendered when collapsed
+    const navLink = screen.getByTestId('sidebar-nav-inbox');
+    const labelSpan = Array.from(navLink.querySelectorAll('span')).find(
+      (el) => el.textContent === 'Inbox',
+    );
+    expect(labelSpan).toBeUndefined();
+  });
+
+  it('shows label text in expanded state', () => {
+    render(<AppSidebar entries={entries} />);
+    const navLink = screen.getByTestId('sidebar-nav-inbox');
+    const labelSpan = Array.from(navLink.querySelectorAll('span')).find(
+      (el) => el.textContent === 'Inbox',
+    );
+    expect(labelSpan).toBeDefined();
+  });
+
+  it('expanded state does not set title/aria-label (label is visible)', () => {
+    render(<AppSidebar entries={entries} />);
+    const navLink = screen.getByTestId('sidebar-nav-inbox');
+    expect(navLink.getAttribute('title')).toBeNull();
+    expect(navLink.getAttribute('aria-label')).toBeNull();
   });
 });

--- a/apps/frontend/src/routes/_authed.tsx
+++ b/apps/frontend/src/routes/_authed.tsx
@@ -10,19 +10,36 @@
 // INSIDE AppFrame — not here. ADR-0020 §taxonomy lock.
 
 import { Outlet, createFileRoute, redirect } from '@tanstack/react-router';
-import { AppFrame } from '../lib/layout/AppFrame';
+import { Database, Flag, Inbox, Layers, Plus, User } from 'lucide-react';
 import { UnauthenticatedError, fetchMe } from '../lib/api';
+import { AppFrame } from '../lib/layout/AppFrame';
 
 // Sidebar entries locked per Slice 3 #18 spec (C5).
 // Per-feature entries are added in their owning slice (AGENTS.md two-consumer rule).
+// Icons mapped from docs/design-prototype/shell.jsx NAV_TREE.voc + NAV_TREE.admin per #95.
 const SIDEBAR_ENTRIES = [
-  { id: 'inbox',    label: 'Inbox',            href: '/vocs?view=inbox' },
-  { id: 'my-vocs',  label: 'My VOCs',          href: '/vocs?view=my' },
-  { id: 'triage',   label: 'Triage',           href: '/vocs?view=triage' },
-  { id: 'create',   label: '+ New VOC',        href: '/vocs?action=create' },
+  { id: 'inbox', label: 'Inbox', href: '/vocs?view=inbox', icon: <Inbox className="h-4 w-4" /> },
+  { id: 'my-vocs', label: 'My VOCs', href: '/vocs?view=my', icon: <User className="h-4 w-4" /> },
+  { id: 'triage', label: 'Triage', href: '/vocs?view=triage', icon: <Flag className="h-4 w-4" /> },
+  {
+    id: 'create',
+    label: '+ New VOC',
+    href: '/vocs?action=create',
+    icon: <Plus className="h-4 w-4" />,
+  },
   // Admin entries — existing routes remain reachable via sidebar.
-  { id: 'admin-ms', label: 'Managed Systems',  href: '/admin/managed-systems' },
-  { id: 'admin-aa', label: 'Analytics Areas',  href: '/admin/analytics-areas' },
+  {
+    id: 'admin-ms',
+    label: 'Managed Systems',
+    href: '/admin/managed-systems',
+    icon: <Database className="h-4 w-4" />,
+  },
+  {
+    id: 'admin-aa',
+    label: 'Analytics Areas',
+    href: '/admin/analytics-areas',
+    icon: <Layers className="h-4 w-4" />,
+  },
 ];
 
 export const Route = createFileRoute('/_authed')({


### PR DESCRIPTION
Closes #95.

## Summary
- Added per-nav `lucide-react` icons mapped from prototype `shell.jsx` NAV_TREE: Inbox→Inbox, My VOCs→User, Triage→Flag, +New VOC→Plus, Managed Systems→Database, Analytics Areas→Layers.
- Collapsed sidebar = icon-only rail: icon stays visible, link stays a working `<a href>` nav, gains `title`/`aria-label` for accessibility; `justify-center` centers the icon.
- Fix: `readInitialCollapsed` now falls back to the `defaultCollapsed` prop when localStorage has no stored value (was always false).

## Verification
- frontend vitest: 477 pass (incl. 6 new AppSidebar tests: icon renders, collapsed icon visible + accessible + correct href).
- typecheck (frontend + @fops/ui) clean; biome clean on touched files.
- Live 1440 collapsed/expanded check appended after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)