### PR TITLE
feat(#109): VOC list row dividers + left severity color bar

### DIFF
--- a/apps/frontend/src/features/voc/components/list/VocRow.tsx
+++ b/apps/frontend/src/features/voc/components/list/VocRow.tsx
@@ -59,6 +59,19 @@ export function formatVocCreatedAt(iso: string): string {
 }
 
 // ---------------------------------------------------------------------------
+// Severity → left-bar color token
+// ---------------------------------------------------------------------------
+
+type Severity = 'low' | 'medium' | 'high' | 'critical';
+
+const SEVERITY_BAR_CLASS: Record<Severity, string> = {
+  low: 'bg-severity-low',
+  medium: 'bg-severity-medium',
+  high: 'bg-severity-high',
+  critical: 'bg-severity-critical',
+};
+
+// ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
@@ -117,6 +130,13 @@ export function VocRow({
     }
   };
 
+  // Determine left-bar color: accent when selected, severity color otherwise.
+  const severityBarClass = selected
+    ? 'bg-accent-primary'
+    : voc.severity !== null
+      ? SEVERITY_BAR_CLASS[voc.severity]
+      : 'bg-border-strong';
+
   return (
     <div
       role="row"
@@ -127,17 +147,26 @@ export function VocRow({
       className={cn(
         // Base layout — prototype .object-row: min-height 60px, padding 10px 20px, gap 12px
         'relative flex w-full items-center gap-3 px-5 py-2.5 min-h-[60px] text-left cursor-pointer',
+        // Row divider — prototype .object-row { border-bottom: 1px solid var(--border-subtle) }
+        'border-b border-border-subtle',
         // Hover
         'hover:bg-surface-row-hover',
-        // Selected: tinted background + 2px left accent bar (prototype parity)
+        // Selected: tinted background
         selected && 'bg-surface-row-selected',
-        selected &&
-          'before:absolute before:left-0 before:top-0 before:bottom-0 before:w-0.5 before:bg-accent-primary before:content-[""]',
         // Permission-limited
         permissionLimited === true && 'opacity-60',
         className,
       )}
     >
+      {/* LEFT EDGE BAR — full row height, 3px, severity-colored (accent when selected).
+          Prototype: .severity-indicator { width:3px; height:16px } but shown as a full-height
+          edge bar here per the issue spec. Single element avoids the ::before double-bar problem. */}
+      <div
+        data-testid="voc-row-left-bar"
+        aria-hidden="true"
+        className={cn('absolute left-0 top-0 bottom-0 w-[3px] rounded-r-sm', severityBarClass)}
+      />
+
       {/* LEAD: checkbox (bulk select) + severity indicator. Click here must not
           open the detail panel. */}
       <div

--- a/apps/frontend/src/features/voc/components/list/__tests__/VocRow.test.tsx
+++ b/apps/frontend/src/features/voc/components/list/__tests__/VocRow.test.tsx
@@ -181,10 +181,63 @@ describe('<VocRow>', () => {
 
   it('applies the selected-row token + left accent bar when selected', () => {
     render(<VocRow voc={BASE_VOC} selected={true} onSelect={onSelect} managedSystem={null} />);
+    const row = screen.getByRole('row');
+    // Prototype parity: tinted selected background
+    expect(row.className).toContain('bg-surface-row-selected');
+    // Left edge bar exists and uses accent-primary color when selected
+    const bar = row.querySelector('[data-testid="voc-row-left-bar"]');
+    expect(bar).not.toBeNull();
+    expect(bar?.className).toContain('bg-accent-primary');
+  });
+
+  it('has a bottom border divider on every row', () => {
+    render(<VocRow voc={BASE_VOC} selected={false} onSelect={onSelect} managedSystem={null} />);
     const cls = screen.getByRole('row').className;
-    // Prototype parity: tinted selected background + 2px left accent bar (not a ring).
-    expect(cls).toContain('bg-surface-row-selected');
-    expect(cls).toContain('before:bg-accent-primary');
+    expect(cls).toContain('border-b');
+    expect(cls).toContain('border-border-subtle');
+  });
+
+  it('renders left-bar with severity-high class for high severity', () => {
+    render(<VocRow voc={BASE_VOC} selected={false} onSelect={onSelect} managedSystem={null} />);
+    const bar = screen.getByTestId('voc-row-left-bar');
+    expect(bar).toBeInTheDocument();
+    expect(bar.className).toContain('bg-severity-high');
+  });
+
+  it('renders left-bar with severity-low class for low severity', () => {
+    const vocLow: VocListItem = { ...BASE_VOC, severity: 'low' };
+    render(<VocRow voc={vocLow} selected={false} onSelect={onSelect} managedSystem={null} />);
+    const bar = screen.getByTestId('voc-row-left-bar');
+    expect(bar.className).toContain('bg-severity-low');
+  });
+
+  it('renders left-bar with severity-medium class for medium severity', () => {
+    const vocMed: VocListItem = { ...BASE_VOC, severity: 'medium' };
+    render(<VocRow voc={vocMed} selected={false} onSelect={onSelect} managedSystem={null} />);
+    const bar = screen.getByTestId('voc-row-left-bar');
+    expect(bar.className).toContain('bg-severity-medium');
+  });
+
+  it('renders left-bar with severity-critical class for critical severity', () => {
+    const vocCrit: VocListItem = { ...BASE_VOC, severity: 'critical' };
+    render(<VocRow voc={vocCrit} selected={false} onSelect={onSelect} managedSystem={null} />);
+    const bar = screen.getByTestId('voc-row-left-bar');
+    expect(bar.className).toContain('bg-severity-critical');
+  });
+
+  it('renders left-bar with neutral token when severity is null', () => {
+    const vocNull: VocListItem = { ...BASE_VOC, severity: null };
+    render(<VocRow voc={vocNull} selected={false} onSelect={onSelect} managedSystem={null} />);
+    const bar = screen.getByTestId('voc-row-left-bar');
+    expect(bar.className).toContain('bg-border-strong');
+  });
+
+  it('left-bar uses accent-primary when selected regardless of severity', () => {
+    const vocNull: VocListItem = { ...BASE_VOC, severity: null };
+    render(<VocRow voc={vocNull} selected={true} onSelect={onSelect} managedSystem={null} />);
+    const bar = screen.getByTestId('voc-row-left-bar');
+    expect(bar.className).toContain('bg-accent-primary');
+    expect(bar.className).not.toContain('bg-border-strong');
   });
 
   it('renders permission-limited variant — title replaced by peek', () => {


### PR DESCRIPTION
Closes #109.

## Changes (VocRow)
- Row divider: `border-b border-border-subtle` (prototype `.object-row` border-bottom).
- Left edge color bar: full-height 3px bar at row left — severity-colored (`bg-severity-low/medium/high/critical`), neutral `bg-border-strong` when severity null (every row has a bar), `bg-accent-primary` when selected (single element, no ::before double-bar). Inline SeverityIndicator pill kept (a11y label + prototype parity).

## Verification
- VocRow vitest 32 pass (9 new: divider, 4 severity colors, null→neutral, selected→accent overrides).
- typecheck/biome no new errors.
- Live 1440 check appended after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)