### PR TITLE
feat(#103): sidebar section grouping + footer (current-slice scope)

### DIFF
--- a/.review/ISSUE-103-CODEX.json
+++ b/.review/ISSUE-103-CODEX.json
@@ -1,0 +1,77 @@
+{
+  "issue": 103,
+  "scope": "CURRENT-SLICE sidebar structure parity only",
+  "files_changed": [
+    "apps/frontend/src/lib/layout/AppSidebar.tsx",
+    "apps/frontend/src/lib/layout/__tests__/AppSidebar.test.tsx",
+    "apps/frontend/src/routes/_authed.tsx",
+    "docs/frontend/routes-and-layout.md",
+    ".review/ISSUE-103-CODEX.json"
+  ],
+  "section_grouping_used": [
+    {
+      "section": "VOC",
+      "entries": ["Inbox", "+ New VOC"]
+    },
+    {
+      "section": "VIEWS",
+      "entries": ["Triage", "My VOCs"]
+    },
+    {
+      "section": "MANAGED SYSTEMS",
+      "entries": ["Managed Systems", "Analytics Areas"]
+    }
+  ],
+  "footer_routes_chosen": {
+    "Workspace settings": {
+      "type": "link",
+      "href": "/admin/placeholder",
+      "reason": "No concrete /admin/settings route file exists in apps/frontend/src/routes/_authed/admin; /admin/placeholder is an existing admin route."
+    },
+    "Invite member": {
+      "type": "disabled_button",
+      "reason": "Prototype item is no-op and no backend/API was invented."
+    }
+  },
+  "collapsed_handling": {
+    "section_labels": "not rendered while collapsed",
+    "nav_items": "existing icon rail behavior preserved with icons, hrefs, title, and aria-label",
+    "footer_items": "icons remain visible; collapsed labels are hidden; title and aria-label provide accessible names"
+  },
+  "verification": {
+    "red_test": {
+      "command": "pnpm --filter @fops/frontend test src/lib/layout/__tests__/AppSidebar.test.tsx",
+      "result": "failed before implementation: missing sidebar-section-voc and sidebar-footer-workspace-settings"
+    },
+    "focused_unit_test": {
+      "command": "pnpm --filter @fops/frontend test src/lib/layout/__tests__/AppSidebar.test.tsx",
+      "result": "13 passed / 13"
+    },
+    "frontend_unit_suite": {
+      "command": "pnpm --filter @fops/frontend test",
+      "result": "480 passed / 480 across 111 files"
+    },
+    "typecheck": {
+      "command": "pnpm typecheck",
+      "result": "blocked by pre-existing backend error: apps/backend/src/cli/storage-bootstrap.ts(54,31) ProcessEnv has no properties in common with StorageEnv"
+    },
+    "frontend_typecheck": {
+      "command": "pnpm --filter @fops/frontend typecheck",
+      "result": "blocked by pre-existing VOC fixture attachment_count/attachments errors and missing routeTree.gen; no AppSidebar.tsx error remains"
+    },
+    "ui_typecheck": {
+      "command": "pnpm --filter @fops/ui typecheck",
+      "result": "passed"
+    },
+    "biome": {
+      "command": "pnpm exec biome check apps/frontend/src/lib/layout/AppSidebar.tsx apps/frontend/src/lib/layout/__tests__/AppSidebar.test.tsx apps/frontend/src/routes/_authed.tsx docs/frontend/routes-and-layout.md .review/ISSUE-103-CODEX.json",
+      "result": "passed for 4 checked files; Markdown ignored by current Biome config"
+    }
+  },
+  "not_built_confirmation": {
+    "count_badges": "not built",
+    "managed_system_scope_selector": "not built",
+    "future_nav_items": "not built",
+    "individual_managed_system_nav_rows": "not built"
+  }
+}

--- a/apps/frontend/src/lib/layout/AppSidebar.tsx
+++ b/apps/frontend/src/lib/layout/AppSidebar.tsx
@@ -1,17 +1,27 @@
 import { cn } from '@fops/ui';
-import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Settings, UserPlus } from 'lucide-react';
 import * as React from 'react';
 
 export interface SidebarNavEntry {
   id: string;
   label: string;
   href: string;
+  section?: string;
   icon?: React.ReactNode;
   active?: boolean;
 }
 
