### PR TITLE
fix(#107): sidebar label 10px + VOC detail section inset alignment

### DIFF
--- a/apps/frontend/src/features/voc/components/detail/ConversationTimeline.tsx
+++ b/apps/frontend/src/features/voc/components/detail/ConversationTimeline.tsx
@@ -34,18 +34,18 @@ export function ConversationTimeline({ voc }: ConversationTimelineProps): React.
     <div>
       <PanelSectionTitle>대화</PanelSectionTitle>
       <Tabs defaultValue="public" className="w-full">
-        <TabsList className="mx-4">
+        <TabsList>
           <TabsTrigger value="public">공개</TabsTrigger>
           <TabsTrigger value="internal">내부</TabsTrigger>
         </TabsList>
-        <TabsContent value="public" className="px-4">
+        <TabsContent value="public">
           <PublicTimeline
             vocId={voc.id}
             inline={publicEntries}
             hasMore={voc.conversation_page.has_more}
           />
         </TabsContent>
-        <TabsContent value="internal" className="px-4">
+        <TabsContent value="internal">
           <InternalTimeline
             vocId={voc.id}
             inline={internalEntries}

--- a/apps/frontend/src/features/voc/components/detail/DescriptionSection.tsx
+++ b/apps/frontend/src/features/voc/components/detail/DescriptionSection.tsx
@@ -41,7 +41,7 @@ export function DescriptionSection({
   const [modalOpen, setModalOpen] = React.useState(false);
 
   return (
-    <div className="px-4">
+    <div>
       <p className="text-xs font-semibold uppercase tracking-wide text-text-muted mb-2">
         BODY
       </p>

--- a/apps/frontend/src/features/voc/components/detail/IdentitySection.tsx
+++ b/apps/frontend/src/features/voc/components/detail/IdentitySection.tsx
@@ -52,9 +52,9 @@ export function IdentitySection({ voc }: IdentitySectionProps): React.ReactEleme
   //   - title mb-1 (4 px) — tight gap to the status row (reference ≈ 8 CSS but
   //     visually feels too wide once the pill carries weight; user feedback
   //     "제목과 뱃지/날짜 간격 너무 넓음").
-  //   - px-6 (24 px) — horizontal inset aligns with DetailPanelSectionNav.
+  //   - horizontal inset now provided by the scroll container (pt-7 px-6 in VocDetailPanel).
   return (
-    <div className="mb-4 px-6 pt-2">
+    <div className="mb-4 pt-2">
       <PanelTitleBlock title={voc.title} className="!px-0 !py-0 mb-1" />
       <div className="flex items-center gap-2 text-xs text-text-muted">
         <ReporterStatusBadge status={voc.reporter_facing_status} />
@@ -93,7 +93,7 @@ export function IdentityMetadataStrip({
   }
 
   return (
-    <div className="flex flex-wrap gap-2 px-4 mt-3 text-xs">
+    <div className="flex flex-wrap gap-2 mt-3 text-xs">
       {hasSeverity && severity !== null && <SeverityBadge severity={severity} />}
       {hasManagedSystem && (
         <ManagedSystemPill name={managedSystem.name} mark={managedSystem.mark} />

--- a/apps/frontend/src/features/voc/components/detail/VocDetailPanel.tsx
+++ b/apps/frontend/src/features/voc/components/detail/VocDetailPanel.tsx
@@ -192,7 +192,7 @@ function FullDetailView({
         {/* Section nav — sticky anchor tabs (prototype: screen-voc.jsx:191) */}
         <DetailPanelSectionNav sections={DETAIL_SECTIONS} scrollRef={scrollRef} />
 
-        <div ref={scrollRef} className="flex flex-col flex-1 min-h-0 overflow-y-auto pb-16">
+        <div ref={scrollRef} className="flex flex-col flex-1 min-h-0 overflow-y-auto pt-7 px-6 pb-16">
           <div data-anchor="overview"><IdentitySection voc={voc} /></div>
           <div data-anchor="triage"><TriageBlock voc={voc} /></div>
           <div data-anchor="description">

--- a/apps/frontend/src/features/voc/components/detail/__tests__/IdentitySection.test.tsx
+++ b/apps/frontend/src/features/voc/components/detail/__tests__/IdentitySection.test.tsx
@@ -49,10 +49,13 @@ describe('<IdentitySection>', () => {
     expect(h2).not.toHaveClass('text-xl');
   });
 
-  it('aligns the title block to the section nav 24px left inset', () => {
+  it('aligns the title block to the section nav 24px left inset (inset now on scroll container)', () => {
     render(<IdentitySection voc={DETAIL_ENVELOPE} />);
     const h2 = screen.getByRole('heading', { level: 2 });
-    expect(h2.parentElement?.parentElement).toHaveClass('px-6');
+    // px-6 removed from IdentitySection; horizontal inset is now on the
+    // VocDetailPanel scroll container (pt-7 px-6 pb-16) — matching triage pattern.
+    expect(h2.parentElement?.parentElement).not.toHaveClass('px-6');
+    expect(h2.parentElement?.parentElement).toHaveClass('mb-4');
   });
 
   it('renders the reporter+time meta line as "<reporter> · <relative>" (no FieldRow labels)', () => {

--- a/apps/frontend/src/lib/layout/AppSidebar.tsx
+++ b/apps/frontend/src/lib/layout/AppSidebar.tsx
@@ -118,7 +118,7 @@ export function AppSidebar({
                 {showSection && (
                   <div
                     className={cn(
-                      'mx-2 mb-1 text-caption font-semibold uppercase tracking-wide text-text-disabled',
+                      'mx-2 mb-1 text-[10px] font-semibold uppercase tracking-wide text-text-disabled',
                       index === 0 ? 'mt-1.5' : 'mt-3.5',
                     )}
                     data-testid={`sidebar-section-${sectionTestId(section)}`}


### PR DESCRIPTION
Closes #107. Follow-up polish from parity review.

## Fixes
- **Sidebar label too big:** `text-caption` (undefined in tailwind preset → ignored) → `text-[10px]` (prototype `.nav-section` = `--text-caption` 10px).
- **VOC detail sections misaligned/flush-left:** adopt the triage detail pattern — scroll container holds the inset (`pt-7 px-6 pb-16`), per-section ad-hoc horizontal padding removed (IdentitySection px-6/px-4, DescriptionSection px-4, ConversationTimeline mx-4/px-4). All section titles now align at 24px like triage detail.

## Verification
- frontend vitest 480/480; typecheck/biome no new errors.
- Live 1440 alignment check (sidebar 10px + detail vs triage) appended after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)