### PR TITLE
fix(#104): VOC inbox row layout to prototype .object-row rhythm

### DIFF
--- a/apps/frontend/src/features/voc/components/list/VocRow.tsx
+++ b/apps/frontend/src/features/voc/components/list/VocRow.tsx
@@ -125,8 +125,8 @@ export function VocRow({
       onClick={onSelect}
       onKeyDown={handleKeyDown}
       className={cn(
-        // Base layout
-        'relative flex w-full items-center gap-3 px-4 h-15 text-left cursor-pointer',
+        // Base layout — prototype .object-row: min-height 60px, padding 10px 20px, gap 12px
+        'relative flex w-full items-center gap-3 px-5 py-2.5 min-h-[60px] text-left cursor-pointer',
         // Hover
         'hover:bg-surface-row-hover',
         // Selected: tinted background + 2px left accent bar (prototype parity)
@@ -185,7 +185,7 @@ export function VocRow({
                 </span>
               )}
             </div>
-            <div className="flex items-center gap-2 text-xs text-text-muted flex-wrap">
+            <div className="flex items-center gap-2 text-xs text-text-muted overflow-hidden">
               <ReporterStatusBadge status={voc.reporter_facing_status} />
               {voc.severity !== null && <SeverityBadge severity={voc.severity} />}
               {managedSystem !== null && managedSystem !== undefined && (


### PR DESCRIPTION
Closes #104.

## Fix
VocRow base layout matched to prototype `.object-row` (`docs/design-prototype/styles.css`): `h-15` (fixed, no padding) → `min-h-[60px] py-2.5 px-5` (60px min + 10px vertical, 20px horizontal). Meta line `flex-wrap` → `overflow-hidden` (single line with `·` separators, per prototype `.row-meta`).
- Element visibility unchanged (severity/similar/AA/avatars stay data-gated; seed severity is null on most rows by design).

## Verification
- VocRow vitest 21/21; typecheck no new errors; biome no new errors (pre-existing role=row hit only).
- Live 1440 height/line check appended after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)