+export interface SidebarFooterItem {
+  id: string;
+  label: string;
+  href?: string;
+  icon: React.ReactNode;
+  disabled?: boolean;
+}
+
 export interface AppSidebarProps {
   entries: SidebarNavEntry[];
+  footerItems?: SidebarFooterItem[];
   workspaceName?: string;
   className?: string;
   /** Override initial collapsed state (for tests / SSR). */
@@ -19,6 +29,20 @@ export interface AppSidebarProps {
 }
 
 const STORAGE_KEY = 'appSidebarCollapsed';
+const DEFAULT_FOOTER_ITEMS: SidebarFooterItem[] = [
+  {
+    id: 'invite-member',
+    label: 'Invite member',
+    icon: <UserPlus className="h-4 w-4" />,
+    disabled: true,
+  },
+  {
+    id: 'workspace-settings',
+    label: 'Workspace settings',
+    href: '/admin/placeholder',
+    icon: <Settings className="h-4 w-4" />,
+  },
+];
 
 function readInitialCollapsed(defaultValue: boolean): boolean {
   if (typeof window === 'undefined') return defaultValue;
@@ -33,6 +57,7 @@ function readInitialCollapsed(defaultValue: boolean): boolean {
 
 export function AppSidebar({
   entries,
+  footerItems = DEFAULT_FOOTER_ITEMS,
   workspaceName = 'FeedbackOps',
   className,
   defaultCollapsed = false,
@@ -81,29 +106,92 @@ export function AppSidebar({
           {collapsed ? <ChevronRight className="h-4 w-4" /> : <ChevronLeft className="h-4 w-4" />}
         </button>
       </div>
-      <nav className="flex-1 overflow-y-auto py-2">
-        <ul className="flex flex-col gap-0.5">
-          {entries.map((e) => (
-            <li key={e.id}>
-              <a
-                href={e.href}
-                className={cn(
-                  'flex items-center gap-2 px-3 py-1.5 text-sm rounded-md mx-2 text-text-secondary hover:bg-surface-row-hover hover:text-text-primary',
-                  collapsed && 'justify-center px-0 mx-1',
-                  e.active && 'bg-surface-row-selected text-text-primary',
+      <nav className="flex-1 overflow-y-auto px-2 py-2">
+        <div className="flex flex-col gap-0.5">
+          {entries.map((e, index) => {
+            const section = e.section;
+            const showSection =
+              !collapsed && section !== undefined && section !== entries[index - 1]?.section;
+
+            return (
+              <React.Fragment key={e.id}>
+                {showSection && (
+                  <div
+                    className={cn(
+                      'mx-2 mb-1 text-caption font-semibold uppercase tracking-wide text-text-disabled',
+                      index === 0 ? 'mt-1.5' : 'mt-3.5',
+                    )}
+                    data-testid={`sidebar-section-${sectionTestId(section)}`}
+                  >
+                    {section}
+                  </div>
                 )}
-                data-testid={`sidebar-nav-${e.id}`}
-                aria-current={e.active ? 'page' : undefined}
-                title={collapsed ? e.label : undefined}
-                aria-label={collapsed ? e.label : undefined}
-              >
-                {e.icon && <span className="shrink-0">{e.icon}</span>}
-                {!collapsed && <span className="truncate">{e.label}</span>}
-              </a>
-            </li>
-          ))}
-        </ul>
+                <a
+                  href={e.href}
+                  className={navItemClass(collapsed, e.active)}
+                  data-testid={`sidebar-nav-${e.id}`}
+                  aria-current={e.active ? 'page' : undefined}
+                  title={collapsed ? e.label : undefined}
+                  aria-label={collapsed ? e.label : undefined}
+                >
+                  {e.icon && <span className="shrink-0">{e.icon}</span>}
+                  {!collapsed && <span className="truncate">{e.label}</span>}
+                </a>
+              </React.Fragment>
+            );
+          })}
+        </div>
       </nav>
+      <div className="border-t border-border-subtle p-2">
+        <div className="flex flex-col gap-0.5">
+          {footerItems.map((item) => (
+            <SidebarFooterLink key={item.id} item={item} collapsed={collapsed} />
+          ))}
+        </div>
+      </div>
     </aside>
   );
+}
+
+function SidebarFooterLink({
+  item,
+  collapsed,
+}: {
+  item: SidebarFooterItem;
+  collapsed: boolean;
+}) {
+  const commonProps = {
+    className: cn(navItemClass(collapsed), item.disabled && 'opacity-60 cursor-not-allowed'),
+    'data-testid': `sidebar-footer-${item.id}`,
+    title: collapsed ? item.label : undefined,
+    'aria-label': collapsed ? item.label : undefined,
+  };
+
+  if (item.href && !item.disabled) {
+    return (
+      <a href={item.href} {...commonProps}>
+        <span className="shrink-0">{item.icon}</span>
+        {!collapsed && <span className="truncate">{item.label}</span>}
+      </a>
+    );
+  }
+
+  return (
+    <button type="button" disabled={item.disabled} {...commonProps}>
+      <span className="shrink-0">{item.icon}</span>
+      {!collapsed && <span className="truncate">{item.label}</span>}
+    </button>
+  );
+}
+
+function navItemClass(collapsed: boolean, active = false) {
+  return cn(
+    'flex items-center gap-2 rounded-md px-3 py-1.5 text-sm text-text-secondary hover:bg-surface-row-hover hover:text-text-primary',
+    collapsed && 'justify-center px-0',
+    active && 'bg-surface-row-selected text-text-primary',
+  );
+}
+
+function sectionTestId(section: string) {
+  return section.toLowerCase().replace(/\s+/g, '-');
 }

--- a/apps/frontend/src/lib/layout/__tests__/AppSidebar.test.tsx
+++ b/apps/frontend/src/lib/layout/__tests__/AppSidebar.test.tsx
@@ -1,11 +1,17 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { Inbox } from 'lucide-react';
+import { Database, Inbox, Plus, Settings } from 'lucide-react';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { AppSidebar } from '../AppSidebar';
 
 const entries = [
-  { id: 'inbox', label: 'Inbox', href: '/inbox', icon: <Inbox className="h-4 w-4" /> },
-  { id: 'my', label: 'My', href: '/my', active: true },
+  {
+    id: 'inbox',
+    label: 'Inbox',
+    href: '/inbox',
+    icon: <Inbox className="h-4 w-4" />,
+    section: 'VOC',
+  },
+  { id: 'my', label: 'My', href: '/my', active: true, section: 'VIEWS' },
 ];
 
 beforeEach(() => {
@@ -87,5 +93,105 @@ describe('AppSidebar', () => {
     const navLink = screen.getByTestId('sidebar-nav-inbox');
     expect(navLink.getAttribute('title')).toBeNull();
     expect(navLink.getAttribute('aria-label')).toBeNull();
+  });
+
+  it('renders section labels in grouping order when expanded', () => {
+    render(
+      <AppSidebar
+        entries={[
+          {
+            id: 'inbox',
+            label: 'Inbox',
+            href: '/inbox',
+            icon: <Inbox className="h-4 w-4" />,
+            section: 'VOC',
+          },
+          {
+            id: 'create',
+            label: '+ New VOC',
+            href: '/create',
+            icon: <Plus className="h-4 w-4" />,
+            section: 'VOC',
+          },
+          { id: 'triage', label: 'Triage', href: '/triage', section: 'VIEWS' },
+          { id: 'my', label: 'My VOCs', href: '/my', section: 'VIEWS' },
+          {
+            id: 'admin-ms',
+            label: 'Managed Systems',
+            href: '/admin/managed-systems',
+            icon: <Database className="h-4 w-4" />,
+            section: 'MANAGED SYSTEMS',
+          },
+        ]}
+      />,
+    );
+
+    const navItems = [
+      screen.getByTestId('sidebar-section-voc'),
+      screen.getByTestId('sidebar-nav-inbox'),
+      screen.getByTestId('sidebar-nav-create'),
+      screen.getByTestId('sidebar-section-views'),
+      screen.getByTestId('sidebar-nav-triage'),
+      screen.getByTestId('sidebar-nav-my'),
+      screen.getByTestId('sidebar-section-managed-systems'),
+      screen.getByTestId('sidebar-nav-admin-ms'),
+    ];
+
+    expect(navItems.map((node) => node.textContent)).toEqual([
+      'VOC',
+      'Inbox',
+      '+ New VOC',
+      'VIEWS',
+      'Triage',
+      'My VOCs',
+      'MANAGED SYSTEMS',
+      'Managed Systems',
+    ]);
+  });
+
+  it('hides section labels when collapsed', () => {
+    render(<AppSidebar entries={entries} defaultCollapsed={true} />);
+
+    expect(screen.queryByTestId('sidebar-section-voc')).not.toBeInTheDocument();
+    expect(screen.queryByText('VOC')).not.toBeInTheDocument();
+  });
+
+  it('renders footer items and keeps collapsed icons accessible', () => {
+    render(
+      <AppSidebar
+        entries={entries}
+        defaultCollapsed={true}
+        footerItems={[
+          {
+            id: 'workspace-settings',
+            label: 'Workspace settings',
+            href: '/admin/placeholder',
+            icon: <Settings className="h-4 w-4" />,
+          },
+          {
+            id: 'invite-member',
+            label: 'Invite member',
+            icon: <Plus className="h-4 w-4" />,
+            disabled: true,
+          },
+        ]}
+      />,
+    );
+
+    const settings = screen.getByTestId('sidebar-footer-workspace-settings');
+    const invite = screen.getByTestId('sidebar-footer-invite-member');
+
+    expect(settings).toHaveAttribute('href', '/admin/placeholder');
+    expect(settings).toHaveAttribute('title', 'Workspace settings');
+    expect(settings).toHaveAttribute('aria-label', 'Workspace settings');
+    expect(settings.querySelector('svg')).not.toBeNull();
+    expect(settings.textContent).toBe('');
+
+    expect(invite).toHaveAttribute('type', 'button');
+    expect(invite).toBeDisabled();
+    expect(invite).toHaveAttribute('title', 'Invite member');
+    expect(invite).toHaveAttribute('aria-label', 'Invite member');
+    expect(invite.querySelector('svg')).not.toBeNull();
+    expect(invite.textContent).toBe('');
   });
 });

--- a/apps/frontend/src/routes/_authed.tsx
+++ b/apps/frontend/src/routes/_authed.tsx
@@ -18,26 +18,47 @@ import { AppFrame } from '../lib/layout/AppFrame';
 // Per-feature entries are added in their owning slice (AGENTS.md two-consumer rule).
 // Icons mapped from docs/design-prototype/shell.jsx NAV_TREE.voc + NAV_TREE.admin per #95.
 const SIDEBAR_ENTRIES = [
-  { id: 'inbox', label: 'Inbox', href: '/vocs?view=inbox', icon: <Inbox className="h-4 w-4" /> },
-  { id: 'my-vocs', label: 'My VOCs', href: '/vocs?view=my', icon: <User className="h-4 w-4" /> },
-  { id: 'triage', label: 'Triage', href: '/vocs?view=triage', icon: <Flag className="h-4 w-4" /> },
+  {
+    id: 'inbox',
+    label: 'Inbox',
+    href: '/vocs?view=inbox',
+    section: 'VOC',
+    icon: <Inbox className="h-4 w-4" />,
+  },
   {
     id: 'create',
     label: '+ New VOC',
     href: '/vocs?action=create',
+    section: 'VOC',
     icon: <Plus className="h-4 w-4" />,
+  },
+  {
+    id: 'triage',
+    label: 'Triage',
+    href: '/vocs?view=triage',
+    section: 'VIEWS',
+    icon: <Flag className="h-4 w-4" />,
+  },
+  {
+    id: 'my-vocs',
+    label: 'My VOCs',
+    href: '/vocs?view=my',
+    section: 'VIEWS',
+    icon: <User className="h-4 w-4" />,
   },
   // Admin entries — existing routes remain reachable via sidebar.
   {
     id: 'admin-ms',
     label: 'Managed Systems',
     href: '/admin/managed-systems',
+    section: 'MANAGED SYSTEMS',
     icon: <Database className="h-4 w-4" />,
   },
   {
     id: 'admin-aa',
     label: 'Analytics Areas',
     href: '/admin/analytics-areas',
+    section: 'MANAGED SYSTEMS',
     icon: <Layers className="h-4 w-4" />,
   },
 ];

--- a/docs/frontend/routes-and-layout.md
+++ b/docs/frontend/routes-and-layout.md
@@ -79,6 +79,12 @@ Admin:
 - Primary nav includes Admin, Managed System Registry, Analytics Areas, Permission Requests, and settings.
 ```
 
+Current sidebar entries are grouped with the prototype section labels `VOC`,
+`VIEWS`, and `MANAGED SYSTEMS`. The current slice exposes only Inbox and + New
+VOC under `VOC`, Triage and My VOCs under `VIEWS`, and Managed Systems and
+Analytics Areas under `MANAGED SYSTEMS`; count badges, global Managed System
+scope selection, and future work routes are outside this sidebar slice.
+
 Routes may exist without being visible in navigation. Direct route access must restore AppShell and render allowed content, summary-visible content, request-access state, not_found, or permission_denied according to backend response.
 
 ## Home Queue Contract


### PR DESCRIPTION
Closes #103.

## Summary (current-slice scope, per user)
- Sidebar nav grouped into prototype-style uppercase sections: **VOC** (Inbox, +New VOC), **VIEWS** (Triage, My VOCs), **MANAGED SYSTEMS** (Managed Systems, Analytics Areas). Added `section?` to `SidebarNavEntry`.
- Footer (`.sidebar-footer` parity): "Invite member" (no-op/disabled, prototype is no-op) + "Workspace settings" (→ /admin/placeholder; no settings route yet).
- Collapsed: section labels + footer text hidden, icon rail + footer icons stay visible/accessible (preserves #95).

## Deferred (out of scope — no data / ahead-of-slice; NOT built)
- Per-item count badges (no live count source).
- "All Managed Systems" scope selector + MS-scope state.
- Queues/Clusters/Findings/Tasks nav (Slices 4–7).

## Verification
- `verify.sh --typecheck`: PASS (no new errors beyond baseline).
- frontend vitest 480; AppSidebar 13; @fops/ui typecheck pass; biome clean.
- Doc-sync: routes-and-layout.md.
- Live 1440 check (sections/footer/collapsed) appended after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)