### PR TITLE
feat(#113): entity link detach lifecycle (Slice 4.2)

### DIFF
--- a/.review/ISSUE-113-DEVIATIONS.md
+++ b/.review/ISSUE-113-DEVIATIONS.md
@@ -1,0 +1,9 @@
+# Issue #113 — Deviations
+
+## D1 · 409 envelope uses existing `conflict.stale_write`
+
+**Prompt directive:** "If link status != 'active' → 409 (already detached/revoked) OR idempotent 200 returning current state — pick 409 and document in DEVIATIONS if you prefer; default to 409 `conflict`."
+
+**Actual change:** Already-detached and lost-race detach attempts return HTTP 409 with code `conflict.stale_write`.
+
+**Reason:** `packages/shared/src/errors/codes.ts` does not define a generic `conflict` code, and that file is outside the Issue #113 allowed touch set. Using an unknown `conflict` string would be remapped by the global error handler to a generic 500. `conflict.stale_write` is an existing 409-class code and preserves the requested HTTP status without widening the touch set.

--- a/.review/ISSUE-113-FIX-PROMPT.txt
+++ b/.review/ISSUE-113-FIX-PROMPT.txt
@@ -1,0 +1,39 @@
+# Issue #113 fix — close existence-leak in detach (authorize before status check)
+
+You are CODEX. Sandbox = workspace-write, no network. Scope: ONE ordering fix + ONE regression test.
+
+## The finding (REVIEWER, major, authz)
+
+In `apps/backend/src/modules/entity-links/service.ts` (~line 231), `detachLink` checks active-status and returns 409 for any non-active in-workspace link BEFORE resolving endpoints and running the both-side `voc.read` authorization. Consequence: an actor lacking scope on the source or target VOC can PATCH an already-detached link and receive 409 (existence leak) instead of 404 — they can distinguish an existing detached/revoked link from a missing one.
+
+## The fix
+
+Reorder `detachLink` so authorization happens FIRST:
+1. Resolve the link row by id within the workspace. Not found / cross-workspace → 404.
+2. Resolve both endpoints and run the SAME both-side `voc.read` helper the create/POST path uses. If the actor lacks scope on EITHER endpoint → 404 (existence-leak guard) — regardless of the link's current status.
+3. ONLY AFTER authorization passes: if status != 'active' → 409 (`conflict.stale_write`, per accepted deviation D1).
+4. Then the transactional `UPDATE ... WHERE id=:id AND status='active'`; 0 rows → 409.
+
+The out-of-scope actor must get 404 for BOTH an active and an already-detached link — identical to a non-existent link. Do not leak status via the response code.
+
+## Regression test
+
+In `apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts`, add a case:
+- Seed + detach a related_to link as an authorized actor.
+- A SECOND actor lacking scope on the target VOC PATCHes that ALREADY-DETACHED link → expect **404** (NOT 409). This proves authorization precedes the status check.
+
+Keep all existing #113 tests passing; do not weaken them.
+
+## Strict scope — ABORT with `.review/ISSUE-113-FIX-BLOCKER.json` if forced wider
+
+ALLOWED:
+- `apps/backend/src/modules/entity-links/service.ts` (reorder only — do not change the 404/409 codes or the transaction)
+- `apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts` (add the one regression case)
+
+FORBIDDEN: anything else (migration, shared, routes, repo signatures, permissions/*, frontend). If the reorder genuinely requires a repo signature change, you may touch `repo.ts` minimally — but prefer reordering existing calls in service.ts.
+
+## After
+
+`pnpm -w typecheck` if you touched types. Commit on branch `feature/113-entity-link-detach`:
+`fix(#113): authorize both-side scope before detach status check (close existence leak)`
+Do NOT push.

--- a/.review/ISSUE-113-PROMPT.txt
+++ b/.review/ISSUE-113-PROMPT.txt
@@ -1,0 +1,78 @@
+# Issue #113 — Slice 4.2 · Entity link detach lifecycle (end-to-end)
+
+You are CODEX. Sandbox = workspace-write, NO network. DB unreachable from sandbox; VERIFIER runs tests outside. Do NOT run migrations/tests/DB yourself — only static checks (typecheck/lint).
+
+## Goal
+
+Authorized SOFT detach of an entity link: a Developer detaches an active link, the row is PRESERVED (no hard delete) with status→`detached` plus actor/reason/timestamp, an audit event fires, and the VOC detail Links tab stops listing it (active-only filter already drops non-active rows). Implements FR-LINK-001A from `docs/design/11-entity-linking.md`.
+
+Builds directly on #112 (merged): `core.entity_links` exists; module `apps/backend/src/modules/entity-links/` has routes.ts (POST+GET), service.ts (`createEntityLinksService`), repo.ts (`resolveVocEndpoint`, `insertActiveVocRelatedToLink`, `selectActiveVocRelatedToLink`, `selectActiveLinksForEndpoint`). Shared types in `packages/shared/src/entity-links.ts` (`entityLinkStatusSchema` already includes `detached`/`revoked`). Migration 0018 granted fops_app INSERT+SELECT only and the active unique/lookup indexes are partial `WHERE status='active'`.
+
+## Design decisions (locked — do not re-litigate; the API draft lists both PATCH and DELETE, we choose PATCH)
+
+- **Verb: `PATCH /entity-links/:id`** with body `{ reason: string }` (reason required, non-empty, trimmed). The endpoint's only supported action this slice is detach (active→detached). DELETE is NOT used — the row persists, so DELETE would be a lie.
+- **Status: `detached` only.** `revoked` stays reserved for admin/policy flows (later slice). `stale` is Slice 7. Do not produce them here.
+- **Detaching the partial unique index:** because the unique index is `WHERE status='active'`, transitioning to `detached` frees the slot — a later active link of the same pair becomes possible. This is intended; do not change the index.
+
+## Migration 0019 (hand-written, like 0018)
+
+Create `apps/backend/migrations/0019_entity_link_detach.sql`:
+- `ALTER TABLE core.entity_links ADD COLUMN detached_by uuid REFERENCES core.actors(id)` (nullable)
+- `ADD COLUMN detach_reason text` (nullable)
+- `ADD COLUMN detached_at timestamptz` (nullable)
+- `GRANT UPDATE ON core.entity_links TO fops_app;` (detach is an UPDATE; fops_app had INSERT+SELECT only). Still NO DELETE grant — hard delete stays impossible.
+- Header comment in the style of 0018.
+
+Then register 0019 in the drizzle meta journal so `drizzle-kit migrate` applies it. IMPORTANT (learned on #112): `drizzle-kit generate` hits a pre-existing 0003/0004 snapshot collision and the hand-written SQL has GRANTs that generate won't emit. Mirror exactly how 0018 was registered: hand-add the `_journal.json` entry (idx 19, tag `0019_entity_link_detach`) and hand-write `apps/backend/migrations/meta/0019_snapshot.json` reflecting the post-0019 schema (the three new columns on entity_links). Update `src/db/schema/core.ts` entityLinks table to add the three columns so the snapshot/schema stay in sync. See `.review/ISSUE-112-META-NOTES.md` (in git history of develop) if you need the exact technique.
+
+## Endpoint behavior
+
+`PATCH /entity-links/:id`:
+- Resolve the link by id within the actor's workspace. Not found / cross-workspace → 404.
+- If link status != 'active' → 409 (already detached/revoked) OR idempotent 200 returning current state — pick 409 and document in DEVIATIONS if you prefer; default to 409 `conflict`.
+- Authorization (same both-side rule as create): actor must hold the SAME VOC-read capability used by POST on BOTH the source and target endpoints' managed systems. If actor lacks scope on either → 404 (existence-leak guard, consistent with #112). Reuse the exact permission helper POST uses — do NOT invent a new capability.
+- Transition in ONE transaction: `UPDATE ... SET status='detached', detached_by=<actor>, detach_reason=<reason>, detached_at=now(), updated_at=now() WHERE id=:id AND status='active'`; if 0 rows updated (lost race) → 409. Emit audit_log `entity_link.detached` with `{ link_id, source, target, relation_type, reason }`. Add the `entity_link.detached` token to `packages/shared/src/enums/audit-events.ts` + its detail schema (mirror `entity_link.created`).
+- Response: 200 with the detached link's id + status (+ detached_at). No body that leaks the other endpoint if actor somehow shouldn't see it (but they passed both-side check, so full ok).
+
+VOC detail Links tab: NO code change needed if `selectActiveLinksForEndpoint` already filters `status='active'` (detached rows auto-drop). VERIFY this is true; if the VOC-detail query does NOT filter on active, add the filter. Either way a detached link must NOT appear on the Links tab.
+
+## Strict scope — ABORT with `.review/ISSUE-113-BLOCKER.json` (real reason_code + blocking_fact) if the touch set escapes
+
+ALLOWED:
+- `apps/backend/migrations/0019_entity_link_detach.sql` (new), `apps/backend/migrations/meta/_journal.json`, `apps/backend/migrations/meta/0019_snapshot.json` (new)
+- `apps/backend/src/db/schema/core.ts` (add 3 columns to entityLinks)
+- `apps/backend/src/modules/entity-links/{routes.ts,service.ts,repo.ts,index.ts}` (add PATCH + detach repo fn + service method)
+- `apps/backend/src/modules/entity-links/__tests__/` (add detach tests; do not weaken existing #112 tests)
+- `apps/backend/src/modules/voc/repo-read.ts` or `read-service.ts` ONLY if the links query needs an explicit `status='active'` filter added
+- `packages/shared/src/entity-links.ts` (detach request schema + detached link response shape), `packages/shared/src/index.ts`, `packages/shared/src/enums/audit-events.ts`
+- Doc-sync (same commit): `docs/design/11-entity-linking.md` (note FR-LINK-001A detach = PATCH, detached-only, #113) + `docs/implementation/06-entity-linking-contract.md`
+- `.review/ISSUE-113-DEVIATIONS.md`
+
+FORBIDDEN (abort if forced):
+- `packages/shared/src/permissions/*`, `auth/*` — reuse existing helpers
+- `apps/frontend/**` (#114 owns UI)
+- new findings table; relation types beyond `related_to`; producing `revoked`/`stale`; visibility tokens beyond #112's `allowed`/`hidden`; FR-LINK-003 queries
+- hard delete of any entity_links row, or granting fops_app DELETE
+
+## Tests (vitest integration; mirror `apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts` setup — note `migrateHandle` (fops_migrate) is used for teardown DELETEs since fops_app cannot delete)
+
+1. PATCH detaches an active related_to link → 200; DB row STILL EXISTS with status='detached', detached_by/detach_reason/detached_at set; audit_log has `entity_link.detached`.
+2. After detach, GET /entity-links by source and the VOC detail Links tab do NOT list the detached link.
+3. PATCH on an already-detached link → 409.
+4. PATCH when actor lacks scope on the target endpoint → 404 (existence-leak guard).
+5. PATCH with empty/missing reason → 422.
+6. Detach frees the active-unique slot: after detaching A→B, a new POST A→B related_to succeeds (proves the partial unique index works as intended).
+
+## Procedure
+
+1. Read #112's module (routes/service/repo) + 0018 SQL + `.review/ISSUE-112-DEVIATIONS.md` to mirror patterns (permission helper, audit emit, transaction wrapping).
+2. Write migration 0019 SQL by hand + register in meta journal/snapshot (mirror 0018 technique). Add the 3 columns to `core.ts`.
+3. Shared types: detach request `{ reason }` + audit event token.
+4. repo: `detachVocRelatedToLink(...)`; service: detach method; routes: PATCH handler.
+5. Verify VOC-detail links query filters active.
+6. Tests above.
+7. `pnpm -w typecheck` + lint; fix only NEW errors.
+8. Doc-sync in the same commit.
+9. Commit on branch `feature/113-entity-link-detach`: `feat(#113): entity link detach lifecycle (PATCH /entity-links/:id)`. Do NOT push.
+
+If a forced scope escape or unresolved spec ambiguity: write `.review/ISSUE-113-BLOCKER.json` `{reason_code, blocking_fact (quoted file:line/clause), what_was_attempted, what_is_blocking}` and exit non-zero. Do not improvise.

--- a/.review/ISSUE-113-REVIEW-PROMPT.txt
+++ b/.review/ISSUE-113-REVIEW-PROMPT.txt
@@ -1,0 +1,20 @@
+You are REVIEWER for FeedbackOps issue #113 (Slice 4.2 entity link detach lifecycle). Adversarial read-only review of the uncommitted diff against the contract in .review/ISSUE-113-PROMPT.txt and the deviations in .review/ISSUE-113-DEVIATIONS.md.
+
+Check in order:
+1. Contract adherence — PATCH /entity-links/:id soft-detach (active→detached), row PRESERVED (no hard delete), detached_by/detach_reason/detached_at set, updated_at set, single transaction, audit entity_link.detached emitted. Migration 0019 adds 3 columns + GRANT UPDATE to fops_app (and NO DELETE grant). Journal/snapshot registered for 0019 (mirror 0018 technique). core.ts entityLinks has the 3 new columns.
+2. Both-side permission — detach requires the SAME VOC-read capability POST uses on BOTH endpoints' managed systems; out-of-scope target → 404 (existence-leak guard, not 403). Confirm it reuses the existing helper, not a new capability.
+3. Active-only visibility — confirm a detached link no longer appears on GET /entity-links and the VOC detail Links tab (selectActiveLinksForEndpoint filters status='active'). If the VOC-detail query was NOT already active-filtered, confirm a filter was added.
+4. Partial unique index — detaching frees the WHERE status='active' slot; a new active POST of the same pair must succeed (test 6). Confirm no index change.
+5. Scope discipline — no forbidden paths (permissions/*, auth/*, apps/frontend/**, findings table, revoked/stale production, DELETE grant, hard delete). 
+6. Deviation D1 — 409 uses existing `conflict.stale_write` because errors/codes.ts is out of scope. Judge: acceptable, or does it block / need a different code?
+7. Tests — do the 6 cases in the prompt exist and genuinely assert (row persists with metadata after detach; audit row; detached link absent from GET + VOC detail; already-detached→409; missing/empty reason→422; out-of-scope→404; re-POST after detach succeeds)? Note any missing/weak case. Confirm teardown uses migrateHandle (fops_migrate) for DELETEs since fops_app cannot delete.
+
+Output ONLY this JSON (no prose around it):
+{
+  "verdict": "approve" | "request_changes" | "block",
+  "summary": "one sentence",
+  "findings": [ { "severity":"block|major|minor|nit", "area":"contract|scope|deviation|tests|authz|audit|migration|other", "file":"path:line", "issue":"one sentence", "fix":"one sentence" } ],
+  "deviations_acceptable_with_doc": [ "..." ],
+  "must_fix_before_commit": [ "..." ]
+}
+If nothing blocks, verdict=approve.

--- a/.review/ISSUE-113-REVIEW.json
+++ b/.review/ISSUE-113-REVIEW.json
@@ -1,0 +1,20 @@
+{
+  "verdict": "request_changes",
+  "summary": "Detach mostly follows the contract, but the service checks active status before both-side VOC-read authorization, leaking detached-link existence/state to out-of-scope actors.",
+  "findings": [
+    {
+      "severity": "major",
+      "area": "authz",
+      "file": "apps/backend/src/modules/entity-links/service.ts:231",
+      "issue": "detachLink returns 409 for any non-active in-workspace link before resolving endpoint scope, so an actor lacking source or target VOC-read can distinguish an existing detached/revoked link from a missing link.",
+      "fix": "Resolve endpoints and run the reused both-side voc.read helper before the status check, and add a regression where an out-of-scope actor PATCHes an already-detached link and still gets 404."
+    }
+  ],
+  "deviations_acceptable_with_doc": [
+    "D1 is acceptable: using existing conflict.stale_write preserves the required HTTP 409 without touching out-of-scope errors/codes.ts."
+  ],
+  "must_fix_before_commit": [
+    "Move the active-status conflict check after both-side authorization so out-of-scope links always return 404, including already-detached rows.",
+    "Add/adjust test coverage for out-of-scope PATCH against an already-detached link returning 404."
+  ]
+}

--- a/.review/ISSUE-113-REVIEW.raw.txt
+++ b/.review/ISSUE-113-REVIEW.raw.txt
@@ -1,0 +1,6532 @@
+OpenAI Codex v0.139.0
+--------
+workdir: /Users/hyojung/Desktop/2026/wt-113-entity-link-detach
+model: gpt-5.5
+provider: openai
+approval: never
+sandbox: read-only
+reasoning effort: medium
+reasoning summaries: none
+session id: 019ecbe5-3b9c-71b1-ad62-bd5025416a8c
+--------
+user
+You are REVIEWER for FeedbackOps issue #113 (Slice 4.2 entity link detach lifecycle). Adversarial read-only review of the uncommitted diff against the contract in .review/ISSUE-113-PROMPT.txt and the deviations in .review/ISSUE-113-DEVIATIONS.md.
+
+Check in order:
+1. Contract adherence — PATCH /entity-links/:id soft-detach (active→detached), row PRESERVED (no hard delete), detached_by/detach_reason/detached_at set, updated_at set, single transaction, audit entity_link.detached emitted. Migration 0019 adds 3 columns + GRANT UPDATE to fops_app (and NO DELETE grant). Journal/snapshot registered for 0019 (mirror 0018 technique). core.ts entityLinks has the 3 new columns.
+2. Both-side permission — detach requires the SAME VOC-read capability POST uses on BOTH endpoints' managed systems; out-of-scope target → 404 (existence-leak guard, not 403). Confirm it reuses the existing helper, not a new capability.
+3. Active-only visibility — confirm a detached link no longer appears on GET /entity-links and the VOC detail Links tab (selectActiveLinksForEndpoint filters status='active'). If the VOC-detail query was NOT already active-filtered, confirm a filter was added.
+4. Partial unique index — detaching frees the WHERE status='active' slot; a new active POST of the same pair must succeed (test 6). Confirm no index change.
+5. Scope discipline — no forbidden paths (permissions/*, auth/*, apps/frontend/**, findings table, revoked/stale production, DELETE grant, hard delete). 
+6. Deviation D1 — 409 uses existing `conflict.stale_write` because errors/codes.ts is out of scope. Judge: acceptable, or does it block / need a different code?
+7. Tests — do the 6 cases in the prompt exist and genuinely assert (row persists with metadata after detach; audit row; detached link absent from GET + VOC detail; already-detached→409; missing/empty reason→422; out-of-scope→404; re-POST after detach succeeds)? Note any missing/weak case. Confirm teardown uses migrateHandle (fops_migrate) for DELETEs since fops_app cannot delete.
+
+Output ONLY this JSON (no prose around it):
+{
+  "verdict": "approve" | "request_changes" | "block",
+  "summary": "one sentence",
+  "findings": [ { "severity":"block|major|minor|nit", "area":"contract|scope|deviation|tests|authz|audit|migration|other", "file":"path:line", "issue":"one sentence", "fix":"one sentence" } ],
+  "deviations_acceptable_with_doc": [ "..." ],
+  "must_fix_before_commit": [ "..." ]
+}
+If nothing blocks, verdict=approve.
+hook: SessionStart
+hook: SessionStart Failed
+hook: UserPromptSubmit
+hook: UserPromptSubmit Failed
+codex
+Using `diagnose`-style read-only review plus the repo’s review rules. I’ll inspect the prompt, deviations, and diff without editing anything.
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse Failed
+hook: PreToolUse Failed
+hook: PreToolUse Failed
+hook: PreToolUse Failed
+exec
+/bin/zsh -lc "sed -n '1,220p' /Users/hyojung/Desktop/2026/wt-113-entity-link-detach/.review/ISSUE-113-DEVIATIONS.md" in /Users/hyojung/Desktop/2026/wt-113-entity-link-detach
+exec
+/bin/zsh -lc "sed -n '1,240p' /Users/hyojung/Desktop/2026/wt-113-entity-link-detach/.review/ISSUE-113-PROMPT.txt" in /Users/hyojung/Desktop/2026/wt-113-entity-link-detach
+ succeeded in 0ms:
+# Issue #113 — Deviations
+
+## D1 · 409 envelope uses existing `conflict.stale_write`
+
+**Prompt directive:** "If link status != 'active' → 409 (already detached/revoked) OR idempotent 200 returning current state — pick 409 and document in DEVIATIONS if you prefer; default to 409 `conflict`."
+
+**Actual change:** Already-detached and lost-race detach attempts return HTTP 409 with code `conflict.stale_write`.
+
+**Reason:** `packages/shared/src/errors/codes.ts` does not define a generic `conflict` code, and that file is outside the Issue #113 allowed touch set. Using an unknown `conflict` string would be remapped by the global error handler to a generic 500. `conflict.stale_write` is an existing 409-class code and preserves the requested HTTP status without widening the touch set.
+
+ succeeded in 0ms:
+# Issue #113 — Slice 4.2 · Entity link detach lifecycle (end-to-end)
+
+You are CODEX. Sandbox = workspace-write, NO network. DB unreachable from sandbox; VERIFIER runs tests outside. Do NOT run migrations/tests/DB yourself — only static checks (typecheck/lint).
+
+## Goal
+
+Authorized SOFT detach of an entity link: a Developer detaches an active link, the row is PRESERVED (no hard delete) with status→`detached` plus actor/reason/timestamp, an audit event fires, and the VOC detail Links tab stops listing it (active-only filter already drops non-active rows). Implements FR-LINK-001A from `docs/design/11-entity-linking.md`.
+
+Builds directly on #112 (merged): `core.entity_links` exists; module `apps/backend/src/modules/entity-links/` has routes.ts (POST+GET), service.ts (`createEntityLinksService`), repo.ts (`resolveVocEndpoint`, `insertActiveVocRelatedToLink`, `selectActiveVocRelatedToLink`, `selectActiveLinksForEndpoint`). Shared types in `packages/shared/src/entity-links.ts` (`entityLinkStatusSchema` already includes `detached`/`revoked`). Migration 0018 granted fops_app INSERT+SELECT only and the active unique/lookup indexes are partial `WHERE status='active'`.
+
+## Design decisions (locked — do not re-litigate; the API draft lists both PATCH and DELETE, we choose PATCH)
+
+- **Verb: `PATCH /entity-links/:id`** with body `{ reason: string }` (reason required, non-empty, trimmed). The endpoint's only supported action this slice is detach (active→detached). DELETE is NOT used — the row persists, so DELETE would be a lie.
+- **Status: `detached` only.** `revoked` stays reserved for admin/policy flows (later slice). `stale` is Slice 7. Do not produce them here.
+- **Detaching the partial unique index:** because the unique index is `WHERE status='active'`, transitioning to `detached` frees the slot — a later active link of the same pair becomes possible. This is intended; do not change the index.
+
+## Migration 0019 (hand-written, like 0018)
+
+Create `apps/backend/migrations/0019_entity_link_detach.sql`:
+- `ALTER TABLE core.entity_links ADD COLUMN detached_by uuid REFERENCES core.actors(id)` (nullable)
+- `ADD COLUMN detach_reason text` (nullable)
+- `ADD COLUMN detached_at timestamptz` (nullable)
+- `GRANT UPDATE ON core.entity_links TO fops_app;` (detach is an UPDATE; fops_app had INSERT+SELECT only). Still NO DELETE grant — hard delete stays impossible.
+- Header comment in the style of 0018.
+
+Then register 0019 in the drizzle meta journal so `drizzle-kit migrate` applies it. IMPORTANT (learned on #112): `drizzle-kit generate` hits a pre-existing 0003/0004 snapshot collision and the hand-written SQL has GRANTs that generate won't emit. Mirror exactly how 0018 was registered: hand-add the `_journal.json` entry (idx 19, tag `0019_entity_link_detach`) and hand-write `apps/backend/migrations/meta/0019_snapshot.json` reflecting the post-0019 schema (the three new columns on entity_links). Update `src/db/schema/core.ts` entityLinks table to add the three columns so the snapshot/schema stay in sync. See `.review/ISSUE-112-META-NOTES.md` (in git history of develop) if you need the exact technique.
+
+## Endpoint behavior
+
+`PATCH /entity-links/:id`:
+- Resolve the link by id within the actor's workspace. Not found / cross-workspace → 404.
+- If link status != 'active' → 409 (already detached/revoked) OR idempotent 200 returning current state — pick 409 and document in DEVIATIONS if you prefer; default to 409 `conflict`.
+- Authorization (same both-side rule as create): actor must hold the SAME VOC-read capability used by POST on BOTH the source and target endpoints' managed systems. If actor lacks scope on either → 404 (existence-leak guard, consistent with #112). Reuse the exact permission helper POST uses — do NOT invent a new capability.
+- Transition in ONE transaction: `UPDATE ... SET status='detached', detached_by=<actor>, detach_reason=<reason>, detached_at=now(), updated_at=now() WHERE id=:id AND status='active'`; if 0 rows updated (lost race) → 409. Emit audit_log `entity_link.detached` with `{ link_id, source, target, relation_type, reason }`. Add the `entity_link.detached` token to `packages/shared/src/enums/audit-events.ts` + its detail schema (mirror `entity_link.created`).
+- Response: 200 with the detached link's id + status (+ detached_at). No body that leaks the other endpoint if actor somehow shouldn't see it (but they passed both-side check, so full ok).
+
+VOC detail Links tab: NO code change needed if `selectActiveLinksForEndpoint` already filters `status='active'` (detached rows auto-drop). VERIFY this is true; if the VOC-detail query does NOT filter on active, add the filter. Either way a detached link must NOT appear on the Links tab.
+
+## Strict scope — ABORT with `.review/ISSUE-113-BLOCKER.json` (real reason_code + blocking_fact) if the touch set escapes
+
+ALLOWED:
+- `apps/backend/migrations/0019_entity_link_detach.sql` (new), `apps/backend/migrations/meta/_journal.json`, `apps/backend/migrations/meta/0019_snapshot.json` (new)
+- `apps/backend/src/db/schema/core.ts` (add 3 columns to entityLinks)
+- `apps/backend/src/modules/entity-links/{routes.ts,service.ts,repo.ts,index.ts}` (add PATCH + detach repo fn + service method)
+- `apps/backend/src/modules/entity-links/__tests__/` (add detach tests; do not weaken existing #112 tests)
+- `apps/backend/src/modules/voc/repo-read.ts` or `read-service.ts` ONLY if the links query needs an explicit `status='active'` filter added
+- `packages/shared/src/entity-links.ts` (detach request schema + detached link response shape), `packages/shared/src/index.ts`, `packages/shared/src/enums/audit-events.ts`
+- Doc-sync (same commit): `docs/design/11-entity-linking.md` (note FR-LINK-001A detach = PATCH, detached-only, #113) + `docs/implementation/06-entity-linking-contract.md`
+- `.review/ISSUE-113-DEVIATIONS.md`
+
+FORBIDDEN (abort if forced):
+- `packages/shared/src/permissions/*`, `auth/*` — reuse existing helpers
+- `apps/frontend/**` (#114 owns UI)
+- new findings table; relation types beyond `related_to`; producing `revoked`/`stale`; visibility tokens beyond #112's `allowed`/`hidden`; FR-LINK-003 queries
+- hard delete of any entity_links row, or granting fops_app DELETE
+
+## Tests (vitest integration; mirror `apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts` setup — note `migrateHandle` (fops_migrate) is used for teardown DELETEs since fops_app cannot delete)
+
+1. PATCH detaches an active related_to link → 200; DB row STILL EXISTS with status='detached', detached_by/detach_reason/detached_at set; audit_log has `entity_link.detached`.
+2. After detach, GET /entity-links by source and the VOC detail Links tab do NOT list the detached link.
+3. PATCH on an already-detached link → 409.
+4. PATCH when actor lacks scope on the target endpoint → 404 (existence-leak guard).
+5. PATCH with empty/missing reason → 422.
+6. Detach frees the active-unique slot: after detaching A→B, a new POST A→B related_to succeeds (proves the partial unique index works as intended).
+
+## Procedure
+
+1. Read #112's module (routes/service/repo) + 0018 SQL + `.review/ISSUE-112-DEVIATIONS.md` to mirror patterns (permission helper, audit emit, transaction wrapping).
+2. Write migration 0019 SQL by hand + register in meta journal/snapshot (mirror 0018 technique). Add the 3 columns to `core.ts`.
+3. Shared types: detach request `{ reason }` + audit event token.
+4. repo: `detachVocRelatedToLink(...)`; service: detach method; routes: PATCH handler.
+5. Verify VOC-detail links query filters active.
+6. Tests above.
+7. `pnpm -w typecheck` + lint; fix only NEW errors.
+8. Doc-sync in the same commit.
+9. Commit on branch `feature/113-entity-link-detach`: `feat(#113): entity link detach lifecycle (PATCH /entity-links/:id)`. Do NOT push.
+
+If a forced scope escape or unresolved spec ambiguity: write `.review/ISSUE-113-BLOCKER.json` `{reason_code, blocking_fact (quoted file:line/clause), what_was_attempted, what_is_blocking}` and exit non-zero. Do not improvise.
+
+hook: PostToolUse
+hook: PostToolUse
+exec
+/bin/zsh -lc 'git diff --name-only' in /Users/hyojung/Desktop/2026/wt-113-entity-link-detach
+ succeeded in 0ms:
+git: warning: confstr() failed with code 5: couldn't get path of DARWIN_USER_TEMP_DIR; using /tmp instead
+apps/backend/migrations/meta/_journal.json
+apps/backend/src/db/schema/core.ts
+apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts
+apps/backend/src/modules/entity-links/repo.ts
+apps/backend/src/modules/entity-links/routes.ts
+apps/backend/src/modules/entity-links/service.ts
+docs/design/11-entity-linking.md
+docs/implementation/06-entity-linking-contract.md
+packages/shared/src/entity-links.ts
+packages/shared/src/enums/audit-events.ts
+
+hook: PostToolUse
+exec
+/bin/zsh -lc 'pwd && git status --short && git diff --stat' in /Users/hyojung/Desktop/2026/wt-113-entity-link-detach
+ succeeded in 0ms:
+/Users/hyojung/Desktop/2026/wt-113-entity-link-detach
+git: warning: confstr() failed with code 5: couldn't get path of DARWIN_USER_TEMP_DIR; using /tmp instead
+ M apps/backend/migrations/meta/_journal.json
+ M apps/backend/src/db/schema/core.ts
+ M apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts
+ M apps/backend/src/modules/entity-links/repo.ts
+ M apps/backend/src/modules/entity-links/routes.ts
+ M apps/backend/src/modules/entity-links/service.ts
+ M docs/design/11-entity-linking.md
+ M docs/implementation/06-entity-linking-contract.md
+ M packages/shared/src/entity-links.ts
+ M packages/shared/src/enums/audit-events.ts
+?? .review/ISSUE-113-DEVIATIONS.md
+?? .review/ISSUE-113-PROMPT.txt
+?? .review/ISSUE-113-REVIEW-PROMPT.txt
+?? .review/ISSUE-113-REVIEW.raw.txt
+?? apps/backend/migrations/0019_entity_link_detach.sql
+?? apps/backend/migrations/meta/0019_snapshot.json
+git: warning: confstr() failed with code 5: couldn't get path of DARWIN_USER_TEMP_DIR; using /tmp instead
+ apps/backend/migrations/meta/_journal.json         |   7 +
+ apps/backend/src/db/schema/core.ts                 |   3 +
+ .../__tests__/entity-links.integration.test.ts     | 162 ++++++++++++++++++++-
+ apps/backend/src/modules/entity-links/repo.ts      |  64 +++++++-
+ apps/backend/src/modules/entity-links/routes.ts    |  44 +++++-
+ apps/backend/src/modules/entity-links/service.ts   |  93 +++++++++++-
+ docs/design/11-entity-linking.md                   |  10 ++
+ docs/implementation/06-entity-linking-contract.md  |  20 +++
+ packages/shared/src/entity-links.ts                |  14 ++
+ packages/shared/src/enums/audit-events.ts          |  19 +++
+ 10 files changed, 428 insertions(+), 8 deletions(-)
+
+hook: PostToolUse
+hook: PostToolUse Failed
+hook: PostToolUse Failed
+hook: PostToolUse Failed
+hook: PostToolUse Failed
+codex
+I have the contract and touch set. Next I’m checking the actual route/service/repo flow, migration metadata, and tests line-by-line for behavioral gaps.
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse Failed
+hook: PreToolUse Failed
+hook: PreToolUse Failed
+hook: PreToolUse Failed
+exec
+/bin/zsh -lc 'git diff -- apps/backend/migrations/0019_entity_link_detach.sql apps/backend/migrations/meta/_journal.json apps/backend/migrations/meta/0019_snapshot.json apps/backend/src/db/schema/core.ts' in /Users/hyojung/Desktop/2026/wt-113-entity-link-detach
+ succeeded in 0ms:
+git: warning: confstr() failed with code 5: couldn't get path of DARWIN_USER_TEMP_DIR; using /tmp instead
+diff --git a/apps/backend/migrations/meta/_journal.json b/apps/backend/migrations/meta/_journal.json
+index 42cc65e..63c72aa 100644
+--- a/apps/backend/migrations/meta/_journal.json
++++ b/apps/backend/migrations/meta/_journal.json
+@@ -134,6 +134,13 @@
+       "when": 1781533641945,
+       "tag": "0018_entity_links",
+       "breakpoints": true
++    },
++    {
++      "idx": 19,
++      "version": "7",
++      "when": 1781534641945,
++      "tag": "0019_entity_link_detach",
++      "breakpoints": true
+     }
+   ]
+ }
+diff --git a/apps/backend/src/db/schema/core.ts b/apps/backend/src/db/schema/core.ts
+index a1cdbaa..9927f02 100644
+--- a/apps/backend/src/db/schema/core.ts
++++ b/apps/backend/src/db/schema/core.ts
+@@ -306,6 +306,9 @@ export const entityLinks = coreSchema.table(
+       .references(() => actors.id),
+     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+     updatedAt: timestamp('updated_at', { withTimezone: true }),
++    detachedBy: uuid('detached_by').references(() => actors.id),
++    detachReason: text('detach_reason'),
++    detachedAt: timestamp('detached_at', { withTimezone: true }),
+   },
+   (t) => ({
+     relationTypeCheck: check(
+
+hook: PostToolUse
+exec
+/bin/zsh -lc 'git diff -- apps/backend/src/modules/entity-links/routes.ts apps/backend/src/modules/entity-links/service.ts apps/backend/src/modules/entity-links/repo.ts' in /Users/hyojung/Desktop/2026/wt-113-entity-link-detach
+ succeeded in 0ms:
+git: warning: confstr() failed with code 5: couldn't get path of DARWIN_USER_TEMP_DIR; using /tmp instead
+diff --git a/apps/backend/src/modules/entity-links/repo.ts b/apps/backend/src/modules/entity-links/repo.ts
+index d360110..02b2748 100644
+--- a/apps/backend/src/modules/entity-links/repo.ts
++++ b/apps/backend/src/modules/entity-links/repo.ts
+@@ -23,6 +23,9 @@ export interface EntityLinkRow {
+   created_by: string;
+   created_at: Date;
+   updated_at: Date | null;
++  detached_by: string | null;
++  detach_reason: string | null;
++  detached_at: Date | null;
+ }
+ 
+ function mapEntityLinkRow(row: Record<string, unknown>): EntityLinkRow {
+@@ -46,6 +49,14 @@ function mapEntityLinkRow(row: Record<string, unknown>): EntityLinkRow {
+         : row.updated_at instanceof Date
+           ? row.updated_at
+           : new Date(row.updated_at as string),
++    detached_by: (row.detached_by as string | null) ?? null,
++    detach_reason: (row.detach_reason as string | null) ?? null,
++    detached_at:
++      row.detached_at === null || row.detached_at === undefined
++        ? null
++        : row.detached_at instanceof Date
++          ? row.detached_at
++          : new Date(row.detached_at as string),
+   };
+ }
+ 
+@@ -96,7 +107,7 @@ export async function insertActiveVocRelatedToLink(
+     RETURNING
+       id, workspace_id, source_type, source_id, target_type, target_id,
+       relation_type, visibility, status, managed_system_id, created_by,
+-      created_at, updated_at
++      created_at, updated_at, detached_by, detach_reason, detached_at
+   `);
+   const insertedRow = inserted.rows[0];
+   if (insertedRow) return { row: mapEntityLinkRow(insertedRow), inserted: true };
+@@ -120,7 +131,7 @@ export async function selectActiveVocRelatedToLink(
+     SELECT
+       id, workspace_id, source_type, source_id, target_type, target_id,
+       relation_type, visibility, status, managed_system_id, created_by,
+-      created_at, updated_at
++      created_at, updated_at, detached_by, detach_reason, detached_at
+     FROM core.entity_links
+     WHERE workspace_id = ${input.workspaceId}
+       AND source_type = 'voc'
+@@ -158,7 +169,7 @@ export async function selectActiveLinksForEndpoint(
+     SELECT
+       id, workspace_id, source_type, source_id, target_type, target_id,
+       relation_type, visibility, status, managed_system_id, created_by,
+-      created_at, updated_at
++      created_at, updated_at, detached_by, detach_reason, detached_at
+     FROM core.entity_links
+     WHERE workspace_id = ${input.workspaceId}
+       AND status = 'active'
+@@ -167,3 +178,50 @@ export async function selectActiveLinksForEndpoint(
+   `);
+   return result.rows.map(mapEntityLinkRow);
+ }
++
++export async function selectEntityLinkById(
++  db: Db | Tx,
++  input: { workspaceId: string; linkId: string },
++): Promise<EntityLinkRow | null> {
++  const result = await (db as Db).execute<Record<string, unknown>>(sql`
++    SELECT
++      id, workspace_id, source_type, source_id, target_type, target_id,
++      relation_type, visibility, status, managed_system_id, created_by,
++      created_at, updated_at, detached_by, detach_reason, detached_at
++    FROM core.entity_links
++    WHERE workspace_id = ${input.workspaceId}
++      AND id = ${input.linkId}
++    LIMIT 1
++  `);
++  const row = result.rows[0];
++  return row ? mapEntityLinkRow(row) : null;
++}
++
++export async function detachVocRelatedToLink(
++  tx: Tx,
++  input: {
++    workspaceId: string;
++    linkId: string;
++    actorId: string;
++    reason: string;
++  },
++): Promise<EntityLinkRow | null> {
++  const updated = await (tx as Db).execute<Record<string, unknown>>(sql`
++    UPDATE core.entity_links
++    SET
++      status = 'detached',
++      detached_by = ${input.actorId},
++      detach_reason = ${input.reason},
++      detached_at = now(),
++      updated_at = now()
++    WHERE workspace_id = ${input.workspaceId}
++      AND id = ${input.linkId}
++      AND status = 'active'
++    RETURNING
++      id, workspace_id, source_type, source_id, target_type, target_id,
++      relation_type, visibility, status, managed_system_id, created_by,
++      created_at, updated_at, detached_by, detach_reason, detached_at
++  `);
++  const row = updated.rows[0];
++  return row ? mapEntityLinkRow(row) : null;
++}
+diff --git a/apps/backend/src/modules/entity-links/routes.ts b/apps/backend/src/modules/entity-links/routes.ts
+index 6107b37..7e1c643 100644
+--- a/apps/backend/src/modules/entity-links/routes.ts
++++ b/apps/backend/src/modules/entity-links/routes.ts
+@@ -1,6 +1,11 @@
+ import type { FastifyPluginAsync } from 'fastify';
++import { z } from 'zod';
+ 
+-import { createEntityLinkRequestSchema, listEntityLinksQuerySchema } from '@fops/shared';
++import {
++  createEntityLinkRequestSchema,
++  detachEntityLinkRequestSchema,
++  listEntityLinksQuerySchema,
++} from '@fops/shared';
+ 
+ import { HttpError, fieldsFromZodIssues, sendError } from '../../lib/errors.js';
+ import { requireSession } from '../../middleware/require-session.js';
+@@ -23,6 +28,7 @@ export const entityLinksRoutes: FastifyPluginAsync<EntityLinksRoutesOptions> = a
+   opts,
+ ) => {
+   const { sessionService, entityLinksService, workspaceId, rateLimitConfig } = opts;
++  const entityLinkParamsSchema = z.object({ id: z.string().uuid() }).strict();
+ 
+   app.route({
+     method: 'POST',
+@@ -100,4 +106,40 @@ export const entityLinksRoutes: FastifyPluginAsync<EntityLinksRoutesOptions> = a
+       return reply.code(200).send({ items });
+     },
+   });
++
++  app.route({
++    method: 'PATCH',
++    url: '/entity-links/:id',
++    preHandler: [requireSession(sessionService), requireWorkspace(workspaceId)],
++    ...(rateLimitConfig ? { config: { rateLimit: rateLimitConfig.mutation as never } } : {}),
++    handler: async (req, reply) => {
++      const sess = req.session;
++      if (!sess) throw new HttpError('internal.unexpected', 'session missing after middleware');
++
++      const parsedParams = entityLinkParamsSchema.safeParse(req.params);
++      if (!parsedParams.success) {
++        return sendError(reply, 'validation.failed', 'invalid route parameters', {
++          fields: fieldsFromZodIssues(parsedParams.error.issues),
++        });
++      }
++
++      const parsed = detachEntityLinkRequestSchema.safeParse(req.body ?? {});
++      if (!parsed.success) {
++        return sendError(reply, 'validation.failed', 'invalid request body', {
++          fields: fieldsFromZodIssues(parsed.error.issues),
++        });
++      }
++
++      const link = await entityLinksService.detachLink({
++        actor: {
++          actor_id: sess.actor_id,
++          workspace_id: sess.workspace_id,
++          role_level: sess.role_level,
++        },
++        linkId: parsedParams.data.id,
++        reason: parsed.data.reason,
++      });
++      return reply.code(200).send(link);
++    },
++  });
+ };
+diff --git a/apps/backend/src/modules/entity-links/service.ts b/apps/backend/src/modules/entity-links/service.ts
+index 8677931..2b3ae7c 100644
+--- a/apps/backend/src/modules/entity-links/service.ts
++++ b/apps/backend/src/modules/entity-links/service.ts
+@@ -1,4 +1,4 @@
+-import type { EntityLinkDto, EntityLinkRef } from '@fops/shared';
++import type { DetachedEntityLinkResponse, EntityLinkDto, EntityLinkRef } from '@fops/shared';
+ 
+ import type { Db } from '../../db/client.js';
+ import { HttpError } from '../../lib/errors.js';
+@@ -6,9 +6,11 @@ import type { AuditService } from '../core/audit/audit-service.js';
+ import type { CheckService } from '../permissions/check-service.js';
+ import {
+   type EntityLinkRow,
++  detachVocRelatedToLink,
+   insertActiveVocRelatedToLink,
+   resolveVocEndpoint,
+   selectActiveLinksForEndpoint,
++  selectEntityLinkById,
+ } from './repo.js';
+ 
+ export interface EntityLinksActor {
+@@ -51,6 +53,17 @@ function toHiddenDto(row: EntityLinkRow): EntityLinkDto {
+   };
+ }
+ 
++function toDetachedResponse(row: EntityLinkRow): DetachedEntityLinkResponse {
++  if (row.status !== 'detached' || row.detached_at === null) {
++    throw new HttpError('internal.unexpected', 'detached entity link row missing detach fields');
++  }
++  return {
++    id: row.id,
++    status: 'detached',
++    detached_at: row.detached_at.toISOString(),
++  };
++}
++
+ async function assertVocReadScope(
+   deps: Pick<EntityLinksServiceDeps, 'checkService'>,
+   actor: EntityLinksActor,
+@@ -192,7 +205,83 @@ export function createEntityLinksService(deps: EntityLinksServiceDeps) {
+     return items;
+   }
+ 
+-  return { createLink, listLinks };
++  async function detachLink(args: {
++    actor: EntityLinksActor;
++    linkId: string;
++    reason: string;
++  }): Promise<DetachedEntityLinkResponse> {
++    const { actor, linkId, reason } = args;
++
++    const link = await selectEntityLinkById(deps.db, {
++      workspaceId: actor.workspace_id,
++      linkId,
++    });
++    if (!link) {
++      throw new HttpError('not_found.record', 'entity link not found');
++    }
++    if (
++      link.source_type !== 'voc' ||
++      link.target_type !== 'voc' ||
++      link.relation_type !== 'related_to'
++    ) {
++      throw new HttpError('validation.failed', 'unsupported entity link tuple', {
++        fields: [{ path: [], code: 'unsupported_tuple' }],
++      });
++    }
++    if (link.status !== 'active') {
++      throw new HttpError('conflict.stale_write', 'entity link is no longer active');
++    }
++
++    const [sourceRow, targetRow] = await Promise.all([
++      resolveVocEndpoint(deps.db, actor.workspace_id, link.source_id),
++      resolveVocEndpoint(deps.db, actor.workspace_id, link.target_id),
++    ]);
++    if (!sourceRow || !targetRow) {
++      throw new HttpError('not_found.record', 'entity link endpoint not found');
++    }
++
++    const [sourceAllowed, targetAllowed] = await Promise.all([
++      assertVocReadScope(deps, actor, sourceRow.managed_system_id),
++      assertVocReadScope(deps, actor, targetRow.managed_system_id),
++    ]);
++    if (!sourceAllowed || !targetAllowed) {
++      throw new HttpError('not_found.record', 'entity link not found');
++    }
++
++    const detached = await deps.db.transaction(async (tx) => {
++      const updated = await detachVocRelatedToLink(tx, {
++        workspaceId: actor.workspace_id,
++        linkId,
++        actorId: actor.actor_id,
++        reason,
++      });
++      if (!updated) {
++        throw new HttpError('conflict.stale_write', 'entity link is no longer active');
++      }
++
++      await deps.auditService.record(tx, {
++        workspace_id: actor.workspace_id,
++        actor_id: actor.actor_id,
++        event_type: 'entity_link.detached',
++        subject_type: 'entity_link',
++        subject_id: updated.id,
++        summary: 'Entity link detached',
++        detail: {
++          link_id: updated.id,
++          source: { type: updated.source_type, id: updated.source_id },
++          target: { type: updated.target_type, id: updated.target_id },
++          relation_type: updated.relation_type,
++          reason,
++        },
++      });
++
++      return updated;
++    });
++
++    return toDetachedResponse(detached);
++  }
++
++  return { createLink, listLinks, detachLink };
+ }
+ 
+ export type EntityLinksService = ReturnType<typeof createEntityLinksService>;
+
+hook: PostToolUse
+exec
+/bin/zsh -lc 'git diff -- apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts' in /Users/hyojung/Desktop/2026/wt-113-entity-link-detach
+ succeeded in 0ms:
+git: warning: confstr() failed with code 5: couldn't get path of DARWIN_USER_TEMP_DIR; using /tmp instead
+diff --git a/apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts b/apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts
+index 0203b45..19021e6 100644
+--- a/apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts
++++ b/apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts
+@@ -1,4 +1,4 @@
+-// POST/GET /entity-links integration tests — Slice 4.1 issue #112.
++// POST/GET/PATCH /entity-links integration tests — Slice 4.1 #112 + Slice 4.2 #113.
+ //
+ // Gate: DATABASE_URL + WORKSPACE_ID + DATABASE_URL_MIGRATE. The migrate role is
+ // required because core.entity_links is append-only to fops_app.
+@@ -82,7 +82,9 @@ describe.skipIf(!runIntegration)('POST/GET /entity-links (#112)', () => {
+       [WORKSPACE_ID, `${SLUG_PREFIX}%`],
+     );
+     await migrateHandle.pool.query(
+-      `delete from core.audit_log where workspace_id = $1 and event_type = 'entity_link.created'`,
++      `delete from core.audit_log
++        where workspace_id = $1
++          and event_type in ('entity_link.created', 'entity_link.detached')`,
+       [WORKSPACE_ID],
+     );
+     await cleanupReadTestTables(dbHandle, WORKSPACE_ID, SLUG_PREFIX);
+@@ -140,6 +142,18 @@ describe.skipIf(!runIntegration)('POST/GET /entity-links (#112)', () => {
+     });
+   }
+ 
++  async function patchEntityLink(cookie: string, linkId: string, payload: Record<string, unknown>) {
++    return await app.inject({
++      method: 'PATCH',
++      url: `/entity-links/${linkId}`,
++      headers: {
++        cookie: `${SESSION_COOKIE_NAME}=${cookie}`,
++        'content-type': 'application/json',
++      },
++      payload,
++    });
++  }
++
+   it('POST creates an active VOC↔VOC related_to link and audit row', async () => {
+     const { msA, sourceVoc, targetVoc } = await seedVocPair();
+ 
+@@ -302,4 +316,148 @@ describe.skipIf(!runIntegration)('POST/GET /entity-links (#112)', () => {
+       body.links?.some((link) => link.id === linkId && link.visibility_state === 'allowed'),
+     ).toBe(true);
+   });
++
++  it('PATCH detaches an active related_to link, preserves the row, and audits the detach', async () => {
++    const { sourceVoc, targetVoc } = await seedVocPair();
++    const create = await postEntityLink(adminCookie, sourceVoc.id, targetVoc.id);
++    expect(create.statusCode).toBe(201);
++    const linkId = create.json<{ id: string }>().id;
++
++    const res = await patchEntityLink(adminCookie, linkId, { reason: 'No longer relevant' });
++    expect(res.statusCode).toBe(200);
++    const body = res.json<{ id: string; status: string; detached_at: string | null }>();
++    expect(body).toMatchObject({ id: linkId, status: 'detached' });
++    expect(body.detached_at).toEqual(expect.any(String));
++
++    const linkRows = await dbHandle.pool.query<{
++      status: string;
++      detached_by: string | null;
++      detach_reason: string | null;
++      detached_at: Date | null;
++    }>(
++      `select status, detached_by, detach_reason, detached_at
++        from core.entity_links
++        where id = $1`,
++      [linkId],
++    );
++    expect(linkRows.rowCount).toBe(1);
++    expect(linkRows.rows[0]).toMatchObject({
++      status: 'detached',
++      detached_by: adminActorId,
++      detach_reason: 'No longer relevant',
++    });
++    expect(linkRows.rows[0]?.detached_at).toBeInstanceOf(Date);
++
++    const auditRows = await dbHandle.pool.query<{ detail: Record<string, unknown> }>(
++      `select detail from core.audit_log
++        where event_type = 'entity_link.detached' and subject_id = $1`,
++      [linkId],
++    );
++    expect(auditRows.rowCount).toBe(1);
++    expect(auditRows.rows[0]?.detail).toMatchObject({
++      link_id: linkId,
++      source: { type: 'voc', id: sourceVoc.id },
++      target: { type: 'voc', id: targetVoc.id },
++      relation_type: 'related_to',
++      reason: 'No longer relevant',
++    });
++  });
++
++  it('after detach, GET /entity-links and VOC detail Links tab omit the detached link', async () => {
++    const { sourceVoc, targetVoc } = await seedVocPair();
++    const create = await postEntityLink(adminCookie, sourceVoc.id, targetVoc.id);
++    expect(create.statusCode).toBe(201);
++    const linkId = create.json<{ id: string }>().id;
++
++    const detach = await patchEntityLink(adminCookie, linkId, { reason: 'Superseded' });
++    expect(detach.statusCode).toBe(200);
++
++    const list = await app.inject({
++      method: 'GET',
++      url: `/entity-links?source_type=voc&source_id=${sourceVoc.id}`,
++      headers: { cookie: `${SESSION_COOKIE_NAME}=${adminCookie}` },
++    });
++    expect(list.statusCode).toBe(200);
++    expect(
++      list.json<{ items: Array<{ id: string }> }>().items.some((item) => item.id === linkId),
++    ).toBe(false);
++
++    const detail = await app.inject({
++      method: 'GET',
++      url: `/vocs/${sourceVoc.id}`,
++      headers: { cookie: `${SESSION_COOKIE_NAME}=${adminCookie}` },
++    });
++    expect(detail.statusCode).toBe(200);
++    const body = detail.json<{ links?: Array<{ id: string }> }>();
++    expect(body.links?.some((link) => link.id === linkId)).toBe(false);
++  });
++
++  it('PATCH on an already-detached link returns 409', async () => {
++    const { sourceVoc, targetVoc } = await seedVocPair();
++    const create = await postEntityLink(adminCookie, sourceVoc.id, targetVoc.id);
++    expect(create.statusCode).toBe(201);
++    const linkId = create.json<{ id: string }>().id;
++
++    const first = await patchEntityLink(adminCookie, linkId, { reason: 'Initial detach' });
++    expect(first.statusCode).toBe(200);
++
++    const second = await patchEntityLink(adminCookie, linkId, { reason: 'Again' });
++    expect(second.statusCode).toBe(409);
++    expect(second.json<{ code: string }>().code).toBe('conflict.stale_write');
++  });
++
++  it('PATCH returns 404 when actor lacks scope on the target endpoint', async () => {
++    const { msA, sourceVoc, targetVoc } = await seedVocPair();
++    const create = await postEntityLink(adminCookie, sourceVoc.id, targetVoc.id);
++    expect(create.statusCode).toBe(201);
++    const linkId = create.json<{ id: string }>().id;
++
++    const { id: devId, externalId } = await insertDevActor(
++      dbHandle,
++      WORKSPACE_ID,
++      uid('detach404'),
++    );
++    await grantCapability(dbHandle, WORKSPACE_ID, devId, 'voc.read', msA, adminActorId);
++    const devCookie = await loginAs(app, externalId);
++
++    const res = await patchEntityLink(devCookie, linkId, { reason: 'No scope' });
++    expect(res.statusCode).toBe(404);
++  });
++
++  it('PATCH rejects missing or empty detach reason', async () => {
++    const { sourceVoc, targetVoc } = await seedVocPair();
++    const create = await postEntityLink(adminCookie, sourceVoc.id, targetVoc.id);
++    expect(create.statusCode).toBe(201);
++    const linkId = create.json<{ id: string }>().id;
++
++    for (const payload of [{}, { reason: '' }, { reason: '   ' }]) {
++      const res = await patchEntityLink(adminCookie, linkId, payload);
++      expect(res.statusCode).toBe(422);
++      expect(res.json<{ code: string }>().code).toBe('validation.failed');
++    }
++  });
++
++  it('detach frees the active unique slot so the same VOC pair can be linked again', async () => {
++    const { sourceVoc, targetVoc } = await seedVocPair();
++    const first = await postEntityLink(adminCookie, sourceVoc.id, targetVoc.id);
++    expect(first.statusCode).toBe(201);
++    const firstId = first.json<{ id: string }>().id;
++
++    const detach = await patchEntityLink(adminCookie, firstId, { reason: 'Relink needed' });
++    expect(detach.statusCode).toBe(200);
++
++    const second = await postEntityLink(adminCookie, sourceVoc.id, targetVoc.id);
++    expect(second.statusCode).toBe(201);
++    expect(second.json<{ id: string }>().id).not.toBe(firstId);
++
++    const count = await dbHandle.pool.query<{ active: number; detached: number }>(
++      `select
++          count(*) filter (where status = 'active')::int as active,
++          count(*) filter (where status = 'detached')::int as detached
++        from core.entity_links
++        where source_id = $1 and target_id = $2`,
++      [sourceVoc.id, targetVoc.id],
++    );
++    expect(count.rows[0]).toMatchObject({ active: 1, detached: 1 });
++  });
+ });
+
+hook: PostToolUse
+exec
+/bin/zsh -lc 'git diff -- packages/shared/src/entity-links.ts packages/shared/src/enums/audit-events.ts docs/design/11-entity-linking.md docs/implementation/06-entity-linking-contract.md' in /Users/hyojung/Desktop/2026/wt-113-entity-link-detach
+ succeeded in 0ms:
+git: warning: confstr() failed with code 5: couldn't get path of DARWIN_USER_TEMP_DIR; using /tmp instead
+diff --git a/docs/design/11-entity-linking.md b/docs/design/11-entity-linking.md
+index 1cc1e32..3a29171 100644
+--- a/docs/design/11-entity-linking.md
++++ b/docs/design/11-entity-linking.md
+@@ -86,6 +86,12 @@ links only. The tracer creates `core.entity_links` rows with `status='active'`,
+ `visibility='internal_only'`, and backend-decided read visibility of `allowed`
+ or `hidden`.
+ 
++Slice 4.2 detach lifecycle (#113): production support detaches only existing
++active VOC↔VOC `related_to` links via `PATCH /entity-links/:id` with a required
++non-empty reason. Detach transitions `status` to `detached`, records
++`detached_by`, `detach_reason`, and `detached_at`, and preserves the row; hard
++delete and `DELETE /entity-links/:id` are intentionally not used.
++
+ ## Visibility
+ 
+ ```text
+@@ -137,6 +143,10 @@ Acceptance Criteria:
+ - Sensitive detach actions are audited.
+ ```
+ 
++Slice 4.2 (#113) implements this for VOC↔VOC `related_to` as `detached` only.
++`revoked` remains reserved for future admin/policy flows and `stale` remains
++deferred.
++
+ ### FR-LINK-002: Enforce Visibility
+ 
+ Priority: MUST
+diff --git a/docs/implementation/06-entity-linking-contract.md b/docs/implementation/06-entity-linking-contract.md
+index ef5356b..52945a0 100644
+--- a/docs/implementation/06-entity-linking-contract.md
++++ b/docs/implementation/06-entity-linking-contract.md
+@@ -68,6 +68,26 @@ voc -> voc
+   as visibility_state=allowed when readable and visibility_state=hidden when not
+ ```
+ 
++## Link Detach Validation
++
++Slice 4.2 detach lifecycle (#113):
++
++```text
++PATCH /entity-links/:id
++- request body: { reason: string } where reason is required, trimmed, and non-empty
++- supported transition: active -> detached only
++- authz: actor must have the same voc.read capability used by link creation on
++  both source and target VOC Managed Systems
++- not found / cross-workspace / missing scope on either endpoint: 404
++- already detached, revoked, stale, or lost update race: 409
++- side effects in one transaction: update status/detach metadata and append
++  audit_log event_type entity_link.detached
++- hard delete is forbidden; fops_app has UPDATE but not DELETE on core.entity_links
++```
++
++Because the active uniqueness constraint is partial (`WHERE status='active'`),
++detaching a link intentionally frees the same VOC pair to be linked again later.
++
+ ## Visibility Enforcement
+ 
+ ```text
+diff --git a/packages/shared/src/entity-links.ts b/packages/shared/src/entity-links.ts
+index 1546123..5da3f74 100644
+--- a/packages/shared/src/entity-links.ts
++++ b/packages/shared/src/entity-links.ts
+@@ -38,6 +38,13 @@ export const createEntityLinkRequestSchema = z
+   .strict();
+ export type CreateEntityLinkRequest = z.infer<typeof createEntityLinkRequestSchema>;
+ 
++export const detachEntityLinkRequestSchema = z
++  .object({
++    reason: z.string().trim().min(1),
++  })
++  .strict();
++export type DetachEntityLinkRequest = z.infer<typeof detachEntityLinkRequestSchema>;
++
+ export const listEntityLinksQuerySchema = z
+   .object({
+     source_type: entityLinkEntityTypeSchema.optional(),
+@@ -107,3 +114,10 @@ export const listEntityLinksResponseSchema = z.object({
+   items: z.array(entityLinkDtoSchema),
+ });
+ export type ListEntityLinksResponse = z.infer<typeof listEntityLinksResponseSchema>;
++
++export const detachedEntityLinkResponseSchema = z.object({
++  id: z.string().uuid(),
++  status: z.literal('detached'),
++  detached_at: z.string().datetime(),
++});
++export type DetachedEntityLinkResponse = z.infer<typeof detachedEntityLinkResponseSchema>;
+diff --git a/packages/shared/src/enums/audit-events.ts b/packages/shared/src/enums/audit-events.ts
+index fefda94..f327a00 100644
+--- a/packages/shared/src/enums/audit-events.ts
++++ b/packages/shared/src/enums/audit-events.ts
+@@ -60,6 +60,8 @@ export const AUDIT_EVENT_TYPES = [
+   'attachment_uploaded',
+   // Slice 4.1 #112: canonical entity link creation tracer.
+   'entity_link.created',
++  // Slice 4.2 #113: audited soft detach lifecycle.
++  'entity_link.detached',
+ ] as const;
+ export type AuditEventType = (typeof AUDIT_EVENT_TYPES)[number];
+ 
+@@ -162,6 +164,21 @@ export const entityLinkCreatedDetailSchema = z.object({
+ });
+ export type EntityLinkCreatedDetail = z.infer<typeof entityLinkCreatedDetailSchema>;
+ 
++export const entityLinkDetachedDetailSchema = z.object({
++  link_id: z.string().uuid(),
++  source: z.object({
++    type: z.literal('voc'),
++    id: z.string().uuid(),
++  }),
++  target: z.object({
++    type: z.literal('voc'),
++    id: z.string().uuid(),
++  }),
++  relation_type: z.literal('related_to'),
++  reason: z.string().min(1),
++});
++export type EntityLinkDetachedDetail = z.infer<typeof entityLinkDetachedDetailSchema>;
++
+ export const AUDIT_EVENT_DETAIL_SCHEMAS = {
+   permission_requested: permissionRequestedDetailSchema,
+   managed_system_registered: managedSystemRegisteredDetailSchema,
+@@ -189,4 +206,6 @@ export const AUDIT_EVENT_DETAIL_SCHEMAS = {
+   attachment_uploaded: attachmentUploadedDetailSchema,
+   // Slice 4.1 #112.
+   'entity_link.created': entityLinkCreatedDetailSchema,
++  // Slice 4.2 #113.
++  'entity_link.detached': entityLinkDetachedDetailSchema,
+ } as const satisfies Record<AuditEventType, z.ZodTypeAny>;
+
+hook: PostToolUse
+hook: PostToolUse Failed
+hook: PostToolUse Failed
+hook: PostToolUse Failed
+hook: PostToolUse Failed
+codex
+The main path is scoped to entity-links plus shared audit/types and docs. I’m checking two likely risk spots now: whether permission failure really maps to 404 on both endpoint systems, and whether migration/test coverage proves `updated_at` and 0019 registration correctly.
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse Failed
+hook: PreToolUse Failed
+hook: PreToolUse Failed
+hook: PreToolUse Failed
+exec
+/bin/zsh -lc "nl -ba apps/backend/src/modules/entity-links/repo.ts | sed -n '1,280p'" in /Users/hyojung/Desktop/2026/wt-113-entity-link-detach
+ succeeded in 0ms:
+     1	import { sql } from 'drizzle-orm';
+     2	
+     3	import type { Db } from '../../db/client.js';
+     4	import { vocs } from '../../db/schema/voc.js';
+     5	import type { Tx } from '../../db/tx.js';
+     6	
+     7	export interface LinkEndpointRow {
+     8	  workspace_id: string;
+     9	  managed_system_id: string;
+    10	}
+    11	
+    12	export interface EntityLinkRow {
+    13	  id: string;
+    14	  workspace_id: string;
+    15	  source_type: 'voc';
+    16	  source_id: string;
+    17	  target_type: 'voc';
+    18	  target_id: string;
+    19	  relation_type: 'related_to';
+    20	  visibility: 'internal_only' | 'summary_visible' | 'visible_to_reporter' | 'admin_only';
+    21	  status: 'active' | 'stale' | 'detached' | 'revoked';
+    22	  managed_system_id: string;
+    23	  created_by: string;
+    24	  created_at: Date;
+    25	  updated_at: Date | null;
+    26	  detached_by: string | null;
+    27	  detach_reason: string | null;
+    28	  detached_at: Date | null;
+    29	}
+    30	
+    31	function mapEntityLinkRow(row: Record<string, unknown>): EntityLinkRow {
+    32	  return {
+    33	    id: row.id as string,
+    34	    workspace_id: row.workspace_id as string,
+    35	    source_type: row.source_type as 'voc',
+    36	    source_id: row.source_id as string,
+    37	    target_type: row.target_type as 'voc',
+    38	    target_id: row.target_id as string,
+    39	    relation_type: row.relation_type as 'related_to',
+    40	    visibility: row.visibility as EntityLinkRow['visibility'],
+    41	    status: row.status as EntityLinkRow['status'],
+    42	    managed_system_id: row.managed_system_id as string,
+    43	    created_by: row.created_by as string,
+    44	    created_at:
+    45	      row.created_at instanceof Date ? row.created_at : new Date(row.created_at as string),
+    46	    updated_at:
+    47	      row.updated_at === null || row.updated_at === undefined
+    48	        ? null
+    49	        : row.updated_at instanceof Date
+    50	          ? row.updated_at
+    51	          : new Date(row.updated_at as string),
+    52	    detached_by: (row.detached_by as string | null) ?? null,
+    53	    detach_reason: (row.detach_reason as string | null) ?? null,
+    54	    detached_at:
+    55	      row.detached_at === null || row.detached_at === undefined
+    56	        ? null
+    57	        : row.detached_at instanceof Date
+    58	          ? row.detached_at
+    59	          : new Date(row.detached_at as string),
+    60	  };
+    61	}
+    62	
+    63	export async function resolveVocEndpoint(
+    64	  db: Db | Tx,
+    65	  workspaceId: string,
+    66	  vocId: string,
+    67	): Promise<LinkEndpointRow | null> {
+    68	  const result = await (db as Db).execute<Record<string, unknown>>(sql`
+    69	    SELECT workspace_id, primary_managed_system_id AS managed_system_id
+    70	    FROM ${vocs}
+    71	    WHERE id = ${vocId}
+    72	      AND workspace_id = ${workspaceId}
+    73	      AND archived_at IS NULL
+    74	  `);
+    75	  const row = result.rows[0];
+    76	  if (!row) return null;
+    77	  return {
+    78	    workspace_id: row.workspace_id as string,
+    79	    managed_system_id: row.managed_system_id as string,
+    80	  };
+    81	}
+    82	
+    83	export async function insertActiveVocRelatedToLink(
+    84	  tx: Tx,
+    85	  input: {
+    86	    workspaceId: string;
+    87	    sourceId: string;
+    88	    targetId: string;
+    89	    managedSystemId: string;
+    90	    createdBy: string;
+    91	    visibility: 'internal_only';
+    92	  },
+    93	): Promise<{ row: EntityLinkRow; inserted: boolean }> {
+    94	  const inserted = await (tx as Db).execute<Record<string, unknown>>(sql`
+    95	    INSERT INTO core.entity_links (
+    96	      workspace_id, source_type, source_id, target_type, target_id,
+    97	      relation_type, visibility, status, managed_system_id, created_by
+    98	    )
+    99	    VALUES (
+   100	      ${input.workspaceId}, 'voc', ${input.sourceId}, 'voc', ${input.targetId},
+   101	      'related_to', ${input.visibility}, 'active', ${input.managedSystemId}, ${input.createdBy}
+   102	    )
+   103	    ON CONFLICT (
+   104	      workspace_id, source_type, source_id, target_type, target_id, relation_type
+   105	    ) WHERE status = 'active'
+   106	    DO NOTHING
+   107	    RETURNING
+   108	      id, workspace_id, source_type, source_id, target_type, target_id,
+   109	      relation_type, visibility, status, managed_system_id, created_by,
+   110	      created_at, updated_at, detached_by, detach_reason, detached_at
+   111	  `);
+   112	  const insertedRow = inserted.rows[0];
+   113	  if (insertedRow) return { row: mapEntityLinkRow(insertedRow), inserted: true };
+   114	
+   115	  const existing = await selectActiveVocRelatedToLink(tx, {
+   116	    workspaceId: input.workspaceId,
+   117	    sourceId: input.sourceId,
+   118	    targetId: input.targetId,
+   119	  });
+   120	  if (!existing) {
+   121	    throw new Error('entity link conflict did not return existing active row');
+   122	  }
+   123	  return { row: existing, inserted: false };
+   124	}
+   125	
+   126	export async function selectActiveVocRelatedToLink(
+   127	  db: Db | Tx,
+   128	  input: { workspaceId: string; sourceId: string; targetId: string },
+   129	): Promise<EntityLinkRow | null> {
+   130	  const result = await (db as Db).execute<Record<string, unknown>>(sql`
+   131	    SELECT
+   132	      id, workspace_id, source_type, source_id, target_type, target_id,
+   133	      relation_type, visibility, status, managed_system_id, created_by,
+   134	      created_at, updated_at, detached_by, detach_reason, detached_at
+   135	    FROM core.entity_links
+   136	    WHERE workspace_id = ${input.workspaceId}
+   137	      AND source_type = 'voc'
+   138	      AND source_id = ${input.sourceId}
+   139	      AND target_type = 'voc'
+   140	      AND target_id = ${input.targetId}
+   141	      AND relation_type = 'related_to'
+   142	      AND status = 'active'
+   143	    LIMIT 1
+   144	  `);
+   145	  const row = result.rows[0];
+   146	  return row ? mapEntityLinkRow(row) : null;
+   147	}
+   148	
+   149	export async function selectActiveLinksForEndpoint(
+   150	  db: Db | Tx,
+   151	  input: {
+   152	    workspaceId: string;
+   153	    endpointType: 'voc';
+   154	    endpointId: string;
+   155	    side?: 'source' | 'target';
+   156	  },
+   157	): Promise<EntityLinkRow[]> {
+   158	  const sidePredicate =
+   159	    input.side === 'source'
+   160	      ? sql`source_type = ${input.endpointType} AND source_id = ${input.endpointId}`
+   161	      : input.side === 'target'
+   162	        ? sql`target_type = ${input.endpointType} AND target_id = ${input.endpointId}`
+   163	        : sql`(
+   164	            (source_type = ${input.endpointType} AND source_id = ${input.endpointId})
+   165	            OR (target_type = ${input.endpointType} AND target_id = ${input.endpointId})
+   166	          )`;
+   167	
+   168	  const result = await (db as Db).execute<Record<string, unknown>>(sql`
+   169	    SELECT
+   170	      id, workspace_id, source_type, source_id, target_type, target_id,
+   171	      relation_type, visibility, status, managed_system_id, created_by,
+   172	      created_at, updated_at, detached_by, detach_reason, detached_at
+   173	    FROM core.entity_links
+   174	    WHERE workspace_id = ${input.workspaceId}
+   175	      AND status = 'active'
+   176	      AND ${sidePredicate}
+   177	    ORDER BY created_at DESC, id DESC
+   178	  `);
+   179	  return result.rows.map(mapEntityLinkRow);
+   180	}
+   181	
+   182	export async function selectEntityLinkById(
+   183	  db: Db | Tx,
+   184	  input: { workspaceId: string; linkId: string },
+   185	): Promise<EntityLinkRow | null> {
+   186	  const result = await (db as Db).execute<Record<string, unknown>>(sql`
+   187	    SELECT
+   188	      id, workspace_id, source_type, source_id, target_type, target_id,
+   189	      relation_type, visibility, status, managed_system_id, created_by,
+   190	      created_at, updated_at, detached_by, detach_reason, detached_at
+   191	    FROM core.entity_links
+   192	    WHERE workspace_id = ${input.workspaceId}
+   193	      AND id = ${input.linkId}
+   194	    LIMIT 1
+   195	  `);
+   196	  const row = result.rows[0];
+   197	  return row ? mapEntityLinkRow(row) : null;
+   198	}
+   199	
+   200	export async function detachVocRelatedToLink(
+   201	  tx: Tx,
+   202	  input: {
+   203	    workspaceId: string;
+   204	    linkId: string;
+   205	    actorId: string;
+   206	    reason: string;
+   207	  },
+   208	): Promise<EntityLinkRow | null> {
+   209	  const updated = await (tx as Db).execute<Record<string, unknown>>(sql`
+   210	    UPDATE core.entity_links
+   211	    SET
+   212	      status = 'detached',
+   213	      detached_by = ${input.actorId},
+   214	      detach_reason = ${input.reason},
+   215	      detached_at = now(),
+   216	      updated_at = now()
+   217	    WHERE workspace_id = ${input.workspaceId}
+   218	      AND id = ${input.linkId}
+   219	      AND status = 'active'
+   220	    RETURNING
+   221	      id, workspace_id, source_type, source_id, target_type, target_id,
+   222	      relation_type, visibility, status, managed_system_id, created_by,
+   223	      created_at, updated_at, detached_by, detach_reason, detached_at
+   224	  `);
+   225	  const row = updated.rows[0];
+   226	  return row ? mapEntityLinkRow(row) : null;
+   227	}
+
+hook: PostToolUse
+exec
+/bin/zsh -lc "nl -ba apps/backend/src/modules/entity-links/service.ts | sed -n '1,320p'" in /Users/hyojung/Desktop/2026/wt-113-entity-link-detach
+ succeeded in 0ms:
+     1	import type { DetachedEntityLinkResponse, EntityLinkDto, EntityLinkRef } from '@fops/shared';
+     2	
+     3	import type { Db } from '../../db/client.js';
+     4	import { HttpError } from '../../lib/errors.js';
+     5	import type { AuditService } from '../core/audit/audit-service.js';
+     6	import type { CheckService } from '../permissions/check-service.js';
+     7	import {
+     8	  type EntityLinkRow,
+     9	  detachVocRelatedToLink,
+    10	  insertActiveVocRelatedToLink,
+    11	  resolveVocEndpoint,
+    12	  selectActiveLinksForEndpoint,
+    13	  selectEntityLinkById,
+    14	} from './repo.js';
+    15	
+    16	export interface EntityLinksActor {
+    17	  actor_id: string;
+    18	  workspace_id: string;
+    19	  role_level: 'admin' | 'developer' | 'user';
+    20	}
+    21	
+    22	export interface EntityLinksServiceDeps {
+    23	  db: Db;
+    24	  checkService: CheckService;
+    25	  auditService: AuditService;
+    26	}
+    27	
+    28	function toAllowedDto(row: EntityLinkRow): EntityLinkDto {
+    29	  return {
+    30	    id: row.id,
+    31	    source_type: row.source_type,
+    32	    source_id: row.source_id,
+    33	    target_type: row.target_type,
+    34	    target_id: row.target_id,
+    35	    relation_type: row.relation_type,
+    36	    visibility: row.visibility,
+    37	    status: row.status,
+    38	    managed_system_id: row.managed_system_id,
+    39	    created_by: row.created_by,
+    40	    created_at: row.created_at.toISOString(),
+    41	    updated_at: row.updated_at ? row.updated_at.toISOString() : null,
+    42	    visibility_state: 'allowed',
+    43	  };
+    44	}
+    45	
+    46	function toHiddenDto(row: EntityLinkRow): EntityLinkDto {
+    47	  return {
+    48	    id: row.id,
+    49	    source_type: row.source_type,
+    50	    target_type: row.target_type,
+    51	    relation_type: row.relation_type,
+    52	    visibility_state: 'hidden',
+    53	  };
+    54	}
+    55	
+    56	function toDetachedResponse(row: EntityLinkRow): DetachedEntityLinkResponse {
+    57	  if (row.status !== 'detached' || row.detached_at === null) {
+    58	    throw new HttpError('internal.unexpected', 'detached entity link row missing detach fields');
+    59	  }
+    60	  return {
+    61	    id: row.id,
+    62	    status: 'detached',
+    63	    detached_at: row.detached_at.toISOString(),
+    64	  };
+    65	}
+    66	
+    67	async function assertVocReadScope(
+    68	  deps: Pick<EntityLinksServiceDeps, 'checkService'>,
+    69	  actor: EntityLinksActor,
+    70	  managedSystemId: string,
+    71	): Promise<boolean> {
+    72	  const decision = await deps.checkService.checkCapability(actor, 'voc.read', {
+    73	    workspace_id: actor.workspace_id,
+    74	    managed_system_id: managedSystemId,
+    75	  });
+    76	  return decision.allow;
+    77	}
+    78	
+    79	export function createEntityLinksService(deps: EntityLinksServiceDeps) {
+    80	  async function createLink(args: {
+    81	    actor: EntityLinksActor;
+    82	    source: EntityLinkRef;
+    83	    target: EntityLinkRef;
+    84	    relation_type: 'related_to';
+    85	    visibility?: 'internal_only';
+    86	  }): Promise<{ link: EntityLinkDto; status: 200 | 201 }> {
+    87	    const { actor, source, target } = args;
+    88	    const visibility = args.visibility ?? 'internal_only';
+    89	
+    90	    if (source.type !== 'voc' || target.type !== 'voc' || args.relation_type !== 'related_to') {
+    91	      throw new HttpError('validation.failed', 'unsupported entity link tuple', {
+    92	        fields: [{ path: [], code: 'unsupported_tuple' }],
+    93	      });
+    94	    }
+    95	    if (visibility !== 'internal_only') {
+    96	      throw new HttpError('validation.failed', 'unsupported visibility', {
+    97	        fields: [{ path: ['visibility'], code: 'unsupported_visibility' }],
+    98	      });
+    99	    }
+   100	    if (source.id === target.id) {
+   101	      throw new HttpError('validation.failed', 'entity link source and target must differ', {
+   102	        fields: [{ path: ['target', 'id'], code: 'self_link' }],
+   103	      });
+   104	    }
+   105	
+   106	    const [sourceRow, targetRow] = await Promise.all([
+   107	      resolveVocEndpoint(deps.db, actor.workspace_id, source.id),
+   108	      resolveVocEndpoint(deps.db, actor.workspace_id, target.id),
+   109	    ]);
+   110	    if (!sourceRow || !targetRow) {
+   111	      throw new HttpError('not_found.record', 'entity link endpoint not found');
+   112	    }
+   113	
+   114	    const sourceAllowed = await assertVocReadScope(deps, actor, sourceRow.managed_system_id);
+   115	    if (!sourceAllowed) {
+   116	      throw new HttpError('permission.denied', 'missing source VOC read scope');
+   117	    }
+   118	
+   119	    const targetAllowed = await assertVocReadScope(deps, actor, targetRow.managed_system_id);
+   120	    if (!targetAllowed) {
+   121	      throw new HttpError('not_found.record', 'entity link endpoint not found');
+   122	    }
+   123	
+   124	    const result = await deps.db.transaction(async (tx) => {
+   125	      const inserted = await insertActiveVocRelatedToLink(tx, {
+   126	        workspaceId: actor.workspace_id,
+   127	        sourceId: source.id,
+   128	        targetId: target.id,
+   129	        managedSystemId: sourceRow.managed_system_id,
+   130	        createdBy: actor.actor_id,
+   131	        visibility,
+   132	      });
+   133	
+   134	      if (inserted.inserted) {
+   135	        await deps.auditService.record(tx, {
+   136	          workspace_id: actor.workspace_id,
+   137	          actor_id: actor.actor_id,
+   138	          event_type: 'entity_link.created',
+   139	          subject_type: 'entity_link',
+   140	          subject_id: inserted.row.id,
+   141	          summary: 'Entity link created',
+   142	          detail: {
+   143	            link_id: inserted.row.id,
+   144	            source,
+   145	            target,
+   146	            relation_type: args.relation_type,
+   147	            visibility,
+   148	          },
+   149	        });
+   150	      }
+   151	
+   152	      return inserted;
+   153	    });
+   154	
+   155	    return { link: toAllowedDto(result.row), status: result.inserted ? 201 : 200 };
+   156	  }
+   157	
+   158	  async function listLinks(args: {
+   159	    actor: EntityLinksActor;
+   160	    endpoint: EntityLinkRef;
+   161	    side?: 'source' | 'target';
+   162	  }): Promise<EntityLinkDto[]> {
+   163	    const { actor, endpoint, side } = args;
+   164	    if (endpoint.type !== 'voc') {
+   165	      throw new HttpError('validation.failed', 'unsupported entity type', {
+   166	        fields: [{ path: ['type'], code: 'unsupported_entity_type' }],
+   167	      });
+   168	    }
+   169	
+   170	    const focus = await resolveVocEndpoint(deps.db, actor.workspace_id, endpoint.id);
+   171	    if (!focus) {
+   172	      throw new HttpError('not_found.record', 'entity link endpoint not found');
+   173	    }
+   174	    const focusAllowed = await assertVocReadScope(deps, actor, focus.managed_system_id);
+   175	    if (!focusAllowed) {
+   176	      throw new HttpError('not_found.record', 'entity link endpoint not found');
+   177	    }
+   178	
+   179	    const listArgs = {
+   180	      workspaceId: actor.workspace_id,
+   181	      endpointType: endpoint.type,
+   182	      endpointId: endpoint.id,
+   183	    };
+   184	    const rows = await selectActiveLinksForEndpoint(
+   185	      deps.db,
+   186	      side === undefined ? listArgs : { ...listArgs, side },
+   187	    );
+   188	
+   189	    const resolvedByVocId = new Map<string, Awaited<ReturnType<typeof resolveVocEndpoint>>>();
+   190	    const items: EntityLinkDto[] = [];
+   191	    for (const row of rows) {
+   192	      const otherId = row.source_id === endpoint.id ? row.target_id : row.source_id;
+   193	      let other = resolvedByVocId.get(otherId);
+   194	      if (other === undefined) {
+   195	        other = await resolveVocEndpoint(deps.db, actor.workspace_id, otherId);
+   196	        resolvedByVocId.set(otherId, other);
+   197	      }
+   198	      if (!other) {
+   199	        items.push(toHiddenDto(row));
+   200	        continue;
+   201	      }
+   202	      const otherAllowed = await assertVocReadScope(deps, actor, other.managed_system_id);
+   203	      items.push(otherAllowed ? toAllowedDto(row) : toHiddenDto(row));
+   204	    }
+   205	    return items;
+   206	  }
+   207	
+   208	  async function detachLink(args: {
+   209	    actor: EntityLinksActor;
+   210	    linkId: string;
+   211	    reason: string;
+   212	  }): Promise<DetachedEntityLinkResponse> {
+   213	    const { actor, linkId, reason } = args;
+   214	
+   215	    const link = await selectEntityLinkById(deps.db, {
+   216	      workspaceId: actor.workspace_id,
+   217	      linkId,
+   218	    });
+   219	    if (!link) {
+   220	      throw new HttpError('not_found.record', 'entity link not found');
+   221	    }
+   222	    if (
+   223	      link.source_type !== 'voc' ||
+   224	      link.target_type !== 'voc' ||
+   225	      link.relation_type !== 'related_to'
+   226	    ) {
+   227	      throw new HttpError('validation.failed', 'unsupported entity link tuple', {
+   228	        fields: [{ path: [], code: 'unsupported_tuple' }],
+   229	      });
+   230	    }
+   231	    if (link.status !== 'active') {
+   232	      throw new HttpError('conflict.stale_write', 'entity link is no longer active');
+   233	    }
+   234	
+   235	    const [sourceRow, targetRow] = await Promise.all([
+   236	      resolveVocEndpoint(deps.db, actor.workspace_id, link.source_id),
+   237	      resolveVocEndpoint(deps.db, actor.workspace_id, link.target_id),
+   238	    ]);
+   239	    if (!sourceRow || !targetRow) {
+   240	      throw new HttpError('not_found.record', 'entity link endpoint not found');
+   241	    }
+   242	
+   243	    const [sourceAllowed, targetAllowed] = await Promise.all([
+   244	      assertVocReadScope(deps, actor, sourceRow.managed_system_id),
+   245	      assertVocReadScope(deps, actor, targetRow.managed_system_id),
+   246	    ]);
+   247	    if (!sourceAllowed || !targetAllowed) {
+   248	      throw new HttpError('not_found.record', 'entity link not found');
+   249	    }
+   250	
+   251	    const detached = await deps.db.transaction(async (tx) => {
+   252	      const updated = await detachVocRelatedToLink(tx, {
+   253	        workspaceId: actor.workspace_id,
+   254	        linkId,
+   255	        actorId: actor.actor_id,
+   256	        reason,
+   257	      });
+   258	      if (!updated) {
+   259	        throw new HttpError('conflict.stale_write', 'entity link is no longer active');
+   260	      }
+   261	
+   262	      await deps.auditService.record(tx, {
+   263	        workspace_id: actor.workspace_id,
+   264	        actor_id: actor.actor_id,
+   265	        event_type: 'entity_link.detached',
+   266	        subject_type: 'entity_link',
+   267	        subject_id: updated.id,
+   268	        summary: 'Entity link detached',
+   269	        detail: {
+   270	          link_id: updated.id,
+   271	          source: { type: updated.source_type, id: updated.source_id },
+   272	          target: { type: updated.target_type, id: updated.target_id },
+   273	          relation_type: updated.relation_type,
+   274	          reason,
+   275	        },
+   276	      });
+   277	
+   278	      return updated;
+   279	    });
+   280	
+   281	    return toDetachedResponse(detached);
+   282	  }
+   283	
+   284	  return { createLink, listLinks, detachLink };
+   285	}
+   286	
+   287	export type EntityLinksService = ReturnType<typeof createEntityLinksService>;
+
+hook: PostToolUse
+exec
+/bin/zsh -lc "rg -n \"DELETE|delete from core\\.entity_links|grant .*delete|revoked|stale|apps/frontend|permissions/|auth/|selectActiveLinksForEndpoint|status = 'active'|entity_link.detached|detached_by|detach_reason|detached_at|updated_at\" .review apps/backend/src apps/backend/migrations packages/shared docs/design/11-entity-linking.md docs/implementation/06-entity-linking-contract.md" in /Users/hyojung/Desktop/2026/wt-113-entity-link-detach
+ succeeded in 0ms:
+docs/implementation/06-entity-linking-contract.md:82:- already detached, revoked, stale, or lost update race: 409
+docs/implementation/06-entity-linking-contract.md:84:  audit_log event_type entity_link.detached
+docs/implementation/06-entity-linking-contract.md:85:- hard delete is forbidden; fops_app has UPDATE but not DELETE on core.entity_links
+docs/design/11-entity-linking.md:27:`status='active'`. It also adds `managed_system_id`, `updated_at`, uniqueness
+docs/design/11-entity-linking.md:92:`detached_by`, `detach_reason`, and `detached_at`, and preserves the row; hard
+docs/design/11-entity-linking.md:93:delete and `DELETE /entity-links/:id` are intentionally not used.
+docs/design/11-entity-linking.md:141:- The entity_link is marked inactive, detached, or revoked with actor, reason,
+docs/design/11-entity-linking.md:147:`revoked` remains reserved for future admin/policy flows and `stale` remains
+docs/design/11-entity-linking.md:178:- Dashboard can detect stale or missing workflow links without treating every unlinked record as incomplete.
+.review/ACTORS-ENDPOINT-NOTE.md:6:`useWorkspaceActors` (`apps/frontend/src/features/voc/hooks/useWorkspaceActors.ts`)
+.review/ACTORS-ENDPOINT-NOTE.md:22:1. **BE route**: `apps/backend/src/modules/auth/list-actors-routes.ts` registered
+.review/ACTORS-ENDPOINT-NOTE.md:26:2. **Shared schema**: `packages/shared/src/auth/list-actors.ts` with
+.review/ACTORS-ENDPOINT-NOTE.md:32:4. **Vite proxy entry**: `/actors` added to `apps/frontend/vite.config.ts`.
+.review/ACTORS-ENDPOINT-NOTE.md:34:   scans `apps/frontend/src/**/*.{ts,tsx}` for `apiClient` / `fetch` URL
+.review/ACTORS-ENDPOINT-NOTE.md:42:file (`apps/frontend/src/features/voc/hooks/useWorkspaceActors.ts`). Adding
+.review/ACTORS-ENDPOINT-NOTE.md:57:  `core/` has no actor read service yet, and `auth/` already owns the actor
+.review/ACTORS-ENDPOINT-NOTE.md:58:  identity surface (`/me`, `/auth/mock-login`). Colocated under
+.review/ACTORS-ENDPOINT-NOTE.md:59:  `apps/backend/src/modules/auth/list-actors-routes.ts`.
+.review/ACTORS-ENDPOINT-NOTE.md:63:- `apps/backend/src/modules/auth/__tests__/list-actors.integration.test.ts`
+.review/ACTORS-ENDPOINT-NOTE.md:66:- `packages/shared/src/auth/__tests__/list-actors.test.ts` (4 schema cases).
+packages/shared/src/errors/codes.ts:54:  'conflict.stale_write',
+apps/backend/src/server.ts:29:import { listActorsRoutes } from './modules/auth/list-actors-routes.js';
+apps/backend/src/server.ts:30:import { createMockAuthProvider } from './modules/auth/mock-auth-provider.js';
+apps/backend/src/server.ts:31:import { authRoutes } from './modules/auth/routes.js';
+apps/backend/src/server.ts:32:import { createSessionService } from './modules/auth/session-service.js';
+apps/backend/src/server.ts:44:} from './modules/permissions/index.js';
+apps/backend/src/server.ts:80:  // route-level `/auth/mock-login` 404 gate stays as defense-in-depth, but
+.review/TITLE-BLOCK-RESTORE.md:31:in root `AGENTS.md` / `apps/frontend/AGENTS.md` / `PRODUCT.md` (the English
+.review/TITLE-BLOCK-RESTORE.md:46:### `apps/frontend/src/features/voc/components/detail/IdentitySection.tsx`
+.review/TITLE-BLOCK-RESTORE.md:66:### `apps/frontend/src/features/voc/components/detail/DescriptionSection.tsx`
+.review/TITLE-BLOCK-RESTORE.md:81:### `apps/frontend/src/features/voc/components/detail/VocDetailPanel.tsx`
+.review/TITLE-BLOCK-RESTORE.md:87:### `apps/frontend/src/features/voc/components/triage/TriagePanel.tsx`
+.review/TITLE-BLOCK-RESTORE.md:105:- `apps/frontend/src/features/voc/components/detail/__tests__/IdentitySection.test.tsx`
+.review/TITLE-BLOCK-RESTORE.md:110:- `apps/frontend/src/features/voc/components/detail/__tests__/DescriptionSection.test.tsx`
+.review/TITLE-BLOCK-RESTORE.md:113:- `apps/frontend/src/features/voc/components/triage/__tests__/TriagePanel.titleBlock.test.tsx` (new)
+.review/TITLE-BLOCK-RESTORE.md:120:- `apps/frontend/src/features/voc/components/detail/__tests__/VocDetailPanel.test.tsx`
+.review/TITLE-BLOCK-RESTORE.md:168:`apps/frontend/AGENTS.md`.
+apps/backend/migrations/0011_slice3_voc_integrity_followups.sql:14:--            fops_app DELETE revoked (archive-over-delete invariant per AGENTS.md).
+apps/backend/migrations/0011_slice3_voc_integrity_followups.sql:104:-- DELETE. The active partial index accelerates active-attachment queries.
+apps/backend/migrations/0011_slice3_voc_integrity_followups.sql:105:-- fops_app DELETE revoked so hard-deletes are impossible from the app layer.
+apps/backend/migrations/0011_slice3_voc_integrity_followups.sql:112:  FOREIGN KEY ("archived_by_actor_id") REFERENCES "core"."actors"("id") ON DELETE no action;
+apps/backend/migrations/0011_slice3_voc_integrity_followups.sql:119:REVOKE DELETE ON "voc"."voc_attachments" FROM fops_app;
+apps/backend/migrations/0010_slice3_voc_foundation.sql:71:  "updated_at"                      timestamp with time zone DEFAULT now() NOT NULL,
+apps/backend/migrations/0010_slice3_voc_foundation.sql:89:  FOREIGN KEY ("workspace_id") REFERENCES "core"."workspaces"("id") ON DELETE no action;
+apps/backend/migrations/0010_slice3_voc_foundation.sql:93:  FOREIGN KEY ("primary_managed_system_id") REFERENCES "core"."managed_systems"("id") ON DELETE no action;
+apps/backend/migrations/0010_slice3_voc_foundation.sql:97:  FOREIGN KEY ("analytics_area_id") REFERENCES "core"."analytics_areas"("id") ON DELETE no action;
+apps/backend/migrations/0010_slice3_voc_foundation.sql:101:  FOREIGN KEY ("reporter_id") REFERENCES "core"."actors"("id") ON DELETE no action;
+apps/backend/migrations/0010_slice3_voc_foundation.sql:105:  FOREIGN KEY ("owner_user_id") REFERENCES "core"."actors"("id") ON DELETE no action;
+apps/backend/migrations/0010_slice3_voc_foundation.sql:109:  FOREIGN KEY ("owner_team_id") REFERENCES "core"."teams"("id") ON DELETE no action;
+apps/backend/migrations/0010_slice3_voc_foundation.sql:113:  FOREIGN KEY ("archived_by_actor_id") REFERENCES "core"."actors"("id") ON DELETE no action;
+apps/backend/migrations/0010_slice3_voc_foundation.sql:165:-- ─── voc.touch_updated_at trigger (matches Slice 2 #9 pattern) ──────────
+apps/backend/migrations/0010_slice3_voc_foundation.sql:166:CREATE OR REPLACE FUNCTION "voc"."touch_updated_at"()
+apps/backend/migrations/0010_slice3_voc_foundation.sql:171:  NEW.updated_at = now();
+apps/backend/migrations/0010_slice3_voc_foundation.sql:176:CREATE TRIGGER "vocs_touch_updated_at_trg"
+apps/backend/migrations/0010_slice3_voc_foundation.sql:178:  FOR EACH ROW EXECUTE FUNCTION "voc"."touch_updated_at"();
+apps/backend/migrations/0010_slice3_voc_foundation.sql:187:GRANT SELECT, INSERT, UPDATE, DELETE ON "voc"."vocs" TO fops_app;
+apps/backend/migrations/0010_slice3_voc_foundation.sql:213:  FOREIGN KEY ("voc_id") REFERENCES "voc"."vocs"("id") ON DELETE cascade;
+apps/backend/migrations/0010_slice3_voc_foundation.sql:216:  FOREIGN KEY ("actor_id") REFERENCES "core"."actors"("id") ON DELETE no action;
+apps/backend/migrations/0010_slice3_voc_foundation.sql:230:  FOREIGN KEY ("voc_id") REFERENCES "voc"."vocs"("id") ON DELETE cascade;
+apps/backend/migrations/0010_slice3_voc_foundation.sql:233:  FOREIGN KEY ("actor_id") REFERENCES "core"."actors"("id") ON DELETE no action;
+apps/backend/migrations/0010_slice3_voc_foundation.sql:265:  FOREIGN KEY ("voc_id") REFERENCES "voc"."vocs"("id") ON DELETE cascade;
+apps/backend/migrations/0010_slice3_voc_foundation.sql:268:  FOREIGN KEY ("actor_id") REFERENCES "core"."actors"("id") ON DELETE no action;
+apps/backend/migrations/0010_slice3_voc_foundation.sql:308:  FOREIGN KEY ("voc_id") REFERENCES "voc"."vocs"("id") ON DELETE cascade;
+apps/backend/migrations/0010_slice3_voc_foundation.sql:311:  FOREIGN KEY ("uploaded_by_actor_id") REFERENCES "core"."actors"("id") ON DELETE no action;
+apps/backend/migrations/0010_slice3_voc_foundation.sql:319:GRANT SELECT, INSERT, UPDATE, DELETE ON "voc"."voc_attachments" TO fops_app;
+apps/backend/migrations/0010_slice3_voc_foundation.sql:395:  FOREIGN KEY ("voc_id") REFERENCES "voc"."vocs"("id") ON DELETE cascade;
+apps/backend/migrations/0010_slice3_voc_foundation.sql:397:GRANT SELECT, INSERT, UPDATE, DELETE ON "voc"."voc_permission_decisions_seed_fixture" TO fops_app;
+packages/shared/src/auth/list-actors.ts:10:// /auth/mock-login payloads in apps/backend/src/modules/auth/routes.ts).
+apps/backend/src/modules/entity-links/service.ts:6:import type { CheckService } from '../permissions/check-service.js';
+apps/backend/src/modules/entity-links/service.ts:12:  selectActiveLinksForEndpoint,
+apps/backend/src/modules/entity-links/service.ts:41:    updated_at: row.updated_at ? row.updated_at.toISOString() : null,
+apps/backend/src/modules/entity-links/service.ts:57:  if (row.status !== 'detached' || row.detached_at === null) {
+apps/backend/src/modules/entity-links/service.ts:63:    detached_at: row.detached_at.toISOString(),
+apps/backend/src/modules/entity-links/service.ts:184:    const rows = await selectActiveLinksForEndpoint(
+apps/backend/src/modules/entity-links/service.ts:232:      throw new HttpError('conflict.stale_write', 'entity link is no longer active');
+apps/backend/src/modules/entity-links/service.ts:259:        throw new HttpError('conflict.stale_write', 'entity link is no longer active');
+apps/backend/src/modules/entity-links/service.ts:265:        event_type: 'entity_link.detached',
+packages/shared/src/index.ts:9:export * from './permissions/index.js';
+packages/shared/src/index.ts:15:export * from './auth/list-actors.js';
+.review/PROTOTYPE-TO-PACK17.md:217:| (description body card) | `DescriptionSection` body card | `rounded-md bg-surface-card-elevated p-4 text-sm text-text-secondary leading-relaxed`. Preceded by uppercase label: `text-xs font-semibold uppercase tracking-wide text-text-muted mb-2` rendered as `BODY` (English, verbatim). `RichContentRenderer` renders inside the card. Empty fallback: `'설명 없음'` with `text-text-muted`. | `<DescriptionSection voc={…} />` (`apps/frontend/src/features/voc/components/detail/`). `bg-surface-card-elevated` = `--color-deep-slate` (`#edf3fb`). Canonical implementation. |
+.review/PROTOTYPE-TO-PACK17.md:218:| (identity metadata chip strip) | `IdentityMetadataStrip` | `flex flex-wrap gap-2 px-4 mt-3 text-xs`. Children: `<SeverityBadge>` (conditional), `<ManagedSystemPill>` (conditional), `<OutlineBadge>` for Analytics Area (conditional), `<OutlineBadge>` for source-context (always present). Rendered by `VocDetailPanel` below `DescriptionSection` as a sibling, anchored to the `data-anchor="description"` section. | Exported from `apps/frontend/src/features/voc/components/detail/IdentitySection.tsx` (feature-local; not in `@fops/ui`). Import directly for VOC detail surfaces only. Chip placement relocates badges out of the title block to avoid competing with the xl title. |
+packages/shared/src/enums/audit-events.ts:64:  'entity_link.detached',
+packages/shared/src/enums/audit-events.ts:210:  'entity_link.detached': entityLinkDetachedDetailSchema,
+apps/backend/migrations/0005_slice2_registry.sql:33:  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+apps/backend/migrations/0005_slice2_registry.sql:39:  ON DELETE no action ON UPDATE no action;
+apps/backend/migrations/0005_slice2_registry.sql:44:  ON DELETE no action ON UPDATE no action;
+apps/backend/migrations/0005_slice2_registry.sql:66:  "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+apps/backend/migrations/0005_slice2_registry.sql:74:  ON DELETE no action ON UPDATE no action;
+apps/backend/migrations/0005_slice2_registry.sql:79:  ON DELETE no action ON UPDATE no action;
+apps/backend/migrations/0005_slice2_registry.sql:84:  ON DELETE no action ON UPDATE no action;
+apps/backend/migrations/0005_slice2_registry.sql:89:  ON DELETE no action ON UPDATE no action;
+apps/backend/migrations/0005_slice2_registry.sql:110:  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+apps/backend/migrations/0005_slice2_registry.sql:116:  ON DELETE no action ON UPDATE no action;
+apps/backend/migrations/0005_slice2_registry.sql:121:  ON DELETE no action ON UPDATE no action;
+apps/backend/migrations/0005_slice2_registry.sql:126:  ON DELETE no action ON UPDATE no action;
+apps/backend/migrations/0005_slice2_registry.sql:131:  ON DELETE no action ON UPDATE no action;
+apps/backend/migrations/0005_slice2_registry.sql:151:GRANT SELECT, INSERT, UPDATE, DELETE ON "core"."managed_systems" TO fops_app;--> statement-breakpoint
+apps/backend/migrations/0005_slice2_registry.sql:152:GRANT SELECT, INSERT, UPDATE, DELETE ON "core"."analytics_areas" TO fops_app;--> statement-breakpoint
+apps/backend/migrations/0005_slice2_registry.sql:153:GRANT SELECT, INSERT, UPDATE, DELETE ON "core"."teams" TO fops_app;
+.review/SLICE-3-19-REVIEW-CYCLE-1.md:15:**Location:** `apps/frontend/src/features/voc/routes/CreateRoute.tsx:17-27`, `apps/frontend/src/features/voc/components/create/VocCreateScreen.tsx:60-74`
+.review/SLICE-3-19-REVIEW-CYCLE-1.md:31:**Location:** `apps/frontend/src/features/voc/components/create/AttachmentDropzone.tsx:55-63`
+apps/backend/migrations/0006_permission_managed_system_fks.sql:17:  ON DELETE no action ON UPDATE no action;
+apps/backend/migrations/0006_permission_managed_system_fks.sql:22:  ON DELETE no action ON UPDATE no action;
+apps/backend/migrations/0006_permission_managed_system_fks.sql:27:  ON DELETE no action ON UPDATE no action;
+packages/shared/src/vocs/list-item.ts:52:  updated_at: z.string().datetime(),
+apps/backend/migrations/0009_teams_grants_tighten.sql:5:-- INSERT/UPDATE/DELETE on core.teams … because no Slice 2 application
+apps/backend/migrations/0009_teams_grants_tighten.sql:10:-- Resolution: revoke INSERT/UPDATE/DELETE on core.teams from fops_app.
+apps/backend/migrations/0009_teams_grants_tighten.sql:16:REVOKE INSERT, UPDATE, DELETE ON "core"."teams" FROM fops_app;
+apps/backend/migrations/0016_voc_attachments_grants.sql:1:-- Slice 3 #22 hotfix: restore DELETE grant on voc.voc_attachments for fops_app.
+apps/backend/migrations/0016_voc_attachments_grants.sql:4:--   * 0010 granted SELECT, INSERT, UPDATE, DELETE on voc.voc_attachments to
+apps/backend/migrations/0016_voc_attachments_grants.sql:6:--   * 0011 then REVOKE'd DELETE in service of the archive-over-delete
+apps/backend/migrations/0016_voc_attachments_grants.sql:9:--     (purge-unlinked-attachments.ts) issues a DELETE against unlinked rows
+apps/backend/migrations/0016_voc_attachments_grants.sql:15:--   Re-grant DELETE on voc.voc_attachments to fops_app. The archive-over-
+apps/backend/migrations/0016_voc_attachments_grants.sql:18:--   job is an internal reclaim path that legitimately DELETEs orphaned
+apps/backend/migrations/0016_voc_attachments_grants.sql:23:GRANT DELETE ON "voc"."voc_attachments" TO fops_app;
+.review/PLAN-22.md:59:| D-20 | `fops_app` role grants on `voc.voc_attachments` = `SELECT, INSERT, UPDATE, DELETE` (migration `0016_grant_app_delete_voc_attachments.sql`). User-facing paths delete only via the service-layer **archive over delete** convention (`archived_at`, `archived_by_actor_id`); the DB-layer `DELETE` privilege exists strictly so the hourly `core.attachments_purge` worker (D-13) can reclaim unlinked rows >24h. The archive-over-delete invariant lives at the service layer, not in the grant set. | Hotfix `fix/22-storage-lazy-and-attachments-grants` (post-PR-merge, 2026-05-22) |
+.review/PLAN-22.md:230:- `apps/frontend/src/lib/api/attachments.ts` (multipart `FormData` upload, idempotency key from `useIdempotencyKey`, error mapping) (~80)
+.review/PLAN-22.md:231:- `apps/frontend/src/lib/api/__tests__/attachments.test.ts` (msw-based) (~100)
+.review/PLAN-22.md:232:- `apps/frontend/src/lib/api/errorMapper.ts` (+ `storage.unavailable` → `tone: 'error'`, Korean copy from D-09; remove `attachment.unsupported_pending_storage_slice` row) (~5)
+.review/PLAN-22.md:233:- `apps/frontend/src/lib/api/index.ts` re-export (~2)
+.review/PLAN-22.md:253:- `apps/frontend/src/features/voc/components/create/AttachmentDropzone.tsx` (replace disabled state with active multi-file upload; per-file state machine `pending → uploading → uploaded(serverId) | error(code)`; per-file row error display) (~140)
+.review/PLAN-22.md:254:- `apps/frontend/src/features/voc/components/create/VocCreateScreen.tsx` (collect `serverAttachmentId`s on submit; pass `attachment_ids[]` to POST `/vocs` body; block submit while any attachment is `uploading`) (~30)
+.review/PLAN-22.md:255:- `apps/frontend/src/features/voc/components/detail/EditDescriptionModal.tsx` (wire Attach button → upload → include `attachment_ids[]` in PATCH body) (~50)
+.review/PLAN-22.md:256:- `apps/frontend/src/features/voc/components/create/__tests__/AttachmentDropzone.test.tsx` (upload happy path, too_large per-row, unsupported_type per-row, storage.unavailable toast, submit blocked while uploading) (~170)
+.review/PLAN-22.md:257:- `apps/frontend/src/features/voc/components/detail/__tests__/EditDescriptionModal.attachments.test.tsx` (~80)
+.review/PLAN-22.md:281:- `apps/frontend/src/features/voc/components/detail/PublicUpdateComposer.tsx` (~50)
+.review/PLAN-22.md:282:- `apps/frontend/src/features/voc/components/detail/InternalCommentComposer.tsx` (~50)
+.review/PLAN-22.md:283:- `apps/frontend/src/features/voc/components/detail/ReporterReplyComposer.tsx` (~50)
+.review/PLAN-22.md:284:- Shared composer dropzone subcomponent `apps/frontend/src/features/voc/components/detail/ComposerAttachmentDropzone.tsx` (extracted from C6 dropzone) (~80)
+.review/PLAN-22.md:285:- `apps/frontend/src/features/voc/components/detail/__tests__/PublicUpdateComposer.attachments.test.tsx` (~70)
+.review/PLAN-22.md:286:- `apps/frontend/src/features/voc/components/detail/__tests__/InternalCommentComposer.attachments.test.tsx` (~70)
+.review/PLAN-22.md:287:- `apps/frontend/src/features/voc/components/detail/__tests__/ReporterReplyComposer.attachments.test.tsx` (~70)
+.review/PLAN-22.md:314:- `apps/frontend/src/features/voc/components/create/rich-toolbar-voc-description.ts` — wire `onAttach: (file) => attachmentsApi.upload(file)` (~10)
+.review/PLAN-22.md:315:- Same wire-up in the three other rich-toolbars (`apps/frontend/src/features/voc/components/detail/rich-toolbars/*.ts`) (~30)
+.review/PLAN-22.md:387:| 3 | C4a · C4b · C5 (FE api + shared/vocs) | no overlap; C5 only touches `shared/vocs/*` and `apps/frontend/src/lib/api/*` |
+apps/backend/migrations/0002_dapper_pgboss.sql:60:  name text REFERENCES pgboss.queue ON DELETE CASCADE,
+apps/backend/migrations/0002_dapper_pgboss.sql:73:  name text not null REFERENCES pgboss.queue ON DELETE CASCADE,
+apps/backend/migrations/0002_dapper_pgboss.sql:208:SELECT pgboss.job_table_run($cmd$ALTER TABLE pgboss.job ADD CONSTRAINT q_fkey FOREIGN KEY (name) REFERENCES pgboss.queue (name) ON DELETE RESTRICT DEFERRABLE INITIALLY DEFERRED$cmd$, 'job_common');
+apps/backend/migrations/0002_dapper_pgboss.sql:209:SELECT pgboss.job_table_run($cmd$ALTER TABLE pgboss.job ADD CONSTRAINT dlq_fkey FOREIGN KEY (dead_letter) REFERENCES pgboss.queue (name) ON DELETE RESTRICT DEFERRABLE INITIALLY DEFERRED$cmd$, 'job_common');
+apps/backend/migrations/0002_dapper_pgboss.sql:287:  EXECUTE pgboss.job_table_format($cmd$ALTER TABLE pgboss.job ADD CONSTRAINT q_fkey FOREIGN KEY (name) REFERENCES pgboss.queue (name) ON DELETE RESTRICT DEFERRABLE INITIALLY DEFERRED$cmd$, tablename);
+apps/backend/migrations/0002_dapper_pgboss.sql:288:  EXECUTE pgboss.job_table_format($cmd$ALTER TABLE pgboss.job ADD CONSTRAINT dlq_fkey FOREIGN KEY (dead_letter) REFERENCES pgboss.queue (name) ON DELETE RESTRICT DEFERRABLE INITIALLY DEFERRED$cmd$, tablename);
+apps/backend/migrations/0002_dapper_pgboss.sql:328:    EXECUTE format('DELETE FROM pgboss.%I WHERE name = %L', v_table, queue_name);
+apps/backend/migrations/0002_dapper_pgboss.sql:331:  DELETE FROM pgboss.queue WHERE name = queue_name;
+apps/backend/migrations/0002_dapper_pgboss.sql:343:GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA pgboss TO fops_app;
+apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts:77:      `delete from core.entity_links
+apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts:87:          and event_type in ('entity_link.created', 'entity_link.detached')`,
+apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts:168:        where id = $1 and status = 'active' and relation_type = 'related_to'`,
+apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts:235:        where source_id = $1 and target_id = $2 and status = 'active'`,
+apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts:328:    const body = res.json<{ id: string; status: string; detached_at: string | null }>();
+apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts:330:    expect(body.detached_at).toEqual(expect.any(String));
+apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts:334:      detached_by: string | null;
+apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts:335:      detach_reason: string | null;
+apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts:336:      detached_at: Date | null;
+apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts:338:      `select status, detached_by, detach_reason, detached_at
+apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts:346:      detached_by: adminActorId,
+apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts:347:      detach_reason: 'No longer relevant',
+apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts:349:    expect(linkRows.rows[0]?.detached_at).toBeInstanceOf(Date);
+apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts:353:        where event_type = 'entity_link.detached' and subject_id = $1`,
+apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts:406:    expect(second.json<{ code: string }>().code).toBe('conflict.stale_write');
+apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts:455:          count(*) filter (where status = 'active')::int as active,
+apps/backend/migrations/0018_entity_links.sql:19:  "updated_at" timestamptz,
+apps/backend/migrations/0018_entity_links.sql:25:    CHECK ("status" IN ('active','stale','detached','revoked')),
+apps/backend/migrations/0019_entity_link_detach.sql:7:  ADD COLUMN IF NOT EXISTS "detached_by" uuid REFERENCES "core"."actors"("id"),
+apps/backend/migrations/0019_entity_link_detach.sql:8:  ADD COLUMN IF NOT EXISTS "detach_reason" text,
+apps/backend/migrations/0019_entity_link_detach.sql:9:  ADD COLUMN IF NOT EXISTS "detached_at" timestamptz;
+apps/backend/migrations/0001_jazzy_miracleman.sql:14:GRANT SELECT, INSERT, UPDATE, DELETE ON "core"."rate_limits" TO fops_app;
+.review/PANEL-SECTION-RHYTHM.md:24:- `apps/frontend/src/features/voc/components/triage/TriagePanel.tsx`
+apps/backend/src/modules/entity-links/repo.ts:21:  status: 'active' | 'stale' | 'detached' | 'revoked';
+apps/backend/src/modules/entity-links/repo.ts:25:  updated_at: Date | null;
+apps/backend/src/modules/entity-links/repo.ts:26:  detached_by: string | null;
+apps/backend/src/modules/entity-links/repo.ts:27:  detach_reason: string | null;
+apps/backend/src/modules/entity-links/repo.ts:28:  detached_at: Date | null;
+apps/backend/src/modules/entity-links/repo.ts:46:    updated_at:
+apps/backend/src/modules/entity-links/repo.ts:47:      row.updated_at === null || row.updated_at === undefined
+apps/backend/src/modules/entity-links/repo.ts:49:        : row.updated_at instanceof Date
+apps/backend/src/modules/entity-links/repo.ts:50:          ? row.updated_at
+apps/backend/src/modules/entity-links/repo.ts:51:          : new Date(row.updated_at as string),
+apps/backend/src/modules/entity-links/repo.ts:52:    detached_by: (row.detached_by as string | null) ?? null,
+apps/backend/src/modules/entity-links/repo.ts:53:    detach_reason: (row.detach_reason as string | null) ?? null,
+apps/backend/src/modules/entity-links/repo.ts:54:    detached_at:
+apps/backend/src/modules/entity-links/repo.ts:55:      row.detached_at === null || row.detached_at === undefined
+apps/backend/src/modules/entity-links/repo.ts:57:        : row.detached_at instanceof Date
+apps/backend/src/modules/entity-links/repo.ts:58:          ? row.detached_at
+apps/backend/src/modules/entity-links/repo.ts:59:          : new Date(row.detached_at as string),
+apps/backend/src/modules/entity-links/repo.ts:105:    ) WHERE status = 'active'
+apps/backend/src/modules/entity-links/repo.ts:110:      created_at, updated_at, detached_by, detach_reason, detached_at
+apps/backend/src/modules/entity-links/repo.ts:134:      created_at, updated_at, detached_by, detach_reason, detached_at
+apps/backend/src/modules/entity-links/repo.ts:142:      AND status = 'active'
+apps/backend/src/modules/entity-links/repo.ts:149:export async function selectActiveLinksForEndpoint(
+apps/backend/src/modules/entity-links/repo.ts:172:      created_at, updated_at, detached_by, detach_reason, detached_at
+apps/backend/src/modules/entity-links/repo.ts:175:      AND status = 'active'
+apps/backend/src/modules/entity-links/repo.ts:190:      created_at, updated_at, detached_by, detach_reason, detached_at
+apps/backend/src/modules/entity-links/repo.ts:213:      detached_by = ${input.actorId},
+apps/backend/src/modules/entity-links/repo.ts:214:      detach_reason = ${input.reason},
+apps/backend/src/modules/entity-links/repo.ts:215:      detached_at = now(),
+apps/backend/src/modules/entity-links/repo.ts:216:      updated_at = now()
+apps/backend/src/modules/entity-links/repo.ts:219:      AND status = 'active'
+apps/backend/src/modules/entity-links/repo.ts:223:      created_at, updated_at, detached_by, detach_reason, detached_at
+apps/backend/migrations/meta/0004_snapshot.json:62:        "updated_at": {
+apps/backend/migrations/meta/0004_snapshot.json:63:          "name": "updated_at",
+apps/backend/migrations/meta/0004_snapshot.json:559:        "revoked_at": {
+apps/backend/migrations/meta/0004_snapshot.json:560:          "name": "revoked_at",
+apps/backend/migrations/meta/0004_snapshot.json:676:        "updated_at": {
+apps/backend/migrations/meta/0004_snapshot.json:677:          "name": "updated_at",
+apps/backend/migrations/meta/0004_snapshot.json:746:        "revoked_at": {
+apps/backend/migrations/meta/0004_snapshot.json:747:          "name": "revoked_at",
+apps/backend/migrations/meta/0004_snapshot.json:752:        "revoked_by_actor_id": {
+apps/backend/migrations/meta/0004_snapshot.json:753:          "name": "revoked_by_actor_id",
+apps/backend/migrations/meta/0004_snapshot.json:804:          "where": "\"permission\".\"permission_denies\".\"revoked_at\" is null",
+apps/backend/migrations/meta/0004_snapshot.json:889:        "revoked_at": {
+apps/backend/migrations/meta/0004_snapshot.json:890:          "name": "revoked_at",
+apps/backend/migrations/meta/0004_snapshot.json:895:        "revoked_by_actor_id": {
+apps/backend/migrations/meta/0004_snapshot.json:896:          "name": "revoked_by_actor_id",
+apps/backend/migrations/meta/0004_snapshot.json:901:        "revoked_reason": {
+apps/backend/migrations/meta/0004_snapshot.json:902:          "name": "revoked_reason",
+apps/backend/migrations/meta/0004_snapshot.json:974:          "where": "\"permission\".\"permission_grants\".\"revoked_at\" is null",
+apps/backend/migrations/meta/0004_snapshot.json:1083:        "updated_at": {
+apps/backend/migrations/meta/0004_snapshot.json:1084:          "name": "updated_at",
+apps/backend/src/modules/entity-links/routes.ts:13:import type { SessionService } from '../auth/session-service.js';
+apps/backend/migrations/0003_modern_shadow_king.sql:22:ALTER TABLE "core"."audit_log" ADD CONSTRAINT "audit_log_workspace_id_workspaces_id_fk" FOREIGN KEY ("workspace_id") REFERENCES "core"."workspaces"("id") ON DELETE no action ON UPDATE no action;
+apps/backend/migrations/0003_modern_shadow_king.sql:25:-- permission.permission_grants — workspace, actor, granted_by, revoked_by.
+apps/backend/migrations/0003_modern_shadow_king.sql:29:  ON DELETE no action ON UPDATE no action;
+apps/backend/migrations/0003_modern_shadow_king.sql:34:  ON DELETE no action ON UPDATE no action;
+apps/backend/migrations/0003_modern_shadow_king.sql:39:  ON DELETE no action ON UPDATE no action;
+apps/backend/migrations/0003_modern_shadow_king.sql:42:  ADD CONSTRAINT "permission_grants_revoked_by_actor_id_actors_id_fk"
+apps/backend/migrations/0003_modern_shadow_king.sql:43:  FOREIGN KEY ("revoked_by_actor_id") REFERENCES "core"."actors"("id")
+apps/backend/migrations/0003_modern_shadow_king.sql:44:  ON DELETE no action ON UPDATE no action;
+apps/backend/migrations/0003_modern_shadow_king.sql:47:-- permission.permission_denies — workspace, actor, created_by, revoked_by.
+apps/backend/migrations/0003_modern_shadow_king.sql:51:  ON DELETE no action ON UPDATE no action;
+apps/backend/migrations/0003_modern_shadow_king.sql:56:  ON DELETE no action ON UPDATE no action;
+apps/backend/migrations/0003_modern_shadow_king.sql:61:  ON DELETE no action ON UPDATE no action;
+apps/backend/migrations/0003_modern_shadow_king.sql:64:  ADD CONSTRAINT "permission_denies_revoked_by_actor_id_actors_id_fk"
+apps/backend/migrations/0003_modern_shadow_king.sql:65:  FOREIGN KEY ("revoked_by_actor_id") REFERENCES "core"."actors"("id")
+apps/backend/migrations/0003_modern_shadow_king.sql:66:  ON DELETE no action ON UPDATE no action;
+apps/backend/migrations/0003_modern_shadow_king.sql:73:  ON DELETE no action ON UPDATE no action;
+apps/backend/migrations/0003_modern_shadow_king.sql:78:  ON DELETE no action ON UPDATE no action;
+apps/backend/migrations/0003_modern_shadow_king.sql:85:-- revoked first because Postgres grants EXECUTE on new functions to
+apps/backend/migrations/meta/0002_snapshot.json:62:        "updated_at": {
+apps/backend/migrations/meta/0002_snapshot.json:63:          "name": "updated_at",
+apps/backend/migrations/meta/0002_snapshot.json:527:        "revoked_at": {
+apps/backend/migrations/meta/0002_snapshot.json:528:          "name": "revoked_at",
+apps/backend/migrations/meta/0002_snapshot.json:636:        "updated_at": {
+apps/backend/migrations/meta/0002_snapshot.json:637:          "name": "updated_at",
+apps/backend/migrations/meta/0002_snapshot.json:706:        "revoked_at": {
+apps/backend/migrations/meta/0002_snapshot.json:707:          "name": "revoked_at",
+apps/backend/migrations/meta/0002_snapshot.json:712:        "revoked_by_actor_id": {
+apps/backend/migrations/meta/0002_snapshot.json:713:          "name": "revoked_by_actor_id",
+apps/backend/migrations/meta/0002_snapshot.json:764:          "where": "\"permission\".\"permission_denies\".\"revoked_at\" is null",
+apps/backend/migrations/meta/0002_snapshot.json:849:        "revoked_at": {
+apps/backend/migrations/meta/0002_snapshot.json:850:          "name": "revoked_at",
+apps/backend/migrations/meta/0002_snapshot.json:855:        "revoked_by_actor_id": {
+apps/backend/migrations/meta/0002_snapshot.json:856:          "name": "revoked_by_actor_id",
+apps/backend/migrations/meta/0002_snapshot.json:861:        "revoked_reason": {
+apps/backend/migrations/meta/0002_snapshot.json:862:          "name": "revoked_reason",
+apps/backend/migrations/meta/0002_snapshot.json:934:          "where": "\"permission\".\"permission_grants\".\"revoked_at\" is null",
+apps/backend/migrations/meta/0002_snapshot.json:1043:        "updated_at": {
+apps/backend/migrations/meta/0002_snapshot.json:1044:          "name": "updated_at",
+apps/backend/migrations/meta/0003_snapshot.json:62:        "updated_at": {
+apps/backend/migrations/meta/0003_snapshot.json:63:          "name": "updated_at",
+apps/backend/migrations/meta/0003_snapshot.json:559:        "revoked_at": {
+apps/backend/migrations/meta/0003_snapshot.json:560:          "name": "revoked_at",
+apps/backend/migrations/meta/0003_snapshot.json:676:        "updated_at": {
+apps/backend/migrations/meta/0003_snapshot.json:677:          "name": "updated_at",
+apps/backend/migrations/meta/0003_snapshot.json:746:        "revoked_at": {
+apps/backend/migrations/meta/0003_snapshot.json:747:          "name": "revoked_at",
+apps/backend/migrations/meta/0003_snapshot.json:752:        "revoked_by_actor_id": {
+apps/backend/migrations/meta/0003_snapshot.json:753:          "name": "revoked_by_actor_id",
+apps/backend/migrations/meta/0003_snapshot.json:804:          "where": "\"permission\".\"permission_denies\".\"revoked_at\" is null",
+apps/backend/migrations/meta/0003_snapshot.json:889:        "revoked_at": {
+apps/backend/migrations/meta/0003_snapshot.json:890:          "name": "revoked_at",
+apps/backend/migrations/meta/0003_snapshot.json:895:        "revoked_by_actor_id": {
+apps/backend/migrations/meta/0003_snapshot.json:896:          "name": "revoked_by_actor_id",
+apps/backend/migrations/meta/0003_snapshot.json:901:        "revoked_reason": {
+apps/backend/migrations/meta/0003_snapshot.json:902:          "name": "revoked_reason",
+apps/backend/migrations/meta/0003_snapshot.json:974:          "where": "\"permission\".\"permission_grants\".\"revoked_at\" is null",
+apps/backend/migrations/meta/0003_snapshot.json:1083:        "updated_at": {
+apps/backend/migrations/meta/0003_snapshot.json:1084:          "name": "updated_at",
+apps/backend/migrations/meta/0018_snapshot.json:62:        "updated_at": {
+apps/backend/migrations/meta/0018_snapshot.json:63:          "name": "updated_at",
+apps/backend/migrations/meta/0018_snapshot.json:220:        "updated_at": {
+apps/backend/migrations/meta/0018_snapshot.json:221:          "name": "updated_at",
+apps/backend/migrations/meta/0018_snapshot.json:646:        "updated_at": {
+apps/backend/migrations/meta/0018_snapshot.json:647:          "name": "updated_at",
+apps/backend/migrations/meta/0018_snapshot.json:842:          "value": "\"core\".\"entity_links\".\"status\" in ('active','stale','detached','revoked')"
+apps/backend/migrations/meta/0018_snapshot.json:1014:        "updated_at": {
+apps/backend/migrations/meta/0018_snapshot.json:1015:          "name": "updated_at",
+apps/backend/migrations/meta/0018_snapshot.json:1232:        "revoked_at": {
+apps/backend/migrations/meta/0018_snapshot.json:1233:          "name": "revoked_at",
+apps/backend/migrations/meta/0018_snapshot.json:1367:        "updated_at": {
+apps/backend/migrations/meta/0018_snapshot.json:1368:          "name": "updated_at",
+apps/backend/migrations/meta/0018_snapshot.json:1474:        "updated_at": {
+apps/backend/migrations/meta/0018_snapshot.json:1475:          "name": "updated_at",
+apps/backend/migrations/meta/0018_snapshot.json:1544:        "revoked_at": {
+apps/backend/migrations/meta/0018_snapshot.json:1545:          "name": "revoked_at",
+apps/backend/migrations/meta/0018_snapshot.json:1550:        "revoked_by_actor_id": {
+apps/backend/migrations/meta/0018_snapshot.json:1551:          "name": "revoked_by_actor_id",
+apps/backend/migrations/meta/0018_snapshot.json:1602:          "where": "\"permission\".\"permission_denies\".\"revoked_at\" is null",
+apps/backend/migrations/meta/0018_snapshot.json:1687:        "revoked_at": {
+apps/backend/migrations/meta/0018_snapshot.json:1688:          "name": "revoked_at",
+apps/backend/migrations/meta/0018_snapshot.json:1693:        "revoked_by_actor_id": {
+apps/backend/migrations/meta/0018_snapshot.json:1694:          "name": "revoked_by_actor_id",
+apps/backend/migrations/meta/0018_snapshot.json:1699:        "revoked_reason": {
+apps/backend/migrations/meta/0018_snapshot.json:1700:          "name": "revoked_reason",
+apps/backend/migrations/meta/0018_snapshot.json:1772:          "where": "\"permission\".\"permission_grants\".\"revoked_at\" is null",
+apps/backend/migrations/meta/0018_snapshot.json:1881:        "updated_at": {
+apps/backend/migrations/meta/0018_snapshot.json:1882:          "name": "updated_at",
+apps/backend/migrations/0000_familiar_centennial.sql:14:	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+apps/backend/migrations/0000_familiar_centennial.sql:48:	"revoked_at" timestamp with time zone,
+apps/backend/migrations/0000_familiar_centennial.sql:57:	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+apps/backend/migrations/0000_familiar_centennial.sql:69:	"revoked_at" timestamp with time zone,
+apps/backend/migrations/0000_familiar_centennial.sql:70:	"revoked_by_actor_id" uuid
+apps/backend/migrations/0000_familiar_centennial.sql:85:	"revoked_at" timestamp with time zone,
+apps/backend/migrations/0000_familiar_centennial.sql:86:	"revoked_by_actor_id" uuid,
+apps/backend/migrations/0000_familiar_centennial.sql:87:	"revoked_reason" text
+apps/backend/migrations/0000_familiar_centennial.sql:106:	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+apps/backend/migrations/0000_familiar_centennial.sql:109:ALTER TABLE "core"."actors" ADD CONSTRAINT "actors_workspace_id_workspaces_id_fk" FOREIGN KEY ("workspace_id") REFERENCES "core"."workspaces"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+apps/backend/migrations/0000_familiar_centennial.sql:110:ALTER TABLE "core"."audit_log" ADD CONSTRAINT "audit_log_actor_id_actors_id_fk" FOREIGN KEY ("actor_id") REFERENCES "core"."actors"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+apps/backend/migrations/0000_familiar_centennial.sql:111:ALTER TABLE "core"."idempotency_keys" ADD CONSTRAINT "idempotency_keys_actor_id_actors_id_fk" FOREIGN KEY ("actor_id") REFERENCES "core"."actors"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+apps/backend/migrations/0000_familiar_centennial.sql:112:ALTER TABLE "core"."sessions" ADD CONSTRAINT "sessions_actor_id_actors_id_fk" FOREIGN KEY ("actor_id") REFERENCES "core"."actors"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+apps/backend/migrations/0000_familiar_centennial.sql:113:ALTER TABLE "core"."sessions" ADD CONSTRAINT "sessions_workspace_id_workspaces_id_fk" FOREIGN KEY ("workspace_id") REFERENCES "core"."workspaces"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+apps/backend/migrations/0000_familiar_centennial.sql:137:  WHERE "revoked_at" is null;--> statement-breakpoint
+apps/backend/migrations/0000_familiar_centennial.sql:154:  WHERE "revoked_at" is null;--> statement-breakpoint
+apps/backend/migrations/0000_familiar_centennial.sql:178:-- rejected | expired | revoked.
+apps/backend/migrations/0000_familiar_centennial.sql:182:  CHECK ("status" in ('pending','needs_more_info','approved','rejected','expired','revoked'));--> statement-breakpoint
+apps/backend/migrations/0000_familiar_centennial.sql:192:--   * core.audit_log:           INSERT, SELECT only (UPDATE/DELETE revoked).
+apps/backend/migrations/0000_familiar_centennial.sql:193:--   * every other Slice 1 tbl:  INSERT, SELECT, UPDATE, DELETE.
+apps/backend/migrations/0000_familiar_centennial.sql:208:GRANT SELECT, INSERT, UPDATE, DELETE ON "core"."workspaces" TO fops_app;--> statement-breakpoint
+apps/backend/migrations/0000_familiar_centennial.sql:209:GRANT SELECT, INSERT, UPDATE, DELETE ON "core"."actors" TO fops_app;--> statement-breakpoint
+apps/backend/migrations/0000_familiar_centennial.sql:210:GRANT SELECT, INSERT, UPDATE, DELETE ON "core"."sessions" TO fops_app;--> statement-breakpoint
+apps/backend/migrations/0000_familiar_centennial.sql:211:GRANT SELECT, INSERT, UPDATE, DELETE ON "core"."idempotency_keys" TO fops_app;--> statement-breakpoint
+apps/backend/migrations/0000_familiar_centennial.sql:212:GRANT SELECT, INSERT, UPDATE, DELETE ON "permission"."permission_grants" TO fops_app;--> statement-breakpoint
+apps/backend/migrations/0000_familiar_centennial.sql:213:GRANT SELECT, INSERT, UPDATE, DELETE ON "permission"."permission_denies" TO fops_app;--> statement-breakpoint
+apps/backend/migrations/0000_familiar_centennial.sql:214:GRANT SELECT, INSERT, UPDATE, DELETE ON "permission"."permission_requests" TO fops_app;--> statement-breakpoint
+apps/backend/migrations/0000_familiar_centennial.sql:216:-- App role: append-only on the audit log. UPDATE / DELETE / TRUNCATE intentionally
+apps/backend/migrations/0000_familiar_centennial.sql:219:REVOKE UPDATE, DELETE, TRUNCATE ON "core"."audit_log" FROM fops_app;
+.review/SLICE-3-CONTEXT-MAP.md:58:- `permissions/` — capability schemas (Slice 1)
+.review/SLICE-3-CONTEXT-MAP.md:69:### `apps/frontend/src/`
+.review/SLICE-3-CONTEXT-MAP.md:72:- `features/admin/permissions/` — permission-state-view, request-access-button, use-permission-check (Slice 1)
+.review/SLICE-3-CONTEXT-MAP.md:74:- `lib/auth/useMe.ts` — react-query /me wrapper (#19)
+.review/SLICE-3-CONTEXT-MAP.md:94:| **Idempotency-Key auto-mint** | `apps/frontend/src/lib/api/client.ts` | POST/PATCH/DELETE only; PUT excluded |
+.review/SLICE-3-CONTEXT-MAP.md:95:| **vocSearchSchema (URL)** | `apps/frontend/src/routes/_authed/vocs.tsx:12` | `.strict()` with explicit `filter.*` dot-keys |
+.review/SLICE-3-CONTEXT-MAP.md:97:| **Vite dev proxy** | `apps/frontend/vite.config.ts` | `/managed-systems /analytics-areas /vocs /permission-requests` w/ bypass for HTML nav |
+apps/backend/migrations/0014_slice3_attachment_storage_activation.sql:38:--   * fops_app DELETE remains revoked (0011 archive-over-delete).
+apps/backend/migrations/0007_pgboss_create_queue_shim.sql:24:--   * Grant fops_app EXECUTE on the new wrapper only. PUBLIC is revoked
+apps/backend/migrations/meta/0001_snapshot.json:62:        "updated_at": {
+apps/backend/migrations/meta/0001_snapshot.json:63:          "name": "updated_at",
+apps/backend/migrations/meta/0001_snapshot.json:527:        "revoked_at": {
+apps/backend/migrations/meta/0001_snapshot.json:528:          "name": "revoked_at",
+apps/backend/migrations/meta/0001_snapshot.json:636:        "updated_at": {
+apps/backend/migrations/meta/0001_snapshot.json:637:          "name": "updated_at",
+apps/backend/migrations/meta/0001_snapshot.json:706:        "revoked_at": {
+apps/backend/migrations/meta/0001_snapshot.json:707:          "name": "revoked_at",
+apps/backend/migrations/meta/0001_snapshot.json:712:        "revoked_by_actor_id": {
+apps/backend/migrations/meta/0001_snapshot.json:713:          "name": "revoked_by_actor_id",
+apps/backend/migrations/meta/0001_snapshot.json:764:          "where": "\"permission\".\"permission_denies\".\"revoked_at\" is null",
+apps/backend/migrations/meta/0001_snapshot.json:849:        "revoked_at": {
+apps/backend/migrations/meta/0001_snapshot.json:850:          "name": "revoked_at",
+apps/backend/migrations/meta/0001_snapshot.json:855:        "revoked_by_actor_id": {
+apps/backend/migrations/meta/0001_snapshot.json:856:          "name": "revoked_by_actor_id",
+apps/backend/migrations/meta/0001_snapshot.json:861:        "revoked_reason": {
+apps/backend/migrations/meta/0001_snapshot.json:862:          "name": "revoked_reason",
+apps/backend/migrations/meta/0001_snapshot.json:934:          "where": "\"permission\".\"permission_grants\".\"revoked_at\" is null",
+apps/backend/migrations/meta/0001_snapshot.json:1043:        "updated_at": {
+apps/backend/migrations/meta/0001_snapshot.json:1044:          "name": "updated_at",
+apps/backend/src/modules/attachments/service.ts:272:    //    NoSuchKey (stale row whose bytes are missing) as 404.
+apps/backend/migrations/meta/0000_snapshot.json:62:        "updated_at": {
+apps/backend/migrations/meta/0000_snapshot.json:63:          "name": "updated_at",
+apps/backend/migrations/meta/0000_snapshot.json:468:        "revoked_at": {
+apps/backend/migrations/meta/0000_snapshot.json:469:          "name": "revoked_at",
+apps/backend/migrations/meta/0000_snapshot.json:577:        "updated_at": {
+apps/backend/migrations/meta/0000_snapshot.json:578:          "name": "updated_at",
+apps/backend/migrations/meta/0000_snapshot.json:647:        "revoked_at": {
+apps/backend/migrations/meta/0000_snapshot.json:648:          "name": "revoked_at",
+apps/backend/migrations/meta/0000_snapshot.json:653:        "revoked_by_actor_id": {
+apps/backend/migrations/meta/0000_snapshot.json:654:          "name": "revoked_by_actor_id",
+apps/backend/migrations/meta/0000_snapshot.json:705:          "where": "\"permission\".\"permission_denies\".\"revoked_at\" is null",
+apps/backend/migrations/meta/0000_snapshot.json:790:        "revoked_at": {
+apps/backend/migrations/meta/0000_snapshot.json:791:          "name": "revoked_at",
+apps/backend/migrations/meta/0000_snapshot.json:796:        "revoked_by_actor_id": {
+apps/backend/migrations/meta/0000_snapshot.json:797:          "name": "revoked_by_actor_id",
+apps/backend/migrations/meta/0000_snapshot.json:802:        "revoked_reason": {
+apps/backend/migrations/meta/0000_snapshot.json:803:          "name": "revoked_reason",
+apps/backend/migrations/meta/0000_snapshot.json:875:          "where": "\"permission\".\"permission_grants\".\"revoked_at\" is null",
+apps/backend/migrations/meta/0000_snapshot.json:984:        "updated_at": {
+apps/backend/migrations/meta/0000_snapshot.json:985:          "name": "updated_at",
+apps/backend/migrations/meta/0019_snapshot.json:62:        "updated_at": {
+apps/backend/migrations/meta/0019_snapshot.json:63:          "name": "updated_at",
+apps/backend/migrations/meta/0019_snapshot.json:216:        "updated_at": {
+apps/backend/migrations/meta/0019_snapshot.json:217:          "name": "updated_at",
+apps/backend/migrations/meta/0019_snapshot.json:618:        "updated_at": {
+apps/backend/migrations/meta/0019_snapshot.json:619:          "name": "updated_at",
+apps/backend/migrations/meta/0019_snapshot.json:624:        "detached_by": {
+apps/backend/migrations/meta/0019_snapshot.json:625:          "name": "detached_by",
+apps/backend/migrations/meta/0019_snapshot.json:630:        "detach_reason": {
+apps/backend/migrations/meta/0019_snapshot.json:631:          "name": "detach_reason",
+apps/backend/migrations/meta/0019_snapshot.json:636:        "detached_at": {
+apps/backend/migrations/meta/0019_snapshot.json:637:          "name": "detached_at",
+apps/backend/migrations/meta/0019_snapshot.json:805:        "entity_links_detached_by_actors_id_fk": {
+apps/backend/migrations/meta/0019_snapshot.json:806:          "name": "entity_links_detached_by_actors_id_fk",
+apps/backend/migrations/meta/0019_snapshot.json:810:          "columnsFrom": ["detached_by"],
+apps/backend/migrations/meta/0019_snapshot.json:830:          "value": "\"core\".\"entity_links\".\"status\" in ('active','stale','detached','revoked')"
+apps/backend/migrations/meta/0019_snapshot.json:995:        "updated_at": {
+apps/backend/migrations/meta/0019_snapshot.json:996:          "name": "updated_at",
+apps/backend/migrations/meta/0019_snapshot.json:1194:        "revoked_at": {
+apps/backend/migrations/meta/0019_snapshot.json:1195:          "name": "revoked_at",
+apps/backend/migrations/meta/0019_snapshot.json:1321:        "updated_at": {
+apps/backend/migrations/meta/0019_snapshot.json:1322:          "name": "updated_at",
+apps/backend/migrations/meta/0019_snapshot.json:1420:        "updated_at": {
+apps/backend/migrations/meta/0019_snapshot.json:1421:          "name": "updated_at",
+apps/backend/migrations/meta/0019_snapshot.json:1490:        "revoked_at": {
+apps/backend/migrations/meta/0019_snapshot.json:1491:          "name": "revoked_at",
+apps/backend/migrations/meta/0019_snapshot.json:1496:        "revoked_by_actor_id": {
+apps/backend/migrations/meta/0019_snapshot.json:1497:          "name": "revoked_by_actor_id",
+apps/backend/migrations/meta/0019_snapshot.json:1548:          "where": "\"permission\".\"permission_denies\".\"revoked_at\" is null",
+apps/backend/migrations/meta/0019_snapshot.json:1633:        "revoked_at": {
+apps/backend/migrations/meta/0019_snapshot.json:1634:          "name": "revoked_at",
+apps/backend/migrations/meta/0019_snapshot.json:1639:        "revoked_by_actor_id": {
+apps/backend/migrations/meta/0019_snapshot.json:1640:          "name": "revoked_by_actor_id",
+apps/backend/migrations/meta/0019_snapshot.json:1645:        "revoked_reason": {
+apps/backend/migrations/meta/0019_snapshot.json:1646:          "name": "revoked_reason",
+apps/backend/migrations/meta/0019_snapshot.json:1718:          "where": "\"permission\".\"permission_grants\".\"revoked_at\" is null",
+apps/backend/migrations/meta/0019_snapshot.json:1827:        "updated_at": {
+apps/backend/migrations/meta/0019_snapshot.json:1828:          "name": "updated_at",
+.review/BADGE-CONSUMERS-VISUAL-AUDIT.md:29:**File:** `apps/frontend/src/features/voc/components/detail/IdentitySection.tsx:61`  
+.review/BADGE-CONSUMERS-VISUAL-AUDIT.md:36:**File:** `apps/frontend/src/features/voc/components/list/VocRow.tsx:122,129`  
+.review/BADGE-CONSUMERS-VISUAL-AUDIT.md:44:**File:** `apps/frontend/src/features/voc/components/triage/TriageRow.tsx:118`  
+.review/BADGE-CONSUMERS-VISUAL-AUDIT.md:52:**File:** `apps/frontend/src/features/voc/components/detail/TimelineEntry.tsx:68,72`  
+.review/BADGE-CONSUMERS-VISUAL-AUDIT.md:59:**File:** `apps/frontend/src/features/voc/components/detail/ReporterStatusChangeBlock.tsx:167,251`  
+.review/BADGE-CONSUMERS-VISUAL-AUDIT.md:65:**File:** `apps/frontend/src/features/voc/components/detail/ComposerPublicPreview.tsx:113`  
+.review/BADGE-CONSUMERS-VISUAL-AUDIT.md:97:- `apps/frontend/src/features/voc/components/list/VocRow.tsx` — inbox row consumer
+.review/BADGE-CONSUMERS-VISUAL-AUDIT.md:98:- `apps/frontend/src/features/voc/components/triage/TriageRow.tsx` — triage row consumer
+.review/BADGE-CONSUMERS-VISUAL-AUDIT.md:99:- `apps/frontend/src/features/voc/components/detail/TimelineEntry.tsx` — timeline consumer
+packages/shared/src/vocs/__tests__/list-item.test.ts:21:  updated_at: '2026-01-01T00:00:00.000Z',
+apps/backend/src/__tests__/env-example-completeness.test.ts:11: * `.env.example` is left stale, breaking `pnpm dev` for anyone who copies
+apps/backend/src/modules/auth/__tests__/auth.integration.test.ts:8://   2. revoked session row rejected
+apps/backend/src/modules/auth/__tests__/auth.integration.test.ts:10://   4. GET /auth/mock-login in NODE_ENV=production → 404
+apps/backend/src/modules/auth/__tests__/auth.integration.test.ts:51:  // Keep the sessions table clean between tests so revoked/expired fixtures
+apps/backend/src/modules/auth/__tests__/auth.integration.test.ts:64:      url: '/auth/mock-login',
+apps/backend/src/modules/auth/__tests__/auth.integration.test.ts:86:      url: '/auth/logout',
+apps/backend/src/modules/auth/__tests__/auth.integration.test.ts:100:  it('revoked session row → 401 auth.session_invalid', async () => {
+apps/backend/src/modules/auth/__tests__/auth.integration.test.ts:103:      url: '/auth/mock-login',
+apps/backend/src/modules/auth/__tests__/auth.integration.test.ts:110:    await dbHandle.pool.query('update core.sessions set revoked_at = now() where id = $1', [
+apps/backend/src/modules/auth/__tests__/auth.integration.test.ts:126:      url: '/auth/mock-login',
+apps/backend/src/modules/auth/__tests__/auth.integration.test.ts:150:      url: '/auth/mock-login',
+apps/backend/src/modules/auth/__tests__/auth.integration.test.ts:188:  // null when revoke commits first (revoked_at IS NULL fails the predicate).
+apps/backend/src/modules/auth/__tests__/auth.integration.test.ts:197:      url: '/auth/mock-login',
+apps/backend/src/modules/auth/__tests__/auth.integration.test.ts:206:    // revoked_at IS NULL — so if revoke wins, touch's UPDATE matches 0 rows
+apps/backend/src/modules/auth/__tests__/auth.integration.test.ts:215:    // because revoked_at is set on the row.
+apps/backend/src/modules/auth/__tests__/auth.integration.test.ts:221:    // the touch returned null too. Either way: the final state is revoked.
+apps/backend/src/modules/auth/__tests__/auth.integration.test.ts:231:  // The original two route tests (GET/POST /auth/mock-login → 404 in prod)
+apps/backend/src/modules/auth/__tests__/auth.integration.test.ts:236:  // route-level 404 stays in `auth/routes.ts:36,52` as defense-in-depth
+apps/backend/src/modules/attachments/routes.ts:29:import type { SessionService } from '../auth/session-service.js';
+apps/backend/src/__tests__/fe-call-endpoints-exist.test.ts:4: * Inverse of `apps/frontend/src/__tests__/vite-proxy-completeness.test.ts`:
+apps/backend/src/__tests__/fe-call-endpoints-exist.test.ts:12: *   - Scan `apps/frontend/src/**\/*.{ts,tsx}` for literal URL strings:
+apps/backend/src/__tests__/fe-call-endpoints-exist.test.ts:40:const FE_SRC = path.join(REPO_ROOT, 'apps/frontend/src');
+.review/ISSUE-113-REVIEW.raw.txt:16:1. Contract adherence — PATCH /entity-links/:id soft-detach (active→detached), row PRESERVED (no hard delete), detached_by/detach_reason/detached_at set, updated_at set, single transaction, audit entity_link.detached emitted. Migration 0019 adds 3 columns + GRANT UPDATE to fops_app (and NO DELETE grant). Journal/snapshot registered for 0019 (mirror 0018 technique). core.ts entityLinks has the 3 new columns.
+.review/ISSUE-113-REVIEW.raw.txt:18:3. Active-only visibility — confirm a detached link no longer appears on GET /entity-links and the VOC detail Links tab (selectActiveLinksForEndpoint filters status='active'). If the VOC-detail query was NOT already active-filtered, confirm a filter was added.
+.review/ISSUE-113-REVIEW.raw.txt:20:5. Scope discipline — no forbidden paths (permissions/*, auth/*, apps/frontend/**, findings table, revoked/stale production, DELETE grant, hard delete). 
+.review/ISSUE-113-REVIEW.raw.txt:21:6. Deviation D1 — 409 uses existing `conflict.stale_write` because errors/codes.ts is out of scope. Judge: acceptable, or does it block / need a different code?
+.review/ISSUE-113-REVIEW.raw.txt:22:7. Tests — do the 6 cases in the prompt exist and genuinely assert (row persists with metadata after detach; audit row; detached link absent from GET + VOC detail; already-detached→409; missing/empty reason→422; out-of-scope→404; re-POST after detach succeeds)? Note any missing/weak case. Confirm teardown uses migrateHandle (fops_migrate) for DELETEs since fops_app cannot delete.
+.review/ISSUE-113-REVIEW.raw.txt:54:## D1 · 409 envelope uses existing `conflict.stale_write`
+.review/ISSUE-113-REVIEW.raw.txt:56:**Prompt directive:** "If link status != 'active' → 409 (already detached/revoked) OR idempotent 200 returning current state — pick 409 and document in DEVIATIONS if you prefer; default to 409 `conflict`."
+.review/ISSUE-113-REVIEW.raw.txt:58:**Actual change:** Already-detached and lost-race detach attempts return HTTP 409 with code `conflict.stale_write`.
+.review/ISSUE-113-REVIEW.raw.txt:60:**Reason:** `packages/shared/src/errors/codes.ts` does not define a generic `conflict` code, and that file is outside the Issue #113 allowed touch set. Using an unknown `conflict` string would be remapped by the global error handler to a generic 500. `conflict.stale_write` is an existing 409-class code and preserves the requested HTTP status without widening the touch set.
+.review/ISSUE-113-REVIEW.raw.txt:71:Builds directly on #112 (merged): `core.entity_links` exists; module `apps/backend/src/modules/entity-links/` has routes.ts (POST+GET), service.ts (`createEntityLinksService`), repo.ts (`resolveVocEndpoint`, `insertActiveVocRelatedToLink`, `selectActiveVocRelatedToLink`, `selectActiveLinksForEndpoint`). Shared types in `packages/shared/src/entity-links.ts` (`entityLinkStatusSchema` already includes `detached`/`revoked`). Migration 0018 granted fops_app INSERT+SELECT only and the active unique/lookup indexes are partial `WHERE status='active'`.
+.review/ISSUE-113-REVIEW.raw.txt:73:## Design decisions (locked — do not re-litigate; the API draft lists both PATCH and DELETE, we choose PATCH)
+.review/ISSUE-113-REVIEW.raw.txt:75:- **Verb: `PATCH /entity-links/:id`** with body `{ reason: string }` (reason required, non-empty, trimmed). The endpoint's only supported action this slice is detach (active→detached). DELETE is NOT used — the row persists, so DELETE would be a lie.
+.review/ISSUE-113-REVIEW.raw.txt:76:- **Status: `detached` only.** `revoked` stays reserved for admin/policy flows (later slice). `stale` is Slice 7. Do not produce them here.
+.review/ISSUE-113-REVIEW.raw.txt:82:- `ALTER TABLE core.entity_links ADD COLUMN detached_by uuid REFERENCES core.actors(id)` (nullable)
+.review/ISSUE-113-REVIEW.raw.txt:83:- `ADD COLUMN detach_reason text` (nullable)
+.review/ISSUE-113-REVIEW.raw.txt:84:- `ADD COLUMN detached_at timestamptz` (nullable)
+.review/ISSUE-113-REVIEW.raw.txt:85:- `GRANT UPDATE ON core.entity_links TO fops_app;` (detach is an UPDATE; fops_app had INSERT+SELECT only). Still NO DELETE grant — hard delete stays impossible.
+.review/ISSUE-113-REVIEW.raw.txt:94:- If link status != 'active' → 409 (already detached/revoked) OR idempotent 200 returning current state — pick 409 and document in DEVIATIONS if you prefer; default to 409 `conflict`.
+.review/ISSUE-113-REVIEW.raw.txt:96:- Transition in ONE transaction: `UPDATE ... SET status='detached', detached_by=<actor>, detach_reason=<reason>, detached_at=now(), updated_at=now() WHERE id=:id AND status='active'`; if 0 rows updated (lost race) → 409. Emit audit_log `entity_link.detached` with `{ link_id, source, target, relation_type, reason }`. Add the `entity_link.detached` token to `packages/shared/src/enums/audit-events.ts` + its detail schema (mirror `entity_link.created`).
+.review/ISSUE-113-REVIEW.raw.txt:97:- Response: 200 with the detached link's id + status (+ detached_at). No body that leaks the other endpoint if actor somehow shouldn't see it (but they passed both-side check, so full ok).
+.review/ISSUE-113-REVIEW.raw.txt:99:VOC detail Links tab: NO code change needed if `selectActiveLinksForEndpoint` already filters `status='active'` (detached rows auto-drop). VERIFY this is true; if the VOC-detail query does NOT filter on active, add the filter. Either way a detached link must NOT appear on the Links tab.
+.review/ISSUE-113-REVIEW.raw.txt:114:- `packages/shared/src/permissions/*`, `auth/*` — reuse existing helpers
+.review/ISSUE-113-REVIEW.raw.txt:115:- `apps/frontend/**` (#114 owns UI)
+.review/ISSUE-113-REVIEW.raw.txt:116:- new findings table; relation types beyond `related_to`; producing `revoked`/`stale`; visibility tokens beyond #112's `allowed`/`hidden`; FR-LINK-003 queries
+.review/ISSUE-113-REVIEW.raw.txt:117:- hard delete of any entity_links row, or granting fops_app DELETE
+.review/ISSUE-113-REVIEW.raw.txt:119:## Tests (vitest integration; mirror `apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts` setup — note `migrateHandle` (fops_migrate) is used for teardown DELETEs since fops_app cannot delete)
+.review/ISSUE-113-REVIEW.raw.txt:121:1. PATCH detaches an active related_to link → 200; DB row STILL EXISTS with status='detached', detached_by/detach_reason/detached_at set; audit_log has `entity_link.detached`.
+.review/ISSUE-113-REVIEW.raw.txt:238:     updatedAt: timestamp('updated_at', { withTimezone: true }),
+.review/ISSUE-113-REVIEW.raw.txt:239:+    detachedBy: uuid('detached_by').references(() => actors.id),
+.review/ISSUE-113-REVIEW.raw.txt:240:+    detachReason: text('detach_reason'),
+.review/ISSUE-113-REVIEW.raw.txt:241:+    detachedAt: timestamp('detached_at', { withTimezone: true }),
+.review/ISSUE-113-REVIEW.raw.txt:258:   updated_at: Date | null;
+.review/ISSUE-113-REVIEW.raw.txt:259:+  detached_by: string | null;
+.review/ISSUE-113-REVIEW.raw.txt:260:+  detach_reason: string | null;
+.review/ISSUE-113-REVIEW.raw.txt:261:+  detached_at: Date | null;
+.review/ISSUE-113-REVIEW.raw.txt:266:         : row.updated_at instanceof Date
+.review/ISSUE-113-REVIEW.raw.txt:267:           ? row.updated_at
+.review/ISSUE-113-REVIEW.raw.txt:268:           : new Date(row.updated_at as string),
+.review/ISSUE-113-REVIEW.raw.txt:269:+    detached_by: (row.detached_by as string | null) ?? null,
+.review/ISSUE-113-REVIEW.raw.txt:270:+    detach_reason: (row.detach_reason as string | null) ?? null,
+.review/ISSUE-113-REVIEW.raw.txt:271:+    detached_at:
+.review/ISSUE-113-REVIEW.raw.txt:272:+      row.detached_at === null || row.detached_at === undefined
+.review/ISSUE-113-REVIEW.raw.txt:274:+        : row.detached_at instanceof Date
+.review/ISSUE-113-REVIEW.raw.txt:275:+          ? row.detached_at
+.review/ISSUE-113-REVIEW.raw.txt:276:+          : new Date(row.detached_at as string),
+.review/ISSUE-113-REVIEW.raw.txt:284:-      created_at, updated_at
+.review/ISSUE-113-REVIEW.raw.txt:285:+      created_at, updated_at, detached_by, detach_reason, detached_at
+.review/ISSUE-113-REVIEW.raw.txt:293:-      created_at, updated_at
+.review/ISSUE-113-REVIEW.raw.txt:294:+      created_at, updated_at, detached_by, detach_reason, detached_at
+.review/ISSUE-113-REVIEW.raw.txt:298:@@ -158,7 +169,7 @@ export async function selectActiveLinksForEndpoint(
+.review/ISSUE-113-REVIEW.raw.txt:302:-      created_at, updated_at
+.review/ISSUE-113-REVIEW.raw.txt:303:+      created_at, updated_at, detached_by, detach_reason, detached_at
+.review/ISSUE-113-REVIEW.raw.txt:306:       AND status = 'active'
+.review/ISSUE-113-REVIEW.raw.txt:307:@@ -167,3 +178,50 @@ export async function selectActiveLinksForEndpoint(
+.review/ISSUE-113-REVIEW.raw.txt:320:+      created_at, updated_at, detached_by, detach_reason, detached_at
+.review/ISSUE-113-REVIEW.raw.txt:343:+      detached_by = ${input.actorId},
+.review/ISSUE-113-REVIEW.raw.txt:344:+      detach_reason = ${input.reason},
+.review/ISSUE-113-REVIEW.raw.txt:345:+      detached_at = now(),
+.review/ISSUE-113-REVIEW.raw.txt:346:+      updated_at = now()
+.review/ISSUE-113-REVIEW.raw.txt:349:+      AND status = 'active'
+.review/ISSUE-113-REVIEW.raw.txt:353:+      created_at, updated_at, detached_by, detach_reason, detached_at
+.review/ISSUE-113-REVIEW.raw.txt:435: import type { CheckService } from '../permissions/check-service.js';
+.review/ISSUE-113-REVIEW.raw.txt:441:   selectActiveLinksForEndpoint,
+.review/ISSUE-113-REVIEW.raw.txt:451:+  if (row.status !== 'detached' || row.detached_at === null) {
+.review/ISSUE-113-REVIEW.raw.txt:457:+    detached_at: row.detached_at.toISOString(),
+.review/ISSUE-113-REVIEW.raw.txt:493:+      throw new HttpError('conflict.stale_write', 'entity link is no longer active');
+.review/ISSUE-113-REVIEW.raw.txt:520:+        throw new HttpError('conflict.stale_write', 'entity link is no longer active');
+.review/ISSUE-113-REVIEW.raw.txt:526:+        event_type: 'entity_link.detached',
+.review/ISSUE-113-REVIEW.raw.txt:572:+          and event_type in ('entity_link.created', 'entity_link.detached')`,
+.review/ISSUE-113-REVIEW.raw.txt:608:+    const body = res.json<{ id: string; status: string; detached_at: string | null }>();
+.review/ISSUE-113-REVIEW.raw.txt:610:+    expect(body.detached_at).toEqual(expect.any(String));
+.review/ISSUE-113-REVIEW.raw.txt:614:+      detached_by: string | null;
+.review/ISSUE-113-REVIEW.raw.txt:615:+      detach_reason: string | null;
+.review/ISSUE-113-REVIEW.raw.txt:616:+      detached_at: Date | null;
+.review/ISSUE-113-REVIEW.raw.txt:618:+      `select status, detached_by, detach_reason, detached_at
+.review/ISSUE-113-REVIEW.raw.txt:626:+      detached_by: adminActorId,
+.review/ISSUE-113-REVIEW.raw.txt:627:+      detach_reason: 'No longer relevant',
+.review/ISSUE-113-REVIEW.raw.txt:629:+    expect(linkRows.rows[0]?.detached_at).toBeInstanceOf(Date);
+.review/ISSUE-113-REVIEW.raw.txt:633:+        where event_type = 'entity_link.detached' and subject_id = $1`,
+.review/ISSUE-113-REVIEW.raw.txt:686:+    expect(second.json<{ code: string }>().code).toBe('conflict.stale_write');
+.review/ISSUE-113-REVIEW.raw.txt:735:+          count(*) filter (where status = 'active')::int as active,
+.review/ISSUE-113-REVIEW.raw.txt:761:+`detached_by`, `detach_reason`, and `detached_at`, and preserves the row; hard
+.review/ISSUE-113-REVIEW.raw.txt:762:+delete and `DELETE /entity-links/:id` are intentionally not used.
+.review/ISSUE-113-REVIEW.raw.txt:772:+`revoked` remains reserved for future admin/policy flows and `stale` remains
+.review/ISSUE-113-REVIEW.raw.txt:797:+- already detached, revoked, stale, or lost update race: 409
+.review/ISSUE-113-REVIEW.raw.txt:799:+  audit_log event_type entity_link.detached
+.review/ISSUE-113-REVIEW.raw.txt:800:+- hard delete is forbidden; fops_app has UPDATE but not DELETE on core.entity_links
+.review/ISSUE-113-REVIEW.raw.txt:835:+  detached_at: z.string().datetime(),
+.review/ISSUE-113-REVIEW.raw.txt:847:+  'entity_link.detached',
+.review/ISSUE-113-REVIEW.raw.txt:878:+  'entity_link.detached': entityLinkDetachedDetailSchema,
+.review/ISSUE-113-REVIEW.raw.txt:887:The main path is scoped to entity-links plus shared audit/types and docs. I’m checking two likely risk spots now: whether permission failure really maps to 404 on both endpoint systems, and whether migration/test coverage proves `updated_at` and 0019 registration correctly.
+.review/ISSUE-113-REVIEW.raw.txt:919:    21	  status: 'active' | 'stale' | 'detached' | 'revoked';
+.review/ISSUE-113-REVIEW.raw.txt:923:    25	  updated_at: Date | null;
+.review/ISSUE-113-REVIEW.raw.txt:924:    26	  detached_by: string | null;
+.review/ISSUE-113-REVIEW.raw.txt:925:    27	  detach_reason: string | null;
+.review/ISSUE-113-REVIEW.raw.txt:926:    28	  detached_at: Date | null;
+.review/ISSUE-113-REVIEW.raw.txt:944:    46	    updated_at:
+.review/ISSUE-113-REVIEW.raw.txt:945:    47	      row.updated_at === null || row.updated_at === undefined
+.review/ISSUE-113-REVIEW.raw.txt:947:    49	        : row.updated_at instanceof Date
+.review/ISSUE-113-REVIEW.raw.txt:948:    50	          ? row.updated_at
+.review/ISSUE-113-REVIEW.raw.txt:949:    51	          : new Date(row.updated_at as string),
+.review/ISSUE-113-REVIEW.raw.txt:950:    52	    detached_by: (row.detached_by as string | null) ?? null,
+.review/ISSUE-113-REVIEW.raw.txt:951:    53	    detach_reason: (row.detach_reason as string | null) ?? null,
+.review/ISSUE-113-REVIEW.raw.txt:952:    54	    detached_at:
+.review/ISSUE-113-REVIEW.raw.txt:953:    55	      row.detached_at === null || row.detached_at === undefined
+.review/ISSUE-113-REVIEW.raw.txt:955:    57	        : row.detached_at instanceof Date
+.review/ISSUE-113-REVIEW.raw.txt:956:    58	          ? row.detached_at
+.review/ISSUE-113-REVIEW.raw.txt:957:    59	          : new Date(row.detached_at as string),
+.review/ISSUE-113-REVIEW.raw.txt:1003:   105	    ) WHERE status = 'active'
+.review/ISSUE-113-REVIEW.raw.txt:1008:   110	      created_at, updated_at, detached_by, detach_reason, detached_at
+.review/ISSUE-113-REVIEW.raw.txt:1032:   134	      created_at, updated_at, detached_by, detach_reason, detached_at
+.review/ISSUE-113-REVIEW.raw.txt:1040:   142	      AND status = 'active'
+.review/ISSUE-113-REVIEW.raw.txt:1047:   149	export async function selectActiveLinksForEndpoint(
+.review/ISSUE-113-REVIEW.raw.txt:1070:   172	      created_at, updated_at, detached_by, detach_reason, detached_at
+.review/ISSUE-113-REVIEW.raw.txt:1073:   175	      AND status = 'active'
+.review/ISSUE-113-REVIEW.raw.txt:1088:   190	      created_at, updated_at, detached_by, detach_reason, detached_at
+.review/ISSUE-113-REVIEW.raw.txt:1111:   213	      detached_by = ${input.actorId},
+.review/ISSUE-113-REVIEW.raw.txt:1112:   214	      detach_reason = ${input.reason},
+.review/ISSUE-113-REVIEW.raw.txt:1113:   215	      detached_at = now(),
+.review/ISSUE-113-REVIEW.raw.txt:1114:   216	      updated_at = now()
+.review/ISSUE-113-REVIEW.raw.txt:1117:   219	      AND status = 'active'
+.review/ISSUE-113-REVIEW.raw.txt:1121:   223	      created_at, updated_at, detached_by, detach_reason, detached_at
+apps/backend/src/modules/managed-systems/__tests__/managed-system.integration.test.ts:41:    url: '/auth/mock-login',
+apps/backend/src/modules/attachments/__tests__/post-attachments-validation.integration.test.ts:5://   * buildServer + cookie session via POST /auth/mock-login.
+apps/backend/src/modules/attachments/__tests__/post-attachments-validation.integration.test.ts:44:    url: '/auth/mock-login',
+apps/backend/src/modules/auth/__tests__/list-actors.integration.test.ts:31:    url: '/auth/mock-login',
+apps/backend/src/lib/rate-limit-actor-cache.ts:3:import type { RateLimitActorIdentity } from '../modules/auth/session-service.js';
+apps/backend/src/db/__tests__/voc-foundation.integration.test.ts:411:  it('fops_app cannot DELETE voc_internal_comments (permission denied)', async () => {
+apps/backend/src/db/__tests__/voc-foundation.integration.test.ts:742:  // GRANT DELETE was restored in 0016 so the internal purge worker
+apps/backend/src/db/__tests__/voc-foundation.integration.test.ts:768:  // 0016: fops_app holds DELETE for the internal purge worker. The
+apps/backend/src/db/__tests__/voc-foundation.integration.test.ts:771:  it('voc_attachments DELETE is permitted for fops_app (purge-worker path)', async () => {
+apps/backend/src/modules/attachments/__tests__/get-attachments-download.integration.test.ts:52:    url: '/auth/mock-login',
+apps/backend/src/modules/managed-systems/__tests__/register.advisory-lock.integration.test.ts:44:    url: '/auth/mock-login',
+apps/backend/src/modules/auth/__tests__/resolve-actors.integration.test.ts:33:    url: '/auth/mock-login',
+apps/backend/src/modules/attachments/__tests__/post-attachments-happy.integration.test.ts:15:// buildServer + cookie session via POST /auth/mock-login; the only addition
+apps/backend/src/modules/attachments/__tests__/post-attachments-happy.integration.test.ts:54:    url: '/auth/mock-login',
+apps/backend/src/db/__tests__/role-grants-product-tables.integration.test.ts:6: * (SELECT/INSERT/UPDATE/DELETE), but several are intentionally append-only or
+apps/backend/src/db/__tests__/role-grants-product-tables.integration.test.ts:23: *     without a paired re-GRANT (e.g. missing DELETE on voc.voc_attachments
+apps/backend/src/db/__tests__/role-grants-product-tables.integration.test.ts:26: *     UPDATE/DELETE, eroding the immutability guarantee.
+apps/backend/src/db/__tests__/role-grants-product-tables.integration.test.ts:42:const DML_PRIVILEGES = ['SELECT', 'INSERT', 'UPDATE', 'DELETE'] as const;
+apps/backend/src/modules/auth/session-service.ts:225:     * the row is missing, revoked, or expired — the caller renders the
+apps/backend/src/modules/auth/session-service.ts:228:     * F-007: the predicate (`revoked_at IS NULL AND expires_at > now()`)
+apps/backend/src/modules/auth/session-service.ts:231:     * see the touch land on an already-revoked row and the request would
+apps/backend/src/modules/auth/session-service.ts:260:             AND revoked_at IS NULL
+apps/backend/src/modules/auth/session-service.ts:306:     * is missing, revoked, or expired — the keyGenerator falls back to IP.
+apps/backend/src/modules/auth/session-service.ts:317:           AND revoked_at IS NULL
+apps/backend/src/modules/auth/session-service.ts:324:    /** Revoke immediately. Idempotent: revoking an already-revoked row is a no-op. */
+apps/backend/src/modules/auth/session-service.ts:329:        .set({ revokedAt: rightNow })
+apps/backend/src/modules/auth/session-service.ts:330:        .where(and(eq(sessions.id, sessionId), isNull(sessions.revokedAt)));
+apps/backend/src/modules/managed-systems/managed-system-service.ts:34:import type { ActorContext, CheckService } from '../permissions/check-service.js';
+apps/backend/src/modules/managed-systems/managed-system-service.ts:69:  updated_at: string;
+apps/backend/src/modules/managed-systems/managed-system-service.ts:114:    updated_at: row.updatedAt.toISOString(),
+apps/backend/src/modules/voc/service.ts:27:import type { CheckService } from '../permissions/check-service.js';
+apps/backend/src/modules/voc/service.ts:28:import type { RoleLevel } from '../auth/session-service.js';
+apps/backend/src/modules/voc/service.ts:59:  updated_at: string;
+apps/backend/src/modules/voc/service.ts:206:      updated_at: row.updatedAt.toISOString(),
+apps/backend/src/modules/voc/service.ts:230:    // previous ordering (stale_write before permission deny) leaked
+apps/backend/src/modules/voc/service.ts:231:    // `current_updated_at` of any in-workspace VOC to actors without
+apps/backend/src/modules/voc/service.ts:261:      // explicit_deny / grant_revoked / grant_expired → generic denied.
+apps/backend/src/modules/voc/service.ts:269:    // 3. Optimistic concurrency check (after permission — C3: no current_updated_at
+apps/backend/src/modules/voc/service.ts:270:    // leak to unauthorised actors; only authorised actors see 409 stale_write detail).
+apps/backend/src/modules/voc/service.ts:272:      throw new HttpError('conflict.stale_write', 'voc updated_at does not match If-Match', {
+apps/backend/src/modules/voc/service.ts:273:        current_updated_at: row.updatedAt.toISOString(),
+apps/backend/src/modules/voc/service.ts:508:      // timestamp so the column doesn't carry a stale "postponed since X" value
+apps/backend/src/modules/voc/service.ts:673:      updated_at: row.updatedAt.toISOString(),
+apps/backend/src/modules/voc/service.ts:686:  //   4. If-Match compare → 409 conflict.stale_write
+apps/backend/src/modules/voc/service.ts:730:      throw new HttpError('conflict.stale_write', 'voc updated_at does not match If-Match', {
+apps/backend/src/modules/voc/service.ts:731:        current_updated_at: row.updatedAt.toISOString(),
+apps/backend/src/modules/voc/service.ts:839:    // through unchanged so the repo guard can bump updated_at.
+.review/ISSUE-103-CODEX.json:5:    "apps/frontend/src/lib/layout/AppSidebar.tsx",
+.review/ISSUE-103-CODEX.json:6:    "apps/frontend/src/lib/layout/__tests__/AppSidebar.test.tsx",
+.review/ISSUE-103-CODEX.json:7:    "apps/frontend/src/routes/_authed.tsx",
+.review/ISSUE-103-CODEX.json:29:      "reason": "No concrete /admin/settings route file exists in apps/frontend/src/routes/_authed/admin; /admin/placeholder is an existing admin route."
+.review/ISSUE-103-CODEX.json:67:      "command": "pnpm exec biome check apps/frontend/src/lib/layout/AppSidebar.tsx apps/frontend/src/lib/layout/__tests__/AppSidebar.test.tsx apps/frontend/src/routes/_authed.tsx docs/frontend/routes-and-layout.md .review/ISSUE-103-CODEX.json",
+apps/backend/src/types/fastify.d.ts:8:import type { RoleLevel } from '../modules/auth/session-service.js';
+apps/backend/src/db/__tests__/migration.test.ts:43:    // UPDATE/DELETE/TRUNCATE are revoked.
+apps/backend/src/db/__tests__/migration.test.ts:46:      /REVOKE\s+UPDATE,\s*DELETE,\s*TRUNCATE\s+ON\s+"core"\."audit_log"\s+FROM\s+fops_app/i,
+apps/backend/src/db/__tests__/migration.test.ts:64:        `GRANT\\s+SELECT,\\s*INSERT,\\s*UPDATE,\\s*DELETE\\s+ON\\s+${tbl.replace(/\./g, '\\.').replace(/"/g, '"')}\\s+TO\\s+fops_app`,
+apps/backend/src/db/__tests__/migration.test.ts:83:      /CREATE UNIQUE INDEX "permission_grants_active_uq"[\s\S]*coalesce\("managed_system_id"[\s\S]*coalesce\("object_type"[\s\S]*coalesce\("object_id"[\s\S]*WHERE "revoked_at" is null/,
+apps/backend/src/db/__tests__/migration.test.ts:119:      /GRANT\s+SELECT,\s*INSERT,\s*UPDATE,\s*DELETE\s+ON\s+ALL TABLES IN SCHEMA pgboss\s+TO\s+fops_app/i,
+apps/backend/src/db/__tests__/migration.test.ts:139:      /GRANT\s+SELECT,\s*INSERT,\s*UPDATE,\s*DELETE\s+ON\s+"core"\."rate_limits"\s+TO\s+fops_app/i,
+apps/backend/src/db/__tests__/migration.test.ts:183:        `GRANT\\s+SELECT,\\s*INSERT,\\s*UPDATE,\\s*DELETE\\s+ON\\s+${tbl.replace(/\./g, '\\.').replace(/"/g, '"')}\\s+TO\\s+fops_app`,
+apps/backend/src/db/__tests__/migration.test.ts:322:      /GRANT\s+(?:SELECT,\s*)?DELETE[\s\S]*workspace_display_counters[\s\S]*TO fops_app/i,
+apps/backend/src/modules/auth/mock-auth-provider.ts:43:        <form method="POST" action="/auth/mock-login">
+packages/shared/src/vocs/__tests__/detail.test.ts:21:  updated_at: '2026-01-01T00:00:00.000Z',
+apps/backend/src/modules/managed-systems/routes.ts:10:import type { SessionService } from '../auth/session-service.js';
+apps/backend/src/modules/managed-systems/routes.ts:11:import type { ActorContext } from '../permissions/check-service.js';
+.review/CHUNK-22-C7b-DEVIATIONS.md:42:After flipping the shared zod request schemas, `apps/frontend` typecheck
+.review/CHUNK-22-C7b-DEVIATIONS.md:46:- `apps/frontend/src/features/voc/components/create/VocCreateScreen.tsx:57`
+.review/CHUNK-22-C7b-DEVIATIONS.md:47:- `apps/frontend/src/features/voc/components/detail/EditDescriptionModal.tsx:92,121,143,192`
+.review/CHUNK-22-C7b-DEVIATIONS.md:48:- `apps/frontend/src/features/voc/hooks/__tests__/useVocEditDescriptionMutation.test.ts:40`
+.review/CHUNK-22-C7b-DEVIATIONS.md:177:### apps/frontend (3 prod, 2 test) — minimal D-1 surgical rename only
+apps/backend/src/modules/voc/conversation-service.ts:28:import type { CheckService } from '../permissions/check-service.js';
+apps/backend/src/modules/voc/conversation-service.ts:29:import type { RoleLevel } from '../auth/session-service.js';
+.review/ISSUE-113-REVIEW-PROMPT.txt:4:1. Contract adherence — PATCH /entity-links/:id soft-detach (active→detached), row PRESERVED (no hard delete), detached_by/detach_reason/detached_at set, updated_at set, single transaction, audit entity_link.detached emitted. Migration 0019 adds 3 columns + GRANT UPDATE to fops_app (and NO DELETE grant). Journal/snapshot registered for 0019 (mirror 0018 technique). core.ts entityLinks has the 3 new columns.
+.review/ISSUE-113-REVIEW-PROMPT.txt:6:3. Active-only visibility — confirm a detached link no longer appears on GET /entity-links and the VOC detail Links tab (selectActiveLinksForEndpoint filters status='active'). If the VOC-detail query was NOT already active-filtered, confirm a filter was added.
+.review/ISSUE-113-REVIEW-PROMPT.txt:8:5. Scope discipline — no forbidden paths (permissions/*, auth/*, apps/frontend/**, findings table, revoked/stale production, DELETE grant, hard delete). 
+.review/ISSUE-113-REVIEW-PROMPT.txt:9:6. Deviation D1 — 409 uses existing `conflict.stale_write` because errors/codes.ts is out of scope. Judge: acceptable, or does it block / need a different code?
+.review/ISSUE-113-REVIEW-PROMPT.txt:10:7. Tests — do the 6 cases in the prompt exist and genuinely assert (row persists with metadata after detach; audit row; detached link absent from GET + VOC detail; already-detached→409; missing/empty reason→422; out-of-scope→404; re-POST after detach succeeds)? Note any missing/weak case. Confirm teardown uses migrateHandle (fops_migrate) for DELETEs since fops_app cannot delete.
+apps/backend/src/db/__tests__/role-grants.integration.test.ts:67:  it('fops_app must NOT DELETE from core.audit_log', async () => {
+apps/backend/src/db/__tests__/role-grants.integration.test.ts:96:    // UPDATE/DELETE the registry tables that Slice 2 services write to.
+apps/backend/src/db/__tests__/role-grants.integration.test.ts:105:      for (const p of ['SELECT', 'INSERT', 'UPDATE', 'DELETE']) {
+apps/backend/src/db/__tests__/role-grants.integration.test.ts:113:    // to core.teams. Migration 0009 revokes INSERT/UPDATE/DELETE so the
+apps/backend/src/db/__tests__/role-grants.integration.test.ts:122:    for (const p of ['INSERT', 'UPDATE', 'DELETE']) {
+apps/backend/src/db/__tests__/role-grants.integration.test.ts:129:    // `_create_queue_unsafe` and revoked EXECUTE from fops_app + PUBLIC.
+apps/backend/src/db/__tests__/role-grants.integration.test.ts:179:    // revoked from fops_app in migration 0003.
+apps/backend/src/modules/auth/auth-provider.ts:24:   * Returns the response a `GET /auth/<provider>/login` should produce. For
+.review/SLICE-3-19-REVIEW-CYCLE-2.md:19:- `apps/frontend/src/features/voc/routes/__tests__/CreateRoute.test.tsx` continues to validate that idle status keeps the modal closed and blocked status opens it.
+apps/backend/src/seed/voc-fixtures.ts:9:// display_id LIKE 'VOC-SEED-%' on each invocation. ON DELETE cascade from
+apps/backend/src/seed/voc-fixtures.ts:165:    // ON DELETE cascade clears voc_public_updates, voc_reporter_replies,
+apps/backend/src/lib/storage/s3-compat.ts:3:// Uses `@aws-sdk/client-s3` for HEAD/GET/DELETE and `@aws-sdk/lib-storage`
+apps/backend/src/modules/auth/list-actors-routes.ts:7:// boundaries.md keep actor reads under `core` ownership, but auth/ already
+apps/backend/src/modules/auth/list-actors-routes.ts:8:// owns the actor identity surface (`/me`, `/auth/mock-login`) and the
+.review/ISSUE-98-CODEX.json:10:    "apps/frontend/src/features/voc/components/triage/VocTriageScreen.tsx",
+.review/ISSUE-98-CODEX.json:11:    "apps/frontend/src/features/voc/components/triage/__tests__/VocTriageScreen.kicker.test.tsx",
+.review/ISSUE-98-CODEX.json:12:    "apps/frontend/src/features/voc/components/triage/__tests__/TriageRow.test.tsx",
+.review/ISSUE-98-CODEX.json:33:      "file": "apps/frontend/src/features/voc/components/triage/VocTriageScreen.tsx",
+.review/ISSUE-98-CODEX.json:61:      "command": "pnpm exec biome check packages/ui/src/toolbar/ListToolbar.tsx packages/ui/src/layout/ListShell.tsx packages/ui/src/toolbar/__tests__/ListToolbar.test.tsx packages/ui/__tests__/shells.test.tsx apps/frontend/src/features/voc/components/triage/VocTriageScreen.tsx apps/frontend/src/features/voc/components/triage/__tests__/TriageRow.test.tsx apps/frontend/src/features/voc/components/triage/__tests__/VocTriageScreen.kicker.test.tsx docs/adr/0020-shell-taxonomy-three-route-shells-and-50px-header-rhythm.md",
+.review/SLICE-3-22-DASHBOARD.html:745:- Did **not** touch `packages/shared/src/vocs/*` or `apps/frontend/*` (C5 territory).
+.review/SLICE-3-22-DASHBOARD.html:751:<article class="chunk-card" data-id="C5" data-wave="2" data-files="packages/shared/src/vocs/attachment.ts apps/frontend/src/lib/api/attachments.ts apps/frontend/src/lib/api/client.ts">
+.review/SLICE-3-22-DASHBOARD.html:763:  <ul class="file-list"><li class="file-pill">packages/shared/src/vocs/attachment.ts</li><li class="file-pill">apps/frontend/src/lib/api/attachments.ts</li><li class="file-pill">apps/frontend/src/lib/api/client.ts</li></ul>
+.review/SLICE-3-22-DASHBOARD.html:857:<article class="chunk-card" data-id="C6" data-wave="4" data-files="apps/frontend/src/features/voc/components/create/attachmentdropzone.tsx apps/frontend/src/features/voc/components/create/voccreatescreen.tsx apps/frontend/src/features/voc/components/detail/editdescriptionmodal.tsx">
+.review/SLICE-3-22-DASHBOARD.html:869:  <ul class="file-list"><li class="file-pill">apps/frontend/src/features/voc/components/create/AttachmentDropzone.tsx</li><li class="file-pill">apps/frontend/src/features/voc/components/create/VocCreateScreen.tsx</li><li class="file-pill">apps/frontend/src/features/voc/components/detail/EditDescriptionModal.tsx</li></ul>
+.review/SLICE-3-22-DASHBOARD.html:916:   with aria-disabled&quot;) was stale.** The disabled assertion no longer applies
+.review/SLICE-3-22-DASHBOARD.html:956:<article class="chunk-card" data-id="C7a" data-wave="4" data-files="apps/frontend/src/features/voc/components/detail/composerattachmentdropzone.tsx apps/frontend/src/features/voc/components/detail/publicupdatecomposer.tsx apps/frontend/src/features/voc/components/detail/internalcommentcomposer.tsx apps/frontend/src/features/voc/components/detail/reporterreplycomposer.tsx">
+.review/SLICE-3-22-DASHBOARD.html:968:  <ul class="file-list"><li class="file-pill">apps/frontend/src/features/voc/components/detail/ComposerAttachmentDropzone.tsx</li><li class="file-pill">apps/frontend/src/features/voc/components/detail/PublicUpdateComposer.tsx</li><li class="file-pill">apps/frontend/src/features/voc/components/detail/InternalCommentComposer.tsx</li><li class="file-pill">apps/frontend/src/features/voc/components/detail/ReporterReplyComposer.tsx</li></ul>
+.review/SLICE-3-22-DASHBOARD.html:981:| Extract `ComposerAttachmentDropzone.tsx` (~80 LOC) | Done as standalone file under `apps/frontend/src/features/voc/components/detail/`. Final size ~290 LOC (mirrors the C6 AttachmentDropzone state machine verbatim — extraction did not actually reduce LOC because the row state machine, upload kickoff, error mapping, and idempotency-key minting are inherent to the contract). Compact variant strips the `Card` chrome + FieldLabel and uses tighter row padding per prototype anchor. |
+.review/SLICE-3-22-DASHBOARD.html:997:- `cd apps/frontend &amp;&amp; pnpm test -- --run src/features/voc/components/detail/__tests__/{PublicUpdate,InternalComment,ReporterReply}Composer.attachments.test.tsx` → 9/9 pass
+.review/SLICE-3-22-DASHBOARD.html:998:- `cd apps/frontend &amp;&amp; pnpm test -- --run` → 427/427 pass, 109 test files
+.review/SLICE-3-22-DASHBOARD.html:1065:After flipping the shared zod request schemas, `apps/frontend` typecheck
+.review/SLICE-3-22-DASHBOARD.html:1069:- `apps/frontend/src/features/voc/components/create/VocCreateScreen.tsx:57`
+.review/SLICE-3-22-DASHBOARD.html:1070:- `apps/frontend/src/features/voc/components/detail/EditDescriptionModal.tsx:92,121,143,192`
+.review/SLICE-3-22-DASHBOARD.html:1071:- `apps/frontend/src/features/voc/hooks/__tests__/useVocEditDescriptionMutation.test.ts:40`
+.review/SLICE-3-22-DASHBOARD.html:1200:### apps/frontend (3 prod, 2 test) — minimal D-1 surgical rename only
+.review/SLICE-3-22-DASHBOARD.html:1579:<li><strong>Bug 2 — purge worker silently no-op'd in prod.</strong> The hourly <code>core.attachments_purge</code> job (PLAN-22 §C4b) tried to <code>DELETE FROM voc.voc_attachments</code> as the <code>fops_app</code> role, but no migration ever granted <code>DELETE</code> on that table to that role. Integration tests passed because they run as the migration superuser; production would have logged the failure and left unlinked rows piling up indefinitely. <strong>Resolution:</strong> commit <code>c6f361a</code> shipped migration <code>0016_grant_app_delete_voc_attachments.sql</code> — <code>GRANT DELETE ON voc.voc_attachments TO fops_app</code>. The archive-over-delete invariant for user-initiated paths is unchanged and now lives explicitly at the service layer; the grant exists strictly so the purge worker can reclaim orphaned uploads. Locked as PLAN-22 D-20.</li>
+apps/backend/src/modules/voc/repo-read.ts:10://   permissions/scope-service.ts which owns that cross-module read. This file
+apps/backend/src/modules/voc/repo-read.ts:27:import type { Scope, ScopeActorContext } from '../permissions/scope-service.js';
+apps/backend/src/modules/voc/repo-read.ts:28:import { actorScopeForCapability } from '../permissions/scope-service.js';
+apps/backend/src/modules/voc/repo-read.ts:177:    updatedAt: toDate(row.updated_at as Date | string),
+apps/backend/src/modules/voc/repo-read.ts:248:        AND el.status = 'active'
+apps/backend/src/modules/voc/repo-read.ts:325:        created_at, updated_at,
+apps/backend/src/modules/voc/repo-read.ts:443:        created_at, updated_at,
+apps/backend/src/modules/voc/repo-read.ts:510:      created_at, updated_at
+apps/backend/src/db/schema/permission.ts:15://   condition from the predicate; uniqueness is enforced over non-revoked
+apps/backend/src/db/schema/permission.ts:48:    revokedAt: timestamp('revoked_at', { withTimezone: true }),
+apps/backend/src/db/schema/permission.ts:49:    revokedByActorId: uuid('revoked_by_actor_id'),
+apps/backend/src/db/schema/permission.ts:50:    revokedReason: text('revoked_reason'),
+apps/backend/src/db/schema/permission.ts:58:    // Partial unique on the effective scope of a non-revoked grant.
+apps/backend/src/db/schema/permission.ts:65:      .where(sql`${t.revokedAt} is null`),
+apps/backend/src/db/schema/permission.ts:84:    revokedAt: timestamp('revoked_at', { withTimezone: true }),
+apps/backend/src/db/schema/permission.ts:85:    revokedByActorId: uuid('revoked_by_actor_id'),
+apps/backend/src/db/schema/permission.ts:92:      .where(sql`${t.revokedAt} is null`),
+apps/backend/src/db/schema/permission.ts:118:    // status: pending | needs_more_info | approved | rejected | expired | revoked
+apps/backend/src/db/schema/permission.ts:125:    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+apps/backend/src/modules/auth/routes.ts:2:// the issue body verbatim: GET/POST /auth/mock-login, POST /auth/logout, GET
+apps/backend/src/modules/auth/routes.ts:28:  // ── GET /auth/mock-login ──────────────────────────────────────────────
+apps/backend/src/modules/auth/routes.ts:34:    url: '/auth/mock-login',
+apps/backend/src/modules/auth/routes.ts:44:  // ── POST /auth/mock-login ─────────────────────────────────────────────
+apps/backend/src/modules/auth/routes.ts:47:    url: '/auth/mock-login',
+apps/backend/src/modules/auth/routes.ts:83:  // ── POST /auth/logout ─────────────────────────────────────────────────
+apps/backend/src/modules/auth/routes.ts:86:    url: '/auth/logout',
+apps/backend/src/modules/auth/routes.ts:115:      // loadAndTouch can return null if the row was concurrently revoked
+apps/backend/src/modules/permissions/scope-service.ts:1:// apps/backend/src/modules/permissions/scope-service.ts
+apps/backend/src/modules/permissions/scope-service.ts:32: * a non-revoked, non-expired grant for `capability`, minus any active denies.
+apps/backend/src/modules/permissions/scope-service.ts:61:    isNull(permissionGrants.revokedAt),
+apps/backend/src/modules/permissions/scope-service.ts:77:    isNull(permissionDenies.revokedAt),
+.review/CHUNK-22-C2-DEVIATIONS.md:53:C2 shipped the column rename (`storage_uri → storage_key`), `linked_at`, and the relaxed XOR. It did **not** touch grants — the `fops_app` role inherited the existing `SELECT, INSERT, UPDATE` privileges from earlier migrations, and no `DELETE` grant existed at C2 GREEN.
+.review/CHUNK-22-C2-DEVIATIONS.md:55:Post-merge, the hourly `core.attachments_purge` worker (PLAN-22 §C4b, migration 0014) needed `DELETE` to reclaim unlinked rows >24h. Hotfix migration `0016_grant_app_delete_voc_attachments.sql` (`fix/22-storage-lazy-and-attachments-grants`, commit `c6f361a`) added `GRANT DELETE ON voc.voc_attachments TO fops_app`. User-initiated removals still go through the service-layer archive (`archived_at`, `archived_by_actor_id`) — the grant is purely for the purge worker. See ADR-0011 second 2026-05-22 amendment, PLAN-22 D-20, and `docs/implementation/04-database-and-migrations.md` §"Archive over delete on voc.voc_attachments".
+apps/backend/src/middleware/require-session.ts:2:// cookie, verifies the row is active (not revoked, not expired), touches
+apps/backend/src/middleware/require-session.ts:6:// "no cookie", "revoked", and "expired" identically so the boundary doesn't
+apps/backend/src/middleware/require-session.ts:11:import type { SessionService } from '../modules/auth/session-service.js';
+apps/backend/src/db/schema/core.ts:38:  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+apps/backend/src/db/schema/core.ts:61:    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+apps/backend/src/db/schema/core.ts:98:    revokedAt: timestamp('revoked_at', { withTimezone: true }),
+apps/backend/src/db/schema/core.ts:201:    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+apps/backend/src/db/schema/core.ts:233:    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+apps/backend/src/db/schema/core.ts:269:    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+apps/backend/src/db/schema/core.ts:308:    updatedAt: timestamp('updated_at', { withTimezone: true }),
+apps/backend/src/db/schema/core.ts:309:    detachedBy: uuid('detached_by').references(() => actors.id),
+apps/backend/src/db/schema/core.ts:310:    detachReason: text('detach_reason'),
+apps/backend/src/db/schema/core.ts:311:    detachedAt: timestamp('detached_at', { withTimezone: true }),
+apps/backend/src/db/schema/core.ts:324:      sql`${t.status} in ('active','stale','detached','revoked')`,
+.review/ISSUE-112-REVIEW.raw.txt:17:1. **Contract adherence** — Does the implementation match every "Required design points" item in the dispatch prompt? Table columns, constraints, unique partial index, composite indexes, GRANTs (fops_app INSERT+SELECT only, no UPDATE/DELETE in this slice), audit_log emit, both-side permission via per-type resolver, visibility decision allowed/hidden with target_id stripped on hidden, VOC detail no-link replacement.
+.review/ISSUE-112-REVIEW.raw.txt:18:2. **Scope discipline** — Any FORBIDDEN paths touched? (apps/frontend/**, packages/shared/src/permissions/**, packages/shared/src/auth/**, new findings table, detach endpoints, additional relation types, FR-LINK-003 missing-link queries, visibility tokens beyond what's required.)
+.review/ISSUE-112-REVIEW.raw.txt:204:- docs/design/14-api-draft.md §"Entity Link APIs" — POST/GET/PATCH/DELETE /entity-links
+.review/ISSUE-112-REVIEW.raw.txt:234:- `packages/shared/src/permissions/*` — reuse existing permission helpers, do NOT add new capabilities
+.review/ISSUE-112-REVIEW.raw.txt:235:- `packages/shared/src/auth/*`
+.review/ISSUE-112-REVIEW.raw.txt:237:- Any FE code (`apps/frontend/**`) — #114 owns `/integration/links` UI; this issue is backend + the VOC detail backend payload only
+.review/ISSUE-112-REVIEW.raw.txt:239:- Detach endpoints `PATCH/DELETE /entity-links/:id` (#113)
+.review/ISSUE-112-REVIEW.raw.txt:255:- `status text not null default 'active'` — enum domain `active|stale|detached|revoked` (only `active` is produced by this slice; `stale` populated later by Slice 7, others by #113)
+.review/ISSUE-112-REVIEW.raw.txt:258:- `updated_at timestamptz` (nullable until first transition; reserved for #113)
+.review/ISSUE-112-REVIEW.raw.txt:265:- GRANTs: `fops_app` gets INSERT + SELECT (UPDATE deferred until #113 needs it; DELETE never — no hard delete)
+.review/ISSUE-112-REVIEW.raw.txt:437:+    updatedAt: timestamp('updated_at', { withTimezone: true }),
+.review/ISSUE-112-REVIEW.raw.txt:450:+      sql`${t.status} in ('active','stale','detached','revoked')`,
+.review/ISSUE-112-REVIEW.raw.txt:493:-import { createMockAuthProvider } from './modules/auth/mock-auth-provider.js';
+.review/ISSUE-112-REVIEW.raw.txt:496: import { listActorsRoutes } from './modules/auth/list-actors-routes.js';
+.review/ISSUE-112-REVIEW.raw.txt:497:+import { createMockAuthProvider } from './modules/auth/mock-auth-provider.js';
+.review/ISSUE-112-REVIEW.raw.txt:498: import { authRoutes } from './modules/auth/routes.js';
+.review/ISSUE-112-REVIEW.raw.txt:499: import { createSessionService } from './modules/auth/session-service.js';
+.review/ISSUE-112-REVIEW.raw.txt:636: export * from './permissions/index.js';
+.review/ISSUE-112-REVIEW.raw.txt:642: export * from './auth/list-actors.js';
+.review/ISSUE-112-REVIEW.raw.txt:705:-import type { CheckService } from '../permissions/check-service.js';
+.review/ISSUE-112-REVIEW.raw.txt:717:+import type { CheckService } from '../permissions/check-service.js';
+.review/ISSUE-112-REVIEW.raw.txt:791: import type { Scope, ScopeActorContext } from '../permissions/scope-service.js';
+.review/ISSUE-112-REVIEW.raw.txt:792: import { actorScopeForCapability } from '../permissions/scope-service.js';
+.review/ISSUE-112-REVIEW.raw.txt:802:+        AND el.status = 'active'
+.review/ISSUE-112-REVIEW.raw.txt:850:    19	  "updated_at" timestamptz,
+.review/ISSUE-112-REVIEW.raw.txt:856:    25	    CHECK ("status" IN ('active','stale','detached','revoked')),
+.review/ISSUE-112-REVIEW.raw.txt:907:    19	export const entityLinkStatusSchema = z.enum(['active', 'stale', 'detached', 'revoked']);
+.review/ISSUE-112-REVIEW.raw.txt:976:    88	  updated_at: z.string().datetime().nullable(),
+.review/ISSUE-112-REVIEW.raw.txt:1024:    21	  status: 'active' | 'stale' | 'detached' | 'revoked';
+.review/ISSUE-112-REVIEW.raw.txt:1028:    25	  updated_at: Date | null;
+.review/ISSUE-112-REVIEW.raw.txt:1046:    43	    updated_at:
+.review/ISSUE-112-REVIEW.raw.txt:1047:    44	      row.updated_at === null || row.updated_at === undefined
+.review/ISSUE-112-REVIEW.raw.txt:1049:    46	        : row.updated_at instanceof Date
+.review/ISSUE-112-REVIEW.raw.txt:1050:    47	          ? row.updated_at
+.review/ISSUE-112-REVIEW.raw.txt:1051:    48	          : new Date(row.updated_at as string),
+.review/ISSUE-112-REVIEW.raw.txt:1097:    94	    ) WHERE status = 'active'
+.review/ISSUE-112-REVIEW.raw.txt:1102:    99	      created_at, updated_at
+.review/ISSUE-112-REVIEW.raw.txt:1126:   123	      created_at, updated_at
+.review/ISSUE-112-REVIEW.raw.txt:1134:   131	      AND status = 'active'
+.review/ISSUE-112-REVIEW.raw.txt:1141:   138	export async function selectActiveLinksForEndpoint(
+.review/ISSUE-112-REVIEW.raw.txt:1164:   161	      created_at, updated_at
+.review/ISSUE-112-REVIEW.raw.txt:1167:   164	      AND status = 'active'
+.review/ISSUE-112-REVIEW.raw.txt:1183:     6	import type { CheckService } from '../permissions/check-service.js';
+.review/ISSUE-112-REVIEW.raw.txt:1188:    11	  selectActiveLinksForEndpoint,
+.review/ISSUE-112-REVIEW.raw.txt:1216:    39	    updated_at: row.updated_at ? row.updated_at.toISOString() : null,
+.review/ISSUE-112-REVIEW.raw.txt:1348:   171	    const rows = await selectActiveLinksForEndpoint(
+.review/ISSUE-112-REVIEW.raw.txt:1411:     8	import type { SessionService } from '../auth/session-service.js';
+.review/ISSUE-112-REVIEW.raw.txt:1588:    76	      `delete from core.entity_links
+.review/ISSUE-112-REVIEW.raw.txt:1665:   153	        where id = $1 and status = 'active' and relation_type = 'related_to'`,
+.review/ISSUE-112-REVIEW.raw.txt:1732:   220	        where source_id = $1 and target_id = $2 and status = 'active'`,
+.review/ISSUE-112-REVIEW.raw.txt:1833:apps/backend/src/modules/permissions/check-service.ts:208:    // admin role implicitly satisfies voc.triage and voc.read (workspace-wide);
+.review/ISSUE-112-REVIEW.raw.txt:1834:apps/backend/src/modules/permissions/check-service.ts:214:      capability === 'voc.read'
+.review/ISSUE-112-REVIEW.raw.txt:1837:apps/backend/src/modules/permissions/scope-service.ts:12://   actorScopeForCapability → multi-MS scope resolution for read-model filtering
+.review/ISSUE-112-REVIEW.raw.txt:1838:apps/backend/src/modules/permissions/scope-service.ts:47:export async function actorScopeForCapability(
+.review/ISSUE-112-REVIEW.raw.txt:1871:apps/backend/src/modules/voc/repo-read.ts:28:import { actorScopeForCapability } from '../permissions/scope-service.js';
+.review/ISSUE-112-REVIEW.raw.txt:1934:apps/backend/src/modules/voc/__tests__/create-voc.integration.test.ts:7://   * fops_migrate pool for core.audit_log cleanup (fops_app cannot DELETE).
+.review/ISSUE-112-REVIEW.raw.txt:1942:apps/backend/src/modules/auth/session-service.ts:3:// Slice 1 #3 has no audits yet (the audit_log writer lands with the first
+.review/ISSUE-112-REVIEW.raw.txt:1947:apps/backend/src/modules/permissions/__tests__/create-request.integration.test.ts:16:import { createAuditService } from '../../core/audit/audit-service.js';
+.review/ISSUE-112-REVIEW.raw.txt:1948:apps/backend/src/modules/permissions/__tests__/create-request.integration.test.ts:64:  // permission_requests, audit_log, idempotency_keys, and integration-test
+.review/ISSUE-112-REVIEW.raw.txt:1949:apps/backend/src/modules/permissions/__tests__/create-request.integration.test.ts:65:  // sessions. audit_log is INSERT-only for fops_app — delete as fops_migrate.
+.review/ISSUE-112-REVIEW.raw.txt:1950:apps/backend/src/modules/permissions/__tests__/create-request.integration.test.ts:75:    // audit_log: revoke prevents UPDATE/DELETE on fops_app. Use the
+.review/ISSUE-112-REVIEW.raw.txt:1951:apps/backend/src/modules/permissions/__tests__/create-request.integration.test.ts:81:      await ops.pool.query(`delete from core.audit_log where event_type = 'permission_requested'`);
+.review/ISSUE-112-REVIEW.raw.txt:1952:apps/backend/src/modules/permissions/__tests__/create-request.integration.test.ts:116:      `select event_type, subject_type, subject_id from core.audit_log
+.review/ISSUE-112-REVIEW.raw.txt:1953:apps/backend/src/modules/permissions/__tests__/create-request.integration.test.ts:205:      `select count(*)::int as n from core.audit_log where workspace_id = $1 and event_type = 'permission_requested'`,
+.review/ISSUE-112-REVIEW.raw.txt:1954:apps/backend/src/modules/permissions/__tests__/create-request.integration.test.ts:441:    const realAudit = createAuditService();
+.review/ISSUE-112-REVIEW.raw.txt:1955:apps/backend/src/modules/permissions/__tests__/create-request.integration.test.ts:445:        input: Parameters<ReturnType<typeof createAuditService>['record']>[1],
+.review/ISSUE-112-REVIEW.raw.txt:1956:apps/backend/src/modules/permissions/__tests__/create-request.integration.test.ts:447:        await realAudit.record(tx as never, input);
+.review/ISSUE-112-REVIEW.raw.txt:1957:apps/backend/src/modules/permissions/__tests__/create-request.integration.test.ts:484:        `select count(*)::int as n from core.audit_log where workspace_id = $1 and event_type = 'permission_requested'`,
+.review/ISSUE-112-REVIEW.raw.txt:1960:apps/backend/src/modules/permissions/request-service.ts:207:      await auditService.record(tx, {
+.review/ISSUE-112-REVIEW.raw.txt:2295:   563	      updated_at: row.updatedAt.toISOString(),
+.review/ISSUE-112-REVIEW.raw.txt:2316:/bin/zsh -lc "nl -ba apps/backend/src/modules/permissions/check-service.ts | sed -n '180,235p'" in /Users/hyojung/Desktop/2026/wt-112-entity-links-evidence
+.review/ISSUE-112-REVIEW.raw.txt:2323:   185	    // If we saw a revoked or expired grant earlier and nothing else allowed,
+.review/ISSUE-112-REVIEW.raw.txt:2327:   189	      return { allow: false, reason: 'grant_revoked', requestable: null };
+.review/ISSUE-112-REVIEW.raw.txt:2401:/bin/zsh -lc 'rg -n "summary_visible|visible_to_reporter|admin_only|detached|revoked|stale|PATCH|DELETE|findings|finding|missing|FR-LINK-003|visibility_state|target_id|source_id" apps/backend/src/modules/entity-links apps/backend/src/modules/voc packages/shared/src/entity-links.ts packages/shared/src/vocs/detail.ts apps/backend/migrations/0018_entity_links.sql docs/design/11-entity-linking.md docs/implementation/06-entity-linking-contract.md' in /Users/hyojung/Desktop/2026/wt-112-entity-links-evidence
+.review/ISSUE-112-REVIEW.raw.txt:2407:apps/backend/migrations/0018_entity_links.sql:25:    CHECK ("status" IN ('active','stale','detached','revoked')),
+.review/ISSUE-112-REVIEW.raw.txt:2427:docs/design/11-entity-linking.md:135:- The entity_link is marked inactive, detached, or revoked with actor, reason,
+.review/ISSUE-112-REVIEW.raw.txt:2434:docs/design/11-entity-linking.md:168:- Dashboard can detect stale or missing workflow links without treating every unlinked record as incomplete.
+.review/ISSUE-112-REVIEW.raw.txt:2439:packages/shared/src/entity-links.ts:19:export const entityLinkStatusSchema = z.enum(['active', 'stale', 'detached', 'revoked']);
+.review/ISSUE-112-REVIEW.raw.txt:2470:apps/backend/src/modules/entity-links/repo.ts:21:  status: 'active' | 'stale' | 'detached' | 'revoked';
+.review/ISSUE-112-REVIEW.raw.txt:2488:apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts:220:        where source_id = $1 and target_id = $2 and status = 'active'`,
+.review/ISSUE-112-REVIEW.raw.txt:2498:apps/backend/src/modules/voc/__tests__/create-voc.integration.test.ts:7://   * fops_migrate pool for core.audit_log cleanup (fops_app cannot DELETE).
+.review/ISSUE-112-REVIEW.raw.txt:2502:apps/backend/src/modules/voc/service.ts:230:    // previous ordering (stale_write before permission deny) leaked
+.review/ISSUE-112-REVIEW.raw.txt:2503:apps/backend/src/modules/voc/service.ts:261:      // explicit_deny / grant_revoked / grant_expired → generic denied.
+.review/ISSUE-112-REVIEW.raw.txt:2504:apps/backend/src/modules/voc/service.ts:270:    // leak to unauthorised actors; only authorised actors see 409 stale_write detail).
+.review/ISSUE-112-REVIEW.raw.txt:2505:apps/backend/src/modules/voc/service.ts:272:      throw new HttpError('conflict.stale_write', 'voc updated_at does not match If-Match', {
+.review/ISSUE-112-REVIEW.raw.txt:2508:apps/backend/src/modules/voc/service.ts:508:      // timestamp so the column doesn't carry a stale "postponed since X" value
+.review/ISSUE-112-REVIEW.raw.txt:2510:apps/backend/src/modules/voc/service.ts:686:  //   4. If-Match compare → 409 conflict.stale_write
+.review/ISSUE-112-REVIEW.raw.txt:2511:apps/backend/src/modules/voc/service.ts:730:      throw new HttpError('conflict.stale_write', 'voc updated_at does not match If-Match', {
+.review/ISSUE-112-REVIEW.raw.txt:2515:apps/backend/src/modules/voc/cursor.ts:16:// Mismatches are rejected as invalid_cursor to prevent stale cursors from
+.review/ISSUE-112-REVIEW.raw.txt:2518:apps/backend/src/modules/voc/__tests__/get-voc.integration.test.ts:453:  it('AC14: stale If-None-Match → 200 + new envelope + new etag', async () => {
+.review/ISSUE-112-REVIEW.raw.txt:2519:apps/backend/src/modules/voc/__tests__/get-voc.integration.test.ts:454:    const msId = await insertMsDirectly(dbHandle, WORKSPACE_ID, `${uid(SLUG_PREFIX)}-stale-etag`, 'Stale ETag MS');
+.review/ISSUE-112-REVIEW.raw.txt:2520:apps/backend/src/modules/voc/__tests__/get-voc.integration.test.ts:457:    const staleEtag = 'W/"1970-01-01T00:00:00.000Z"';
+.review/ISSUE-112-REVIEW.raw.txt:2521:apps/backend/src/modules/voc/__tests__/get-voc.integration.test.ts:464:        'if-none-match': staleEtag,
+.review/ISSUE-112-REVIEW.raw.txt:2522:apps/backend/src/modules/voc/__tests__/get-voc.integration.test.ts:470:    expect(newEtag).not.toBe(staleEtag);
+.review/ISSUE-112-REVIEW.raw.txt:2523:apps/backend/src/modules/voc/__tests__/get-voc.integration.test.ts:512:    // Multi-value If-None-Match with stale + current ETags.
+.review/ISSUE-112-REVIEW.raw.txt:2524:apps/backend/src/modules/voc/__tests__/get-voc.integration.test.ts:518:        'if-none-match': `"stale-etag", ${etag}`,
+.review/ISSUE-112-REVIEW.raw.txt:2530:apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:816:  it('case 19: If-Match mismatch → 409 conflict.stale_write with detail.current_updated_at', async () => {
+.review/ISSUE-112-REVIEW.raw.txt:2531:apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:818:    const msId = await createMs(app, admin, 'it-pd-stale', 'Stale');
+.review/ISSUE-112-REVIEW.raw.txt:2532:apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:834:    expect(body.code).toBe('conflict.stale_write');
+.review/ISSUE-112-REVIEW.raw.txt:2534:apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:866:  // Case 21: stale If-Match race (sequential simulation)
+.review/ISSUE-112-REVIEW.raw.txt:2535:apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:867:  it('case 21: second PATCH with stale If-Match → 409 conflict.stale_write', async () => {
+.review/ISSUE-112-REVIEW.raw.txt:2536:apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:869:    const msId = await createMs(app, admin, 'it-pd-race-stale', 'Race Stale');
+.review/ISSUE-112-REVIEW.raw.txt:2537:apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:884:    // Second edit with original (now stale) If-Match
+.review/ISSUE-112-REVIEW.raw.txt:2538:apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:887:      ifMatch: voc.updated_at, // stale
+.review/ISSUE-112-REVIEW.raw.txt:2539:apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:890:    expect(res2.json().code).toBe('conflict.stale_write');
+.review/ISSUE-112-REVIEW.raw.txt:2542:apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:1018:  // Case 26: Reporter + stale If-Match + already-triaged → state check fires first
+.review/ISSUE-112-REVIEW.raw.txt:2543:apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:1019:  it('case 26: Reporter + stale If-Match + triaged VOC → 409 conflict.triage_already_committed (state before If-Match)', async () => {
+.review/ISSUE-112-REVIEW.raw.txt:2544:apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:1034:      ifMatch: bogus, // stale
+.review/ISSUE-112-REVIEW.raw.txt:2545:apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:1037:    // triage_already_committed fires before stale_write (per plan §ordering)
+.review/ISSUE-112-REVIEW.raw.txt:2546:apps/backend/src/modules/voc/__tests__/_seed-helpers.ts:377:  revokedByActorId: string,
+.review/ISSUE-112-REVIEW.raw.txt:2547:apps/backend/src/modules/voc/__tests__/_seed-helpers.ts:380:    `update permission.permission_denies set revoked_at = now(), revoked_by_actor_id = $2 where id = $1`,
+.review/ISSUE-112-REVIEW.raw.txt:2548:apps/backend/src/modules/voc/__tests__/_seed-helpers.ts:381:    [denyId, revokedByActorId],
+.review/ISSUE-112-REVIEW.raw.txt:2549:apps/backend/src/modules/voc/__tests__/_seed-helpers.ts:391: *   2. voc_permission_decisions_seed_fixture (fops_app has DELETE on this table)
+.review/ISSUE-112-REVIEW.raw.txt:2550:apps/backend/src/modules/voc/__tests__/_seed-helpers.ts:393: *      have ON DELETE CASCADE on voc_id, so cascade automatically. fops_app has no
+.review/ISSUE-112-REVIEW.raw.txt:2551:apps/backend/src/modules/voc/__tests__/_seed-helpers.ts:394: *      DELETE on conversation tables; they are append-only at the product layer.
+.review/ISSUE-112-REVIEW.raw.txt:2552:apps/backend/src/modules/voc/__tests__/_seed-helpers.ts:421:  // 2. Clean permission decisions seed fixture (fops_app has DELETE).
+.review/ISSUE-112-REVIEW.raw.txt:2553:apps/backend/src/modules/voc/__tests__/_seed-helpers.ts:441:  // 3. Delete VOCs — conversation tables cascade automatically (ON DELETE CASCADE).
+.review/ISSUE-112-REVIEW.raw.txt:2554:apps/backend/src/modules/voc/__tests__/_seed-helpers.ts:442:  //    fops_app has DELETE on voc.vocs, but NOT on conversation tables.
+.review/ISSUE-112-REVIEW.raw.txt:2557:apps/backend/src/modules/voc/__tests__/repo-read.integration.test.ts:206:      `DELETE FROM permission.permission_grants
+.review/ISSUE-112-REVIEW.raw.txt:2558:apps/backend/src/modules/voc/__tests__/repo-read.integration.test.ts:212:      `DELETE FROM voc.vocs
+.review/ISSUE-112-REVIEW.raw.txt:2559:apps/backend/src/modules/voc/__tests__/repo-read.integration.test.ts:219:      `DELETE FROM core.managed_systems WHERE slug LIKE $1`,
+.review/ISSUE-112-REVIEW.raw.txt:2560:apps/backend/src/modules/voc/__tests__/repo-read.integration.test.ts:223:      `DELETE FROM core.sessions WHERE actor_id IN (SELECT id FROM core.actors WHERE external_id LIKE $1)`,
+.review/ISSUE-112-REVIEW.raw.txt:2561:apps/backend/src/modules/voc/__tests__/repo-read.integration.test.ts:227:      `DELETE FROM core.actors WHERE external_id LIKE $1 AND workspace_id = $2`,
+.review/ISSUE-112-REVIEW.raw.txt:2572:apps/backend/src/modules/voc/routes.ts:195:      // fresh If-Match (e.g. after a 409 stale_write → refetch → retry)
+.review/ISSUE-112-REVIEW.raw.txt:2579:apps/backend/src/modules/voc/routes.ts:339:  // across pages. Frontend stale-while-revalidate (TanStack Query) masks this;
+.review/ISSUE-112-REVIEW.raw.txt:2589:apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:169:// Revokes a permission grant by setting revoked_at now().
+.review/ISSUE-112-REVIEW.raw.txt:2590:apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:173:  revokedByActorId: string,
+.review/ISSUE-112-REVIEW.raw.txt:2591:apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:177:        set revoked_at = now(), revoked_by_actor_id = $2, revoked_reason = 'test'
+.review/ISSUE-112-REVIEW.raw.txt:2592:apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:179:    [grantId, revokedByActorId],
+.review/ISSUE-112-REVIEW.raw.txt:2601:apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:448:  // ── 3. If-Match mismatch → 409 conflict.stale_write ───────────────────
+.review/ISSUE-112-REVIEW.raw.txt:2602:apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:449:  // C3: uses admin so the permission check passes and only the stale_write
+.review/ISSUE-112-REVIEW.raw.txt:2603:apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:452:  it('admin PATCH with stale If-Match → 409 conflict.stale_write + current_updated_at', async () => {
+.review/ISSUE-112-REVIEW.raw.txt:2604:apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:454:    const msId = await createMs(app, admin, 'it-patch-stale', 'Stale MS');
+.review/ISSUE-112-REVIEW.raw.txt:2605:apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:474:    expect(body.code).toBe('conflict.stale_write');
+.review/ISSUE-112-REVIEW.raw.txt:2606:apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:508:    // Must be 403 from permission check — NOT 409 from stale_write.
+.review/ISSUE-112-REVIEW.raw.txt:2627:apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:914:  // Without C5 the column keeps a stale timestamp; downstream readers would
+.review/ISSUE-112-REVIEW.raw.txt:2641:apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:1166:  // ── 16. Permission revocation race: grant revoked mid-session → 403 ────
+.review/ISSUE-112-REVIEW.raw.txt:2642:apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:1172:  // the permission recheck entirely would return 200 here. The revoked-grant
+.review/ISSUE-112-REVIEW.raw.txt:2643:apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:1173:  // path returns `permission.denied` (reason: grant_revoked), not
+.review/ISSUE-112-REVIEW.raw.txt:2644:apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:1176:  it('revoked grant → second PATCH returns 403 permission.denied (reason: grant_revoked)', async () => {
+.review/ISSUE-112-REVIEW.raw.txt:2646:apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:1202:    // Revoke the grant — next tx will see it revoked.
+.review/ISSUE-112-REVIEW.raw.txt:2647:apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:1205:    // Second PATCH: grant is revoked → 403 permission.denied.
+.review/ISSUE-112-REVIEW.raw.txt:2648:apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:1206:    // F1: revoked grant → permission.denied (not scope_required, which
+.review/ISSUE-112-REVIEW.raw.txt:2649:apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:1217:    expect(res2.json().detail.reason).toBe('grant_revoked');
+.review/ISSUE-112-REVIEW.raw.txt:2651:apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:1260:  // ── 18. Concurrent PATCH stale_write (real lock contention via Promise.all) ──
+.review/ISSUE-112-REVIEW.raw.txt:2654:apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:1269:  it('two concurrent PATCHes with same If-Match: one 200, one 409 conflict.stale_write', async () => {
+.review/ISSUE-112-REVIEW.raw.txt:2655:apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:1290:    expect(loser.json().code).toBe('conflict.stale_write');
+.review/ISSUE-112-REVIEW.raw.txt:2684:packages/shared/src/auth/__tests__/list-actors.test.ts
+.review/ISSUE-112-REVIEW.raw.txt:2685:packages/shared/src/auth/list-actors.ts
+.review/ISSUE-112-REVIEW.raw.txt:2694:packages/shared/src/permissions/__tests__/permission-decision.test.ts
+.review/ISSUE-112-REVIEW.raw.txt:2695:packages/shared/src/permissions/index.ts
+.review/ISSUE-112-REVIEW.raw.txt:2729:/bin/zsh -lc 'rg -n "packages/shared/src/permissions|packages/shared/src/auth|apps/frontend|src/permissions|src/auth|findings|FR-LINK-003|PATCH /entity-links|DELETE /entity-links|relation_type.*(?!related_to)" .review/ISSUE-112-DEVIATIONS.md apps/backend/src/modules/entity-links apps/backend/src/modules/voc packages/shared/src docs -g '"'*.*'" in /Users/hyojung/Desktop/2026/wt-112-entity-links-evidence
+.review/ISSUE-112-REVIEW.raw.txt:2732:    (?:packages/shared/src/permissions|packages/shared/src/auth|apps/frontend|src/permissions|src/auth|findings|FR-LINK-003|PATCH /entity-links|DELETE /entity-links|relation_type.*(?!related_to))
+.review/ISSUE-112-REVIEW.raw.txt:2760:     9	export * from './permissions/index.js';
+.review/ISSUE-112-REVIEW.raw.txt:2766:    15	export * from './auth/list-actors.js';
+.review/ISSUE-112-REVIEW.raw.txt:2840:   308	    updatedAt: timestamp('updated_at', { withTimezone: true }),
+.review/ISSUE-112-REVIEW.raw.txt:2853:   321	      sql`${t.status} in ('active','stale','detached','revoked')`,
+.review/ISSUE-112-REVIEW.raw.txt:2932:+`status='active'`. It also adds `managed_system_id`, `updated_at`, uniqueness
+packages/shared/src/vocs/edit-description-request.ts:53:  'updated_at',
+packages/shared/src/vocs/edit-description-request.ts:77:  updated_at: 'validation.unexpected_field',
+.review/ISSUE-112-REVIEW-PROMPT.txt:5:1. **Contract adherence** — Does the implementation match every "Required design points" item in the dispatch prompt? Table columns, constraints, unique partial index, composite indexes, GRANTs (fops_app INSERT+SELECT only, no UPDATE/DELETE in this slice), audit_log emit, both-side permission via per-type resolver, visibility decision allowed/hidden with target_id stripped on hidden, VOC detail no-link replacement.
+.review/ISSUE-112-REVIEW-PROMPT.txt:6:2. **Scope discipline** — Any FORBIDDEN paths touched? (apps/frontend/**, packages/shared/src/permissions/**, packages/shared/src/auth/**, new findings table, detach endpoints, additional relation types, FR-LINK-003 missing-link queries, visibility tokens beyond what's required.)
+apps/backend/src/db/schema/voc.ts:70:    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+apps/backend/src/db/schema/voc.ts:114:// fops_app gets SELECT + INSERT only (no UPDATE/DELETE) per ADR-0019.
+apps/backend/src/db/schema/voc.ts:207:// IM-03 / AGENTS.md; fops_app DELETE revoked.
+apps/backend/src/modules/voc/__tests__/create-voc.integration.test.ts:5://   * buildServer + cookie session via POST /auth/mock-login (no Bearer).
+apps/backend/src/modules/voc/__tests__/create-voc.integration.test.ts:7://   * fops_migrate pool for core.audit_log cleanup (fops_app cannot DELETE).
+apps/backend/src/modules/voc/__tests__/create-voc.integration.test.ts:41:    url: '/auth/mock-login',
+apps/backend/src/modules/core/jobs/idempotency-purge.ts:40:    sql`DELETE FROM core.idempotency_keys WHERE created_at < now() - interval '24 hours'`,
+.review/CHUNK-22-C6-DEVIATIONS.md:45:   with aria-disabled") was stale.** The disabled assertion no longer applies
+.review/CHUNK-22-C6-DEVIATIONS.md:124:- Added `apps/frontend/src/features/voc/lib/format-file-size.ts` and pointed
+.review/CHUNK-22-C4b-DEVIATIONS.md:82:- Did **not** touch `packages/shared/src/vocs/*` or `apps/frontend/*` (C5 territory).
+.review/CHUNK-22-C4b-DEVIATIONS.md:86:## 2026-05-22 amendment — DB DELETE grant (post-merge hotfix)
+.review/CHUNK-22-C4b-DEVIATIONS.md:88:The purge job's `DELETE FROM voc.voc_attachments WHERE id = $1` assumes the `fops_app` role
+.review/CHUNK-22-C4b-DEVIATIONS.md:89:has `DELETE` privilege on `voc.voc_attachments`. At C4b merge time this grant was **not**
+.review/CHUNK-22-C4b-DEVIATIONS.md:96:`GRANT DELETE ON voc.voc_attachments TO fops_app`. The archive-over-delete invariant for
+packages/shared/src/entity-links.ts:19:export const entityLinkStatusSchema = z.enum(['active', 'stale', 'detached', 'revoked']);
+packages/shared/src/entity-links.ts:95:  updated_at: z.string().datetime().nullable(),
+packages/shared/src/entity-links.ts:121:  detached_at: z.string().datetime(),
+.review/VOC-DETAIL-CRITIQUE.md:25:**Target:** `apps/frontend/src/features/voc/components/detail/` (Slice 3 #20 + #21)
+.review/VOC-DETAIL-CRITIQUE.md:75:**File:** `apps/frontend/src/features/voc/components/detail/NextActionFooter.tsx:41-45`
+.review/VOC-DETAIL-CRITIQUE.md:83:**File:** `apps/frontend/src/features/voc/components/detail/ComposerTabs.tsx:58`
+.review/VOC-DETAIL-CRITIQUE.md:90:**File:** `apps/frontend/src/features/voc/components/detail/ComposerSection.tsx:160-191`
+.review/VOC-DETAIL-CRITIQUE.md:96:**File:** `apps/frontend/src/features/voc/components/detail/TriageBlock.tsx:19`
+.review/VOC-DETAIL-CRITIQUE.md:111:**File:** `apps/frontend/src/features/voc/components/detail/ComposerSection.tsx:142-153`
+.review/VOC-DETAIL-CRITIQUE.md:119:**File:** `apps/frontend/src/features/voc/components/detail/VocDetailPanel.tsx:201`
+.review/VOC-DETAIL-CRITIQUE.md:140:**File:** `apps/frontend/src/features/voc/components/detail/ConversationTimeline.tsx:36-55`
+apps/backend/src/modules/permissions/__tests__/check-route.integration.test.ts:1:// Integration tests for GET /me/permissions/check (issue #4 acceptance).
+apps/backend/src/modules/permissions/__tests__/check-route.integration.test.ts:3:// Same skip-pattern as modules/auth/__tests__/auth.integration.test.ts.
+apps/backend/src/modules/permissions/__tests__/check-route.integration.test.ts:30:    url: '/auth/mock-login',
+apps/backend/src/modules/permissions/__tests__/check-route.integration.test.ts:39:describe.skipIf(!runIntegration)('GET /me/permissions/check', () => {
+apps/backend/src/modules/permissions/__tests__/check-route.integration.test.ts:69:      url: '/me/permissions/check?capability=workspace.admin',
+apps/backend/src/modules/permissions/__tests__/check-route.integration.test.ts:82:      url: '/me/permissions/check?capability=workspace.admin',
+apps/backend/src/modules/permissions/__tests__/check-route.integration.test.ts:97:      url: '/me/permissions/check?capability=workspace.read',
+apps/backend/src/modules/permissions/__tests__/check-route.integration.test.ts:107:      url: '/me/permissions/check?capability=workspace.admin',
+apps/backend/src/modules/permissions/__tests__/check-route.integration.test.ts:138:      url: `/me/permissions/check?capability=workspace.admin&managed_system_id=${otherMs}`,
+apps/backend/src/modules/permissions/__tests__/check-route.integration.test.ts:147:      url: '/me/permissions/check?capability=workspace.admin',
+apps/backend/src/modules/permissions/__tests__/check-route.integration.test.ts:158:      url: '/me/permissions/check?capability=nonsense.action',
+.review/deferred-items.md:2:- 2026-05-23 — Pre-existing FE typecheck errors in `apps/frontend/src/routes/**/*.tsx` (TanStack Router `useNavigate({ from })` arg mismatch — codegen drift in `routeTree.gen.ts`). Confirmed unrelated to the `/actors` endpoint work via `git stash` reproduction. Out of scope.
+.review/baselines/CAPTURE-INSTRUCTIONS.md:22:   POST /auth/mock-login { "external_id": "admin-001" }
+.review/ISSUE-113-DEVIATIONS.md:3:## D1 · 409 envelope uses existing `conflict.stale_write`
+.review/ISSUE-113-DEVIATIONS.md:5:**Prompt directive:** "If link status != 'active' → 409 (already detached/revoked) OR idempotent 200 returning current state — pick 409 and document in DEVIATIONS if you prefer; default to 409 `conflict`."
+.review/ISSUE-113-DEVIATIONS.md:7:**Actual change:** Already-detached and lost-race detach attempts return HTTP 409 with code `conflict.stale_write`.
+.review/ISSUE-113-DEVIATIONS.md:9:**Reason:** `packages/shared/src/errors/codes.ts` does not define a generic `conflict` code, and that file is outside the Issue #113 allowed touch set. Using an unknown `conflict` string would be remapped by the global error handler to a generic 500. `conflict.stale_write` is an existing 409-class code and preserves the requested HTTP status without widening the touch set.
+apps/backend/src/modules/core/idempotency/__tests__/run-idempotent.integration.test.ts:59:        DELETE FROM core.idempotency_keys WHERE actor_id = ${actorId} AND key = ${key}
+apps/backend/src/modules/core/idempotency/__tests__/run-idempotent.integration.test.ts:86:        DELETE FROM core.idempotency_keys WHERE actor_id = ${actorId} AND key = ${key}
+apps/backend/src/modules/core/idempotency/__tests__/run-idempotent.integration.test.ts:140:        DELETE FROM core.idempotency_keys WHERE actor_id = ${actorId} AND key = ${key}
+apps/backend/src/modules/permissions/__tests__/list-mine.integration.test.ts:28:    url: '/auth/mock-login',
+apps/backend/src/modules/permissions/__tests__/list-mine.integration.test.ts:105:  it('includes needs_more_info; excludes approved/rejected/expired/revoked', async () => {
+apps/backend/src/modules/permissions/__tests__/list-mine.integration.test.ts:114:    // approved/rejected/expired/revoked rows can repeat the capability.
+apps/backend/src/modules/permissions/__tests__/list-mine.integration.test.ts:126:        ($1, $2, 'workspace.admin', 'v', 'revoked', null)`,
+apps/backend/src/modules/analytics-areas/__tests__/cross-workspace.integration.test.ts:31:import { createCheckService, type ActorContext } from '../../permissions/check-service.js';
+apps/backend/src/modules/core/idempotency/__tests__/idempotency-service.race.integration.test.ts:102:        DELETE FROM core.idempotency_keys WHERE actor_id = ${actorId} AND key = ${key}
+packages/shared/AGENTS.md:14:- Imports from `apps/backend` or `apps/frontend`.
+apps/backend/src/modules/permissions/__tests__/state-mapper.test.ts:2:// Slice 1 dead branches (hidden_existence, rejected, expired, revoked,
+apps/backend/src/modules/permissions/__tests__/state-mapper.test.ts:81:  it('grant_revoked → revoked (dead branch in Slice 1)', () => {
+apps/backend/src/modules/permissions/__tests__/state-mapper.test.ts:82:    const d: Decision = { allow: false, reason: 'grant_revoked', requestable: null };
+apps/backend/src/modules/permissions/__tests__/state-mapper.test.ts:83:    expect(toFrontendState(d, null)).toBe('revoked');
+apps/backend/src/modules/permissions/__tests__/state-mapper.test.ts:109:      [{ allow: false, reason: 'grant_revoked', requestable: null }, null],
+.review/CHUNK-DEVIATIONS-V1-KICKER.md:7:- `apps/frontend/src/routes/_authed/vocs.tsx`
+.review/CHUNK-DEVIATIONS-V1-KICKER.md:8:- `apps/frontend/src/features/voc/components/triage/VocTriageScreen.tsx`
+.review/CHUNK-DEVIATIONS-V1-KICKER.md:9:- `apps/frontend/src/routes/__tests__/vocs.test.tsx`
+.review/CHUNK-DEVIATIONS-V1-KICKER.md:10:- `apps/frontend/src/features/voc/components/triage/__tests__/VocTriageScreen.kicker.test.tsx` (new)
+.review/CHUNK-DEVIATIONS-V1-KICKER.md:14:- `apps/frontend/AGENTS.md` (one-liner about optional toolbar)
+.review/CHUNK-DEVIATIONS-V1-KICKER.md:40:### D-V1-03: Pixel-diff baseline is stale
+.review/CHUNK-DEVIATIONS-V1-KICKER.md:46:**Decision:** Re-capture is deferred to a follow-up chunk. This chunk ships only the structural + test change. The pixel-diff staleness is documented here per `apps/frontend/AGENTS.md §Page-Level Pixel-Diff` which states: "If absent [after a layout change], state the baseline is stale, capture a fresh screenshot, and queue a prototype refresh follow-up issue."
+.review/CHUNK-DEVIATIONS-V1-KICKER.md:68:The route test that previously asserted "Triage Console" (from ShellHeader, rendered before the permission gate) now needs the kicker inside VocTriageScreen. VocTriageScreen only renders after `usePermissionCheck` returns `approved`. Therefore a new `stubFetchMeTriage()` helper was added that also stubs `/me/permissions/check` → `{ state: 'approved' }` and `/vocs` → `{ items: [], total: 0 }`.
+.review/CHUNK-DEVIATIONS-V1-KICKER.md:78:| FE (`apps/frontend`) | 388 | 391 | +3 (kicker tests) |
+apps/backend/src/modules/analytics-areas/__tests__/analytics-area.integration.test.ts:37:    url: '/auth/mock-login',
+apps/backend/src/lib/errors.ts:63:  | { current_updated_at: string }
+.review/archive/slice-3-backend/SLICE-3-15-REVIEW-CYCLE-2.md:20:`apps/backend/src/modules/permissions/scope-service.ts:102-117`
+.review/archive/slice-3-backend/SLICE-3-15-REVIEW-CYCLE-2.md:46:### N-MAJ-3 — `cleanupReadTestTables` performs unscoped `DELETE FROM core.idempotency_keys` and `core.rate_limits` in `beforeEach`
+.review/archive/slice-3-backend/SLICE-3-15-REVIEW-CYCLE-2.md:75:// Frontend stale-while-revalidate masks this; integration test coverage
+.review/archive/slice-3-backend/SLICE-3-15-REVIEW-CYCLE-2.md:82:The query filters `workspace_id = ${workspaceId}` so it's actually safe today. However, `allManagedSystemIds` already filters by `workspaceId`, and `outOfScopeSummary` passes `diffMsIds` derived from that — but if `effectiveScope.kind === 'scoped'`, `diffMsIds` comes from `actorEffectiveScope` (which itself comes from `permission_grants` without joining `managed_systems` for workspace check). A grant row with a stale `managed_system_id` referencing a different workspace's MS would leak into the diff set; the `workspace_id = ${workspaceId}` clause on line 738 saves the count (returns 0 for that MS) but the histogram could still report 0 across non-existent MSs (harmless).
+.review/archive/slice-3-backend/SLICE-3-15-REVIEW-CYCLE-2.md:99:### N-MIN-2 — `getVocDetail` summary path: `checkService.checkCapability` is called only to compute `reason`, but the result `decision.allow=true` branch returns `'unknown'` — silent contract violation if a future grant lookup goes async-stale
+.review/archive/slice-3-backend/SLICE-3-15-REVIEW-CYCLE-2.md:106:### N-MIN-3 — `getVocDetail` ETag uses only `voc.updated_at`; mutable `voc_permission_decisions_seed_fixture` writes do not invalidate
+.review/archive/slice-3-backend/SLICE-3-15-REVIEW-CYCLE-2.md:109:The plan claims the seed fixture is immutable. That table has `DELETE` granted to `fops_app` (confirmed in `_seed-helpers.ts:376`), and the test helper `insertPermissionDecisionsSeed` writes rows post-VOC-creation. In production, if Slice 4 starts writing real per-actor decisions to that table (or any tooling does so), the ETag will return 304 for a stale `permission_decisions` payload.
+.review/archive/slice-3-backend/SLICE-3-15-REVIEW-CYCLE-2.md:111:**Fix:** compose `max(voc_permission_decisions_seed_fixture.updated_at)` (add `updated_at` column if needed) into the ETag, OR document in F19 that the composite must include this table too.
+.review/archive/slice-3-backend/SLICE-3-15-REVIEW-CYCLE-2.md:134:### N-MIN-6 — `view=my` ignores read/triage scopes entirely — a reporter can fetch their own VOCs from MSs the workspace later revoked them from
+apps/backend/src/modules/permissions/__tests__/check-service.test.ts:27:  // revoked branches exercise a non-seeded row (the seeded user has role
+apps/backend/src/modules/permissions/__tests__/check-service.test.ts:280:  it('grant revoked → grant_revoked', async () => {
+apps/backend/src/modules/permissions/__tests__/check-service.test.ts:291:      revokedAt: sql`now()`,
+apps/backend/src/modules/permissions/__tests__/check-service.test.ts:292:      revokedByActorId: adminActor.actor_id,
+apps/backend/src/modules/permissions/__tests__/check-service.test.ts:299:      reason: 'grant_revoked',
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:4://   * buildServer + cookie session via POST /auth/mock-login.
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:40:    url: '/auth/mock-login',
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:109:  return res.json() as { id: string; display_id: string; updated_at: string };
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:169:// Revokes a permission grant by setting revoked_at now().
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:173:  revokedByActorId: string,
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:177:        set revoked_at = now(), revoked_by_actor_id = $2, revoked_reason = 'test'
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:179:    [grantId, revokedByActorId],
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:388:      { idempotencyKey: randomUUID(), ifMatch: voc.updated_at },
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:401:    expect(body.updated_at).not.toBe(voc.updated_at);
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:448:  // ── 3. If-Match mismatch → 409 conflict.stale_write ───────────────────
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:449:  // C3: uses admin so the permission check passes and only the stale_write
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:451:  // regardless of If-Match value — no current_updated_at leak.
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:452:  it('admin PATCH with stale If-Match → 409 conflict.stale_write + current_updated_at', async () => {
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:454:    const msId = await createMs(app, admin, 'it-patch-stale', 'Stale MS');
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:474:    expect(body.code).toBe('conflict.stale_write');
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:475:    const cur = body.detail.current_updated_at as string;
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:483:  // without voc.triage must not receive current_updated_at in any form — that
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:485:  it('developer without grant + bogus If-Match → 403 permission.scope_required, no current_updated_at', async () => {
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:508:    // Must be 403 from permission check — NOT 409 from stale_write.
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:512:    // No current_updated_at leak in any part of the response.
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:513:    expect(JSON.stringify(body)).not.toContain('current_updated_at');
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:534:      { idempotencyKey: randomUUID(), ifMatch: voc.updated_at },
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:537:    const body1 = res1.json() as { updated_at: string };
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:545:      { idempotencyKey: randomUUID(), ifMatch: body1.updated_at },
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:579:      { idempotencyKey: randomUUID(), ifMatch: voc.updated_at },
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:582:    const body1 = res1.json() as { updated_at: string };
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:591:      { idempotencyKey: randomUUID(), ifMatch: body1.updated_at },
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:627:      { idempotencyKey: randomUUID(), ifMatch: voc.updated_at },
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:631:    // updated_at unchanged — no UPDATE was issued (empty diff path).
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:632:    expect((res.json() as { updated_at: string }).updated_at).toBe(voc.updated_at);
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:659:      { idempotencyKey: randomUUID(), ifMatch: voc.updated_at },
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:683:      { idempotencyKey: randomUUID(), ifMatch: voc.updated_at },
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:709:      { idempotencyKey: randomUUID(), ifMatch: voc.updated_at },
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:733:      { idempotencyKey: randomUUID(), ifMatch: voc.updated_at },
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:757:      { idempotencyKey: randomUUID(), ifMatch: voc.updated_at },
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:781:      { idempotencyKey: randomUUID(), ifMatch: voc.updated_at },
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:827:      { idempotencyKey: randomUUID(), ifMatch: voc.updated_at },
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:867:      { idempotencyKey: randomUUID(), ifMatch: voc.updated_at },
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:892:      { idempotencyKey: randomUUID(), ifMatch: voc.updated_at },
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:895:    const triaged = res1.json() as { updated_at: string };
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:903:      { idempotencyKey: randomUUID(), ifMatch: triaged.updated_at },
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:914:  // Without C5 the column keeps a stale timestamp; downstream readers would
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:933:      { idempotencyKey: randomUUID(), ifMatch: voc.updated_at },
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:944:    const afterPostponeAt = (res1.json() as { updated_at: string }).updated_at;
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:982:      { idempotencyKey: randomUUID(), ifMatch: voc.updated_at },
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:1012:      { idempotencyKey: randomUUID(), ifMatch: voc.updated_at },
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:1015:    const afterPatch1 = (res1.json() as { updated_at: string }).updated_at;
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:1064:      { idempotencyKey: randomUUID(), ifMatch: voc.updated_at },
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:1093:      { idempotencyKey: randomUUID(), ifMatch: voc.updated_at },
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:1126:      { idempotencyKey: randomUUID(), ifMatch: voc.updated_at },
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:1153:      { idempotencyKey: randomUUID(), ifMatch: voc.updated_at },
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:1166:  // ── 16. Permission revocation race: grant revoked mid-session → 403 ────
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:1172:  // the permission recheck entirely would return 200 here. The revoked-grant
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:1173:  // path returns `permission.denied` (reason: grant_revoked), not
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:1176:  it('revoked grant → second PATCH returns 403 permission.denied (reason: grant_revoked)', async () => {
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:1197:      { idempotencyKey: randomUUID(), ifMatch: voc.updated_at },
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:1200:    const afterPatch1 = (res1.json() as { updated_at: string }).updated_at;
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:1202:    // Revoke the grant — next tx will see it revoked.
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:1205:    // Second PATCH: grant is revoked → 403 permission.denied.
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:1206:    // F1: revoked grant → permission.denied (not scope_required, which
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:1217:    expect(res2.json().detail.reason).toBe('grant_revoked');
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:1239:      { idempotencyKey: randomUUID(), ifMatch: voc.updated_at },
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:1243:    // F5: assert updated_at is unchanged (no UPDATE was issued) and full
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:1245:    const body = res.json() as { updated_at: string; severity: unknown; triage_state: string };
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:1246:    expect(body.updated_at).toBe(voc.updated_at);
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:1260:  // ── 18. Concurrent PATCH stale_write (real lock contention via Promise.all) ──
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:1269:  it('two concurrent PATCHes with same If-Match: one 200, one 409 conflict.stale_write', async () => {
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:1279:    const sharedIfMatch = voc.updated_at;
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:1290:    expect(loser.json().code).toBe('conflict.stale_write');
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:1295:    // updated_at must have advanced beyond the original If-Match value.
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:1296:    expect(winner.json().updated_at).not.toBe(sharedIfMatch);
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:1321:    const res1 = await patchVoc(app, admin, voc.id, body, { idempotencyKey: key, ifMatch: voc.updated_at });
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:1324:    const res2 = await patchVoc(app, admin, voc.id, body, { idempotencyKey: key, ifMatch: voc.updated_at });
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:1329:    // F8: explicitly assert updated_at is identical across both responses —
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:1331:    expect(res1.json().updated_at).toBe(res2.json().updated_at);
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:1359:      { idempotencyKey: key, ifMatch: voc.updated_at },
+apps/backend/src/modules/voc/__tests__/patch-voc.integration.test.ts:1362:    const afterPatch = (res1.json() as { updated_at: string }).updated_at;
+apps/backend/src/modules/analytics-areas/analytics-area-service.ts:30:import type { ActorContext, CheckService } from '../permissions/check-service.js';
+apps/backend/src/modules/analytics-areas/analytics-area-service.ts:61:  updated_at: string;
+apps/backend/src/modules/analytics-areas/analytics-area-service.ts:105:    updated_at: row.updatedAt.toISOString(),
+apps/backend/src/modules/core/jobs/rate-limits-purge.ts:45:    sql`DELETE FROM core.rate_limits WHERE expires_at < now() - interval '1 hour'`,
+packages/shared/CONTEXT.md:3:Cross-app code (types, utilities) shared between `apps/frontend` and `apps/backend`.
+apps/backend/src/modules/analytics-areas/routes.ts:9:import type { SessionService } from '../auth/session-service.js';
+apps/backend/src/modules/analytics-areas/routes.ts:10:import type { ActorContext } from '../permissions/check-service.js';
+apps/backend/src/modules/permissions/__tests__/create-request.integration.test.ts:38:    url: '/auth/mock-login',
+apps/backend/src/modules/permissions/__tests__/create-request.integration.test.ts:75:    // audit_log: revoke prevents UPDATE/DELETE on fops_app. Use the
+.review/archive/slice-3-backend/SLICE-3-14-REVIEW-CYCLE-2.md:5:Cycle 1's 14 fix commits closed F1–F20 cleanly at the unit / module level. Cycle-2 sweep found **two real bugs that the fixes either introduced or failed to surface** (one P0 test-suite-breaker, one P1 missed permission/owner edge case), plus **two operational findings cycle 1 did not exercise** (one P1 info-leak via stale_write ordering, one P2 hash-semantic shift). Type-check is clean; no regressions in unrelated modules; `requestable_permission` hoist is correctly scoped (only one producer exists in the tree). Posture: **two P0/P1 issues block merge; everything else can land as follow-ups.**
+.review/archive/slice-3-backend/SLICE-3-14-REVIEW-CYCLE-2.md:14:  - Compounding: `cleanupProductTables` also deletes `mock-dev-%` actors (line 253-256). `core.audit_log.actor_id` has `FK ... REFERENCES actors(id)` with no CASCADE (default RESTRICT — `db/schema/core.ts:122-124`). Test 16 (revoked-grant) writes a `voc_severity_set` row whose `actor_id` is the dev actor. On the next `beforeEach`, the actor delete will raise `update or delete on table "actors" violates foreign key constraint` and abort the run (or silently leave actors orphaned, depending on Postgres txn boundary).
+.review/archive/slice-3-backend/SLICE-3-14-REVIEW-CYCLE-2.md:27:- **[C3] Permission re-check fires AFTER `conflict.stale_write`, leaking `current_updated_at` of any in-workspace VOC to actors who lack `voc.triage`**
+.review/archive/slice-3-backend/SLICE-3-14-REVIEW-CYCLE-2.md:29:  - What: ordering inside `updateVoc` is: (1) select FOR UPDATE → 404 if missing; (2) **If-Match mismatch → 409 stale_write with `current_updated_at`**; (3) MS lock + archive check; (4) **permission re-check**. A developer with no `voc.triage` grant who sends a PATCH with a bogus `If-Match` against any in-workspace VOC receives `body.detail.current_updated_at` — leaking the live `updated_at` of records they cannot otherwise read mutate.
+.review/archive/slice-3-backend/SLICE-3-14-REVIEW-CYCLE-2.md:31:  - Severity: P1 for security/privacy. In practice `updated_at` rarely encodes secrets, but it does enable activity-frequency probing on any VOC ("who is being triaged hourly vs. weekly"). ADR-0019 §D wants the permission check to be authoritative; failing fast on stale_write before authorisation is a subtle ordering bug.
+.review/archive/slice-3-backend/SLICE-3-14-REVIEW-CYCLE-2.md:32:  - Fix: move the permission re-check to fire **before** the If-Match comparison. Reorder lines 215-247 to run immediately after the MS archive check at line 209-213 — actually best position is right after the VOC FOR UPDATE select (line 195) and before the stale_write check at line 200. The MS lock can stay where it is; the permission check only needs the VOC's `primaryManagedSystemId`, which is already on `row`. Update test 3 (`patch-voc.integration.test.ts:416-443`) to also assert that a dev actor without grant + bogus If-Match returns 403 (not 409). Add a dedicated test: "developer without grant + stale If-Match → 403, not 409, and response has no current_updated_at".
+.review/archive/slice-3-backend/SLICE-3-14-REVIEW-CYCLE-2.md:41:    1. Revert F6 and accept the cycle-1-flagged anomaly that retry-after-refetch replays the cached body silently (probably wrong — cached body has stale `updated_at`).
+.review/archive/slice-3-backend/SLICE-3-14-REVIEW-CYCLE-2.md:54:  - What: F4 fix correctly fires both PATCHes via `Promise.all` and asserts `[200, 409]`. But the test only inspects the loser (asserts code = `conflict.stale_write`). It doesn't assert the winner's body has the expected severity (one of 'low' or 'medium') — so a regression where the winning PATCH wrote nothing would pass.
+.review/archive/slice-3-backend/SLICE-3-14-REVIEW-CYCLE-2.md:55:  - Fix: `const winner = res1.statusCode === 200 ? res1 : res2; expect(['low', 'medium']).toContain(winner.json().severity); expect(winner.json().updated_at).not.toBe(sharedIfMatch);`. Also assert one and only one `voc_severity_set` audit row.
+.review/archive/slice-3-backend/SLICE-3-14-REVIEW-CYCLE-2.md:70:- **[C11] `permission.denied` envelope now carries `detail.reason: 'grant_revoked' | 'grant_expired' | 'explicit_deny'`** (`service.ts:243-246`). This is the F1 fix landing point. A non-admin observer of error responses can now distinguish "I once had access and you took it" from "I never had access". Operationally acceptable (FE shows the reason anyway), but flag for any future PII review — the discriminator leaks the existence of revocation/expiry events the actor may not otherwise know about.
+.review/archive/slice-3-backend/SLICE-3-14-REVIEW-CYCLE-2.md:76:- **F1 reason discrimination**: `permission.denied` is also thrown by AA and MS services (`analytics-area-service.ts:124`, `managed-system-service.ts:133`) without `detail.reason` — the new VOC variant adds `detail.reason` but doesn't break existing consumers since those throw with `undefined` detail. No state-mapper tests broke (state-mapper at `permissions/state-mapper.ts:44` discriminates on `Decision.reason`, not the HTTP envelope).
+.review/archive/slice-3-backend/SLICE-3-14-REVIEW-CYCLE-2.md:78:- **F6 hash including ifMatch**: test 19 happens to use the same If-Match on both calls (`afterPatch1` for first PATCH, then reuses `voc.updated_at` — wait, let me re-check; the test re-uses `voc.updated_at` for both replays at line 1099 + 1102 — same ifMatch, same hash, cache replay works). Confirmed.
+.review/archive/slice-3-backend/SLICE-3-14-REVIEW-CYCLE-2.md:80:- **F4 Promise.all concurrency**: both `app.inject` calls fire concurrently; one wins the FOR UPDATE lock; the second blocks until first commits then reads the new `updated_at` and 409s on If-Match. Real lock exercise (would fail if `for update` were removed: the second PATCH would still read the original `updated_at` snapshot under READ COMMITTED, so the If-Match check would PASS, both would UPDATE, the loser's UPDATE would silently overwrite without 409 — F4 is therefore a meaningful regression sentinel).
+.review/archive/slice-3-backend/SLICE-3-14-REVIEW-CYCLE-2.md:83:- **Empty-diff path**: F5 fix now asserts `updated_at` equality + envelope toMatchObject (lines 1037-1042). Adequate.
+.review/archive/slice-3-backend/SLICE-3-14-REVIEW-CYCLE-2.md:95:3. **C3 (P1)**: Reorder permission check to fire BEFORE stale_write. Test 3 needs amending (currently uses admin actor so still 409). Add a dedicated dev-no-grant + bogus-If-Match test asserting 403. **Recommend approve the reorder.** Any objection on perf grounds (extra permission lookup before a cheap header compare)? The permission lookup is bounded by 2 SELECTs on indexed tables — negligible compared to the FOR UPDATE on VOC.
+apps/backend/src/config.ts:8:  // (INSERT/SELECT/UPDATE/DELETE on non-audit tables, INSERT/SELECT only on
+apps/backend/src/modules/core/jobs/purge-unlinked-attachments.ts:67: *      DELETE the DB row by id. The size_bytes contributes to
+apps/backend/src/modules/core/jobs/purge-unlinked-attachments.ts:105:    const del = await pool.query('DELETE FROM voc.voc_attachments WHERE id = $1', [row.id]);
+.review/archive/slice-3-backend/SLICE-3-17-REVIEW-CYCLE-2.md:14:| C2-4 | MINOR | Case 20 not truly concurrent (uses `forceTriageState` direct SQL) | **Documented in plan §risks + matches #14 cycle-2 carry-over.** Outcome (state-check fires before stale_write) is what matters; true two-tx fixture is a follow-up across the codebase. |
+.review/archive/slice-3-backend/SLICE-3-17-REVIEW-CYCLE-2.md:24:- `updateVocDescriptionFields` workspace_id filter present + always sets `updated_at = now()`.
+.review/archive/slice-3-backend/SLICE-3-15-PLAN.md:16:2. **`effective_scope` does NOT exist on session.** Resolve per-request. Slice 3 definition: actor's effective scope = MSs where actor holds *any* non-revoked grant of *any* capability, PLUS workspace-wide-grant MSs (= all workspace MSs), PLUS admin → all workspace MSs. Distinguish from `voc.read scope` (subset).
+.review/archive/slice-3-backend/SLICE-3-15-PLAN.md:18:4. **ETag/If-None-Match** infrastructure absent. Implement in route handler. Slice 3: weak ETag `W/"<voc.updated_at-iso>"` — conversation tables are immutable post-create *in Slice 3* (POSTs land in #16). Follow-up filed for #16: composite ETag (voc.updated_at + max visible conversation.created_at).
+.review/archive/slice-3-backend/SLICE-3-15-PLAN.md:38:- `apps/backend/src/modules/permissions/check-service.ts:205-219` — `roleSatisfies` admin → also `voc.read`.
+.review/archive/slice-3-backend/SLICE-3-15-PLAN.md:57:// Effective scope: ANY non-revoked grant (capability ignored) intersected
+.review/archive/slice-3-backend/SLICE-3-15-PLAN.md:155:const etag = `W/"${row.updated_at.toISOString()}"`;  // weak
+.review/archive/slice-3-backend/SLICE-3-15-PLAN.md:161:Justification: conversation tables don't mutate in Slice 3 (write paths #16). Permission_decisions seed is immutable. So `voc.updated_at` is sufficient. Follow-up filed at `apps/backend/src/modules/voc/read-service.ts` TODO comment: compose with `max(conversation.created_at)` once #16 lands.
+.review/archive/slice-3-backend/SLICE-3-15-PLAN.md:202:| ETag composite under-spec'd | MAJOR | Slice 3: `W/"<voc.updated_at>"` weak ETag — safe since conversation immutable; TODO for #16. |
+.review/archive/slice-3-backend/SLICE-3-15-PLAN.md:215:- **F19** — composite detail ETag once #16 ships conversation POSTs (`voc.updated_at + max visible conv.created_at`).
+apps/backend/src/modules/permissions/__tests__/list-all.integration.test.ts:30:    url: '/auth/mock-login',
+apps/backend/src/modules/permissions/state-mapper.ts:8:// The remaining branches (hidden_existence, rejected, expired, revoked,
+apps/backend/src/modules/permissions/state-mapper.ts:22:  | 'revoked'
+apps/backend/src/modules/permissions/state-mapper.ts:44:    case 'grant_revoked':
+apps/backend/src/modules/permissions/state-mapper.ts:45:      return 'revoked';
+.review/archive/slice-3-backend/SLICE-3-15-REVIEW-CYCLE-1.md:8:`apps/backend/src/modules/permissions/scope-service.ts:43`
+.review/archive/slice-3-backend/SLICE-3-15-REVIEW-CYCLE-1.md:9:`actorReadScope()` / `actorTriageScope()` only consult `permission_grants`. An actor with a stale `voc.read` grant AND an active `permission_denies` row still gets read access.
+.review/archive/slice-3-backend/SLICE-3-15-REVIEW-CYCLE-1.md:11:**Fix:** Subtract active denies (`revoked_at IS NULL`) for the same `(workspace_id, actor_id, capability)`. Scope rules:
+.review/archive/slice-3-backend/SLICE-3-15-REVIEW-CYCLE-1.md:35:Currently: any non-revoked grant of ANY capability. Lets future MS-scoped non-VOC capabilities widen VOC summary visibility / out_of_scope counts. Existence/activity probe surface beyond intended.
+apps/backend/src/modules/permissions/routes.ts:15:import type { SessionService } from '../auth/session-service.js';
+apps/backend/src/modules/permissions/routes.ts:54:  // ── GET /me/permissions/check ───────────────────────────────────────────
+apps/backend/src/modules/permissions/routes.ts:62:    url: '/me/permissions/check',
+apps/backend/src/modules/permissions/routes.ts:119:      // other status (approved/expired/revoked) is irrelevant for the
+apps/backend/src/modules/permissions/check-service.ts:14://                           allow via direct_grant (or grant_expired/revoked)
+apps/backend/src/modules/permissions/check-service.ts:47:  | 'grant_revoked'
+apps/backend/src/modules/permissions/check-service.ts:99:    // (2) explicit deny — any active deny row (revoked_at IS NULL) blocks
+apps/backend/src/modules/permissions/check-service.ts:109:          isNull(permissionDenies.revokedAt),
+apps/backend/src/modules/permissions/check-service.ts:117:    // (3) direct capability grant. Active = NOT revoked AND (expires_at NULL
+apps/backend/src/modules/permissions/check-service.ts:120:    // grant_expired / grant_revoked from no_grant in a single round-trip.
+apps/backend/src/modules/permissions/check-service.ts:124:        revokedAt: permissionGrants.revokedAt,
+apps/backend/src/modules/permissions/check-service.ts:144:      if (row.revokedAt !== null) {
+apps/backend/src/modules/permissions/check-service.ts:173:        if (row.revokedAt !== null) {
+apps/backend/src/modules/permissions/check-service.ts:185:    // If we saw a revoked or expired grant earlier and nothing else allowed,
+apps/backend/src/modules/permissions/check-service.ts:189:      return { allow: false, reason: 'grant_revoked', requestable: null };
+.review/archive/slice-3-backend/SLICE-3-16-REVIEW-CYCLE-2.md:28:| M6 | MAJOR | Reporter-reply / internal-comment do NOT bump `vocs.updated_at`; envelope ETag stale relative to conversation list. Subsequent `GET` with `If-None-Match` → 304 even though conversation changed | #15 read-service already has TODO for composite ETag once #16 lands. Filed as **F19** (already on backlog); will be addressed when frontend conversation refresh is wired. |
+apps/backend/src/modules/voc/__tests__/repo-read.integration.test.ts:206:      `DELETE FROM permission.permission_grants
+apps/backend/src/modules/voc/__tests__/repo-read.integration.test.ts:212:      `DELETE FROM voc.vocs
+apps/backend/src/modules/voc/__tests__/repo-read.integration.test.ts:219:      `DELETE FROM core.managed_systems WHERE slug LIKE $1`,
+apps/backend/src/modules/voc/__tests__/repo-read.integration.test.ts:223:      `DELETE FROM core.sessions WHERE actor_id IN (SELECT id FROM core.actors WHERE external_id LIKE $1)`,
+apps/backend/src/modules/voc/__tests__/repo-read.integration.test.ts:227:      `DELETE FROM core.actors WHERE external_id LIKE $1 AND workspace_id = $2`,
+apps/backend/src/modules/voc/repo.ts:125:    updated_at: Date | string;
+apps/backend/src/modules/voc/repo.ts:132:      archived_at, created_at, updated_at
+apps/backend/src/modules/voc/repo.ts:158:    updatedAt: toDate(row.updated_at),
+apps/backend/src/modules/voc/repo.ts:267:// Bumps reporter_facing_status and updated_at on voc.vocs.
+apps/backend/src/modules/voc/repo.ts:283:        updated_at = now()
+apps/backend/src/modules/voc/repo.ts:315:  const setClauses: ReturnType<typeof sql>[] = [sql`updated_at = now()`];
+apps/backend/src/modules/voc/repo.ts:344:    updated_at: Date | string;
+apps/backend/src/modules/voc/repo.ts:355:      archived_at, created_at, updated_at
+apps/backend/src/modules/voc/repo.ts:381:    updatedAt: toDate(row.updated_at),
+apps/backend/src/modules/voc/__tests__/get-vocs-smoke.integration.test.ts:39:    url: '/auth/mock-login',
+apps/backend/src/modules/voc/cursor.ts:16:// Mismatches are rejected as invalid_cursor to prevent stale cursors from
+apps/backend/src/modules/voc/__tests__/get-voc.integration.test.ts:80:  async function insertVoc(msId: string, title: string): Promise<{ id: string; updated_at: string }> {
+apps/backend/src/modules/voc/__tests__/get-voc.integration.test.ts:110:    expect(body.updated_at).toBeDefined();
+apps/backend/src/modules/voc/__tests__/get-voc.integration.test.ts:453:  it('AC14: stale If-None-Match → 200 + new envelope + new etag', async () => {
+apps/backend/src/modules/voc/__tests__/get-voc.integration.test.ts:454:    const msId = await insertMsDirectly(dbHandle, WORKSPACE_ID, `${uid(SLUG_PREFIX)}-stale-etag`, 'Stale ETag MS');
+apps/backend/src/modules/voc/__tests__/get-voc.integration.test.ts:457:    const staleEtag = 'W/"1970-01-01T00:00:00.000Z"';
+apps/backend/src/modules/voc/__tests__/get-voc.integration.test.ts:464:        'if-none-match': staleEtag,
+apps/backend/src/modules/voc/__tests__/get-voc.integration.test.ts:470:    expect(newEtag).not.toBe(staleEtag);
+apps/backend/src/modules/voc/__tests__/get-voc.integration.test.ts:512:    // Multi-value If-None-Match with stale + current ETags.
+apps/backend/src/modules/voc/__tests__/get-voc.integration.test.ts:518:        'if-none-match': `"stale-etag", ${etag}`,
+apps/backend/src/modules/voc/routes.ts:29:import type { SessionService } from '../auth/session-service.js';
+apps/backend/src/modules/voc/routes.ts:195:      // fresh If-Match (e.g. after a 409 stale_write → refetch → retry)
+apps/backend/src/modules/voc/routes.ts:339:  // across pages. Frontend stale-while-revalidate (TanStack Query) masks this;
+apps/backend/src/modules/voc/__tests__/_seed-helpers.ts:28:    url: '/auth/mock-login',
+apps/backend/src/modules/voc/__tests__/_seed-helpers.ts:103:): Promise<{ id: string; display_id: string; updated_at: string }> {
+apps/backend/src/modules/voc/__tests__/_seed-helpers.ts:111:  return res.json() as { id: string; display_id: string; updated_at: string };
+apps/backend/src/modules/voc/__tests__/_seed-helpers.ts:172:): Promise<{ id: string; updated_at: string }> {
+apps/backend/src/modules/voc/__tests__/_seed-helpers.ts:180:  const res = await dbHandle.pool.query<{ id: string; updated_at: string }>(
+apps/backend/src/modules/voc/__tests__/_seed-helpers.ts:190:     returning id, updated_at::text as updated_at`,
+apps/backend/src/modules/voc/__tests__/_seed-helpers.ts:195:  return { id: row.id, updated_at: row.updated_at };
+apps/backend/src/modules/voc/__tests__/_seed-helpers.ts:377:  revokedByActorId: string,
+apps/backend/src/modules/voc/__tests__/_seed-helpers.ts:380:    `update permission.permission_denies set revoked_at = now(), revoked_by_actor_id = $2 where id = $1`,
+apps/backend/src/modules/voc/__tests__/_seed-helpers.ts:381:    [denyId, revokedByActorId],
+apps/backend/src/modules/voc/__tests__/_seed-helpers.ts:391: *   2. voc_permission_decisions_seed_fixture (fops_app has DELETE on this table)
+apps/backend/src/modules/voc/__tests__/_seed-helpers.ts:393: *      have ON DELETE CASCADE on voc_id, so cascade automatically. fops_app has no
+apps/backend/src/modules/voc/__tests__/_seed-helpers.ts:394: *      DELETE on conversation tables; they are append-only at the product layer.
+apps/backend/src/modules/voc/__tests__/_seed-helpers.ts:421:  // 2. Clean permission decisions seed fixture (fops_app has DELETE).
+apps/backend/src/modules/voc/__tests__/_seed-helpers.ts:441:  // 3. Delete VOCs — conversation tables cascade automatically (ON DELETE CASCADE).
+apps/backend/src/modules/voc/__tests__/_seed-helpers.ts:442:  //    fops_app has DELETE on voc.vocs, but NOT on conversation tables.
+.review/archive/slice-1-2/USER-VERIFICATION-CHECKLIST.md:47:| **DB-003** | ADR-0019 Section C: migration 0009 revokes INSERT/UPDATE/DELETE on `core.teams` from `fops_app`. SELECT remains. The team CRUD slice restores write grants alongside the management service. | `97bac9a` |
+.review/archive/slice-1-2/USER-VERIFICATION-CHECKLIST.md:202:update core.managed_systems set archived_at = now(), updated_at = now()
+apps/backend/src/modules/voc/read-service.ts:13:// ETag (Slice 3): weak W/"<voc.updated_at-ISO>". Conversation tables immutable
+apps/backend/src/modules/voc/read-service.ts:31:import type { CheckService } from '../permissions/check-service.js';
+apps/backend/src/modules/voc/read-service.ts:115:    updated_at: row.updatedAt.toISOString(),
+apps/backend/src/modules/voc/read-service.ts:563:      updated_at: row.updatedAt.toISOString(),
+apps/backend/src/modules/voc/read-service.ts:759:      updated_at: row.updatedAt.toISOString(),
+apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:35:    url: '/auth/mock-login',
+apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:89:  return res.json() as { id: string; display_id: string; updated_at: string };
+apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:191:    `update voc.vocs set triage_state = $2, updated_at = now() where id = $1`,
+apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:352:    }, { idempotencyKey: randomUUID(), ifMatch: voc.updated_at });
+apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:357:    expect(body.updated_at).not.toBe(voc.updated_at);
+apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:382:    }, { idempotencyKey: randomUUID(), ifMatch: voc.updated_at });
+apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:407:    }, { idempotencyKey: randomUUID(), ifMatch: voc.updated_at });
+apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:438:    }, { idempotencyKey: randomUUID(), ifMatch: voc.updated_at });
+apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:441:    // updated_at should NOT change — empty diff
+apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:442:    expect(res.json().updated_at).toBe(voc.updated_at);
+apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:471:    }, { idempotencyKey: randomUUID(), ifMatch: voc.updated_at });
+apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:490:    }, { idempotencyKey: randomUUID(), ifMatch: voc.updated_at });
+apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:515:    }, { idempotencyKey: randomUUID(), ifMatch: voc.updated_at });
+apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:537:    // Refresh updated_at
+apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:538:    const fresh = await dbHandle.pool.query<{ updated_at: string }>(
+apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:539:      `select updated_at::text as updated_at from voc.vocs where id = $1`,
+apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:542:    const freshAt = fresh.rows[0]?.updated_at ?? voc.updated_at;
+apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:569:    }, { idempotencyKey: randomUUID(), ifMatch: voc.updated_at });
+apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:590:    }, { idempotencyKey: randomUUID(), ifMatch: voc.updated_at });
+apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:610:      idempotencyKey: randomUUID(), ifMatch: voc.updated_at,
+apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:629:      idempotencyKey: randomUUID(), ifMatch: voc.updated_at,
+apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:653:    }, { idempotencyKey: randomUUID(), ifMatch: voc.updated_at });
+apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:672:    }, { idempotencyKey: randomUUID(), ifMatch: voc.updated_at });
+apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:709:    }, { idempotencyKey: randomUUID(), ifMatch: voc.updated_at });
+apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:747:    }, { idempotencyKey: randomUUID(), ifMatch: voc.updated_at });
+apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:782:    }, { idempotencyKey: randomUUID(), ifMatch: voc.updated_at });
+apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:816:  it('case 19: If-Match mismatch → 409 conflict.stale_write with detail.current_updated_at', async () => {
+apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:818:    const msId = await createMs(app, admin, 'it-pd-stale', 'Stale');
+apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:834:    expect(body.code).toBe('conflict.stale_write');
+apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:835:    expect(body.detail?.current_updated_at).toBeDefined();
+apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:836:    expect(body.detail?.current_updated_at).not.toBe(bogus);
+apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:858:      ifMatch: voc.updated_at,
+apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:866:  // Case 21: stale If-Match race (sequential simulation)
+apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:867:  it('case 21: second PATCH with stale If-Match → 409 conflict.stale_write', async () => {
+apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:869:    const msId = await createMs(app, admin, 'it-pd-race-stale', 'Race Stale');
+apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:880:      ifMatch: voc.updated_at,
+apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:884:    // Second edit with original (now stale) If-Match
+apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:887:      ifMatch: voc.updated_at, // stale
+apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:890:    expect(res2.json().code).toBe('conflict.stale_write');
+apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:910:      idempotencyKey: key, ifMatch: voc.updated_at,
+apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:921:      idempotencyKey: key, ifMatch: voc.updated_at,
+apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:940:      idempotencyKey: key, ifMatch: voc.updated_at,
+apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:946:      idempotencyKey: key, ifMatch: voc.updated_at,
+apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:965:      idempotencyKey: key, ifMatch: voc.updated_at,
+apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:968:    const freshAt = res1.json().updated_at as string;
+apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:996:    let updatedAt = voc.updated_at;
+apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:1007:        updatedAt = (res.json() as { updated_at: string }).updated_at;
+apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:1018:  // Case 26: Reporter + stale If-Match + already-triaged → state check fires first
+apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:1019:  it('case 26: Reporter + stale If-Match + triaged VOC → 409 conflict.triage_already_committed (state before If-Match)', async () => {
+apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:1034:      ifMatch: bogus, // stale
+apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:1037:    // triage_already_committed fires before stale_write (per plan §ordering)
+apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:1056:    }, { idempotencyKey: randomUUID(), ifMatch: voc.updated_at });
+apps/backend/src/modules/voc/__tests__/patch-description.integration.test.ts:1097:    }, { idempotencyKey: randomUUID(), ifMatch: voc.updated_at });
+.review/SLICE-3-19-PLAN.html:107:    <h3>의존성 (apps/frontend)</h3>
+apps/backend/src/modules/voc/__tests__/read-service.test.ts:19:import type { Decision } from '../../permissions/check-service.js';
+.review/archive/slice-3-backend/SLICE-3-16-PLAN.md:17:3. **`fops_app` GRANT** on the three conversation tables = `SELECT, INSERT` only — append-only enforced at role level. Do not attempt UPDATE/DELETE.
+.review/archive/slice-3-backend/SLICE-3-16-PLAN.md:83:Drizzle schema mirror in `apps/backend/src/db/schema/voc.ts` updated to `jsonb('body_rich_content')` (nullable). Single CHECK enforces all three skip-row invariants (codex cycle-1 fix — DB protects against stale skip_reason on non-skip rows).
+.review/archive/slice-3-backend/SLICE-3-16-PLAN.md:91:- `updateVocReporterStatus(tx, args: { vocId, nextStatus, expectedUpdatedAt? }): Promise<void>` (no If-Match here; updated_at bumps inside the same tx).
+.review/archive/slice-3-backend/SLICE-3-16-PLAN.md:116:8. If status changed: `UPDATE vocs SET reporter_facing_status = next, updated_at = now() WHERE id = vocId`.
+.review/archive/slice-3-backend/SLICE-3-16-PLAN.md:232:| DB constraint allows stale skip_reason on non-skip rows | MAJOR | Migration 0012 replaces CHECK with full skip-row invariant: skip=true ⇒ body NULL + skip_reason ≥8 trimmed; skip=false ⇒ body NOT NULL + skip_reason IS NULL. |
+.review/archive/slice-1-2/SLICE-1-REVIEW.md:6:**Where:** `packages/shared/src/enums/audit-events.ts:12`, `apps/backend/src/modules/permissions/request-service.ts:73`
+.review/archive/slice-1-2/SLICE-1-REVIEW.md:19:**Where:** `apps/frontend/src/features/admin/permissions/request-access-button.tsx:40`
+.review/archive/slice-1-2/SLICE-1-REVIEW.md:36:have neither a workspace nor actor FK. Result: a future cleanup that drops a stale workspace row leaves orphan permission
+.review/archive/slice-1-2/SLICE-1-REVIEW.md:43:### [F-004] GET /me/permissions/check open-request lookup ignores `managed_system_id`, can render wrong UI state
+.review/archive/slice-1-2/SLICE-1-REVIEW.md:44:**Where:** `apps/backend/src/modules/permissions/routes.ts:126-137`
+.review/archive/slice-1-2/SLICE-1-REVIEW.md:72:**Where:** `apps/backend/src/config.ts:15`, `apps/backend/src/server.ts:17,180`, `apps/backend/src/modules/auth/routes.ts:3-4`
+.review/archive/slice-1-2/SLICE-1-REVIEW.md:75:instantiates it unconditionally. The `apps/backend/src/modules/auth/routes.ts:3-4` comment claims "the plugin is the only
+.review/archive/slice-1-2/SLICE-1-REVIEW.md:85:**Where:** `apps/backend/src/modules/auth/session-service.ts:168-220`
+.review/archive/slice-1-2/SLICE-1-REVIEW.md:88:touch `last_seen_at`. Between (1) and (3) a concurrent `revoke()` can set `revoked_at`; the UPDATE then writes
+.review/archive/slice-1-2/SLICE-1-REVIEW.md:89:`last_seen_at` over the revoked row, and `requireSession` proceeds to populate `req.session` even though the row is
+.review/archive/slice-1-2/SLICE-1-REVIEW.md:90:revoked at commit time. The request continues end-to-end against a revoked session.
+.review/archive/slice-1-2/SLICE-1-REVIEW.md:92:into a single SQL: `UPDATE core.sessions SET last_seen_at = $now WHERE id = $id AND revoked_at IS NULL AND expires_at > $now RETURNING …`,
+.review/archive/slice-1-2/SLICE-1-REVIEW.md:96:**Where:** `apps/backend/src/modules/auth/session-service.ts:151-152`
+.review/archive/slice-1-2/SLICE-1-REVIEW.md:145:**Where:** `apps/backend/src/modules/permissions/routes.ts:31-32`
+.review/archive/slice-1-2/SLICE-1-REVIEW.md:155:**Where:** `apps/frontend/src/routes/login.tsx:62`
+.review/archive/slice-1-2/SLICE-1-REVIEW.md:164:`apps/backend/src/modules/permissions/check-service.ts:178-188`
+.review/archive/slice-1-2/SLICE-1-REVIEW.md:187:**Where:** `apps/frontend/src/routes/login.tsx`, `apps/backend/src/modules/auth/routes.ts:36-43,53`
+.review/archive/slice-1-2/SLICE-1-REVIEW.md:188:**Why it matters:** The backend `/auth/mock-login` correctly returns 404 in production (`isProd || authProvider.name !== 'mock'`).
+.review/archive/slice-1-2/SLICE-1-REVIEW.md:197:**Where:** `apps/backend/src/modules/auth/session-service.ts:237`
+.review/archive/slice-1-2/SLICE-1-REVIEW.md:205:**Where:** `apps/backend/src/modules/permissions/check-service.ts:155`,
+.review/archive/slice-1-2/SLICE-1-REVIEW.md:209:in particular is the exact gap behind F-004; if F-004 is fixed, this TODO becomes stale, and if F-004 isn't fixed,
+.review/archive/slice-1-2/SLICE-1-REVIEW.md:226:**Where:** `apps/backend/src/modules/auth/routes.ts:133`,
+.review/archive/slice-1-2/SLICE-1-REVIEW.md:227:`apps/backend/src/modules/auth/jobs.ts`,
+.review/archive/slice-1-2/SLICE-1-REVIEW.md:228:`apps/backend/src/modules/permissions/jobs.ts`
+.review/archive/slice-1-2/SLICE-1-REVIEW.md:246:**Where:** `apps/backend/src/modules/permissions/routes.ts:55-65, 98-103, 189-191, 218-221`
+.review/archive/slice-1-2/SLICE-1-REVIEW.md:248:GET /me/permissions/check handler ignores it and inlines the same query. Tiny code-quality issue that ladders into
+.review/archive/slice-1-2/SLICE-1-REVIEW.md:250:actor record (AGENTS.md:66 — services own permissions/actors).
+.review/archive/slice-1-2/SLICE-1-REVIEW.md:258:- No `apps/frontend` file branches on `role_level` to enforce a decision; the field is rendered only as display text in index.tsx and login.tsx.
+.review/archive/slice-1-2/F010-AND-SLICE2-REVIEW-http.md:13:**Why it matters:** ADR-0006:16 says the providers are switched by `AUTH_PROVIDER` and Slice 1 ships only mock. The route layer in `apps/backend/src/modules/auth/routes.ts:36,52` correctly 404s the `/auth/mock-login` HTML+POST handlers when `nodeEnv === 'production'`, but the `buildServer` switch will happily instantiate `createMockAuthProvider` in production if the operator forgets to flip `AUTH_PROVIDER=oidc`. The mock provider mints `AuthClaims` from any `external_id` row in `core.actors`; combined with a misconfigured ingress that exposes the POST endpoint, this is a silent authentication-bypass surface. Even with the route gate in place, the policy bug is "boot succeeded with `AUTH_PROVIDER=mock` in prod" — the operator-facing failure should be loud at boot, not at first /auth/mock-login hit. CWE-489 (Active Debug Code / dev provider reachable in prod).
+.review/archive/slice-1-2/F010-AND-SLICE2-REVIEW-http.md:34:**Where:** `apps/backend/src/server.ts:60-65` (no `redact` block in the logger config) plus header reads at `apps/backend/src/modules/permissions/routes.ts:168`, `managed-systems/routes.ts:67`, `analytics-areas/routes.ts:64`.
+.review/archive/slice-1-2/F010-AND-SLICE2-REVIEW-http.md:41:**Where:** `apps/backend/src/modules/permissions/routes.ts:57-67`, `managed-systems/routes.ts:57-64`, `analytics-areas/routes.ts:54-61`.
+.review/archive/slice-1-2/F010-AND-SLICE2-REVIEW-http.md:60:- `Idempotency-Key` UUIDv4 regex (ADR-0015:72) is consistent across all three mutation modules (`managed-systems/routes.ts:16-17`, `analytics-areas/routes.ts:14-15`, `permissions/routes.ts:33-34`) — Slice 1 #7 tightening preserved.
+.review/archive/slice-1-2/F010-AND-SLICE2-REVIEW-http.md:63:- Mock-login HTML route is gated behind `nodeEnv !== 'production'` AND `authProvider.name === 'mock'` (`auth/routes.ts:36,52`); 404 (`not_found.record`) avoids existence-leak.
+.review/archive/slice-1-2/F010-AND-SLICE2-REVIEW-http.md:64:- Session cookie carries `httpOnly`, `sameSite: 'lax'`, `secure: isProd`, `path: '/'`, and an explicit expiry (`auth/routes.ts:63-69`).
+.review/archive/next-session/NEXT-SESSION-PROMPT-SLICE-3-16.md:42:- conversation 테이블은 append-only (fops_app은 SELECT + INSERT만, 0010 migration). UPDATE/DELETE 시도하지 말 것.
+.review/archive/next-session/NEXT-SESSION-PROMPT-SLICE-3-16.md:51:- 권한 helper: `apps/backend/src/modules/permissions/{check-service,scope-service}.ts`
+.review/archive/slice-1-2/F010-AND-SLICE2-REVIEW-tests.md:3:Scope: Slice 2 #8 (F-010 shim), #9 (registry schema), #10 (Managed System write path), #11 (Analytics Area write path + cascade activation). Backend integration suites under `apps/backend/src/modules/{managed-systems,analytics-areas,core/jobs,permissions,auth}/__tests__` and `apps/backend/src/db/__tests__`; frontend route + picker tests under `apps/frontend/src`.
+.review/archive/slice-1-2/F010-AND-SLICE2-REVIEW-tests.md:9:**Why it matters:** ADR-0017 audit detail schema for `analytics_area_registered` embeds `workspace_id`, the service writes `workspace_id` into every row, but no test fails when a session for actor in workspace B targets `/managed-systems` (or `/analytics-areas`) for workspace A. The whole "Managed System is workspace-scoped, slug reuse is per-workspace" invariant (`docs/adr/0017:38` "`(workspace_id, slug)` is a partial unique index") has zero negative coverage. The CheckService has a `workspace_mismatch` branch (`apps/backend/src/modules/permissions/check-service.ts:80-82`) but nothing asserts that branch fires for MS/AA mutations.
+.review/archive/slice-1-2/F010-AND-SLICE2-REVIEW-tests.md:78:**Why it matters:** Frontend grouping (`apps/frontend/src/routes/admin/analytics-areas.tsx`) depends on a stable order to render `aa-group-ms-tab` / `aa-group-ms-pbi`. ADR-0017 does not lock ordering, but the admin UI silently depends on it.
+.review/archive/slice-1-2/F010-AND-SLICE2-REVIEW-tests.md:82:**Where:** `apps/frontend/src/routes/admin/managed-systems.test.tsx` (3 tests). Component exposes `archive-${slug}`, `save-${slug}`, `include-archived-checkbox` test ids (`apps/frontend/src/routes/admin/managed-systems.tsx:82,257,265`) but no test exercises them.
+.review/archive/slice-1-2/F010-AND-SLICE2-REVIEW-tests.md:87:**Where:** `apps/frontend/src/routes/admin/analytics-areas.test.tsx` covers grouped list, filter switch, create error, and gate. No archive interaction. No test for clearing the filter back to grouped.
+.review/archive/slice-1-2/F010-AND-SLICE2-REVIEW-tests.md:125:**Why it matters:** ADR-0017:65 "`GET /analytics-areas/:id` returns archived rows by id, and historical records (VOC, Finding, Task, Survey) join through the UUID and render the archived row's `name` with an archived-state indicator." If a future migration adds `ON DELETE CASCADE` or filters FK by `archived_at IS NULL`, history breaks.
+.review/archive/slice-1-2/F010-AND-SLICE2-REVIEW-tests.md:135:- ADR-0008 audit-log INSERT-only for fops_app: `role-grants.integration.test.ts:42-71` covers INSERT/UPDATE/DELETE matrix.
+.review/archive/slice-1-2/F010-AND-SLICE2-REVIEW-services.md:5:`apps/backend/src/modules/permissions/check-service.ts`,
+.review/archive/slice-1-2/F010-AND-SLICE2-REVIEW-services.md:6:`apps/backend/src/modules/permissions/request-service.ts`,
+.review/archive/slice-1-2/F010-AND-SLICE2-REVIEW-services.md:24:`apps/backend/src/modules/permissions/request-service.ts:110-189`.
+.review/archive/slice-1-2/F010-AND-SLICE2-REVIEW-services.md:58:`apps/backend/src/modules/permissions/check-service.ts:71-78,86-97,106-120`.
+.review/archive/slice-1-2/F010-AND-SLICE2-REVIEW-services.md:68:behalf of an actor whose `workspace.admin` was already revoked at
+.review/archive/slice-1-2/F010-AND-SLICE2-REVIEW-services.md:74:MS-scoped grant path will exercise this gap immediately (a revoked
+.review/archive/slice-1-2/F010-AND-SLICE2-REVIEW-services.md:135:**Where:** `apps/backend/src/modules/permissions/check-service.ts:128-136,153-161`.
+.review/archive/slice-1-2/F010-AND-SLICE2-REVIEW-services.md:165:`apps/backend/src/modules/permissions/request-service.ts:114,192,219`.
+.review/archive/slice-1-2/F010-AND-SLICE2-REVIEW-db.md:56:grants `SELECT, INSERT, UPDATE, DELETE ON core.teams TO fops_app`.
+.review/archive/slice-1-2/F010-AND-SLICE2-REVIEW-db.md:59:> "Standard role grants: `fops_app` gets SELECT/INSERT/UPDATE/DELETE; `fops_migrate` retains ALL."
+.review/archive/slice-1-2/F010-AND-SLICE2-REVIEW-db.md:63:> "`fops_app` cannot INSERT/UPDATE/DELETE on `core.teams` for normal product flows because no Slice 2 application service touches it."
+.review/archive/slice-1-2/F010-AND-SLICE2-REVIEW-db.md:145:  fops_app and explicitly `REVOKE UPDATE, DELETE, TRUNCATE`; no later
+.review/archive/slice-1-2/F010-AND-SLICE2-REVIEW-db.md:149:  wrapper; PUBLIC is revoked from both wrapper and `_create_queue_unsafe`;
+.review/archive/slice-1-2/F010-AND-SLICE2-REVIEW-db.md:172:  not the reverse. `ON DELETE no action` is consistent with the
+.review/SLICE-3-20-REVIEW-CYCLE-1-codex.md:32:- File: `apps/frontend/src/features/voc/components/detail/ConversationTimeline.tsx`
+.review/SLICE-3-20-REVIEW-CYCLE-1-codex.md:38:- File: `apps/frontend/src/features/voc/hooks/usePermissionDecision.ts`
+.review/ISSUE-113-PROMPT.txt:9:Builds directly on #112 (merged): `core.entity_links` exists; module `apps/backend/src/modules/entity-links/` has routes.ts (POST+GET), service.ts (`createEntityLinksService`), repo.ts (`resolveVocEndpoint`, `insertActiveVocRelatedToLink`, `selectActiveVocRelatedToLink`, `selectActiveLinksForEndpoint`). Shared types in `packages/shared/src/entity-links.ts` (`entityLinkStatusSchema` already includes `detached`/`revoked`). Migration 0018 granted fops_app INSERT+SELECT only and the active unique/lookup indexes are partial `WHERE status='active'`.
+.review/ISSUE-113-PROMPT.txt:11:## Design decisions (locked — do not re-litigate; the API draft lists both PATCH and DELETE, we choose PATCH)
+.review/ISSUE-113-PROMPT.txt:13:- **Verb: `PATCH /entity-links/:id`** with body `{ reason: string }` (reason required, non-empty, trimmed). The endpoint's only supported action this slice is detach (active→detached). DELETE is NOT used — the row persists, so DELETE would be a lie.
+.review/ISSUE-113-PROMPT.txt:14:- **Status: `detached` only.** `revoked` stays reserved for admin/policy flows (later slice). `stale` is Slice 7. Do not produce them here.
+.review/ISSUE-113-PROMPT.txt:20:- `ALTER TABLE core.entity_links ADD COLUMN detached_by uuid REFERENCES core.actors(id)` (nullable)
+.review/ISSUE-113-PROMPT.txt:21:- `ADD COLUMN detach_reason text` (nullable)
+.review/ISSUE-113-PROMPT.txt:22:- `ADD COLUMN detached_at timestamptz` (nullable)
+.review/ISSUE-113-PROMPT.txt:23:- `GRANT UPDATE ON core.entity_links TO fops_app;` (detach is an UPDATE; fops_app had INSERT+SELECT only). Still NO DELETE grant — hard delete stays impossible.
+.review/ISSUE-113-PROMPT.txt:32:- If link status != 'active' → 409 (already detached/revoked) OR idempotent 200 returning current state — pick 409 and document in DEVIATIONS if you prefer; default to 409 `conflict`.
+.review/ISSUE-113-PROMPT.txt:34:- Transition in ONE transaction: `UPDATE ... SET status='detached', detached_by=<actor>, detach_reason=<reason>, detached_at=now(), updated_at=now() WHERE id=:id AND status='active'`; if 0 rows updated (lost race) → 409. Emit audit_log `entity_link.detached` with `{ link_id, source, target, relation_type, reason }`. Add the `entity_link.detached` token to `packages/shared/src/enums/audit-events.ts` + its detail schema (mirror `entity_link.created`).
+.review/ISSUE-113-PROMPT.txt:35:- Response: 200 with the detached link's id + status (+ detached_at). No body that leaks the other endpoint if actor somehow shouldn't see it (but they passed both-side check, so full ok).
+.review/ISSUE-113-PROMPT.txt:37:VOC detail Links tab: NO code change needed if `selectActiveLinksForEndpoint` already filters `status='active'` (detached rows auto-drop). VERIFY this is true; if the VOC-detail query does NOT filter on active, add the filter. Either way a detached link must NOT appear on the Links tab.
+.review/ISSUE-113-PROMPT.txt:52:- `packages/shared/src/permissions/*`, `auth/*` — reuse existing helpers
+.review/ISSUE-113-PROMPT.txt:53:- `apps/frontend/**` (#114 owns UI)
+.review/ISSUE-113-PROMPT.txt:54:- new findings table; relation types beyond `related_to`; producing `revoked`/`stale`; visibility tokens beyond #112's `allowed`/`hidden`; FR-LINK-003 queries
+.review/ISSUE-113-PROMPT.txt:55:- hard delete of any entity_links row, or granting fops_app DELETE
+.review/ISSUE-113-PROMPT.txt:57:## Tests (vitest integration; mirror `apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts` setup — note `migrateHandle` (fops_migrate) is used for teardown DELETEs since fops_app cannot delete)
+.review/ISSUE-113-PROMPT.txt:59:1. PATCH detaches an active related_to link → 200; DB row STILL EXISTS with status='detached', detached_by/detach_reason/detached_at set; audit_log has `entity_link.detached`.
+.review/archive/slice-3-backend/SLICE-3-14-REVIEW-CYCLE-1.md:7:However: (a) severity-clear (`severity: null` de-triage) is **silently dropped from the audit log** — both in the standard and postpone paths; (b) the `permission.scope_required` envelope nests `requestable_permission` under `detail` instead of the top-level position defined by `ErrorEnvelope`, locking a new convention that contradicts ADR-0012; (c) the concurrency claim ("SELECT FOR UPDATE verified") is **not actually exercised** by test 18 (sequential awaits); (d) the empty-diff path doesn't assert envelope byte-identity; (e) a non-MS-scoped Developer scope_required currently leaks via `decision.reason !== allow` rather than discriminating between `no_grant`, `grant_revoked`, `grant_expired` — every denial collapses to `scope_required` with a `requestable_permission` regardless of whether a request is even possible.
+.review/archive/slice-3-backend/SLICE-3-14-REVIEW-CYCLE-1.md:17:  - What: The service treats any `decision.allow !== true` as `permission.scope_required` and unconditionally includes `requestable_permission`. But `checkCapability` can return `reason: 'explicit_deny'` (cannot be requested), `'grant_revoked'`, `'grant_expired'`, `'no_grant'`. ADR-0012 / ErrorEnvelope semantics: `permission.denied` is the generic deny; `permission.scope_required` is specifically the case where the actor *may request* MS scope. An explicit deny should be `permission.denied` with no `requestable_permission` (spec §"Non-MS-scope Developer → 403 permission.scope_required" applies only to that one denial reason).
+.review/archive/slice-3-backend/SLICE-3-14-REVIEW-CYCLE-1.md:18:  - Why it matters: A denied actor whose grant was just revoked sees a "request access" button that opens a request flow which permission-policy.md likely rejects; an actor with an explicit deny gets misled into requesting a capability they can never have. Also breaks audit/state-mapper attribution (state mapper discriminates on `Decision.reason`).
+.review/archive/slice-3-backend/SLICE-3-14-REVIEW-CYCLE-1.md:19:  - Fix: Branch on `decision.reason` in `service.ts:221-234`. If `decision.reason === 'explicit_deny'` → throw `permission.denied`. If `'grant_revoked'` / `'grant_expired'` → also `permission.denied` (with reason in detail, no `requestable_permission`). Only `'no_grant'` (and `developer` role missing the MS-scoped grant) maps to `permission.scope_required` with `requiredScope: [msId]`. Update test 16 to assert the revoke case returns either `permission.denied` (if you take this branch) or to assert the reason discriminator.
+.review/archive/slice-3-backend/SLICE-3-14-REVIEW-CYCLE-1.md:40:  - What: The two `await app.inject(...)` calls are sequential — the second only fires after the first returns. The 409 in `res2` is caused exclusively by the `If-Match` check, not by `SELECT FOR UPDATE` lock contention. The comment at line 853 admits "sequential simulation" but the spec AC says "SELECT FOR UPDATE on VOC row verified by concurrent-PATCH integration test (two txns race; second receives stale_write)" — the lock is not verified.
+.review/archive/slice-3-backend/SLICE-3-14-REVIEW-CYCLE-1.md:42:  - Fix: Fire both PATCHes without `await` (use `Promise.all([patchVoc(...), patchVoc(...)])`). One will win the row lock, the other will queue, and once the first commits the second will see the new `updated_at` and return 409. Alternatively: open a tx via the raw `dbHandle.pool`, `SELECT … FOR UPDATE` the VOC row outside Fastify, then call PATCH inside a 100 ms `setTimeout` and assert PATCH blocks/eventually returns 409. The `Promise.all` version is simpler and adequate.
+.review/archive/slice-3-backend/SLICE-3-14-REVIEW-CYCLE-1.md:44:- **[F5] Empty-diff test does not assert envelope byte-identity / updated_at stability**
+.review/archive/slice-3-backend/SLICE-3-14-REVIEW-CYCLE-1.md:46:  - What: Spec §8.4 step 6: "empty diff returns 200 OK with unchanged envelope and no audit row". Test only checks status + audit-row count delta. Does not assert `body.updated_at === voc.updated_at` or that any other field is unchanged.
+.review/archive/slice-3-backend/SLICE-3-14-REVIEW-CYCLE-1.md:47:  - Why it matters: A future change that always touches `updated_at = NOW()` regardless of diff would pass the test but break the contract. Also note `service.ts:425-428`: the empty-diff branch returns `composeEnvelope(row, nextStates)` where `row.updatedAt` is the original — but if a later refactor moved the UPDATE before the diff check, this property silently breaks.
+.review/archive/slice-3-backend/SLICE-3-14-REVIEW-CYCLE-1.md:48:  - Fix: Add `expect(res.json().updated_at).toBe(voc.updated_at)` and `expect(res.json()).toMatchObject({ id: voc.id, severity: null, triage_state: 'untriaged', ... })` with the full envelope.
+.review/archive/slice-3-backend/SLICE-3-14-REVIEW-CYCLE-1.md:52:- **[F6] Idempotency hash does not include `If-Match`; replay can mask stale-write**
+.review/archive/slice-3-backend/SLICE-3-14-REVIEW-CYCLE-1.md:54:  - What: `hashRequestBody({ vocId, ...rawBody })`. Two PATCHes with the same body + same key but different `If-Match` headers (e.g., client retried after a refetch) will both hit the cache and replay the original 200 — even if the second request would otherwise stale-write. This is technically ADR-0015-compliant (same key + same body → cached), but operationally surprising.
+.review/archive/slice-3-backend/SLICE-3-14-REVIEW-CYCLE-1.md:55:  - Why it matters: A retry after an intervening server-side change is silently swallowed; the client thinks its second intent landed when in fact the cached body is from a stale tx.
+.review/archive/slice-3-backend/SLICE-3-14-REVIEW-CYCLE-1.md:66:  - What: The test asserts `res1.json() === res2.json()` and counts `voc_severity_set` audit rows. But the cached-replay path returns the **stored body** — that body would be byte-identical even if the second request triggered a second real UPDATE (since the idempotency-cache write happens AFTER the UPDATE). The audit-row count check is the only real evidence. A stronger assertion would be on `updated_at` stability or on `voc.vocs.updated_at` in DB.
+.review/archive/slice-3-backend/SLICE-3-14-REVIEW-CYCLE-1.md:67:  - Why it matters: If a future refactor removes the idempotency lookup but keeps the cache write, this test still passes (one row inserted, one cached body returned, two real UPDATEs — both audit rows emitted, but the second UPDATE is by the second handler which sees the cached lookup result... actually this would fail. OK, the count check is sufficient.) Still, asserting on `updated_at` is more direct evidence.
+.review/archive/slice-3-backend/SLICE-3-14-REVIEW-CYCLE-1.md:68:  - Fix: Add `expect(res1.json().updated_at).toBe(res2.json().updated_at)` (already implicit in `toEqual`, but make it explicit). Optionally query `voc.vocs.updated_at` and assert it changed only once vs. the original.
+.review/archive/slice-3-backend/SLICE-3-14-REVIEW-CYCLE-1.md:78:  - What: The session cookie carries `role_level` (a snapshot), not the grant set. The grant check happens at tx time via `checkService.checkCapability(..., { tx })`. The test correctly exercises this: first PATCH succeeds, grant is revoked, second PATCH fails. But the test doesn't prove the check used `tx` (vs. the pool with a stale snapshot). To prove tx-binding, you'd need a scenario where the revoke happens inside the same transaction. That's hard to construct from a test harness.
+.review/archive/slice-3-backend/SLICE-3-14-REVIEW-CYCLE-1.md:80:  - Fix: Add a comment to the test explaining the chain of inference. Optional: add a second-tier test using a `BEGIN; UPDATE permission_grants SET revoked_at = NOW() ... COMMIT;` between the SELECT in handler and the UPDATE, but that requires test-harness instrumentation.
+.review/archive/slice-3-backend/SLICE-3-14-REVIEW-CYCLE-1.md:89:  - What: `actor: { actor_id: string; workspace_id: string; role_level: string }` — `RoleLevel` is exported from `apps/backend/src/modules/auth/session-service.ts:19` (`'admin' | 'developer' | 'user'`). Using `string` lets typos and invalid roles through.
+.review/archive/slice-3-backend/SLICE-3-14-REVIEW-CYCLE-1.md:97:- **[F14] Postpone path is unconditional UPDATE; replaying `{ postpone_review: true }` on already-postponed VOC emits a new audit row + bumps `updated_at` every call**
+.review/archive/slice-3-backend/SLICE-3-14-REVIEW-CYCLE-1.md:99:  - What: No empty-diff short-circuit on the postpone path. Each call writes `triage_state_review_postponed_at = NOW()`, bumps `updated_at`, emits `voc_triage_postponed`. If client clicks "보류" twice in a row, two audit rows.
+.review/archive/slice-3-backend/SLICE-3-14-REVIEW-CYCLE-1.md:154:- ErrorCode union extended with `conflict.stale_write`, `voc.reporter_status_via_public_update_only`, `permission.scope_required` and STATUS_BY_PREFIX maps each to 409/422/403.
+.review/archive/slice-3-backend/SLICE-3-14-REVIEW-CYCLE-1.md:161:1. **F1 (P0)**: Should `permission.scope_required` discriminate by `Decision.reason`? Recommend yes — explicit_deny → `permission.denied`, grant_revoked → `permission.denied` with detail, no_grant + developer + MS-eligible → `permission.scope_required`. Approve the branching logic before implementer changes test 16.
+.review/archive/slice-3-backend/SLICE-3-17-PLAN.md:24:| MAJOR | Empty-diff: no UPDATE, no updated_at bump, no audit | **Accepted.** Doc explicitly in service comment + tests. Idempotency still records the 200 envelope so replay returns cached. |
+.review/archive/slice-3-backend/SLICE-3-17-PLAN.md:27:| MINOR | Add test: reporter + stale If-Match + triaged row → `conflict.triage_already_committed` (state check fires first) | Added to test enum (case 26). |
+.review/archive/slice-3-backend/SLICE-3-17-PLAN.md:47:     'display_id','id','created_at','updated_at',
+.review/archive/slice-3-backend/SLICE-3-17-PLAN.md:96:- Triage-state gate: `voc.triage_state === 'untriaged'`. Any other state → `conflict.triage_already_committed` (new code). Race window: Reporter's tx must `SELECT FOR UPDATE` before reading triage_state, so a concurrent triage commit either lands first (Reporter sees committed) or queues behind Reporter (Reporter wins, Admin's later `SELECT FOR UPDATE` sees `updated_at` changed → stale_write).
+.review/archive/slice-3-backend/SLICE-3-17-PLAN.md:157:19. `If-Match` mismatch → 409 conflict.stale_write with `detail.current_updated_at`.
+.review/archive/slice-3-backend/SLICE-3-17-PLAN.md:161:21. Reporter and Admin race tightly with same starting `updated_at` → exactly one wins, other returns 409 conflict.stale_write (or triage_already_committed depending on order).
+.review/archive/slice-3-backend/SLICE-3-17-PLAN.md:172:26. Reporter + stale If-Match + already-triaged VOC → 409 `conflict.triage_already_committed` (state check fires before If-Match per plan ordering).
+.review/archive/slice-3-backend/SLICE-3-17-PLAN.md:180:3. **Idempotency-hash-with-If-Match** carries the same caveat as #14: client must use fresh Idempotency-Key after a 409 stale_write refetch. Documented in #14; restate here for Reporter UX.
+.review/archive/slice-3-backend/SLICE-3-14-TEST-CHECKLIST.md:41:- [ ] **T3** admin stale If-Match → 409 `conflict.stale_write` + `detail.current_updated_at` ISO
+.review/archive/slice-3-backend/SLICE-3-14-TEST-CHECKLIST.md:42:- [ ] **T3b** dev no-grant + bogus If-Match → 403 `permission.scope_required`, NO `current_updated_at` leak (C3)
+.review/archive/slice-3-backend/SLICE-3-14-TEST-CHECKLIST.md:74:- [ ] **T16** revoked grant → 403 `permission.denied` with `detail.reason='grant_revoked'` (F1 reason discrimination)
+.review/archive/slice-3-backend/SLICE-3-14-TEST-CHECKLIST.md:77:- [ ] **T17** `{}` → 200, `updated_at` unchanged, zero new audit (F5)
+.review/archive/slice-3-backend/SLICE-3-14-TEST-CHECKLIST.md:79:- [ ] **T19** idempotency replay same key+body → both 200, same `updated_at`, one DB write (F8)
+.review/archive/slice-3-backend/SLICE-3-14-TEST-CHECKLIST.md:84:- [ ] **Error envelope shape** — curl PATCH with bogus If-Match, confirm response body has `code`, `message`, `detail.current_updated_at` as ISO string
+.review/archive/slice-3-backend/SLICE-3-14-TEST-CHECKLIST.md:86:- [ ] **`permission.denied` reason discriminator** — revoke a grant, PATCH → confirm `body.detail.reason === 'grant_revoked'` and NO `requestable_permission`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-2.md:13:| P2-2 | CONFIRM | `client.ts:21` `MUTATION_METHODS = {POST, PATCH, DELETE}` — PUT removed. Comment at `:19` documents the contract. |
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-2.md:14:| P2-3 | PARTIAL | `dev-rich-editor.tsx:101-125` adds two buttons that feed fake `rich_content.disallowed_node` and `conflict.stale_write` envelopes through `errorMapper` → `toast`. The editor's actual `doc` state is NOT consumed by the demo — buttons fire fixed envelopes. The end-to-end editor→sanitizer→toast loop still cannot be exercised here; only the toast-mapping segment can. Acceptable as a smoke harness; real wiring lands in #19. |
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-2.md:40:**File:line:** `apps/frontend/src/routes/_authed/vocs.tsx:11-22`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-2.md:58:**File:line:** `packages/ui/src/rich-content/RichEditor.tsx` (no test); `apps/frontend/src/routes/_authed.tsx` (no test for the non-`UnauthenticatedError` re-throw branch); `apps/frontend/src/lib/layout/AppFrame.tsx:28-42` (slot lifecycle covered by `AppFrame.test.tsx`, but no test for the override-warn path — register A, then B, then unmount B → expect A re-visible).
+.review/SLICE-3-87-managed-systems-pixel-diff.html:29:  <strong>Gate:</strong> No HIGH, no copy mismatch, 0 MEDIUM → <strong>merge OK with inline note</strong> (per apps/frontend/AGENTS.md CP-pixel §5).<br />
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-CYCLE-2.md:10:| P0-2 Shell taxonomy violation | CONFIRM | `.review/SLICE-3-18-PLAN.md:14,205-229,233-256` | C4a builds exactly 3 shells in `packages/ui/src/layout/`; AppFrame demoted to `apps/frontend/src/lib/layout/`; explicit "NOT a 4th shell" guard. |
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-CYCLE-2.md:12:| P1-2 TipTap workspace placement | CONFIRM | `.review/SLICE-3-18-PLAN.md:104-112,154,170` | TipTap deps moved to `packages/ui` in C1b pre-install for C2; no install in `apps/frontend`. |
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-CYCLE-2.md:49:**Issue:** Current `@fops/ui` `test` script is `echo 'no tests yet' && exit 0`. No vitest config exists in `packages/ui/` (only in `apps/backend`, `apps/frontend`, `packages/shared`). The plan repeatedly invokes `pnpm --filter @fops/ui test` (C1a, C1b, C1c, C2, C4a) expecting it to run `packages/ui/src/styles/__tests__/token-fidelity.test.ts`, `packages/ui/__tests__/shadcn-smoke.test.tsx`, `packages/ui/__tests__/button-loading.test.tsx`, `packages/ui/__tests__/rich-content.test.tsx`, `packages/ui/__tests__/shell-taxonomy.test.tsx`. As written, **all those tests will be invisible** — the script returns 0 without running anything.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-CYCLE-2.md:54:**File:line:** `apps/frontend/src/routes/admin/managed-systems.tsx:90,96,142,185,229,270`, `admin/analytics-areas.tsx:132,170,215,255,308,339` + plan line 340
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-CYCLE-2.md:57:**Suggested fix:** C1a must include an audit step: grep `apps/frontend/src/routes/` for token classnames, build a rename map (`text-status-danger` → `text-accent-danger` or new `text-danger`; `border-surface-overlay` → `border-default` or new mapped name), and apply the rename inside C1a (not deferred). Add to C1a Files list: `apps/frontend/src/routes/admin/*.tsx`, `apps/frontend/src/routes/login.tsx`. Add a test or grep-assertion that no `.tsx` references a class whose Tailwind key is not resolvable.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-CYCLE-2.md:76:**Issue:** Test "iterates ERROR_CODES and asserts non-empty Korean message". Plan §C3 line 184 hardcodes per-prefix tone mapping (auth.*→error, rate_limited.*→warning, etc.). But the test as described does NOT assert: (a) tone ∈ `{error, warning, info}` (typo like `'warn'` slips through); (b) `conflict.stale_write` actually classifies as `warning` with retry action (the only special-case); (c) when a future Slice 4 adds a `entity_link.*` prefix to `ERROR_CODES`, the iteration will still pass with the fallback message — but the test gives no signal that NEW codes need Korean copy review. The test passes silently for unknowns rather than flagging them.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-CYCLE-2.md:78:**Suggested fix:** Test should: (a) assert `tone` is in literal `{'error','warning','info'}`; (b) assert that for every code where prefix matches a Slice 3 owner (`voc.*`, `rich_content.*`, `attachment.*`, `reporter_facing_status.*`, `conflict.stale_write`, `conflict.triage_already_committed`), the Korean message is NOT the generic fallback string; (c) assert `conflict.stale_write` maps to `{tone: 'warning', action: {…}}` specifically. New Slice 4 codes will then deliberately fail the test until their owner adds copy.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-CYCLE-2.md:110:**Issue:** Plan installs `lucide-react` into `packages/ui` (and one already in `apps/frontend@0.469.0`). React 19's peer-dep enforcement is strict. lucide-react 0.469 declares `react@^16 || ^17 || ^18` — it works in practice but pnpm strict-peer mode warns. Plan doesn't address whether pnpm warning is treated as failure in CI.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-CYCLE-2.md:113:#### P3-B: `@tiptap/react` peer-resolution from apps/frontend
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-CYCLE-2.md:115:**Issue:** Plan risk line 345 acknowledges this. Worth elevating: when `apps/frontend` imports `<RichEditor>` from `@fops/ui`, React reconciliation requires only ONE copy of React. With pnpm workspaces + `peerDependencies: react ^19` in both `apps/frontend` and `packages/ui`, this should dedupe — but TipTap's internal ProseMirror has its own React adapter. Plan should add a verification: `pnpm dedupe --check react react-dom @tiptap/react`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-CYCLE-2.md:146:- Did not verify `pnpm dedupe` actually dedupes React across `packages/ui` + `apps/frontend`.
+.review/ISSUE-112-PROMPT.txt:12:- docs/design/14-api-draft.md §"Entity Link APIs" — POST/GET/PATCH/DELETE /entity-links
+.review/ISSUE-112-PROMPT.txt:42:- `packages/shared/src/permissions/*` — reuse existing permission helpers, do NOT add new capabilities
+.review/ISSUE-112-PROMPT.txt:43:- `packages/shared/src/auth/*`
+.review/ISSUE-112-PROMPT.txt:45:- Any FE code (`apps/frontend/**`) — #114 owns `/integration/links` UI; this issue is backend + the VOC detail backend payload only
+.review/ISSUE-112-PROMPT.txt:47:- Detach endpoints `PATCH/DELETE /entity-links/:id` (#113)
+.review/ISSUE-112-PROMPT.txt:63:- `status text not null default 'active'` — enum domain `active|stale|detached|revoked` (only `active` is produced by this slice; `stale` populated later by Slice 7, others by #113)
+.review/ISSUE-112-PROMPT.txt:66:- `updated_at timestamptz` (nullable until first transition; reserved for #113)
+.review/ISSUE-112-PROMPT.txt:73:- GRANTs: `fops_app` gets INSERT + SELECT (UPDATE deferred until #113 needs it; DELETE never — no hard delete)
+.review/CHUNK-3-DEVIATIONS.md:11:**Files modified:** `apps/frontend/src/features/voc/hooks/useUndoableMutation.ts`
+.review/CHUNK-3-DEVIATIONS.md:41:### D-REV1-#2: undoLast branched on stale React state closure
+.review/CHUNK-3-DEVIATIONS.md:69:### D-REV1-#4: compensating PATCH used a stale If-Match
+.review/CHUNK-3-DEVIATIONS.md:73:**Issue:** The compensating PATCH reused the original `If-Match` (voc.updated_at at confirm time). After the first PATCH committed, that ETag was stale and the compensating PATCH self-failed with `conflict.stale_write`.
+.review/CHUNK-3-DEVIATIONS.md:75:**Fix:** `useUndoableMutation.compensateFn` now receives `(snapshot, output)` where `output` is the resolved mutation response. `TriagePanel` reads `output.updated_at` and overrides `snapshot.ifMatch` with that fresh value before calling `executeCompensatingPatch`. The fresh `Idempotency-Key` requirement (D-3.5 / spec §5.3) is preserved.
+.review/CHUNK-3-DEVIATIONS.md:93:**New integration test (codex required):** `VocTriageScreen.errorRollback.test.tsx` — exercises the FULL `VocTriageScreen` (not direct `TriagePanel`), so auto-advance actually happens before the error lands. Both `conflict.stale_write` (409) and `permission.denied` (403) paths verified.
+.review/CHUNK-3-DEVIATIONS.md:117:**Files modified:** `apps/frontend/src/features/voc/hooks/useUndoableMutation.ts`, `apps/frontend/src/features/voc/components/triage/TriageActions.tsx`.
+.review/CHUNK-3-DEVIATIONS.md:119:**RED → GREEN test:** `apps/frontend/src/features/voc/hooks/__tests__/useUndoableMutation.abortRace.test.ts` — 3 cases: (a) abort-after-settle runs compensateFn with the server output, (b) second mutate fires onAbort with the first input, (c) preempted call resolving later runs compensateFn against the first snapshot/output.
+.review/CHUNK-3-DEVIATIONS.md:130:**Issue:** `UndoToast.onAction` invoked `undoLastRef.current()`, which reads the latest hook state. After call A settled and a follow-up call B started, the still-visible toast A's button now operated on call B — clicking A's stale toast aborted/undid the unrelated newer call.
+.review/CHUNK-3-DEVIATIONS.md:134:- `undoLast(callToken?)` accepts an optional token. When provided and the current call's token doesn't match, the call is a no-op (the toast is stale). Omitting the token preserves the legacy "undo the latest" semantics for callers that don't manage tokens.
+.review/CHUNK-3-DEVIATIONS.md:137:**Files modified:** `apps/frontend/src/features/voc/hooks/useUndoableMutation.ts`, `apps/frontend/src/features/voc/components/triage/TriagePanel.tsx`.
+.review/CHUNK-3-DEVIATIONS.md:139:**RED → GREEN test:** `apps/frontend/src/features/voc/components/triage/__tests__/TriagePanel.undoTokenBinding.test.tsx` — call A settles, call B starts and stays in-flight, clicking toast A asserts (a) call B's controller is not aborted and (b) `onOptimisticRestore` is not invoked.
+.review/CHUNK-3-DEVIATIONS.md:147:**Issue:** `apiClient` returns `undefined` for an empty 200 response body (`client.ts:64`). The compensate guard checked `output !== null` and then dereferenced `output.updated_at` — `undefined !== null` is true, so the path threw `TypeError: Cannot read properties of undefined`, propagating as an unhandled rejection inside `compensateFn` and leaving the queue and server divergent.
+.review/CHUNK-3-DEVIATIONS.md:150:- `compensateFn` now treats both `null` and an `output` lacking a string `updated_at` as "fresh updated_at unknown".
+.review/CHUNK-3-DEVIATIONS.md:151:- When fresh `updated_at` is missing it refetches `['voc', vocId]` via `queryClient.refetchQueries({ ..., type: 'all' })` (so the refetch fires even when there's no active observer) and reads the fresh value off the cache. If the cache is empty, it falls back to `fetchQuery` against the same key with the standard `apiClient<…>('GET', /vocs/:id)` queryFn.
+.review/CHUNK-3-DEVIATIONS.md:152:- Only when both paths fail does it fall back to the stale baseline; the compensating PATCH may then 409, but it will not throw inside `compensateFn`.
+.review/CHUNK-3-DEVIATIONS.md:155:**Files modified:** `apps/frontend/src/features/voc/components/triage/TriagePanel.tsx`, `apps/frontend/src/features/voc/routes/__tests__/TriageRoute.test.tsx`, `apps/frontend/src/features/voc/routes/__tests__/TriageRoute.capability.test.tsx`.
+.review/CHUNK-3-DEVIATIONS.md:157:**RED → GREEN test:** `apps/frontend/src/features/voc/components/triage/__tests__/TriagePanel.emptyBodyCompensate.test.tsx` — first PATCH returns an empty 200 body; the undo path asserts (a) the VOC detail GET fires, (b) the compensating PATCH `If-Match` carries the refetched `updated_at`, (c) no unhandled rejection and `onOptimisticRestore` fires on the success path.
+.review/CHUNK-3-DEVIATIONS.md:161:## REV-4 (codex Cycle 4) — Cluster Y P1 fix: refetch-failure surface error + no stale PATCH
+.review/CHUNK-3-DEVIATIONS.md:163:### D-REV4-P1: refetch failure in compensateFn now surfaces toast and stops stale PATCH
+.review/CHUNK-3-DEVIATIONS.md:167:**Issue:** When the first PATCH response lacks a fresh `updated_at`, `compensateFn` refetches the VOC. The prior catch block silently swallowed refetch errors and fell through to `executeCompensatingPatch` with a stale `If-Match` — guaranteed to 409. `undoLast` used `void compensate()` (fire-and-forget), so any `compensateFn` rejection became an unhandled promise rejection with no user-facing feedback.
+.review/CHUNK-3-DEVIATIONS.md:170:1. `TriagePanel.tsx` catch block: surface `toast.error('VOC를 새로 불러올 수 없습니다. 잠시 후 다시 시도해 주세요.')`, tag the error with `__refetchFailure: true`, re-throw to stop the stale PATCH.
+.review/CHUNK-3-DEVIATIONS.md:175:- `apps/frontend/src/features/voc/components/triage/TriagePanel.tsx`
+.review/CHUNK-3-DEVIATIONS.md:176:- `apps/frontend/src/features/voc/hooks/useUndoableMutation.ts`
+.review/CHUNK-3-DEVIATIONS.md:178:**RED → GREEN test:** `apps/frontend/src/features/voc/components/triage/__tests__/TriagePanel.refetchFailure.test.tsx` — 3 cases covering all required behaviors.
+.review/SLICE-3-20-PLAN.html:103:  <h3>toolbar/, panel/, permissions/, entity/, feedback/, forms/</h3>
+.review/SLICE-3-20-PLAN.html:116:    <li><code>PermissionBlockedPanel</code> request_access CTA target route <code>/admin/permissions/requests</code> 미존재 → placeholder toast 또는 navigate 시도. 본 PR은 navigate만 시도 + 부재 시 404 허용.</li>
+.review/PIXEL-MATCH-TITLE-BLOCK.md:43:- `apps/frontend/src/features/voc/components/detail/IdentitySection.tsx`
+.review/PIXEL-MATCH-TITLE-BLOCK.md:82:- `apps/frontend` voc detail tests — 96 / 96 pass.
+.review/PIXEL-MATCH-TITLE-BLOCK.md:84:- `apps/frontend` `tsc --noEmit` — clean.
+.review/CHUNK-22-C7a-DEVIATIONS.md:11:| Extract `ComposerAttachmentDropzone.tsx` (~80 LOC) | Done as standalone file under `apps/frontend/src/features/voc/components/detail/`. Final size ~290 LOC (mirrors the C6 AttachmentDropzone state machine verbatim — extraction did not actually reduce LOC because the row state machine, upload kickoff, error mapping, and idempotency-key minting are inherent to the contract). Compact variant strips the `Card` chrome + FieldLabel and uses tighter row padding per prototype anchor. |
+.review/CHUNK-22-C7a-DEVIATIONS.md:27:- `cd apps/frontend && pnpm test -- --run src/features/voc/components/detail/__tests__/{PublicUpdate,InternalComment,ReporterReply}Composer.attachments.test.tsx` → 9/9 pass
+.review/CHUNK-22-C7a-DEVIATIONS.md:28:- `cd apps/frontend && pnpm test -- --run` → 427/427 pass, 109 test files
+.review/SLICE-3-88-analytics-areas-pixel-diff.html:24:<code>POST /auth/mock-login {external_id:"mock-admin-1"}</code>. Captured at viewport 1440.
+.review/SLICE-3-20-REVIEW-CYCLE-2.md:9:  - `apps/frontend/src/features/voc/hooks/usePermissionDecision.ts:35-42` adds the safe-default branch.
+.review/SLICE-3-20-REVIEW-CYCLE-2.md:10:  - Test updated (`apps/frontend/src/features/voc/hooks/__tests__/usePermissionDecision.test.ts`): one existing test renamed/strengthened + one new test asserts the non-`_self` path still returns null (no over-defaulting).
+.review/SLICE-3-20-REVIEW-CYCLE-2.md:14:  - `apps/frontend/src/features/voc/components/detail/ConversationTimeline.tsx:27-32` adds a TODO comment locking the deferral to #21.
+.review/SLICE-3-19-PLAN.md:18:**의존성 (apps/frontend):**
+.review/SLICE-3-19-PLAN.md:22:- `apps/frontend/src/features/voc/routes/CreateRoute.tsx`
+.review/SLICE-3-19-PLAN.md:23:- `apps/frontend/src/features/voc/components/create/VocCreateScreen.tsx`
+.review/SLICE-3-19-PLAN.md:24:- `apps/frontend/src/features/voc/components/create/SourceContextSegmented.tsx`
+.review/SLICE-3-19-PLAN.md:25:- `apps/frontend/src/features/voc/components/create/AttachmentDropzone.tsx`
+.review/SLICE-3-19-PLAN.md:26:- `apps/frontend/src/features/voc/components/create/ReporterCard.tsx`
+.review/SLICE-3-19-PLAN.md:27:- `apps/frontend/src/features/voc/components/create/SeverityDisclaimerCard.tsx`
+.review/SLICE-3-19-PLAN.md:28:- `apps/frontend/src/features/voc/components/create/rich-toolbar-voc-description.ts`
+.review/SLICE-3-19-PLAN.md:29:- `apps/frontend/src/features/voc/hooks/useMe.ts` (if not exists — `/me` query wrapper)
+.review/SLICE-3-19-PLAN.md:30:- `apps/frontend/src/features/voc/hooks/useVocCreateMutation.ts`
+.review/SLICE-3-20-PLAN.md:66:4. **`PermissionBlockedPanel` `request_access` CTA** — `/admin/permissions/requests?action=create&capability=…` 라우트 미존재. Slice 3+ 영역. 본 PR은 navigate만 호출 + 404 허용 OR placeholder toast로 처리.
+.review/ISSUE-99-CODEX.json:6:    "apps/frontend/src/features/voc/components/detail/IdentitySection.tsx",
+.review/ISSUE-99-CODEX.json:7:    "apps/frontend/src/features/voc/components/detail/__tests__/IdentitySection.test.tsx",
+.review/ISSUE-99-CODEX.json:8:    "apps/frontend/src/features/voc/components/triage/TriagePanel.tsx",
+.review/ISSUE-99-CODEX.json:9:    "apps/frontend/src/features/voc/components/triage/__tests__/TriagePanel.titleBlock.test.tsx",
+.review/ISSUE-99-CODEX.json:45:    "command": "rg -n \"PanelTitleBlock[^\\\\n]*size=\\\\\\\"xl\\\\\\\"|size=\\\\{'xl'\\\\}|size='xl'\" apps/frontend/src packages docs/frontend -g '*.{ts,tsx,md}'",
+.review/ISSUE-99-CODEX.json:68:      "command": "pnpm exec biome check packages/ui/src/panel/PanelTitleBlock.tsx packages/ui/src/panel/DetailPanelHeader.tsx packages/ui/src/panel/__tests__/PanelTitleBlock.test.tsx packages/ui/src/panel/__tests__/DetailPanelHeader.test.tsx apps/frontend/src/features/voc/components/detail/IdentitySection.tsx apps/frontend/src/features/voc/components/detail/__tests__/IdentitySection.test.tsx apps/frontend/src/features/voc/components/triage/TriagePanel.tsx apps/frontend/src/features/voc/components/triage/__tests__/TriagePanel.titleBlock.test.tsx docs/frontend/specs/voc.md",
+.review/CHUNK-2-DEVIATIONS.md:10:- **Files modified:** `apps/frontend/src/features/voc/routes/__tests__/TriageRoute.test.tsx`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-1-codex.md:52:10. `apps/frontend/src/lib/api/{client,errorMapper,useIdempotencyKey}.ts` + tests
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-1-codex.md:53:11. `apps/frontend/src/lib/layout/{AppFrame,AppRail,AppSidebar}.tsx` + tests
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-1-codex.md:54:12. `apps/frontend/src/lib/panel/useFullscreenPanel.ts`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-1-codex.md:55:13. `apps/frontend/src/routes/_authed.tsx` + `_authed/admin/*` (relocation)
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-1-codex.md:56:14. `apps/frontend/src/routes/_authed/vocs.tsx` (zod search + per-view shell)
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-1-codex.md:57:15. `apps/frontend/src/routes/__root.tsx` (Toaster + custom icons)
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-1-codex.md:58:16. `apps/frontend/src/routes/dev-rich-editor.tsx`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-1-codex.md:60:18. `apps/frontend/src/components-test-pickers.test.tsx` (post-C1c chip-click migration)
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-1-codex.md:69:6. **Three shells + AppFrame** — exactly 3 shells in packages/ui/src/layout/? AppFrame is NOT exported from @fops/ui (lives in apps/frontend only)? 50px header rhythm enforced (h-toolbar token)? DetailPanelSlot single-registrant + last-write-wins warn?
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-1-codex.md:70:7. **_authed.tsx auth guard** — fetchMe + redirect /login replicated from existing per-route guard? Admin route per-route guards DELETED? File moves used git mv (history preserved)? Route.id NOT used anywhere?
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-1-codex.md:73:10. **errorMapper** — every ERROR_CODES code covered? Slice-3-owner codes have non-fallback Korean? conflict.stale_write maps to warning + action? tone classification ∈ {error, warning, info}? Fallback for unknown codes?
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-1-codex.md:77:14. **Build size** — `apps/frontend` bundle is 985 kB (gzip 299 kB). Acceptable for slice 3 prologue? Code-split warning — any quick wins?
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-1-codex.md:806:### P2-1 — `useIdempotencyKey` returns a stale key for the render where `If-Match` changes
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-1-codex.md:807:**File:line:** `apps/frontend/src/lib/api/useIdempotencyKey.ts:27`  
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-1-codex.md:809:**Why it matters:** A mutation triggered by an effect or immediately after prop/state reconciliation can send the new `If-Match` with the old `Idempotency-Key`, recreating the stale-write/idempotency reuse failure this hook was meant to prevent.  
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-1-codex.md:813:**File:line:** `apps/frontend/src/lib/api/client.ts:19`  
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-1-codex.md:814:**Issue:** `MUTATION_METHODS` includes `PUT`, but the plan and API client contract only locked auto-minting for `POST/PATCH/DELETE`.  
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-1-codex.md:819:**File:line:** `apps/frontend/src/routes/dev-rich-editor.tsx:61`, `apps/frontend/src/routes/dev-rich-editor.tsx:67`  
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-1-codex.md:825:**File:line:** `packages/ui/src/components/shadcn/combobox.tsx:59`, `packages/ui/src/rich-content/RichContentRenderer.tsx:55`, `apps/frontend/src/lib/layout/AppRail.tsx:1`  
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-1-codex.md:835:- P1-B: IMPLEMENTED — old invalid classes are gone; token coverage test scans semantic prefixes (`apps/frontend/src/__tests__/token-class-coverage.test.ts:31`).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-1-codex.md:836:- P1-C: IMPLEMENTED — `_authed.beforeLoad` calls `fetchMe` and redirects unauthenticated users (`apps/frontend/src/routes/_authed.tsx:28`).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-1-codex.md:838:- P1-E: IMPLEMENTED — tests assert valid tones, Slice 3 non-fallback copy, and stale-write action (`apps/frontend/src/lib/api/__tests__/errorMapper.test.ts:5`, `:42`, `:53`).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-1-codex.md:840:- P2-B: IMPLEMENTED — window-guarded localStorage initializer (`apps/frontend/src/lib/layout/AppSidebar.tsx:23`).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-1-codex.md:841:- P2-C: PARTIAL — Toaster/errorMapper exist, but no editor sanitizer error toast flow (`apps/frontend/src/routes/dev-rich-editor.tsx:61`).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-1-codex.md:884:### P2-1 — `useIdempotencyKey` returns a stale key for the render where `If-Match` changes
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-1-codex.md:885:**File:line:** `apps/frontend/src/lib/api/useIdempotencyKey.ts:27`  
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-1-codex.md:887:**Why it matters:** A mutation triggered by an effect or immediately after prop/state reconciliation can send the new `If-Match` with the old `Idempotency-Key`, recreating the stale-write/idempotency reuse failure this hook was meant to prevent.  
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-1-codex.md:891:**File:line:** `apps/frontend/src/lib/api/client.ts:19`  
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-1-codex.md:892:**Issue:** `MUTATION_METHODS` includes `PUT`, but the plan and API client contract only locked auto-minting for `POST/PATCH/DELETE`.  
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-1-codex.md:897:**File:line:** `apps/frontend/src/routes/dev-rich-editor.tsx:61`, `apps/frontend/src/routes/dev-rich-editor.tsx:67`  
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-1-codex.md:903:**File:line:** `packages/ui/src/components/shadcn/combobox.tsx:59`, `packages/ui/src/rich-content/RichContentRenderer.tsx:55`, `apps/frontend/src/lib/layout/AppRail.tsx:1`  
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-1-codex.md:913:- P1-B: IMPLEMENTED — old invalid classes are gone; token coverage test scans semantic prefixes (`apps/frontend/src/__tests__/token-class-coverage.test.ts:31`).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-1-codex.md:914:- P1-C: IMPLEMENTED — `_authed.beforeLoad` calls `fetchMe` and redirects unauthenticated users (`apps/frontend/src/routes/_authed.tsx:28`).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-1-codex.md:916:- P1-E: IMPLEMENTED — tests assert valid tones, Slice 3 non-fallback copy, and stale-write action (`apps/frontend/src/lib/api/__tests__/errorMapper.test.ts:5`, `:42`, `:53`).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-1-codex.md:918:- P2-B: IMPLEMENTED — window-guarded localStorage initializer (`apps/frontend/src/lib/layout/AppSidebar.tsx:23`).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-1-codex.md:919:- P2-C: PARTIAL — Toaster/errorMapper exist, but no editor sanitizer error toast flow (`apps/frontend/src/routes/dev-rich-editor.tsx:61`).
+.review/HOTFIX-22-STORAGE-AND-GRANTS-DEVIATIONS.md:1:# Hotfix Slice 3 #22 — storage lazy init + voc_attachments DELETE grant
+.review/HOTFIX-22-STORAGE-AND-GRANTS-DEVIATIONS.md:51:## Bug 2 — Missing DELETE grant on voc_attachments for fops_app (FIXED)
+.review/HOTFIX-22-STORAGE-AND-GRANTS-DEVIATIONS.md:55:`DELETE FROM voc.voc_attachments WHERE id = $1`. Test invariant test
+.review/HOTFIX-22-STORAGE-AND-GRANTS-DEVIATIONS.md:56:"`voc_attachments archive write succeeds; fops_app DELETE is rejected`" was
+.review/HOTFIX-22-STORAGE-AND-GRANTS-DEVIATIONS.md:57:failing in the opposite direction: the DELETE succeeded. Investigation showed
+.review/HOTFIX-22-STORAGE-AND-GRANTS-DEVIATIONS.md:63:- `0010_slice3_voc_foundation.sql:319` — `GRANT SELECT, INSERT, UPDATE, DELETE
+.review/HOTFIX-22-STORAGE-AND-GRANTS-DEVIATIONS.md:65:- `0011_slice3_voc_integrity_followups.sql:119` — `REVOKE DELETE ON
+.review/HOTFIX-22-STORAGE-AND-GRANTS-DEVIATIONS.md:69:  worker, whose handler legitimately DELETEs orphaned rows. **Missing
+.review/HOTFIX-22-STORAGE-AND-GRANTS-DEVIATIONS.md:75:GRANT DELETE ON "voc"."voc_attachments" TO fops_app;
+.review/HOTFIX-22-STORAGE-AND-GRANTS-DEVIATIONS.md:80:`information_schema.role_table_grants` — `fops_app` now holds DELETE +
+.review/HOTFIX-22-STORAGE-AND-GRANTS-DEVIATIONS.md:85:sole user-facing entry point and writes `archived_at` rather than DELETEing;
+.review/HOTFIX-22-STORAGE-AND-GRANTS-DEVIATIONS.md:86:the purge worker is an internal reclaim path that DELETEs only rows whose
+.review/HOTFIX-22-STORAGE-AND-GRANTS-DEVIATIONS.md:94:- `voc_attachments DELETE is permitted for fops_app (purge-worker path)` —
+.review/HOTFIX-22-STORAGE-AND-GRANTS-DEVIATIONS.md:95:  replaces the old `DELETE is rejected` assertion to reflect the new policy.
+.review/HOTFIX-22-STORAGE-AND-GRANTS-DEVIATIONS.md:110:  `DELETE FROM core.audit_log` via the fops_app pool, but `fops_app` has only
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:14:- ADR-0020 taxonomy enforced: `packages/ui/src/layout/` exports exactly 3 shells (PageShell, ListShell, WorkbenchShell). AppFrame in `apps/frontend/src/lib/layout/` is NOT a 4th shell.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:82:- Modify/audit: `apps/frontend/src/routes/admin/managed-systems.tsx`, `apps/frontend/src/routes/admin/analytics-areas.tsx`, `apps/frontend/src/routes/login.tsx`, `apps/frontend/src/routes/index.tsx` and any other route file referencing token classes — grep first, build rename map, then apply.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:83:- Create: `apps/frontend/src/__tests__/token-class-coverage.test.ts` — grep/scan `.tsx` class strings and assert no `text|border|bg|ring|fill|stroke` token class references a Tailwind theme key that is not resolvable via `resolveConfig`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:84:- Modify: `apps/frontend/src/styles.css` — keep `@import "@fops/ui/styles/tokens.css"` + `semantic.css` + tailwind directives.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:90:  `grep -rn '\(text\|border\|bg\|ring\|fill\|stroke\)-\(status\|surface\|accent\|severity\|reporter\|internal\|confidence\|focus\)-' apps/frontend/src/`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:112:# apps/frontend — app-level deps only
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:123:**TipTap deps belong in packages/ui (not apps/frontend):**
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:124:TipTap React bindings live in `packages/ui` because RichEditor is a shared component. `apps/frontend` gets them transitively via `@fops/ui`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:130:# apps/frontend does NOT directly install @tiptap/* — consumed via @fops/ui
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:137:- Modify: `apps/frontend/src/features/admin/permissions/request-access-button.tsx:115` — `variant="primary"` → `variant="default"` (or leave with primary alias).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:158:- (existing) `apps/frontend/src/components-test-pickers.test.tsx` — must pass unchanged.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:161:- Read first: `packages/ui/src/components/{ManagedSystemPicker,AnalyticsAreaPicker}.tsx`, `apps/frontend/src/components-test-pickers.test.tsx`, `docs/frontend/specs/voc.md` §3.4.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:181:- Create: `apps/frontend/src/routes/dev-rich-editor.tsx` — temporary demo route (keep behind `import.meta.env.DEV` guard or delete in Final). Renders RichEditor + RichContentRenderer side by side, with surface picker + mode toggle.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:189:- Constraint: `@tiptap/react` lives in `packages/ui` — do NOT install it in `apps/frontend`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:190:- Constraint: keep `apps/frontend/src/routes/dev-rich-editor.tsx` available after C2 so C3 can validate sanitizer-fail toast flow against the demo route; C5 may delete it only if no later checkpoint needs it.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:201:**Goal:** `<Toaster>` mounted in `__root.tsx`. `apiClient`, `errorMapper`, `useIdempotencyKey` land in `apps/frontend/src/lib/api/`. ALL codes in `ERROR_CODES` from `@fops/shared` covered with Korean copy and tone classification.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:204:- Create: `apps/frontend/src/lib/api/errorMapper.ts` — maps `{ code, detail }` to `{ tone: 'error'|'warning'|'info', message: string, action?: { label, run } }`. **Catalog is generated by iterating `ERROR_CODES` from `@fops/shared`** — no manually typed list. Every code must map to a non-empty Korean message. Export `GENERIC_ERROR_MESSAGE = '일시적 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.'` so tests compare to the fallback constant directly. Fallback for unknown codes: `{ tone: 'error', message: GENERIC_ERROR_MESSAGE }`. Tone per category: `auth.*` → `error`, `permission.*` → `error`, `rate_limited.*` → `warning`, `validation.*` → `error`, `conflict.*` → `error` (except `conflict.stale_write` → `warning` with retry action), `not_found.*` → `error`, `internal.*` → `error`, `voc.*` → `error`, `rich_content.*` → `error`, `attachment.*` → `warning`, `reporter_facing_status.*` → `warning`. Required codes at minimum (from `packages/shared/src/errors/codes.ts`): `auth.session_invalid`, `auth.session_required`, `auth.session_expired`, `auth.workspace_mismatch`, `permission.denied`, `rate_limited.actor`, `rate_limited.ip`, `validation.failed`, `validation.malformed_request`, `validation.unknown_capability`, `conflict.idempotency_key_reuse`, `conflict.capability_already_granted`, `conflict.permission_request_duplicate`, `validation.malformed_idempotency_key`, `validation.sensitive_reason_required`, `validation.immutable_field`, `conflict.duplicate_slug`, `conflict.parent_archived`, `conflict.record_archived`, `not_found.record`, `internal.unexpected`, `voc.severity_not_user_settable`, `validation.unexpected_field`, `rich_content.disallowed_node`, `rich_content.external_image_forbidden`, `attachment.unsupported_pending_storage_slice`, `conflict.stale_write`, `voc.reporter_status_via_public_update_only`, `permission.scope_required`, `reporter_facing_status.invalid_transition`, `reporter_facing_status.gate_blocked`, `conflict.triage_already_committed`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:205:- Create: `apps/frontend/src/lib/api/client.ts` — `apiClient(method, path, { body?, idempotencyKey?, ifMatch?, signal? })`. Auto-mint Idempotency-Key UUIDv4 on POST/PATCH/DELETE when not supplied. Attach `Authorization` from session store. Parse JSON. Non-2xx → throw `ApiError extends Error { code, detail, status, requestId }`. 304 → return `{ status: 304, etag }`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:206:- Create: `apps/frontend/src/lib/api/useIdempotencyKey.ts` — `useIdempotencyKey(ifMatchEtag?: string)`. Returns stable UUIDv4 per render-tree until consumed; `markConsumed()` mints fresh. **When `ifMatchEtag` changes value, the hook MUST automatically mint a fresh UUIDv4** — this prevents `conflict.idempotency_key_reuse` after a stale-write refetch (BE includes `ifMatch` in the idempotency hash per `apps/backend/src/modules/voc/routes.ts:225`, so a retry with a new `If-Match` value is a semantically different request that needs a new key).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:207:- Create: `apps/frontend/src/lib/api/types.ts` — `ApiErrorEnvelope` matching BE `errors/envelope.ts`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:208:- Modify: `apps/frontend/src/routes/__root.tsx` — mount `<Toaster position="bottom-center" />` from `sonner`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:209:- Create: `apps/frontend/src/lib/api/__tests__/errorMapper.test.ts` — **iterate `ERROR_CODES` from `@fops/shared` and assert each maps to a non-empty Korean message** (not a manual catalog). This test auto-covers new codes added to `codes.ts` without test update. Locked assertions: (1) every `ERROR_CODES` mapping has `tone` in literal set `{ 'error', 'warning', 'info' }`; (2) every code with prefix/member in `{ voc.*, rich_content.*, attachment.*, reporter_facing_status.*, conflict.stale_write, conflict.triage_already_committed, conflict.idempotency_key_reuse }` has Korean message not equal to exported `GENERIC_ERROR_MESSAGE`; (3) `conflict.stale_write` maps to `{ tone: 'warning', action: { label: <not undefined>, run: <fn> } }`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:210:- Create: `apps/frontend/src/lib/api/__tests__/client.test.ts` — mock fetch: POST mints Idempotency-Key, GET omits, Authorization attached, 422 throws ApiError, 304 returns ETag. Add test case: same `useIdempotencyKey` instance + changed `ifMatchEtag` → new key minted automatically.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:219:**CHECKPOINT 2.5** — playground HTML demonstrating: Toaster tones + Korean copy for 3+ representative codes (`conflict.stale_write` warning + retry action, `permission.denied` error, `rate_limited.ip` warning) + RichEditor demo rendering sanitizer-rejected content with toast surfaced via apiClient mock. Requires C2 `/dev-rich-editor` route to still exist when C3 lands. AskUserQuestion: "토스트 UX + 에러 메시지 OK?"
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:256:## C4b — AppFrame in apps/frontend + useFullscreenPanel hook
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:258:**Goal:** `<AppFrame>` in `apps/frontend/src/lib/layout/` composes Rail(52) + Sidebar(240/56) + (shell outlet) + the single global DetailPanelSlot(440). AppFrame consumes one of the 3 shells as its inner outlet. It is NOT exported as a shell — it is the authenticated route frame. `useFullscreenPanel` hook ready for #20 to consume.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:263:- Create: `apps/frontend/src/lib/layout/AppFrame.tsx` — flex row Rail(52) + Sidebar(240/56) + Main(flex-1, shell outlet) + DetailPanelSlot(440 conditional). Headers conform to 50px rhythm via ShellHeader from `packages/ui`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:264:- Create: `apps/frontend/src/lib/layout/AppRail.tsx` — 52px vertical, workspace switcher placeholder + lucide-react utility icons.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:265:- Create: `apps/frontend/src/lib/layout/AppSidebar.tsx` — 240px nav list. Slice 3 entries: Inbox, My VOCs, Triage, + New VOC. Collapse state uses SSR-safe initializer:
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:273:- Create: `apps/frontend/src/lib/layout/DetailPanelSlot.tsx` — fixed 440 right column. min 360 / max 520. Hidden when no content registered via `useDetailPanelSlot()`. This is the single rendering surface for all shell `detailPanel` content.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:274:- Create: `apps/frontend/src/lib/layout/useDetailPanelSlot.ts` — context-based slot register/clear hook. Forbid multiple registrants: throw in dev (and warn in prod) if called twice with overlapping lifetimes, using a ref to track active ownership.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:275:- Create: `apps/frontend/src/lib/panel/useFullscreenPanel.ts` — `[isFullscreen, toggle]`. Esc collapses. Route change clears.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:276:- Create: `apps/frontend/src/lib/layout/__tests__/AppFrame.test.tsx` — Rail/Sidebar/Main present; sidebar first-paint width matches stored `localStorage.appSidebarCollapsed` before any user interaction; sidebar collapse toggle writes localStorage; DetailPanelSlot collapses when empty; multiple overlapping `useDetailPanelSlot()` registrants throw/warn.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:277:- Create: `apps/frontend/src/lib/panel/__tests__/useFullscreenPanel.test.tsx` — toggle flips boolean; Esc dispatches collapse; route change clears (mock router).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:283:- Constraint: AppFrame is NOT exported from `packages/ui` — it lives in `apps/frontend/src/lib/layout/` only.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:296:- `apps/frontend/src/routes/_authed.tsx` — new TanStack pathless layout route. Includes a `beforeLoad` callback that calls `fetchMe()` (same auth pattern currently used in admin routes) and `redirect({ to: '/login' })` on `UnauthenticatedError`. Wraps children with `<AppFrame>`. Login + non-authed routes do NOT use this layout and do NOT render AppFrame.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:297:- Per-route auth guards in admin pages are DELETED in C5 after `_authed.beforeLoad` centralizes the guard.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:299:  - `apps/frontend/src/routes/admin/managed-systems.tsx` → `apps/frontend/src/routes/_authed/admin/managed-systems.tsx`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:300:  - `apps/frontend/src/routes/admin/analytics-areas.tsx` → `apps/frontend/src/routes/_authed/admin/analytics-areas.tsx`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:301:  - `apps/frontend/src/routes/admin/placeholder.tsx` → `apps/frontend/src/routes/_authed/admin/placeholder.tsx`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:302:  - Test file imports updated: `apps/frontend/src/routes/admin/*.test.tsx` move alongside their routes.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:305:- `/vocs` route file = `apps/frontend/src/routes/_authed/vocs.tsx`. Public path string is `/vocs`; `_authed` is pathless. Per-view shell selection: `view=inbox|my` → `<ListShell>`, `view=triage` → `<WorkbenchShell>`, `action=create` → `<PageShell>` (default when no view/action = `<ListShell>`).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:309:- Create: `apps/frontend/src/routes/_authed.tsx` — TanStack layout route. `beforeLoad` calls `fetchMe()` and redirects unauthenticated users to `/login`; renders `<AppFrame><Outlet /></AppFrame>`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:310:- Create: `apps/frontend/src/routes/_authed/vocs.tsx` — `createFileRoute('/_authed/vocs')` with validateSearch zod. Component selects shell based on `view`/`action`. Main = placeholder text.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:311:- Modify: `apps/frontend/src/routes/__root.tsx` — minimal; providers + `<Outlet>` only (no AppFrame).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:312:- Move: `apps/frontend/src/routes/admin/managed-systems.tsx` → `apps/frontend/src/routes/_authed/admin/managed-systems.tsx`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:313:- Move: `apps/frontend/src/routes/admin/analytics-areas.tsx` → `apps/frontend/src/routes/_authed/admin/analytics-areas.tsx`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:314:- Move: `apps/frontend/src/routes/admin/placeholder.tsx` → `apps/frontend/src/routes/_authed/admin/placeholder.tsx`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:315:- Move: `apps/frontend/src/routes/admin/*.test.tsx` → alongside relocated `_authed/admin/*` routes; update imports.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:317:- Auto-regen: `apps/frontend/src/routeTree.gen.ts` (TanStackRouterVite plugin handles on dev).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:318:- Create: `apps/frontend/src/routes/__tests__/vocs.test.tsx` — navigating to `/vocs?view=inbox` resolves; invalid `?view=foo` rejected by zod; sidebar `+ New VOC` href = `/vocs?action=create`; `view=triage` renders WorkbenchShell.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:319:- Delete: `apps/frontend/src/routes/dev-rich-editor.tsx` IF it was added in C2 and is no longer needed (or keep behind DEV flag).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:334:- Read first: `apps/frontend/src/routes/__root.tsx`, `apps/frontend/vite.config.ts`, `apps/frontend/src/routes/admin/managed-systems.tsx` (existing TanStack file-route pattern), `apps/frontend/src/lib/layout/AppFrame.tsx` (just created in C4b), `packages/ui/src/layout/` (shells).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:337:- Constraint: no `Route.id` navigation. Run `grep -rn 'Route\\.id\\|from: .*Route\\.id\\|to: .*Route\\.id' apps/frontend/src/` and refactor any hits to literal `to:` path strings.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:370:- Sonnet dispatches read AGENTS.md hierarchy first (`apps/frontend/AGENTS.md` mandatory).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:375:- **AppFrame in `apps/frontend` NEVER becomes a 4th exported shell. Shell taxonomy = 3 (PageShell/ListShell/WorkbenchShell) per ADR-0020.**
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN.md:391:- `@tiptap/react` in `packages/ui` — verify `apps/frontend` resolves it transitively via workspace link without explicit install; if pnpm strict-mode blocks it, add a peer dep declaration.
+.review/CHUNK-5-DEVIATIONS.md:28:   - **Description:** Initial `useCallback` approach for `getDraft` had a stale closure risk. Resolved by returning a direct function reference `(surface) => state[surface]` with `[state]` dependency, which is equivalent and cleaner.
+.review/CHUNK-5-DEVIATIONS.md:75:**Files modified:** `apps/frontend/src/features/voc/components/detail/ComposerSection.tsx`, `apps/frontend/src/features/voc/components/detail/__tests__/ComposerSection.test.tsx` (stub RichEditor now emits onChange on click so the new derivation lights up).
+.review/CHUNK-5-DEVIATIONS.md:77:**RED → GREEN test:** `apps/frontend/src/features/voc/components/detail/__tests__/ComposerDirtyKeyboard.test.tsx` — keyboard typing (no container click) triggers DirtyConfirmation; empty drafts allow direct close.
+.review/CHUNK-5-DEVIATIONS.md:89:**Files modified:** `apps/frontend/src/features/voc/hooks/useComposerDraft.ts`.
+.review/CHUNK-5-DEVIATIONS.md:91:**RED → GREEN test:** `apps/frontend/src/features/voc/hooks/__tests__/useComposerDraft.vocSwitchRace.test.tsx` — uses a child component that records `draft.state.public` synchronously inside its render function and asserts null on every render after the vocId switch.
+.review/CHUNK-5-DEVIATIONS.md:105:- Net effect: submit success (which sets the parent draft to `null`) and VOC switch (which resets per-VOC draft to `null`) left stale body text visible in the composer editor.
+.review/CHUNK-5-DEVIATIONS.md:112:**Files modified:** `packages/ui/src/rich-content/RichEditor.tsx`, `apps/frontend/src/features/voc/components/detail/PublicUpdateComposer.tsx`, `apps/frontend/src/features/voc/components/detail/ReporterReplyComposer.tsx`, `apps/frontend/src/features/voc/components/detail/InternalCommentComposer.tsx`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:26:7. `apps/frontend/src/routes/admin/managed-systems.tsx` + `admin/analytics-areas.tsx` + `login.tsx` (token classnames referenced per P1-B — grep for `text-status-*`, `border-surface-*`, `bg-surface-*`)
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:28:9. `apps/frontend/src/routes/__root.tsx` (current root layout per P1-C)
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:55:  - Modify: `apps/frontend/src/routes/admin/managed-systems.tsx`, `apps/frontend/src/routes/admin/analytics-areas.tsx`, `apps/frontend/src/routes/login.tsx`, `apps/frontend/src/routes/index.tsx` (and any other route file referencing token classes — grep first).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:56:  - Audit step before tokens port: `grep -rn '\(text\|border\|bg\|ring\|fill\|stroke\)-\(status\|surface\|accent\|severity\|reporter\|internal\|confidence\|focus\)-' apps/frontend/src/` → build rename map → apply.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:60:- Add grep-assertion test to C1a verification: assert no `.tsx` references a class whose Tailwind theme key is not resolvable via `resolveConfig`. Place in `apps/frontend/src/__tests__/token-class-coverage.test.ts` OR in `packages/ui` if it can scan apps/frontend.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:64:  1. `apps/frontend/src/routes/_authed.tsx` includes a `beforeLoad` callback that calls `fetchMe()` (existing pattern in admin routes) and `redirect({ to: '/login' })` on `UnauthenticatedError`. Per-route auth guards in admin pages are DELETED in C5.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:66:     - `apps/frontend/src/routes/admin/managed-systems.tsx` → `apps/frontend/src/routes/_authed/admin/managed-systems.tsx`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:67:     - `apps/frontend/src/routes/admin/analytics-areas.tsx` → `apps/frontend/src/routes/_authed/admin/analytics-areas.tsx`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:68:     - `apps/frontend/src/routes/admin/placeholder.tsx` → `apps/frontend/src/routes/_authed/admin/placeholder.tsx`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:69:     - Test file imports updated: `apps/frontend/src/routes/admin/*.test.tsx` move alongside their routes.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:71:  3. `apps/frontend/src/routes/login.tsx` stays at current location (sibling of `_authed.tsx`, outside the layout).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:86:  2. For every code with prefix in `{voc.*, rich_content.*, attachment.*, reporter_facing_status.*, conflict.stale_write, conflict.triage_already_committed, conflict.idempotency_key_reuse}`: Korean message is NOT the generic fallback string.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:87:  3. `conflict.stale_write` specifically maps to `{tone: 'warning', action: {label: <not undefined>, run: <fn>}}`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:243:277:      {type:'create', path:'apps/frontend/src/routes/_authed.tsx  // layout route: <AppFrame><Outlet/></AppFrame>'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:244:278:      {type:'create', path:'apps/frontend/src/routes/_authed/vocs.tsx  // shell selection per view/action'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:245:280:      {type:'modify', path:'apps/frontend/src/routes/admin/  // re-parent under _authed as PageShell (or file follow-up)'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:277:93:# apps/frontend — app-level deps only
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:280:111:# apps/frontend does NOT directly install @tiptap/* — consumed via @fops/ui
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:293:199:**CHECKPOINT 2.5** — small playground demonstrating: Toaster position (bottom-center), tone variants (success / error / warning / info) with Korean copy, at least 3 representative error codes rendered as toasts (`conflict.stale_write` warning + retry action, `permission.denied` error, `rate_limited.ip` warning). AskUserQuestion: "토스트 UX + 에러 메시지 OK?"
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:298:233:## C4b — AppFrame in apps/frontend + useFullscreenPanel hook
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:337:- ADR-0020 taxonomy enforced: `packages/ui/src/layout/` exports exactly 3 shells (PageShell, ListShell, WorkbenchShell). AppFrame in `apps/frontend/src/lib/layout/` is NOT a 4th shell.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:391:- Modify: `apps/frontend/src/styles.css` — keep `@import "@fops/ui/styles/tokens.css"` + `semantic.css` + tailwind directives.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:416:# apps/frontend — app-level deps only
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:427:**TipTap deps belong in packages/ui (not apps/frontend):**
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:428:TipTap React bindings live in `packages/ui` because RichEditor is a shared component. `apps/frontend` gets them transitively via `@fops/ui`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:434:# apps/frontend does NOT directly install @tiptap/* — consumed via @fops/ui
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:441:- Modify: `apps/frontend/src/features/admin/permissions/request-access-button.tsx:115` — `variant="primary"` → `variant="default"` (or leave with primary alias).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:462:- (existing) `apps/frontend/src/components-test-pickers.test.tsx` — must pass unchanged.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:468:- Read first: `packages/ui/src/components/{ManagedSystemPicker,AnalyticsAreaPicker}.tsx`, `apps/frontend/src/components-test-pickers.test.tsx`, `docs/frontend/specs/voc.md` §3.4.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:488:- Create: `apps/frontend/src/routes/dev-rich-editor.tsx` — temporary demo route (keep behind `import.meta.env.DEV` guard or delete in Final). Renders RichEditor + RichContentRenderer side by side, with surface picker + mode toggle.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:496:- Constraint: `@tiptap/react` lives in `packages/ui` — do NOT install it in `apps/frontend`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:507:**Goal:** `<Toaster>` mounted in `__root.tsx`. `apiClient`, `errorMapper`, `useIdempotencyKey` land in `apps/frontend/src/lib/api/`. ALL codes in `ERROR_CODES` from `@fops/shared` covered with Korean copy and tone classification.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:510:- Create: `apps/frontend/src/lib/api/errorMapper.ts` — maps `{ code, detail }` to `{ tone: 'error'|'warning'|'info', message: string, action?: { label, run } }`. **Catalog is generated by iterating `ERROR_CODES` from `@fops/shared`** — no manually typed list. Every code must map to a non-empty Korean message. Fallback for unknown codes: `{ tone: 'error', message: '일시적 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.' }`. Tone per category: `auth.*` → `error`, `permission.*` → `error`, `rate_limited.*` → `warning`, `validation.*` → `error`, `conflict.*` → `error` (except `conflict.stale_write` → `warning` with retry action), `not_found.*` → `error`, `internal.*` → `error`, `voc.*` → `error`, `rich_content.*` → `error`, `attachment.*` → `warning`, `reporter_facing_status.*` → `warning`. Required codes at minimum (from `packages/shared/src/errors/codes.ts`): `auth.session_invalid`, `auth.session_required`, `auth.session_expired`, `auth.workspace_mismatch`, `permission.denied`, `rate_limited.actor`, `rate_limited.ip`, `validation.failed`, `validation.malformed_request`, `validation.unknown_capability`, `conflict.idempotency_key_reuse`, `conflict.capability_already_granted`, `conflict.permission_request_duplicate`, `validation.malformed_idempotency_key`, `validation.sensitive_reason_required`, `validation.immutable_field`, `conflict.duplicate_slug`, `conflict.parent_archived`, `conflict.record_archived`, `not_found.record`, `internal.unexpected`, `voc.severity_not_user_settable`, `validation.unexpected_field`, `rich_content.disallowed_node`, `rich_content.external_image_forbidden`, `attachment.unsupported_pending_storage_slice`, `conflict.stale_write`, `voc.reporter_status_via_public_update_only`, `permission.scope_required`, `reporter_facing_status.invalid_transition`, `reporter_facing_status.gate_blocked`, `conflict.triage_already_committed`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:511:- Create: `apps/frontend/src/lib/api/client.ts` — `apiClient(method, path, { body?, idempotencyKey?, ifMatch?, signal? })`. Auto-mint Idempotency-Key UUIDv4 on POST/PATCH/DELETE when not supplied. Attach `Authorization` from session store. Parse JSON. Non-2xx → throw `ApiError extends Error { code, detail, status, requestId }`. 304 → return `{ status: 304, etag }`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:512:- Create: `apps/frontend/src/lib/api/useIdempotencyKey.ts` — `useIdempotencyKey(ifMatchEtag?: string)`. Returns stable UUIDv4 per render-tree until consumed; `markConsumed()` mints fresh. **When `ifMatchEtag` changes value, the hook MUST automatically mint a fresh UUIDv4** — this prevents `conflict.idempotency_key_reuse` after a stale-write refetch (BE includes `ifMatch` in the idempotency hash per `apps/backend/src/modules/voc/routes.ts:225`, so a retry with a new `If-Match` value is a semantically different request that needs a new key).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:513:- Create: `apps/frontend/src/lib/api/types.ts` — `ApiErrorEnvelope` matching BE `errors/envelope.ts`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:514:- Modify: `apps/frontend/src/routes/__root.tsx` — mount `<Toaster position="bottom-center" />` from `sonner`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:515:- Create: `apps/frontend/src/lib/api/__tests__/errorMapper.test.ts` — **iterate `ERROR_CODES` from `@fops/shared` and assert each maps to a non-empty Korean message** (not a manual catalog). This test auto-covers new codes added to `codes.ts` without test update.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:516:- Create: `apps/frontend/src/lib/api/__tests__/client.test.ts` — mock fetch: POST mints Idempotency-Key, GET omits, Authorization attached, 422 throws ApiError, 304 returns ETag. Add test case: same `useIdempotencyKey` instance + changed `ifMatchEtag` → new key minted automatically.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:525:**CHECKPOINT 2.5** — small playground demonstrating: Toaster position (bottom-center), tone variants (success / error / warning / info) with Korean copy, at least 3 representative error codes rendered as toasts (`conflict.stale_write` warning + retry action, `permission.denied` error, `rate_limited.ip` warning). AskUserQuestion: "토스트 UX + 에러 메시지 OK?"
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:559:## C4b — AppFrame in apps/frontend + useFullscreenPanel hook
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:561:**Goal:** `<AppFrame>` in `apps/frontend/src/lib/layout/` composes Rail(52) + Sidebar(240/56) + (shell outlet) + DetailPanelSlot(440). AppFrame consumes one of the 3 shells as its inner outlet. It is NOT exported as a shell — it is the authenticated route frame. `useFullscreenPanel` hook ready for #20 to consume.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:566:- Create: `apps/frontend/src/lib/layout/AppFrame.tsx` — flex row Rail(52) + Sidebar(240/56) + Main(flex-1, shell outlet) + DetailPanelSlot(440 conditional). Headers conform to 50px rhythm via ShellHeader from `packages/ui`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:581:- Create: `apps/frontend/src/lib/layout/AppFrame.tsx` — flex row Rail(52) + Sidebar(240/56) + Main(flex-1, shell outlet) + DetailPanelSlot(440 conditional). Headers conform to 50px rhythm via ShellHeader from `packages/ui`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:582:- Create: `apps/frontend/src/lib/layout/AppRail.tsx` — 52px vertical, workspace switcher placeholder + lucide-react utility icons.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:583:- Create: `apps/frontend/src/lib/layout/AppSidebar.tsx` — 240px nav list. Slice 3 entries: Inbox, My VOCs, Triage, + New VOC. Collapse button writes `localStorage.appSidebarCollapsed`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:584:- Create: `apps/frontend/src/lib/layout/DetailPanelSlot.tsx` — fixed 440 right column. min 360 / max 520. Hidden when no content registered via `useDetailPanelSlot()`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:585:- Create: `apps/frontend/src/lib/layout/useDetailPanelSlot.ts` — context-based slot register/clear hook.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:586:- Create: `apps/frontend/src/lib/panel/useFullscreenPanel.ts` — `[isFullscreen, toggle]`. Esc collapses. Route change clears.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:587:- Create: `apps/frontend/src/lib/layout/__tests__/AppFrame.test.tsx` — Rail/Sidebar/Main present; sidebar collapse toggle writes localStorage; DetailPanelSlot collapses when empty.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:588:- Create: `apps/frontend/src/lib/panel/__tests__/useFullscreenPanel.test.tsx` — toggle flips boolean; Esc dispatches collapse; route change clears (mock router).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:594:- Constraint: AppFrame is NOT exported from `packages/ui` — it lives in `apps/frontend/src/lib/layout/` only.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:606:- `apps/frontend/src/routes/_authed.tsx` — new TanStack layout route. Wraps children with `<AppFrame>`. Login + non-authed routes do NOT use this layout and do NOT render AppFrame.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:609:- `/vocs` route = `apps/frontend/src/routes/_authed/vocs.tsx`. Per-view shell selection: `view=inbox|my` → `<ListShell>`, `view=triage` → `<WorkbenchShell>`, `action=create` → `<PageShell>` (default when no view/action = `<ListShell>`).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:612:- Create: `apps/frontend/src/routes/_authed.tsx` — TanStack layout route. Renders `<AppFrame><Outlet /></AppFrame>`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:613:- Create: `apps/frontend/src/routes/_authed/vocs.tsx` — `createFileRoute('/_authed/vocs')` with validateSearch zod. Component selects shell based on `view`/`action`. Main = placeholder text.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:614:- Modify: `apps/frontend/src/routes/__root.tsx` — minimal; providers + `<Outlet>` only (no AppFrame).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:615:- Relocate or re-parent: `apps/frontend/src/routes/admin/` — move under `_authed` so admin pages get AppFrame. If not done in C5, create a follow-up GitHub issue before closing this chunk.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:616:- Auto-regen: `apps/frontend/src/routeTree.gen.ts` (TanStackRouterVite plugin handles on dev).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:617:- Create: `apps/frontend/src/routes/__tests__/vocs.test.tsx` — navigating to `/_authed/vocs?view=inbox` resolves; invalid `?view=foo` rejected by zod; sidebar `+ New VOC` href = `/_authed/vocs?action=create`; `view=triage` renders WorkbenchShell.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:618:- Delete: `apps/frontend/src/routes/dev-rich-editor.tsx` IF it was added in C2 and is no longer needed (or keep behind DEV flag).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:633:- Read first: `apps/frontend/src/routes/__root.tsx`, `apps/frontend/vite.config.ts`, `apps/frontend/src/routes/admin/managed-systems.tsx` (existing TanStack file-route pattern), `apps/frontend/src/lib/layout/AppFrame.tsx` (just created in C4b), `packages/ui/src/layout/` (shells).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:668:- Sonnet dispatches read AGENTS.md hierarchy first (`apps/frontend/AGENTS.md` mandatory).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:671:- **AppFrame in `apps/frontend` NEVER becomes a 4th exported shell. Shell taxonomy = 3 (PageShell/ListShell/WorkbenchShell) per ADR-0020.**
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:686:- `@tiptap/react` in `packages/ui` — verify `apps/frontend` resolves it transitively via workspace link without explicit install; if pnpm strict-mode blocks it, add a peer dep declaration.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:745:      {type:'modify', path:'apps/frontend/src/styles.css  // @import tokens.css + semantic.css'}
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:760:      {type:'modify', path:'apps/frontend/src/features/admin/permissions/request-access-button.tsx:115  // variant primary→default'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:766:# apps/frontend — app-level only; NO direct @tiptap/* (consumed via @fops/ui)
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:788:    goal:'<RichEditor> + <RichContentRenderer> + attachmentRef + mention. Demo route on dev-only. reporter_visible strips mentions. No @tiptap/* in apps/frontend.',
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:794:      {type:'create', path:'apps/frontend/src/routes/dev-rich-editor.tsx  // DEV-only demo'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:798:    dispatch:'Sonnet. Read rich-editor.jsx + ADR-0011 + BE sanitizer.ts. Constraints: surface = opaque pass-through; StarterKit image:false; demo = local state only; @tiptap/* must NOT be installed in apps/frontend.',
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:807:      {type:'create', path:'apps/frontend/src/lib/api/{client,errorMapper,useIdempotencyKey,types}.ts'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:808:      {type:'modify', path:'apps/frontend/src/routes/__root.tsx  // <Toaster position="bottom-center"/>'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:809:      {type:'create', path:'apps/frontend/src/lib/api/__tests__/{errorMapper,client}.test.ts'}
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:836:    goal:'AppFrame in apps/frontend/src/lib/layout/ composes Rail+Sidebar+shell outlet+DetailPanelSlot. NOT a 4th shell — app-internal only. useFullscreenPanel hook.',
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:838:      {type:'create', path:'apps/frontend/src/lib/layout/AppFrame.tsx  // NOT exported as shell; wraps one of 3 shells'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:839:      {type:'create', path:'apps/frontend/src/lib/layout/AppRail.tsx'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:840:      {type:'create', path:'apps/frontend/src/lib/layout/AppSidebar.tsx  // collapse→localStorage'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:841:      {type:'create', path:'apps/frontend/src/lib/layout/DetailPanelSlot.tsx  // 440px, min 360, max 520'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:842:      {type:'create', path:'apps/frontend/src/lib/layout/useDetailPanelSlot.ts'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:843:      {type:'create', path:'apps/frontend/src/lib/panel/useFullscreenPanel.ts  // Esc collapses, route change clears'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:844:      {type:'create', path:'apps/frontend/src/lib/layout/__tests__/AppFrame.test.tsx'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:845:      {type:'create', path:'apps/frontend/src/lib/panel/__tests__/useFullscreenPanel.test.tsx'}
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:857:      {type:'create', path:'apps/frontend/src/routes/_authed.tsx  // layout route: <AppFrame><Outlet/></AppFrame>'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:858:      {type:'create', path:'apps/frontend/src/routes/_authed/vocs.tsx  // shell selection per view/action'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:859:      {type:'modify', path:'apps/frontend/src/routes/__root.tsx  // minimal: providers + <Outlet> only'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:860:      {type:'modify', path:'apps/frontend/src/routes/admin/  // re-parent under _authed as PageShell (or file follow-up)'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:861:      {type:'create', path:'apps/frontend/src/routes/__tests__/vocs.test.tsx  // shell per view + login NOT in AppFrame'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:862:      {type:'delete', path:'apps/frontend/src/routes/dev-rich-editor.tsx  // if not kept behind DEV flag'}
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:925: - ADR-0020 taxonomy enforced: `packages/ui/src/layout/` exports exactly 3 shells (PageShell, ListShell, WorkbenchShell). AppFrame in `apps/frontend/src/lib/layout/` is NOT a 4th shell.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:976:+- Modify/audit: `apps/frontend/src/routes/admin/managed-systems.tsx`, `apps/frontend/src/routes/admin/analytics-areas.tsx`, `apps/frontend/src/routes/login.tsx`, `apps/frontend/src/routes/index.tsx` and any other route file referencing token classes — grep first, build rename map, then apply.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:977:+- Create: `apps/frontend/src/__tests__/token-class-coverage.test.ts` — grep/scan `.tsx` class strings and assert no `text|border|bg|ring|fill|stroke` token class references a Tailwind theme key that is not resolvable via `resolveConfig`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:978: - Modify: `apps/frontend/src/styles.css` — keep `@import "@fops/ui/styles/tokens.css"` + `semantic.css` + tailwind directives.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:984:+  `grep -rn '\(text\|border\|bg\|ring\|fill\|stroke\)-\(status\|surface\|accent\|severity\|reporter\|internal\|confidence\|focus\)-' apps/frontend/src/`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1028: - Modify: `apps/frontend/src/features/admin/permissions/request-access-button.tsx:115` — `variant="primary"` → `variant="default"` (or leave with primary alias).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1068: - ADR-0020 taxonomy enforced: `packages/ui/src/layout/` exports exactly 3 shells (PageShell, ListShell, WorkbenchShell). AppFrame in `apps/frontend/src/lib/layout/` is NOT a 4th shell.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1119:+- Modify/audit: `apps/frontend/src/routes/admin/managed-systems.tsx`, `apps/frontend/src/routes/admin/analytics-areas.tsx`, `apps/frontend/src/routes/login.tsx`, `apps/frontend/src/routes/index.tsx` and any other route file referencing token classes — grep first, build rename map, then apply.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1120:+- Create: `apps/frontend/src/__tests__/token-class-coverage.test.ts` — grep/scan `.tsx` class strings and assert no `text|border|bg|ring|fill|stroke` token class references a Tailwind theme key that is not resolvable via `resolveConfig`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1121: - Modify: `apps/frontend/src/styles.css` — keep `@import "@fops/ui/styles/tokens.css"` + `semantic.css` + tailwind directives.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1127:+  `grep -rn '\(text\|border\|bg\|ring\|fill\|stroke\)-\(status\|surface\|accent\|severity\|reporter\|internal\|confidence\|focus\)-' apps/frontend/src/`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1171: - Modify: `apps/frontend/src/features/admin/permissions/request-access-button.tsx:115` — `variant="primary"` → `variant="default"` (or leave with primary alias).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1214: - ADR-0020 taxonomy enforced: `packages/ui/src/layout/` exports exactly 3 shells (PageShell, ListShell, WorkbenchShell). AppFrame in `apps/frontend/src/lib/layout/` is NOT a 4th shell.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1265:+- Modify/audit: `apps/frontend/src/routes/admin/managed-systems.tsx`, `apps/frontend/src/routes/admin/analytics-areas.tsx`, `apps/frontend/src/routes/login.tsx`, `apps/frontend/src/routes/index.tsx` and any other route file referencing token classes — grep first, build rename map, then apply.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1266:+- Create: `apps/frontend/src/__tests__/token-class-coverage.test.ts` — grep/scan `.tsx` class strings and assert no `text|border|bg|ring|fill|stroke` token class references a Tailwind theme key that is not resolvable via `resolveConfig`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1267: - Modify: `apps/frontend/src/styles.css` — keep `@import "@fops/ui/styles/tokens.css"` + `semantic.css` + tailwind directives.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1273:+  `grep -rn '\(text\|border\|bg\|ring\|fill\|stroke\)-\(status\|surface\|accent\|severity\|reporter\|internal\|confidence\|focus\)-' apps/frontend/src/`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1317: - Modify: `apps/frontend/src/features/admin/permissions/request-access-button.tsx:115` — `variant="primary"` → `variant="default"` (or leave with primary alias).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1337: - Constraint: `@tiptap/react` lives in `packages/ui` — do NOT install it in `apps/frontend`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1339:+- Constraint: keep `apps/frontend/src/routes/dev-rich-editor.tsx` available after C2 so C3 can validate sanitizer-fail toast flow against the demo route; C5 may delete it only if no later checkpoint needs it.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1345: **Goal:** `<Toaster>` mounted in `__root.tsx`. `apiClient`, `errorMapper`, `useIdempotencyKey` land in `apps/frontend/src/lib/api/`. ALL codes in `ERROR_CODES` from `@fops/shared` covered with Korean copy and tone classification.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1348:-- Create: `apps/frontend/src/lib/api/errorMapper.ts` — maps `{ code, detail }` to `{ tone: 'error'|'warning'|'info', message: string, action?: { label, run } }`. **Catalog is generated by iterating `ERROR_CODES` from `@fops/shared`** — no manually typed list. Every code must map to a non-empty Korean message. Fallback for unknown codes: `{ tone: 'error', message: '일시적 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.' }`. Tone per category: `auth.*` → `error`, `permission.*` → `error`, `rate_limited.*` → `warning`, `validation.*` → `error`, `conflict.*` → `error` (except `conflict.stale_write` → `warning` with retry action), `not_found.*` → `error`, `internal.*` → `error`, `voc.*` → `error`, `rich_content.*` → `error`, `attachment.*` → `warning`, `reporter_facing_status.*` → `warning`. Required codes at minimum (from `packages/shared/src/errors/codes.ts`): `auth.session_invalid`, `auth.session_required`, `auth.session_expired`, `auth.workspace_mismatch`, `permission.denied`, `rate_limited.actor`, `rate_limited.ip`, `validation.failed`, `validation.malformed_request`, `validation.unknown_capability`, `conflict.idempotency_key_reuse`, `conflict.capability_already_granted`, `conflict.permission_request_duplicate`, `validation.malformed_idempotency_key`, `validation.sensitive_reason_required`, `validation.immutable_field`, `conflict.duplicate_slug`, `conflict.parent_archived`, `conflict.record_archived`, `not_found.record`, `internal.unexpected`, `voc.severity_not_user_settable`, `validation.unexpected_field`, `rich_content.disallowed_node`, `rich_content.external_image_forbidden`, `attachment.unsupported_pending_storage_slice`, `conflict.stale_write`, `voc.reporter_status_via_public_update_only`, `permission.scope_required`, `reporter_facing_status.invalid_transition`, `reporter_facing_status.gate_blocked`, `conflict.triage_already_committed`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1349:+- Create: `apps/frontend/src/lib/api/errorMapper.ts` — maps `{ code, detail }` to `{ tone: 'error'|'warning'|'info', message: string, action?: { label, run } }`. **Catalog is generated by iterating `ERROR_CODES` from `@fops/shared`** — no manually typed list. Every code must map to a non-empty Korean message. Export `GENERIC_ERROR_MESSAGE = '일시적 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.'` so tests compare to the fallback constant directly. Fallback for unknown codes: `{ tone: 'error', message: GENERIC_ERROR_MESSAGE }`. Tone per category: `auth.*` → `error`, `permission.*` → `error`, `rate_limited.*` → `warning`, `validation.*` → `error`, `conflict.*` → `error` (except `conflict.stale_write` → `warning` with retry action), `not_found.*` → `error`, `internal.*` → `error`, `voc.*` → `error`, `rich_content.*` → `error`, `attachment.*` → `warning`, `reporter_facing_status.*` → `warning`. Required codes at minimum (from `packages/shared/src/errors/codes.ts`): `auth.session_invalid`, `auth.session_required`, `auth.session_expired`, `auth.workspace_mismatch`, `permission.denied`, `rate_limited.actor`, `rate_limited.ip`, `validation.failed`, `validation.malformed_request`, `validation.unknown_capability`, `conflict.idempotency_key_reuse`, `conflict.capability_already_granted`, `conflict.permission_request_duplicate`, `validation.malformed_idempotency_key`, `validation.sensitive_reason_required`, `validation.immutable_field`, `conflict.duplicate_slug`, `conflict.parent_archived`, `conflict.record_archived`, `not_found.record`, `internal.unexpected`, `voc.severity_not_user_settable`, `validation.unexpected_field`, `rich_content.disallowed_node`, `rich_content.external_image_forbidden`, `attachment.unsupported_pending_storage_slice`, `conflict.stale_write`, `voc.reporter_status_via_public_update_only`, `permission.scope_required`, `reporter_facing_status.invalid_transition`, `reporter_facing_status.gate_blocked`, `conflict.triage_already_committed`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1350: - Create: `apps/frontend/src/lib/api/client.ts` — `apiClient(method, path, { body?, idempotencyKey?, ifMatch?, signal? })`. Auto-mint Idempotency-Key UUIDv4 on POST/PATCH/DELETE when not supplied. Attach `Authorization` from session store. Parse JSON. Non-2xx → throw `ApiError extends Error { code, detail, status, requestId }`. 304 → return `{ status: 304, etag }`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1351: - Create: `apps/frontend/src/lib/api/useIdempotencyKey.ts` — `useIdempotencyKey(ifMatchEtag?: string)`. Returns stable UUIDv4 per render-tree until consumed; `markConsumed()` mints fresh. **When `ifMatchEtag` changes value, the hook MUST automatically mint a fresh UUIDv4** — this prevents `conflict.idempotency_key_reuse` after a stale-write refetch (BE includes `ifMatch` in the idempotency hash per `apps/backend/src/modules/voc/routes.ts:225`, so a retry with a new `If-Match` value is a semantically different request that needs a new key).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1352: - Create: `apps/frontend/src/lib/api/types.ts` — `ApiErrorEnvelope` matching BE `errors/envelope.ts`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1353: - Modify: `apps/frontend/src/routes/__root.tsx` — mount `<Toaster position="bottom-center" />` from `sonner`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1354:-- Create: `apps/frontend/src/lib/api/__tests__/errorMapper.test.ts` — **iterate `ERROR_CODES` from `@fops/shared` and assert each maps to a non-empty Korean message** (not a manual catalog). This test auto-covers new codes added to `codes.ts` without test update.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1355:+- Create: `apps/frontend/src/lib/api/__tests__/errorMapper.test.ts` — **iterate `ERROR_CODES` from `@fops/shared` and assert each maps to a non-empty Korean message** (not a manual catalog). This test auto-covers new codes added to `codes.ts` without test update. Locked assertions: (1) every `ERROR_CODES` mapping has `tone` in literal set `{ 'error', 'warning', 'info' }`; (2) every code with prefix/member in `{ voc.*, rich_content.*, attachment.*, reporter_facing_status.*, conflict.stale_write, conflict.triage_already_committed, conflict.idempotency_key_reuse }` has Korean message not equal to exported `GENERIC_ERROR_MESSAGE`; (3) `conflict.stale_write` maps to `{ tone: 'warning', action: { label: <not undefined>, run: <fn> } }`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1356: - Create: `apps/frontend/src/lib/api/__tests__/client.test.ts` — mock fetch: POST mints Idempotency-Key, GET omits, Authorization attached, 422 throws ApiError, 304 returns ETag. Add test case: same `useIdempotencyKey` instance + changed `ifMatchEtag` → new key minted automatically.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1363:-**CHECKPOINT 2.5** — small playground demonstrating: Toaster position (bottom-center), tone variants (success / error / warning / info) with Korean copy, at least 3 representative error codes rendered as toasts (`conflict.stale_write` warning + retry action, `permission.denied` error, `rate_limited.ip` warning). AskUserQuestion: "토스트 UX + 에러 메시지 OK?"
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1364:+**CHECKPOINT 2.5** — playground HTML demonstrating: Toaster tones + Korean copy for 3+ representative codes (`conflict.stale_write` warning + retry action, `permission.denied` error, `rate_limited.ip` warning) + RichEditor demo rendering sanitizer-rejected content with toast surfaced via apiClient mock. Requires C2 `/dev-rich-editor` route to still exist when C3 lands. AskUserQuestion: "토스트 UX + 에러 메시지 OK?"
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1393: ## C4b — AppFrame in apps/frontend + useFullscreenPanel hook
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1395:-**Goal:** `<AppFrame>` in `apps/frontend/src/lib/layout/` composes Rail(52) + Sidebar(240/56) + (shell outlet) + DetailPanelSlot(440). AppFrame consumes one of the 3 shells as its inner outlet. It is NOT exported as a shell — it is the authenticated route frame. `useFullscreenPanel` hook ready for #20 to consume.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1396:+**Goal:** `<AppFrame>` in `apps/frontend/src/lib/layout/` composes Rail(52) + Sidebar(240/56) + (shell outlet) + the single global DetailPanelSlot(440). AppFrame consumes one of the 3 shells as its inner outlet. It is NOT exported as a shell — it is the authenticated route frame. `useFullscreenPanel` hook ready for #20 to consume.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1401: - Create: `apps/frontend/src/lib/layout/AppFrame.tsx` — flex row Rail(52) + Sidebar(240/56) + Main(flex-1, shell outlet) + DetailPanelSlot(440 conditional). Headers conform to 50px rhythm via ShellHeader from `packages/ui`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1402: - Create: `apps/frontend/src/lib/layout/AppRail.tsx` — 52px vertical, workspace switcher placeholder + lucide-react utility icons.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1403:-- Create: `apps/frontend/src/lib/layout/AppSidebar.tsx` — 240px nav list. Slice 3 entries: Inbox, My VOCs, Triage, + New VOC. Collapse button writes `localStorage.appSidebarCollapsed`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1404:-- Create: `apps/frontend/src/lib/layout/DetailPanelSlot.tsx` — fixed 440 right column. min 360 / max 520. Hidden when no content registered via `useDetailPanelSlot()`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1405:-- Create: `apps/frontend/src/lib/layout/useDetailPanelSlot.ts` — context-based slot register/clear hook.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1406:+- Create: `apps/frontend/src/lib/layout/AppSidebar.tsx` — 240px nav list. Slice 3 entries: Inbox, My VOCs, Triage, + New VOC. Collapse state uses SSR-safe initializer:
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1414:+- Create: `apps/frontend/src/lib/layout/DetailPanelSlot.tsx` — fixed 440 right column. min 360 / max 520. Hidden when no content registered via `useDetailPanelSlot()`. This is the single rendering surface for all shell `detailPanel` content.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1415:+- Create: `apps/frontend/src/lib/layout/useDetailPanelSlot.ts` — context-based slot register/clear hook. Forbid multiple registrants: throw in dev (and warn in prod) if called twice with overlapping lifetimes, using a ref to track active ownership.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1416: - Create: `apps/frontend/src/lib/panel/useFullscreenPanel.ts` — `[isFullscreen, toggle]`. Esc collapses. Route change clears.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1417:-- Create: `apps/frontend/src/lib/layout/__tests__/AppFrame.test.tsx` — Rail/Sidebar/Main present; sidebar collapse toggle writes localStorage; DetailPanelSlot collapses when empty.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1418:+- Create: `apps/frontend/src/lib/layout/__tests__/AppFrame.test.tsx` — Rail/Sidebar/Main present; sidebar first-paint width matches stored `localStorage.appSidebarCollapsed` before any user interaction; sidebar collapse toggle writes localStorage; DetailPanelSlot collapses when empty; multiple overlapping `useDetailPanelSlot()` registrants throw/warn.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1419: - Create: `apps/frontend/src/lib/panel/__tests__/useFullscreenPanel.test.tsx` — toggle flips boolean; Esc dispatches collapse; route change clears (mock router).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1425: - Constraint: AppFrame is NOT exported from `packages/ui` — it lives in `apps/frontend/src/lib/layout/` only.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1453: - ADR-0020 taxonomy enforced: `packages/ui/src/layout/` exports exactly 3 shells (PageShell, ListShell, WorkbenchShell). AppFrame in `apps/frontend/src/lib/layout/` is NOT a 4th shell.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1504:+- Modify/audit: `apps/frontend/src/routes/admin/managed-systems.tsx`, `apps/frontend/src/routes/admin/analytics-areas.tsx`, `apps/frontend/src/routes/login.tsx`, `apps/frontend/src/routes/index.tsx` and any other route file referencing token classes — grep first, build rename map, then apply.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1505:+- Create: `apps/frontend/src/__tests__/token-class-coverage.test.ts` — grep/scan `.tsx` class strings and assert no `text|border|bg|ring|fill|stroke` token class references a Tailwind theme key that is not resolvable via `resolveConfig`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1506: - Modify: `apps/frontend/src/styles.css` — keep `@import "@fops/ui/styles/tokens.css"` + `semantic.css` + tailwind directives.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1512:+  `grep -rn '\(text\|border\|bg\|ring\|fill\|stroke\)-\(status\|surface\|accent\|severity\|reporter\|internal\|confidence\|focus\)-' apps/frontend/src/`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1556: - Modify: `apps/frontend/src/features/admin/permissions/request-access-button.tsx:115` — `variant="primary"` → `variant="default"` (or leave with primary alias).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1576: - Constraint: `@tiptap/react` lives in `packages/ui` — do NOT install it in `apps/frontend`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1578:+- Constraint: keep `apps/frontend/src/routes/dev-rich-editor.tsx` available after C2 so C3 can validate sanitizer-fail toast flow against the demo route; C5 may delete it only if no later checkpoint needs it.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1584: **Goal:** `<Toaster>` mounted in `__root.tsx`. `apiClient`, `errorMapper`, `useIdempotencyKey` land in `apps/frontend/src/lib/api/`. ALL codes in `ERROR_CODES` from `@fops/shared` covered with Korean copy and tone classification.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1587:-- Create: `apps/frontend/src/lib/api/errorMapper.ts` — maps `{ code, detail }` to `{ tone: 'error'|'warning'|'info', message: string, action?: { label, run } }`. **Catalog is generated by iterating `ERROR_CODES` from `@fops/shared`** — no manually typed list. Every code must map to a non-empty Korean message. Fallback for unknown codes: `{ tone: 'error', message: '일시적 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.' }`. Tone per category: `auth.*` → `error`, `permission.*` → `error`, `rate_limited.*` → `warning`, `validation.*` → `error`, `conflict.*` → `error` (except `conflict.stale_write` → `warning` with retry action), `not_found.*` → `error`, `internal.*` → `error`, `voc.*` → `error`, `rich_content.*` → `error`, `attachment.*` → `warning`, `reporter_facing_status.*` → `warning`. Required codes at minimum (from `packages/shared/src/errors/codes.ts`): `auth.session_invalid`, `auth.session_required`, `auth.session_expired`, `auth.workspace_mismatch`, `permission.denied`, `rate_limited.actor`, `rate_limited.ip`, `validation.failed`, `validation.malformed_request`, `validation.unknown_capability`, `conflict.idempotency_key_reuse`, `conflict.capability_already_granted`, `conflict.permission_request_duplicate`, `validation.malformed_idempotency_key`, `validation.sensitive_reason_required`, `validation.immutable_field`, `conflict.duplicate_slug`, `conflict.parent_archived`, `conflict.record_archived`, `not_found.record`, `internal.unexpected`, `voc.severity_not_user_settable`, `validation.unexpected_field`, `rich_content.disallowed_node`, `rich_content.external_image_forbidden`, `attachment.unsupported_pending_storage_slice`, `conflict.stale_write`, `voc.reporter_status_via_public_update_only`, `permission.scope_required`, `reporter_facing_status.invalid_transition`, `reporter_facing_status.gate_blocked`, `conflict.triage_already_committed`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1588:+- Create: `apps/frontend/src/lib/api/errorMapper.ts` — maps `{ code, detail }` to `{ tone: 'error'|'warning'|'info', message: string, action?: { label, run } }`. **Catalog is generated by iterating `ERROR_CODES` from `@fops/shared`** — no manually typed list. Every code must map to a non-empty Korean message. Export `GENERIC_ERROR_MESSAGE = '일시적 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.'` so tests compare to the fallback constant directly. Fallback for unknown codes: `{ tone: 'error', message: GENERIC_ERROR_MESSAGE }`. Tone per category: `auth.*` → `error`, `permission.*` → `error`, `rate_limited.*` → `warning`, `validation.*` → `error`, `conflict.*` → `error` (except `conflict.stale_write` → `warning` with retry action), `not_found.*` → `error`, `internal.*` → `error`, `voc.*` → `error`, `rich_content.*` → `error`, `attachment.*` → `warning`, `reporter_facing_status.*` → `warning`. Required codes at minimum (from `packages/shared/src/errors/codes.ts`): `auth.session_invalid`, `auth.session_required`, `auth.session_expired`, `auth.workspace_mismatch`, `permission.denied`, `rate_limited.actor`, `rate_limited.ip`, `validation.failed`, `validation.malformed_request`, `validation.unknown_capability`, `conflict.idempotency_key_reuse`, `conflict.capability_already_granted`, `conflict.permission_request_duplicate`, `validation.malformed_idempotency_key`, `validation.sensitive_reason_required`, `validation.immutable_field`, `conflict.duplicate_slug`, `conflict.parent_archived`, `conflict.record_archived`, `not_found.record`, `internal.unexpected`, `voc.severity_not_user_settable`, `validation.unexpected_field`, `rich_content.disallowed_node`, `rich_content.external_image_forbidden`, `attachment.unsupported_pending_storage_slice`, `conflict.stale_write`, `voc.reporter_status_via_public_update_only`, `permission.scope_required`, `reporter_facing_status.invalid_transition`, `reporter_facing_status.gate_blocked`, `conflict.triage_already_committed`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1589: - Create: `apps/frontend/src/lib/api/client.ts` — `apiClient(method, path, { body?, idempotencyKey?, ifMatch?, signal? })`. Auto-mint Idempotency-Key UUIDv4 on POST/PATCH/DELETE when not supplied. Attach `Authorization` from session store. Parse JSON. Non-2xx → throw `ApiError extends Error { code, detail, status, requestId }`. 304 → return `{ status: 304, etag }`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1590: - Create: `apps/frontend/src/lib/api/useIdempotencyKey.ts` — `useIdempotencyKey(ifMatchEtag?: string)`. Returns stable UUIDv4 per render-tree until consumed; `markConsumed()` mints fresh. **When `ifMatchEtag` changes value, the hook MUST automatically mint a fresh UUIDv4** — this prevents `conflict.idempotency_key_reuse` after a stale-write refetch (BE includes `ifMatch` in the idempotency hash per `apps/backend/src/modules/voc/routes.ts:225`, so a retry with a new `If-Match` value is a semantically different request that needs a new key).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1591: - Create: `apps/frontend/src/lib/api/types.ts` — `ApiErrorEnvelope` matching BE `errors/envelope.ts`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1592: - Modify: `apps/frontend/src/routes/__root.tsx` — mount `<Toaster position="bottom-center" />` from `sonner`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1593:-- Create: `apps/frontend/src/lib/api/__tests__/errorMapper.test.ts` — **iterate `ERROR_CODES` from `@fops/shared` and assert each maps to a non-empty Korean message** (not a manual catalog). This test auto-covers new codes added to `codes.ts` without test update.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1594:+- Create: `apps/frontend/src/lib/api/__tests__/errorMapper.test.ts` — **iterate `ERROR_CODES` from `@fops/shared` and assert each maps to a non-empty Korean message** (not a manual catalog). This test auto-covers new codes added to `codes.ts` without test update. Locked assertions: (1) every `ERROR_CODES` mapping has `tone` in literal set `{ 'error', 'warning', 'info' }`; (2) every code with prefix/member in `{ voc.*, rich_content.*, attachment.*, reporter_facing_status.*, conflict.stale_write, conflict.triage_already_committed, conflict.idempotency_key_reuse }` has Korean message not equal to exported `GENERIC_ERROR_MESSAGE`; (3) `conflict.stale_write` maps to `{ tone: 'warning', action: { label: <not undefined>, run: <fn> } }`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1595: - Create: `apps/frontend/src/lib/api/__tests__/client.test.ts` — mock fetch: POST mints Idempotency-Key, GET omits, Authorization attached, 422 throws ApiError, 304 returns ETag. Add test case: same `useIdempotencyKey` instance + changed `ifMatchEtag` → new key minted automatically.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1602:-**CHECKPOINT 2.5** — small playground demonstrating: Toaster position (bottom-center), tone variants (success / error / warning / info) with Korean copy, at least 3 representative error codes rendered as toasts (`conflict.stale_write` warning + retry action, `permission.denied` error, `rate_limited.ip` warning). AskUserQuestion: "토스트 UX + 에러 메시지 OK?"
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1603:+**CHECKPOINT 2.5** — playground HTML demonstrating: Toaster tones + Korean copy for 3+ representative codes (`conflict.stale_write` warning + retry action, `permission.denied` error, `rate_limited.ip` warning) + RichEditor demo rendering sanitizer-rejected content with toast surfaced via apiClient mock. Requires C2 `/dev-rich-editor` route to still exist when C3 lands. AskUserQuestion: "토스트 UX + 에러 메시지 OK?"
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1632: ## C4b — AppFrame in apps/frontend + useFullscreenPanel hook
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1634:-**Goal:** `<AppFrame>` in `apps/frontend/src/lib/layout/` composes Rail(52) + Sidebar(240/56) + (shell outlet) + DetailPanelSlot(440). AppFrame consumes one of the 3 shells as its inner outlet. It is NOT exported as a shell — it is the authenticated route frame. `useFullscreenPanel` hook ready for #20 to consume.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1635:+**Goal:** `<AppFrame>` in `apps/frontend/src/lib/layout/` composes Rail(52) + Sidebar(240/56) + (shell outlet) + the single global DetailPanelSlot(440). AppFrame consumes one of the 3 shells as its inner outlet. It is NOT exported as a shell — it is the authenticated route frame. `useFullscreenPanel` hook ready for #20 to consume.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1640: - Create: `apps/frontend/src/lib/layout/AppFrame.tsx` — flex row Rail(52) + Sidebar(240/56) + Main(flex-1, shell outlet) + DetailPanelSlot(440 conditional). Headers conform to 50px rhythm via ShellHeader from `packages/ui`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1641: - Create: `apps/frontend/src/lib/layout/AppRail.tsx` — 52px vertical, workspace switcher placeholder + lucide-react utility icons.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1642:-- Create: `apps/frontend/src/lib/layout/AppSidebar.tsx` — 240px nav list. Slice 3 entries: Inbox, My VOCs, Triage, + New VOC. Collapse button writes `localStorage.appSidebarCollapsed`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1643:-- Create: `apps/frontend/src/lib/layout/DetailPanelSlot.tsx` — fixed 440 right column. min 360 / max 520. Hidden when no content registered via `useDetailPanelSlot()`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1644:-- Create: `apps/frontend/src/lib/layout/useDetailPanelSlot.ts` — context-based slot register/clear hook.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1645:+- Create: `apps/frontend/src/lib/layout/AppSidebar.tsx` — 240px nav list. Slice 3 entries: Inbox, My VOCs, Triage, + New VOC. Collapse state uses SSR-safe initializer:
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1653:+- Create: `apps/frontend/src/lib/layout/DetailPanelSlot.tsx` — fixed 440 right column. min 360 / max 520. Hidden when no content registered via `useDetailPanelSlot()`. This is the single rendering surface for all shell `detailPanel` content.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1654:+- Create: `apps/frontend/src/lib/layout/useDetailPanelSlot.ts` — context-based slot register/clear hook. Forbid multiple registrants: throw in dev (and warn in prod) if called twice with overlapping lifetimes, using a ref to track active ownership.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1655: - Create: `apps/frontend/src/lib/panel/useFullscreenPanel.ts` — `[isFullscreen, toggle]`. Esc collapses. Route change clears.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1656:-- Create: `apps/frontend/src/lib/layout/__tests__/AppFrame.test.tsx` — Rail/Sidebar/Main present; sidebar collapse toggle writes localStorage; DetailPanelSlot collapses when empty.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1657:+- Create: `apps/frontend/src/lib/layout/__tests__/AppFrame.test.tsx` — Rail/Sidebar/Main present; sidebar first-paint width matches stored `localStorage.appSidebarCollapsed` before any user interaction; sidebar collapse toggle writes localStorage; DetailPanelSlot collapses when empty; multiple overlapping `useDetailPanelSlot()` registrants throw/warn.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1658: - Create: `apps/frontend/src/lib/panel/__tests__/useFullscreenPanel.test.tsx` — toggle flips boolean; Esc dispatches collapse; route change clears (mock router).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1664: - Constraint: AppFrame is NOT exported from `packages/ui` — it lives in `apps/frontend/src/lib/layout/` only.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1695: - ADR-0020 taxonomy enforced: `packages/ui/src/layout/` exports exactly 3 shells (PageShell, ListShell, WorkbenchShell). AppFrame in `apps/frontend/src/lib/layout/` is NOT a 4th shell.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1746:+- Modify/audit: `apps/frontend/src/routes/admin/managed-systems.tsx`, `apps/frontend/src/routes/admin/analytics-areas.tsx`, `apps/frontend/src/routes/login.tsx`, `apps/frontend/src/routes/index.tsx` and any other route file referencing token classes — grep first, build rename map, then apply.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1747:+- Create: `apps/frontend/src/__tests__/token-class-coverage.test.ts` — grep/scan `.tsx` class strings and assert no `text|border|bg|ring|fill|stroke` token class references a Tailwind theme key that is not resolvable via `resolveConfig`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1748: - Modify: `apps/frontend/src/styles.css` — keep `@import "@fops/ui/styles/tokens.css"` + `semantic.css` + tailwind directives.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1754:+  `grep -rn '\(text\|border\|bg\|ring\|fill\|stroke\)-\(status\|surface\|accent\|severity\|reporter\|internal\|confidence\|focus\)-' apps/frontend/src/`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1798: - Modify: `apps/frontend/src/features/admin/permissions/request-access-button.tsx:115` — `variant="primary"` → `variant="default"` (or leave with primary alias).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1818: - Constraint: `@tiptap/react` lives in `packages/ui` — do NOT install it in `apps/frontend`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1820:+- Constraint: keep `apps/frontend/src/routes/dev-rich-editor.tsx` available after C2 so C3 can validate sanitizer-fail toast flow against the demo route; C5 may delete it only if no later checkpoint needs it.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1826: **Goal:** `<Toaster>` mounted in `__root.tsx`. `apiClient`, `errorMapper`, `useIdempotencyKey` land in `apps/frontend/src/lib/api/`. ALL codes in `ERROR_CODES` from `@fops/shared` covered with Korean copy and tone classification.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1829:-- Create: `apps/frontend/src/lib/api/errorMapper.ts` — maps `{ code, detail }` to `{ tone: 'error'|'warning'|'info', message: string, action?: { label, run } }`. **Catalog is generated by iterating `ERROR_CODES` from `@fops/shared`** — no manually typed list. Every code must map to a non-empty Korean message. Fallback for unknown codes: `{ tone: 'error', message: '일시적 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.' }`. Tone per category: `auth.*` → `error`, `permission.*` → `error`, `rate_limited.*` → `warning`, `validation.*` → `error`, `conflict.*` → `error` (except `conflict.stale_write` → `warning` with retry action), `not_found.*` → `error`, `internal.*` → `error`, `voc.*` → `error`, `rich_content.*` → `error`, `attachment.*` → `warning`, `reporter_facing_status.*` → `warning`. Required codes at minimum (from `packages/shared/src/errors/codes.ts`): `auth.session_invalid`, `auth.session_required`, `auth.session_expired`, `auth.workspace_mismatch`, `permission.denied`, `rate_limited.actor`, `rate_limited.ip`, `validation.failed`, `validation.malformed_request`, `validation.unknown_capability`, `conflict.idempotency_key_reuse`, `conflict.capability_already_granted`, `conflict.permission_request_duplicate`, `validation.malformed_idempotency_key`, `validation.sensitive_reason_required`, `validation.immutable_field`, `conflict.duplicate_slug`, `conflict.parent_archived`, `conflict.record_archived`, `not_found.record`, `internal.unexpected`, `voc.severity_not_user_settable`, `validation.unexpected_field`, `rich_content.disallowed_node`, `rich_content.external_image_forbidden`, `attachment.unsupported_pending_storage_slice`, `conflict.stale_write`, `voc.reporter_status_via_public_update_only`, `permission.scope_required`, `reporter_facing_status.invalid_transition`, `reporter_facing_status.gate_blocked`, `conflict.triage_already_committed`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1830:+- Create: `apps/frontend/src/lib/api/errorMapper.ts` — maps `{ code, detail }` to `{ tone: 'error'|'warning'|'info', message: string, action?: { label, run } }`. **Catalog is generated by iterating `ERROR_CODES` from `@fops/shared`** — no manually typed list. Every code must map to a non-empty Korean message. Export `GENERIC_ERROR_MESSAGE = '일시적 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.'` so tests compare to the fallback constant directly. Fallback for unknown codes: `{ tone: 'error', message: GENERIC_ERROR_MESSAGE }`. Tone per category: `auth.*` → `error`, `permission.*` → `error`, `rate_limited.*` → `warning`, `validation.*` → `error`, `conflict.*` → `error` (except `conflict.stale_write` → `warning` with retry action), `not_found.*` → `error`, `internal.*` → `error`, `voc.*` → `error`, `rich_content.*` → `error`, `attachment.*` → `warning`, `reporter_facing_status.*` → `warning`. Required codes at minimum (from `packages/shared/src/errors/codes.ts`): `auth.session_invalid`, `auth.session_required`, `auth.session_expired`, `auth.workspace_mismatch`, `permission.denied`, `rate_limited.actor`, `rate_limited.ip`, `validation.failed`, `validation.malformed_request`, `validation.unknown_capability`, `conflict.idempotency_key_reuse`, `conflict.capability_already_granted`, `conflict.permission_request_duplicate`, `validation.malformed_idempotency_key`, `validation.sensitive_reason_required`, `validation.immutable_field`, `conflict.duplicate_slug`, `conflict.parent_archived`, `conflict.record_archived`, `not_found.record`, `internal.unexpected`, `voc.severity_not_user_settable`, `validation.unexpected_field`, `rich_content.disallowed_node`, `rich_content.external_image_forbidden`, `attachment.unsupported_pending_storage_slice`, `conflict.stale_write`, `voc.reporter_status_via_public_update_only`, `permission.scope_required`, `reporter_facing_status.invalid_transition`, `reporter_facing_status.gate_blocked`, `conflict.triage_already_committed`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1831: - Create: `apps/frontend/src/lib/api/client.ts` — `apiClient(method, path, { body?, idempotencyKey?, ifMatch?, signal? })`. Auto-mint Idempotency-Key UUIDv4 on POST/PATCH/DELETE when not supplied. Attach `Authorization` from session store. Parse JSON. Non-2xx → throw `ApiError extends Error { code, detail, status, requestId }`. 304 → return `{ status: 304, etag }`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1832: - Create: `apps/frontend/src/lib/api/useIdempotencyKey.ts` — `useIdempotencyKey(ifMatchEtag?: string)`. Returns stable UUIDv4 per render-tree until consumed; `markConsumed()` mints fresh. **When `ifMatchEtag` changes value, the hook MUST automatically mint a fresh UUIDv4** — this prevents `conflict.idempotency_key_reuse` after a stale-write refetch (BE includes `ifMatch` in the idempotency hash per `apps/backend/src/modules/voc/routes.ts:225`, so a retry with a new `If-Match` value is a semantically different request that needs a new key).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1833: - Create: `apps/frontend/src/lib/api/types.ts` — `ApiErrorEnvelope` matching BE `errors/envelope.ts`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1834: - Modify: `apps/frontend/src/routes/__root.tsx` — mount `<Toaster position="bottom-center" />` from `sonner`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1835:-- Create: `apps/frontend/src/lib/api/__tests__/errorMapper.test.ts` — **iterate `ERROR_CODES` from `@fops/shared` and assert each maps to a non-empty Korean message** (not a manual catalog). This test auto-covers new codes added to `codes.ts` without test update.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1836:+- Create: `apps/frontend/src/lib/api/__tests__/errorMapper.test.ts` — **iterate `ERROR_CODES` from `@fops/shared` and assert each maps to a non-empty Korean message** (not a manual catalog). This test auto-covers new codes added to `codes.ts` without test update. Locked assertions: (1) every `ERROR_CODES` mapping has `tone` in literal set `{ 'error', 'warning', 'info' }`; (2) every code with prefix/member in `{ voc.*, rich_content.*, attachment.*, reporter_facing_status.*, conflict.stale_write, conflict.triage_already_committed, conflict.idempotency_key_reuse }` has Korean message not equal to exported `GENERIC_ERROR_MESSAGE`; (3) `conflict.stale_write` maps to `{ tone: 'warning', action: { label: <not undefined>, run: <fn> } }`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1837: - Create: `apps/frontend/src/lib/api/__tests__/client.test.ts` — mock fetch: POST mints Idempotency-Key, GET omits, Authorization attached, 422 throws ApiError, 304 returns ETag. Add test case: same `useIdempotencyKey` instance + changed `ifMatchEtag` → new key minted automatically.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1844:-**CHECKPOINT 2.5** — small playground demonstrating: Toaster position (bottom-center), tone variants (success / error / warning / info) with Korean copy, at least 3 representative error codes rendered as toasts (`conflict.stale_write` warning + retry action, `permission.denied` error, `rate_limited.ip` warning). AskUserQuestion: "토스트 UX + 에러 메시지 OK?"
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1845:+**CHECKPOINT 2.5** — playground HTML demonstrating: Toaster tones + Korean copy for 3+ representative codes (`conflict.stale_write` warning + retry action, `permission.denied` error, `rate_limited.ip` warning) + RichEditor demo rendering sanitizer-rejected content with toast surfaced via apiClient mock. Requires C2 `/dev-rich-editor` route to still exist when C3 lands. AskUserQuestion: "토스트 UX + 에러 메시지 OK?"
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1874: ## C4b — AppFrame in apps/frontend + useFullscreenPanel hook
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1876:-**Goal:** `<AppFrame>` in `apps/frontend/src/lib/layout/` composes Rail(52) + Sidebar(240/56) + (shell outlet) + DetailPanelSlot(440). AppFrame consumes one of the 3 shells as its inner outlet. It is NOT exported as a shell — it is the authenticated route frame. `useFullscreenPanel` hook ready for #20 to consume.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1877:+**Goal:** `<AppFrame>` in `apps/frontend/src/lib/layout/` composes Rail(52) + Sidebar(240/56) + (shell outlet) + the single global DetailPanelSlot(440). AppFrame consumes one of the 3 shells as its inner outlet. It is NOT exported as a shell — it is the authenticated route frame. `useFullscreenPanel` hook ready for #20 to consume.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1882: - Create: `apps/frontend/src/lib/layout/AppFrame.tsx` — flex row Rail(52) + Sidebar(240/56) + Main(flex-1, shell outlet) + DetailPanelSlot(440 conditional). Headers conform to 50px rhythm via ShellHeader from `packages/ui`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1883: - Create: `apps/frontend/src/lib/layout/AppRail.tsx` — 52px vertical, workspace switcher placeholder + lucide-react utility icons.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1884:-- Create: `apps/frontend/src/lib/layout/AppSidebar.tsx` — 240px nav list. Slice 3 entries: Inbox, My VOCs, Triage, + New VOC. Collapse button writes `localStorage.appSidebarCollapsed`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1885:-- Create: `apps/frontend/src/lib/layout/DetailPanelSlot.tsx` — fixed 440 right column. min 360 / max 520. Hidden when no content registered via `useDetailPanelSlot()`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1886:-- Create: `apps/frontend/src/lib/layout/useDetailPanelSlot.ts` — context-based slot register/clear hook.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1887:+- Create: `apps/frontend/src/lib/layout/AppSidebar.tsx` — 240px nav list. Slice 3 entries: Inbox, My VOCs, Triage, + New VOC. Collapse state uses SSR-safe initializer:
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1895:+- Create: `apps/frontend/src/lib/layout/DetailPanelSlot.tsx` — fixed 440 right column. min 360 / max 520. Hidden when no content registered via `useDetailPanelSlot()`. This is the single rendering surface for all shell `detailPanel` content.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1896:+- Create: `apps/frontend/src/lib/layout/useDetailPanelSlot.ts` — context-based slot register/clear hook. Forbid multiple registrants: throw in dev (and warn in prod) if called twice with overlapping lifetimes, using a ref to track active ownership.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1897: - Create: `apps/frontend/src/lib/panel/useFullscreenPanel.ts` — `[isFullscreen, toggle]`. Esc collapses. Route change clears.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1898:-- Create: `apps/frontend/src/lib/layout/__tests__/AppFrame.test.tsx` — Rail/Sidebar/Main present; sidebar collapse toggle writes localStorage; DetailPanelSlot collapses when empty.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1899:+- Create: `apps/frontend/src/lib/layout/__tests__/AppFrame.test.tsx` — Rail/Sidebar/Main present; sidebar first-paint width matches stored `localStorage.appSidebarCollapsed` before any user interaction; sidebar collapse toggle writes localStorage; DetailPanelSlot collapses when empty; multiple overlapping `useDetailPanelSlot()` registrants throw/warn.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1900: - Create: `apps/frontend/src/lib/panel/__tests__/useFullscreenPanel.test.tsx` — toggle flips boolean; Esc dispatches collapse; route change clears (mock router).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1906: - Constraint: AppFrame is NOT exported from `packages/ui` — it lives in `apps/frontend/src/lib/layout/` only.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1915:-- `apps/frontend/src/routes/_authed.tsx` — new TanStack layout route. Wraps children with `<AppFrame>`. Login + non-authed routes do NOT use this layout and do NOT render AppFrame.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1917:+- `apps/frontend/src/routes/_authed.tsx` — new TanStack pathless layout route. Includes a `beforeLoad` callback that calls `fetchMe()` (same auth pattern currently used in admin routes) and `redirect({ to: '/login' })` on `UnauthenticatedError`. Wraps children with `<AppFrame>`. Login + non-authed routes do NOT use this layout and do NOT render AppFrame.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1918:+- Per-route auth guards in admin pages are DELETED in C5 after `_authed.beforeLoad` centralizes the guard.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1920:+  - `apps/frontend/src/routes/admin/managed-systems.tsx` → `apps/frontend/src/routes/_authed/admin/managed-systems.tsx`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1921:+  - `apps/frontend/src/routes/admin/analytics-areas.tsx` → `apps/frontend/src/routes/_authed/admin/analytics-areas.tsx`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1922:+  - `apps/frontend/src/routes/admin/placeholder.tsx` → `apps/frontend/src/routes/_authed/admin/placeholder.tsx`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1923:+  - Test file imports updated: `apps/frontend/src/routes/admin/*.test.tsx` move alongside their routes.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1926:-- `/vocs` route = `apps/frontend/src/routes/_authed/vocs.tsx`. Per-view shell selection: `view=inbox|my` → `<ListShell>`, `view=triage` → `<WorkbenchShell>`, `action=create` → `<PageShell>` (default when no view/action = `<ListShell>`).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1927:+- `/vocs` route file = `apps/frontend/src/routes/_authed/vocs.tsx`. Public path string is `/vocs`; `_authed` is pathless. Per-view shell selection: `view=inbox|my` → `<ListShell>`, `view=triage` → `<WorkbenchShell>`, `action=create` → `<PageShell>` (default when no view/action = `<ListShell>`).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1931:-- Create: `apps/frontend/src/routes/_authed.tsx` — TanStack layout route. Renders `<AppFrame><Outlet /></AppFrame>`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1932:+- Create: `apps/frontend/src/routes/_authed.tsx` — TanStack layout route. `beforeLoad` calls `fetchMe()` and redirects unauthenticated users to `/login`; renders `<AppFrame><Outlet /></AppFrame>`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1933: - Create: `apps/frontend/src/routes/_authed/vocs.tsx` — `createFileRoute('/_authed/vocs')` with validateSearch zod. Component selects shell based on `view`/`action`. Main = placeholder text.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1934: - Modify: `apps/frontend/src/routes/__root.tsx` — minimal; providers + `<Outlet>` only (no AppFrame).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1935:-- Relocate or re-parent: `apps/frontend/src/routes/admin/` — move under `_authed` so admin pages get AppFrame. If not done in C5, create a follow-up GitHub issue before closing this chunk.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1936:+- Move: `apps/frontend/src/routes/admin/managed-systems.tsx` → `apps/frontend/src/routes/_authed/admin/managed-systems.tsx`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1937:+- Move: `apps/frontend/src/routes/admin/analytics-areas.tsx` → `apps/frontend/src/routes/_authed/admin/analytics-areas.tsx`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1938:+- Move: `apps/frontend/src/routes/admin/placeholder.tsx` → `apps/frontend/src/routes/_authed/admin/placeholder.tsx`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1939:+- Move: `apps/frontend/src/routes/admin/*.test.tsx` → alongside relocated `_authed/admin/*` routes; update imports.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1941: - Auto-regen: `apps/frontend/src/routeTree.gen.ts` (TanStackRouterVite plugin handles on dev).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1942:-- Create: `apps/frontend/src/routes/__tests__/vocs.test.tsx` — navigating to `/_authed/vocs?view=inbox` resolves; invalid `?view=foo` rejected by zod; sidebar `+ New VOC` href = `/_authed/vocs?action=create`; `view=triage` renders WorkbenchShell.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1943:+- Create: `apps/frontend/src/routes/__tests__/vocs.test.tsx` — navigating to `/vocs?view=inbox` resolves; invalid `?view=foo` rejected by zod; sidebar `+ New VOC` href = `/vocs?action=create`; `view=triage` renders WorkbenchShell.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1944: - Delete: `apps/frontend/src/routes/dev-rich-editor.tsx` IF it was added in C2 and is no longer needed (or keep behind DEV flag).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1948: - Read first: `apps/frontend/src/routes/__root.tsx`, `apps/frontend/vite.config.ts`, `apps/frontend/src/routes/admin/managed-systems.tsx` (existing TanStack file-route pattern), `apps/frontend/src/lib/layout/AppFrame.tsx` (just created in C4b), `packages/ui/src/layout/` (shells).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1952:+- Constraint: no `Route.id` navigation. Run `grep -rn 'Route\\.id\\|from: .*Route\\.id\\|to: .*Route\\.id' apps/frontend/src/` and refactor any hits to literal `to:` path strings.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1971: - Sonnet dispatches read AGENTS.md hierarchy first (`apps/frontend/AGENTS.md` mandatory).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1976: - **AppFrame in `apps/frontend` NEVER becomes a 4th exported shell. Shell taxonomy = 3 (PageShell/ListShell/WorkbenchShell) per ADR-0020.**
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:1987: - `@tiptap/react` in `packages/ui` — verify `apps/frontend` resolves it transitively via workspace link without explicit install; if pnpm strict-mode blocks it, add a peer dep declaration.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2013: - ADR-0020 taxonomy enforced: `packages/ui/src/layout/` exports exactly 3 shells (PageShell, ListShell, WorkbenchShell). AppFrame in `apps/frontend/src/lib/layout/` is NOT a 4th shell.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2064:+- Modify/audit: `apps/frontend/src/routes/admin/managed-systems.tsx`, `apps/frontend/src/routes/admin/analytics-areas.tsx`, `apps/frontend/src/routes/login.tsx`, `apps/frontend/src/routes/index.tsx` and any other route file referencing token classes — grep first, build rename map, then apply.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2065:+- Create: `apps/frontend/src/__tests__/token-class-coverage.test.ts` — grep/scan `.tsx` class strings and assert no `text|border|bg|ring|fill|stroke` token class references a Tailwind theme key that is not resolvable via `resolveConfig`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2066: - Modify: `apps/frontend/src/styles.css` — keep `@import "@fops/ui/styles/tokens.css"` + `semantic.css` + tailwind directives.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2072:+  `grep -rn '\(text\|border\|bg\|ring\|fill\|stroke\)-\(status\|surface\|accent\|severity\|reporter\|internal\|confidence\|focus\)-' apps/frontend/src/`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2116: - Modify: `apps/frontend/src/features/admin/permissions/request-access-button.tsx:115` — `variant="primary"` → `variant="default"` (or leave with primary alias).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2136: - Constraint: `@tiptap/react` lives in `packages/ui` — do NOT install it in `apps/frontend`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2138:+- Constraint: keep `apps/frontend/src/routes/dev-rich-editor.tsx` available after C2 so C3 can validate sanitizer-fail toast flow against the demo route; C5 may delete it only if no later checkpoint needs it.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2144: **Goal:** `<Toaster>` mounted in `__root.tsx`. `apiClient`, `errorMapper`, `useIdempotencyKey` land in `apps/frontend/src/lib/api/`. ALL codes in `ERROR_CODES` from `@fops/shared` covered with Korean copy and tone classification.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2147:-- Create: `apps/frontend/src/lib/api/errorMapper.ts` — maps `{ code, detail }` to `{ tone: 'error'|'warning'|'info', message: string, action?: { label, run } }`. **Catalog is generated by iterating `ERROR_CODES` from `@fops/shared`** — no manually typed list. Every code must map to a non-empty Korean message. Fallback for unknown codes: `{ tone: 'error', message: '일시적 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.' }`. Tone per category: `auth.*` → `error`, `permission.*` → `error`, `rate_limited.*` → `warning`, `validation.*` → `error`, `conflict.*` → `error` (except `conflict.stale_write` → `warning` with retry action), `not_found.*` → `error`, `internal.*` → `error`, `voc.*` → `error`, `rich_content.*` → `error`, `attachment.*` → `warning`, `reporter_facing_status.*` → `warning`. Required codes at minimum (from `packages/shared/src/errors/codes.ts`): `auth.session_invalid`, `auth.session_required`, `auth.session_expired`, `auth.workspace_mismatch`, `permission.denied`, `rate_limited.actor`, `rate_limited.ip`, `validation.failed`, `validation.malformed_request`, `validation.unknown_capability`, `conflict.idempotency_key_reuse`, `conflict.capability_already_granted`, `conflict.permission_request_duplicate`, `validation.malformed_idempotency_key`, `validation.sensitive_reason_required`, `validation.immutable_field`, `conflict.duplicate_slug`, `conflict.parent_archived`, `conflict.record_archived`, `not_found.record`, `internal.unexpected`, `voc.severity_not_user_settable`, `validation.unexpected_field`, `rich_content.disallowed_node`, `rich_content.external_image_forbidden`, `attachment.unsupported_pending_storage_slice`, `conflict.stale_write`, `voc.reporter_status_via_public_update_only`, `permission.scope_required`, `reporter_facing_status.invalid_transition`, `reporter_facing_status.gate_blocked`, `conflict.triage_already_committed`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2148:+- Create: `apps/frontend/src/lib/api/errorMapper.ts` — maps `{ code, detail }` to `{ tone: 'error'|'warning'|'info', message: string, action?: { label, run } }`. **Catalog is generated by iterating `ERROR_CODES` from `@fops/shared`** — no manually typed list. Every code must map to a non-empty Korean message. Export `GENERIC_ERROR_MESSAGE = '일시적 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.'` so tests compare to the fallback constant directly. Fallback for unknown codes: `{ tone: 'error', message: GENERIC_ERROR_MESSAGE }`. Tone per category: `auth.*` → `error`, `permission.*` → `error`, `rate_limited.*` → `warning`, `validation.*` → `error`, `conflict.*` → `error` (except `conflict.stale_write` → `warning` with retry action), `not_found.*` → `error`, `internal.*` → `error`, `voc.*` → `error`, `rich_content.*` → `error`, `attachment.*` → `warning`, `reporter_facing_status.*` → `warning`. Required codes at minimum (from `packages/shared/src/errors/codes.ts`): `auth.session_invalid`, `auth.session_required`, `auth.session_expired`, `auth.workspace_mismatch`, `permission.denied`, `rate_limited.actor`, `rate_limited.ip`, `validation.failed`, `validation.malformed_request`, `validation.unknown_capability`, `conflict.idempotency_key_reuse`, `conflict.capability_already_granted`, `conflict.permission_request_duplicate`, `validation.malformed_idempotency_key`, `validation.sensitive_reason_required`, `validation.immutable_field`, `conflict.duplicate_slug`, `conflict.parent_archived`, `conflict.record_archived`, `not_found.record`, `internal.unexpected`, `voc.severity_not_user_settable`, `validation.unexpected_field`, `rich_content.disallowed_node`, `rich_content.external_image_forbidden`, `attachment.unsupported_pending_storage_slice`, `conflict.stale_write`, `voc.reporter_status_via_public_update_only`, `permission.scope_required`, `reporter_facing_status.invalid_transition`, `reporter_facing_status.gate_blocked`, `conflict.triage_already_committed`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2149: - Create: `apps/frontend/src/lib/api/client.ts` — `apiClient(method, path, { body?, idempotencyKey?, ifMatch?, signal? })`. Auto-mint Idempotency-Key UUIDv4 on POST/PATCH/DELETE when not supplied. Attach `Authorization` from session store. Parse JSON. Non-2xx → throw `ApiError extends Error { code, detail, status, requestId }`. 304 → return `{ status: 304, etag }`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2150: - Create: `apps/frontend/src/lib/api/useIdempotencyKey.ts` — `useIdempotencyKey(ifMatchEtag?: string)`. Returns stable UUIDv4 per render-tree until consumed; `markConsumed()` mints fresh. **When `ifMatchEtag` changes value, the hook MUST automatically mint a fresh UUIDv4** — this prevents `conflict.idempotency_key_reuse` after a stale-write refetch (BE includes `ifMatch` in the idempotency hash per `apps/backend/src/modules/voc/routes.ts:225`, so a retry with a new `If-Match` value is a semantically different request that needs a new key).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2151: - Create: `apps/frontend/src/lib/api/types.ts` — `ApiErrorEnvelope` matching BE `errors/envelope.ts`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2152: - Modify: `apps/frontend/src/routes/__root.tsx` — mount `<Toaster position="bottom-center" />` from `sonner`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2153:-- Create: `apps/frontend/src/lib/api/__tests__/errorMapper.test.ts` — **iterate `ERROR_CODES` from `@fops/shared` and assert each maps to a non-empty Korean message** (not a manual catalog). This test auto-covers new codes added to `codes.ts` without test update.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2154:+- Create: `apps/frontend/src/lib/api/__tests__/errorMapper.test.ts` — **iterate `ERROR_CODES` from `@fops/shared` and assert each maps to a non-empty Korean message** (not a manual catalog). This test auto-covers new codes added to `codes.ts` without test update. Locked assertions: (1) every `ERROR_CODES` mapping has `tone` in literal set `{ 'error', 'warning', 'info' }`; (2) every code with prefix/member in `{ voc.*, rich_content.*, attachment.*, reporter_facing_status.*, conflict.stale_write, conflict.triage_already_committed, conflict.idempotency_key_reuse }` has Korean message not equal to exported `GENERIC_ERROR_MESSAGE`; (3) `conflict.stale_write` maps to `{ tone: 'warning', action: { label: <not undefined>, run: <fn> } }`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2155: - Create: `apps/frontend/src/lib/api/__tests__/client.test.ts` — mock fetch: POST mints Idempotency-Key, GET omits, Authorization attached, 422 throws ApiError, 304 returns ETag. Add test case: same `useIdempotencyKey` instance + changed `ifMatchEtag` → new key minted automatically.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2162:-**CHECKPOINT 2.5** — small playground demonstrating: Toaster position (bottom-center), tone variants (success / error / warning / info) with Korean copy, at least 3 representative error codes rendered as toasts (`conflict.stale_write` warning + retry action, `permission.denied` error, `rate_limited.ip` warning). AskUserQuestion: "토스트 UX + 에러 메시지 OK?"
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2163:+**CHECKPOINT 2.5** — playground HTML demonstrating: Toaster tones + Korean copy for 3+ representative codes (`conflict.stale_write` warning + retry action, `permission.denied` error, `rate_limited.ip` warning) + RichEditor demo rendering sanitizer-rejected content with toast surfaced via apiClient mock. Requires C2 `/dev-rich-editor` route to still exist when C3 lands. AskUserQuestion: "토스트 UX + 에러 메시지 OK?"
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2192: ## C4b — AppFrame in apps/frontend + useFullscreenPanel hook
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2194:-**Goal:** `<AppFrame>` in `apps/frontend/src/lib/layout/` composes Rail(52) + Sidebar(240/56) + (shell outlet) + DetailPanelSlot(440). AppFrame consumes one of the 3 shells as its inner outlet. It is NOT exported as a shell — it is the authenticated route frame. `useFullscreenPanel` hook ready for #20 to consume.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2195:+**Goal:** `<AppFrame>` in `apps/frontend/src/lib/layout/` composes Rail(52) + Sidebar(240/56) + (shell outlet) + the single global DetailPanelSlot(440). AppFrame consumes one of the 3 shells as its inner outlet. It is NOT exported as a shell — it is the authenticated route frame. `useFullscreenPanel` hook ready for #20 to consume.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2200: - Create: `apps/frontend/src/lib/layout/AppFrame.tsx` — flex row Rail(52) + Sidebar(240/56) + Main(flex-1, shell outlet) + DetailPanelSlot(440 conditional). Headers conform to 50px rhythm via ShellHeader from `packages/ui`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2201: - Create: `apps/frontend/src/lib/layout/AppRail.tsx` — 52px vertical, workspace switcher placeholder + lucide-react utility icons.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2202:-- Create: `apps/frontend/src/lib/layout/AppSidebar.tsx` — 240px nav list. Slice 3 entries: Inbox, My VOCs, Triage, + New VOC. Collapse button writes `localStorage.appSidebarCollapsed`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2203:-- Create: `apps/frontend/src/lib/layout/DetailPanelSlot.tsx` — fixed 440 right column. min 360 / max 520. Hidden when no content registered via `useDetailPanelSlot()`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2204:-- Create: `apps/frontend/src/lib/layout/useDetailPanelSlot.ts` — context-based slot register/clear hook.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2205:+- Create: `apps/frontend/src/lib/layout/AppSidebar.tsx` — 240px nav list. Slice 3 entries: Inbox, My VOCs, Triage, + New VOC. Collapse state uses SSR-safe initializer:
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2213:+- Create: `apps/frontend/src/lib/layout/DetailPanelSlot.tsx` — fixed 440 right column. min 360 / max 520. Hidden when no content registered via `useDetailPanelSlot()`. This is the single rendering surface for all shell `detailPanel` content.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2214:+- Create: `apps/frontend/src/lib/layout/useDetailPanelSlot.ts` — context-based slot register/clear hook. Forbid multiple registrants: throw in dev (and warn in prod) if called twice with overlapping lifetimes, using a ref to track active ownership.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2215: - Create: `apps/frontend/src/lib/panel/useFullscreenPanel.ts` — `[isFullscreen, toggle]`. Esc collapses. Route change clears.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2216:-- Create: `apps/frontend/src/lib/layout/__tests__/AppFrame.test.tsx` — Rail/Sidebar/Main present; sidebar collapse toggle writes localStorage; DetailPanelSlot collapses when empty.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2217:+- Create: `apps/frontend/src/lib/layout/__tests__/AppFrame.test.tsx` — Rail/Sidebar/Main present; sidebar first-paint width matches stored `localStorage.appSidebarCollapsed` before any user interaction; sidebar collapse toggle writes localStorage; DetailPanelSlot collapses when empty; multiple overlapping `useDetailPanelSlot()` registrants throw/warn.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2218: - Create: `apps/frontend/src/lib/panel/__tests__/useFullscreenPanel.test.tsx` — toggle flips boolean; Esc dispatches collapse; route change clears (mock router).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2224: - Constraint: AppFrame is NOT exported from `packages/ui` — it lives in `apps/frontend/src/lib/layout/` only.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2233:-- `apps/frontend/src/routes/_authed.tsx` — new TanStack layout route. Wraps children with `<AppFrame>`. Login + non-authed routes do NOT use this layout and do NOT render AppFrame.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2235:+- `apps/frontend/src/routes/_authed.tsx` — new TanStack pathless layout route. Includes a `beforeLoad` callback that calls `fetchMe()` (same auth pattern currently used in admin routes) and `redirect({ to: '/login' })` on `UnauthenticatedError`. Wraps children with `<AppFrame>`. Login + non-authed routes do NOT use this layout and do NOT render AppFrame.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2236:+- Per-route auth guards in admin pages are DELETED in C5 after `_authed.beforeLoad` centralizes the guard.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2238:+  - `apps/frontend/src/routes/admin/managed-systems.tsx` → `apps/frontend/src/routes/_authed/admin/managed-systems.tsx`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2239:+  - `apps/frontend/src/routes/admin/analytics-areas.tsx` → `apps/frontend/src/routes/_authed/admin/analytics-areas.tsx`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2240:+  - `apps/frontend/src/routes/admin/placeholder.tsx` → `apps/frontend/src/routes/_authed/admin/placeholder.tsx`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2241:+  - Test file imports updated: `apps/frontend/src/routes/admin/*.test.tsx` move alongside their routes.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2244:-- `/vocs` route = `apps/frontend/src/routes/_authed/vocs.tsx`. Per-view shell selection: `view=inbox|my` → `<ListShell>`, `view=triage` → `<WorkbenchShell>`, `action=create` → `<PageShell>` (default when no view/action = `<ListShell>`).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2245:+- `/vocs` route file = `apps/frontend/src/routes/_authed/vocs.tsx`. Public path string is `/vocs`; `_authed` is pathless. Per-view shell selection: `view=inbox|my` → `<ListShell>`, `view=triage` → `<WorkbenchShell>`, `action=create` → `<PageShell>` (default when no view/action = `<ListShell>`).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2249:-- Create: `apps/frontend/src/routes/_authed.tsx` — TanStack layout route. Renders `<AppFrame><Outlet /></AppFrame>`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2250:+- Create: `apps/frontend/src/routes/_authed.tsx` — TanStack layout route. `beforeLoad` calls `fetchMe()` and redirects unauthenticated users to `/login`; renders `<AppFrame><Outlet /></AppFrame>`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2251: - Create: `apps/frontend/src/routes/_authed/vocs.tsx` — `createFileRoute('/_authed/vocs')` with validateSearch zod. Component selects shell based on `view`/`action`. Main = placeholder text.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2252: - Modify: `apps/frontend/src/routes/__root.tsx` — minimal; providers + `<Outlet>` only (no AppFrame).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2253:-- Relocate or re-parent: `apps/frontend/src/routes/admin/` — move under `_authed` so admin pages get AppFrame. If not done in C5, create a follow-up GitHub issue before closing this chunk.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2254:+- Move: `apps/frontend/src/routes/admin/managed-systems.tsx` → `apps/frontend/src/routes/_authed/admin/managed-systems.tsx`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2255:+- Move: `apps/frontend/src/routes/admin/analytics-areas.tsx` → `apps/frontend/src/routes/_authed/admin/analytics-areas.tsx`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2256:+- Move: `apps/frontend/src/routes/admin/placeholder.tsx` → `apps/frontend/src/routes/_authed/admin/placeholder.tsx`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2257:+- Move: `apps/frontend/src/routes/admin/*.test.tsx` → alongside relocated `_authed/admin/*` routes; update imports.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2259: - Auto-regen: `apps/frontend/src/routeTree.gen.ts` (TanStackRouterVite plugin handles on dev).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2260:-- Create: `apps/frontend/src/routes/__tests__/vocs.test.tsx` — navigating to `/_authed/vocs?view=inbox` resolves; invalid `?view=foo` rejected by zod; sidebar `+ New VOC` href = `/_authed/vocs?action=create`; `view=triage` renders WorkbenchShell.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2261:+- Create: `apps/frontend/src/routes/__tests__/vocs.test.tsx` — navigating to `/vocs?view=inbox` resolves; invalid `?view=foo` rejected by zod; sidebar `+ New VOC` href = `/vocs?action=create`; `view=triage` renders WorkbenchShell.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2262: - Delete: `apps/frontend/src/routes/dev-rich-editor.tsx` IF it was added in C2 and is no longer needed (or keep behind DEV flag).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2266: - Read first: `apps/frontend/src/routes/__root.tsx`, `apps/frontend/vite.config.ts`, `apps/frontend/src/routes/admin/managed-systems.tsx` (existing TanStack file-route pattern), `apps/frontend/src/lib/layout/AppFrame.tsx` (just created in C4b), `packages/ui/src/layout/` (shells).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2270:+- Constraint: no `Route.id` navigation. Run `grep -rn 'Route\\.id\\|from: .*Route\\.id\\|to: .*Route\\.id' apps/frontend/src/` and refactor any hits to literal `to:` path strings.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2289: - Sonnet dispatches read AGENTS.md hierarchy first (`apps/frontend/AGENTS.md` mandatory).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2294: - **AppFrame in `apps/frontend` NEVER becomes a 4th exported shell. Shell taxonomy = 3 (PageShell/ListShell/WorkbenchShell) per ADR-0020.**
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2305: - `@tiptap/react` in `packages/ui` — verify `apps/frontend` resolves it transitively via workspace link without explicit install; if pnpm strict-mode blocks it, add a peer dep declaration.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2330:258:**Goal:** `<AppFrame>` in `apps/frontend/src/lib/layout/` composes Rail(52) + Sidebar(240/56) + (shell outlet) + the single global DetailPanelSlot(440). AppFrame consumes one of the 3 shells as its inner outlet. It is NOT exported as a shell — it is the authenticated route frame. `useFullscreenPanel` hook ready for #20 to consume.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2331:263:- Create: `apps/frontend/src/lib/layout/AppFrame.tsx` — flex row Rail(52) + Sidebar(240/56) + Main(flex-1, shell outlet) + DetailPanelSlot(440 conditional). Headers conform to 50px rhythm via ShellHeader from `packages/ui`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2332:273:- Create: `apps/frontend/src/lib/layout/DetailPanelSlot.tsx` — fixed 440 right column. min 360 / max 520. Hidden when no content registered via `useDetailPanelSlot()`. This is the single rendering surface for all shell `detailPanel` content.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2333:274:- Create: `apps/frontend/src/lib/layout/useDetailPanelSlot.ts` — context-based slot register/clear hook. Forbid multiple registrants: throw in dev (and warn in prod) if called twice with overlapping lifetimes, using a ref to track active ownership.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2334:276:- Create: `apps/frontend/src/lib/layout/__tests__/AppFrame.test.tsx` — Rail/Sidebar/Main present; sidebar first-paint width matches stored `localStorage.appSidebarCollapsed` before any user interaction; sidebar collapse toggle writes localStorage; DetailPanelSlot collapses when empty; multiple overlapping `useDetailPanelSlot()` registrants throw/warn.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2337:305:- `/vocs` route file = `apps/frontend/src/routes/_authed/vocs.tsx`. Public path string is `/vocs`; `_authed` is pathless. Per-view shell selection: `view=inbox|my` → `<ListShell>`, `view=triage` → `<WorkbenchShell>`, `action=create` → `<PageShell>` (default when no view/action = `<ListShell>`).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2339:310:- Create: `apps/frontend/src/routes/_authed/vocs.tsx` — `createFileRoute('/_authed/vocs')` with validateSearch zod. Component selects shell based on `view`/`action`. Main = placeholder text.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2340:337:- Constraint: no `Route.id` navigation. Run `grep -rn 'Route\\.id\\|from: .*Route\\.id\\|to: .*Route\\.id' apps/frontend/src/` and refactor any hits to literal `to:` path strings.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2368: - ADR-0020 taxonomy enforced: `packages/ui/src/layout/` exports exactly 3 shells (PageShell, ListShell, WorkbenchShell). AppFrame in `apps/frontend/src/lib/layout/` is NOT a 4th shell.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2419:+- Modify/audit: `apps/frontend/src/routes/admin/managed-systems.tsx`, `apps/frontend/src/routes/admin/analytics-areas.tsx`, `apps/frontend/src/routes/login.tsx`, `apps/frontend/src/routes/index.tsx` and any other route file referencing token classes — grep first, build rename map, then apply.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2420:+- Create: `apps/frontend/src/__tests__/token-class-coverage.test.ts` — grep/scan `.tsx` class strings and assert no `text|border|bg|ring|fill|stroke` token class references a Tailwind theme key that is not resolvable via `resolveConfig`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2421: - Modify: `apps/frontend/src/styles.css` — keep `@import "@fops/ui/styles/tokens.css"` + `semantic.css` + tailwind directives.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2427:+  `grep -rn '\(text\|border\|bg\|ring\|fill\|stroke\)-\(status\|surface\|accent\|severity\|reporter\|internal\|confidence\|focus\)-' apps/frontend/src/`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2471: - Modify: `apps/frontend/src/features/admin/permissions/request-access-button.tsx:115` — `variant="primary"` → `variant="default"` (or leave with primary alias).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2491: - Constraint: `@tiptap/react` lives in `packages/ui` — do NOT install it in `apps/frontend`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2493:+- Constraint: keep `apps/frontend/src/routes/dev-rich-editor.tsx` available after C2 so C3 can validate sanitizer-fail toast flow against the demo route; C5 may delete it only if no later checkpoint needs it.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2499: **Goal:** `<Toaster>` mounted in `__root.tsx`. `apiClient`, `errorMapper`, `useIdempotencyKey` land in `apps/frontend/src/lib/api/`. ALL codes in `ERROR_CODES` from `@fops/shared` covered with Korean copy and tone classification.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2502:-- Create: `apps/frontend/src/lib/api/errorMapper.ts` — maps `{ code, detail }` to `{ tone: 'error'|'warning'|'info', message: string, action?: { label, run } }`. **Catalog is generated by iterating `ERROR_CODES` from `@fops/shared`** — no manually typed list. Every code must map to a non-empty Korean message. Fallback for unknown codes: `{ tone: 'error', message: '일시적 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.' }`. Tone per category: `auth.*` → `error`, `permission.*` → `error`, `rate_limited.*` → `warning`, `validation.*` → `error`, `conflict.*` → `error` (except `conflict.stale_write` → `warning` with retry action), `not_found.*` → `error`, `internal.*` → `error`, `voc.*` → `error`, `rich_content.*` → `error`, `attachment.*` → `warning`, `reporter_facing_status.*` → `warning`. Required codes at minimum (from `packages/shared/src/errors/codes.ts`): `auth.session_invalid`, `auth.session_required`, `auth.session_expired`, `auth.workspace_mismatch`, `permission.denied`, `rate_limited.actor`, `rate_limited.ip`, `validation.failed`, `validation.malformed_request`, `validation.unknown_capability`, `conflict.idempotency_key_reuse`, `conflict.capability_already_granted`, `conflict.permission_request_duplicate`, `validation.malformed_idempotency_key`, `validation.sensitive_reason_required`, `validation.immutable_field`, `conflict.duplicate_slug`, `conflict.parent_archived`, `conflict.record_archived`, `not_found.record`, `internal.unexpected`, `voc.severity_not_user_settable`, `validation.unexpected_field`, `rich_content.disallowed_node`, `rich_content.external_image_forbidden`, `attachment.unsupported_pending_storage_slice`, `conflict.stale_write`, `voc.reporter_status_via_public_update_only`, `permission.scope_required`, `reporter_facing_status.invalid_transition`, `reporter_facing_status.gate_blocked`, `conflict.triage_already_committed`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2503:+- Create: `apps/frontend/src/lib/api/errorMapper.ts` — maps `{ code, detail }` to `{ tone: 'error'|'warning'|'info', message: string, action?: { label, run } }`. **Catalog is generated by iterating `ERROR_CODES` from `@fops/shared`** — no manually typed list. Every code must map to a non-empty Korean message. Export `GENERIC_ERROR_MESSAGE = '일시적 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.'` so tests compare to the fallback constant directly. Fallback for unknown codes: `{ tone: 'error', message: GENERIC_ERROR_MESSAGE }`. Tone per category: `auth.*` → `error`, `permission.*` → `error`, `rate_limited.*` → `warning`, `validation.*` → `error`, `conflict.*` → `error` (except `conflict.stale_write` → `warning` with retry action), `not_found.*` → `error`, `internal.*` → `error`, `voc.*` → `error`, `rich_content.*` → `error`, `attachment.*` → `warning`, `reporter_facing_status.*` → `warning`. Required codes at minimum (from `packages/shared/src/errors/codes.ts`): `auth.session_invalid`, `auth.session_required`, `auth.session_expired`, `auth.workspace_mismatch`, `permission.denied`, `rate_limited.actor`, `rate_limited.ip`, `validation.failed`, `validation.malformed_request`, `validation.unknown_capability`, `conflict.idempotency_key_reuse`, `conflict.capability_already_granted`, `conflict.permission_request_duplicate`, `validation.malformed_idempotency_key`, `validation.sensitive_reason_required`, `validation.immutable_field`, `conflict.duplicate_slug`, `conflict.parent_archived`, `conflict.record_archived`, `not_found.record`, `internal.unexpected`, `voc.severity_not_user_settable`, `validation.unexpected_field`, `rich_content.disallowed_node`, `rich_content.external_image_forbidden`, `attachment.unsupported_pending_storage_slice`, `conflict.stale_write`, `voc.reporter_status_via_public_update_only`, `permission.scope_required`, `reporter_facing_status.invalid_transition`, `reporter_facing_status.gate_blocked`, `conflict.triage_already_committed`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2504: - Create: `apps/frontend/src/lib/api/client.ts` — `apiClient(method, path, { body?, idempotencyKey?, ifMatch?, signal? })`. Auto-mint Idempotency-Key UUIDv4 on POST/PATCH/DELETE when not supplied. Attach `Authorization` from session store. Parse JSON. Non-2xx → throw `ApiError extends Error { code, detail, status, requestId }`. 304 → return `{ status: 304, etag }`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2505: - Create: `apps/frontend/src/lib/api/useIdempotencyKey.ts` — `useIdempotencyKey(ifMatchEtag?: string)`. Returns stable UUIDv4 per render-tree until consumed; `markConsumed()` mints fresh. **When `ifMatchEtag` changes value, the hook MUST automatically mint a fresh UUIDv4** — this prevents `conflict.idempotency_key_reuse` after a stale-write refetch (BE includes `ifMatch` in the idempotency hash per `apps/backend/src/modules/voc/routes.ts:225`, so a retry with a new `If-Match` value is a semantically different request that needs a new key).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2506: - Create: `apps/frontend/src/lib/api/types.ts` — `ApiErrorEnvelope` matching BE `errors/envelope.ts`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2507: - Modify: `apps/frontend/src/routes/__root.tsx` — mount `<Toaster position="bottom-center" />` from `sonner`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2508:-- Create: `apps/frontend/src/lib/api/__tests__/errorMapper.test.ts` — **iterate `ERROR_CODES` from `@fops/shared` and assert each maps to a non-empty Korean message** (not a manual catalog). This test auto-covers new codes added to `codes.ts` without test update.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2509:+- Create: `apps/frontend/src/lib/api/__tests__/errorMapper.test.ts` — **iterate `ERROR_CODES` from `@fops/shared` and assert each maps to a non-empty Korean message** (not a manual catalog). This test auto-covers new codes added to `codes.ts` without test update. Locked assertions: (1) every `ERROR_CODES` mapping has `tone` in literal set `{ 'error', 'warning', 'info' }`; (2) every code with prefix/member in `{ voc.*, rich_content.*, attachment.*, reporter_facing_status.*, conflict.stale_write, conflict.triage_already_committed, conflict.idempotency_key_reuse }` has Korean message not equal to exported `GENERIC_ERROR_MESSAGE`; (3) `conflict.stale_write` maps to `{ tone: 'warning', action: { label: <not undefined>, run: <fn> } }`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2510: - Create: `apps/frontend/src/lib/api/__tests__/client.test.ts` — mock fetch: POST mints Idempotency-Key, GET omits, Authorization attached, 422 throws ApiError, 304 returns ETag. Add test case: same `useIdempotencyKey` instance + changed `ifMatchEtag` → new key minted automatically.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2517:-**CHECKPOINT 2.5** — small playground demonstrating: Toaster position (bottom-center), tone variants (success / error / warning / info) with Korean copy, at least 3 representative error codes rendered as toasts (`conflict.stale_write` warning + retry action, `permission.denied` error, `rate_limited.ip` warning). AskUserQuestion: "토스트 UX + 에러 메시지 OK?"
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2518:+**CHECKPOINT 2.5** — playground HTML demonstrating: Toaster tones + Korean copy for 3+ representative codes (`conflict.stale_write` warning + retry action, `permission.denied` error, `rate_limited.ip` warning) + RichEditor demo rendering sanitizer-rejected content with toast surfaced via apiClient mock. Requires C2 `/dev-rich-editor` route to still exist when C3 lands. AskUserQuestion: "토스트 UX + 에러 메시지 OK?"
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2547: ## C4b — AppFrame in apps/frontend + useFullscreenPanel hook
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2549:-**Goal:** `<AppFrame>` in `apps/frontend/src/lib/layout/` composes Rail(52) + Sidebar(240/56) + (shell outlet) + DetailPanelSlot(440). AppFrame consumes one of the 3 shells as its inner outlet. It is NOT exported as a shell — it is the authenticated route frame. `useFullscreenPanel` hook ready for #20 to consume.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2550:+**Goal:** `<AppFrame>` in `apps/frontend/src/lib/layout/` composes Rail(52) + Sidebar(240/56) + (shell outlet) + the single global DetailPanelSlot(440). AppFrame consumes one of the 3 shells as its inner outlet. It is NOT exported as a shell — it is the authenticated route frame. `useFullscreenPanel` hook ready for #20 to consume.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2555: - Create: `apps/frontend/src/lib/layout/AppFrame.tsx` — flex row Rail(52) + Sidebar(240/56) + Main(flex-1, shell outlet) + DetailPanelSlot(440 conditional). Headers conform to 50px rhythm via ShellHeader from `packages/ui`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2556: - Create: `apps/frontend/src/lib/layout/AppRail.tsx` — 52px vertical, workspace switcher placeholder + lucide-react utility icons.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2557:-- Create: `apps/frontend/src/lib/layout/AppSidebar.tsx` — 240px nav list. Slice 3 entries: Inbox, My VOCs, Triage, + New VOC. Collapse button writes `localStorage.appSidebarCollapsed`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2558:-- Create: `apps/frontend/src/lib/layout/DetailPanelSlot.tsx` — fixed 440 right column. min 360 / max 520. Hidden when no content registered via `useDetailPanelSlot()`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2559:-- Create: `apps/frontend/src/lib/layout/useDetailPanelSlot.ts` — context-based slot register/clear hook.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2560:+- Create: `apps/frontend/src/lib/layout/AppSidebar.tsx` — 240px nav list. Slice 3 entries: Inbox, My VOCs, Triage, + New VOC. Collapse state uses SSR-safe initializer:
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2568:+- Create: `apps/frontend/src/lib/layout/DetailPanelSlot.tsx` — fixed 440 right column. min 360 / max 520. Hidden when no content registered via `useDetailPanelSlot()`. This is the single rendering surface for all shell `detailPanel` content.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2569:+- Create: `apps/frontend/src/lib/layout/useDetailPanelSlot.ts` — context-based slot register/clear hook. Forbid multiple registrants: throw in dev (and warn in prod) if called twice with overlapping lifetimes, using a ref to track active ownership.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2570: - Create: `apps/frontend/src/lib/panel/useFullscreenPanel.ts` — `[isFullscreen, toggle]`. Esc collapses. Route change clears.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2571:-- Create: `apps/frontend/src/lib/layout/__tests__/AppFrame.test.tsx` — Rail/Sidebar/Main present; sidebar collapse toggle writes localStorage; DetailPanelSlot collapses when empty.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2572:+- Create: `apps/frontend/src/lib/layout/__tests__/AppFrame.test.tsx` — Rail/Sidebar/Main present; sidebar first-paint width matches stored `localStorage.appSidebarCollapsed` before any user interaction; sidebar collapse toggle writes localStorage; DetailPanelSlot collapses when empty; multiple overlapping `useDetailPanelSlot()` registrants throw/warn.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2573: - Create: `apps/frontend/src/lib/panel/__tests__/useFullscreenPanel.test.tsx` — toggle flips boolean; Esc dispatches collapse; route change clears (mock router).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2579: - Constraint: AppFrame is NOT exported from `packages/ui` — it lives in `apps/frontend/src/lib/layout/` only.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2588:-- `apps/frontend/src/routes/_authed.tsx` — new TanStack layout route. Wraps children with `<AppFrame>`. Login + non-authed routes do NOT use this layout and do NOT render AppFrame.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2590:+- `apps/frontend/src/routes/_authed.tsx` — new TanStack pathless layout route. Includes a `beforeLoad` callback that calls `fetchMe()` (same auth pattern currently used in admin routes) and `redirect({ to: '/login' })` on `UnauthenticatedError`. Wraps children with `<AppFrame>`. Login + non-authed routes do NOT use this layout and do NOT render AppFrame.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2591:+- Per-route auth guards in admin pages are DELETED in C5 after `_authed.beforeLoad` centralizes the guard.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2593:+  - `apps/frontend/src/routes/admin/managed-systems.tsx` → `apps/frontend/src/routes/_authed/admin/managed-systems.tsx`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2594:+  - `apps/frontend/src/routes/admin/analytics-areas.tsx` → `apps/frontend/src/routes/_authed/admin/analytics-areas.tsx`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2595:+  - `apps/frontend/src/routes/admin/placeholder.tsx` → `apps/frontend/src/routes/_authed/admin/placeholder.tsx`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2596:+  - Test file imports updated: `apps/frontend/src/routes/admin/*.test.tsx` move alongside their routes.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2599:-- `/vocs` route = `apps/frontend/src/routes/_authed/vocs.tsx`. Per-view shell selection: `view=inbox|my` → `<ListShell>`, `view=triage` → `<WorkbenchShell>`, `action=create` → `<PageShell>` (default when no view/action = `<ListShell>`).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2600:+- `/vocs` route file = `apps/frontend/src/routes/_authed/vocs.tsx`. Public path string is `/vocs`; `_authed` is pathless. Per-view shell selection: `view=inbox|my` → `<ListShell>`, `view=triage` → `<WorkbenchShell>`, `action=create` → `<PageShell>` (default when no view/action = `<ListShell>`).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2604:-- Create: `apps/frontend/src/routes/_authed.tsx` — TanStack layout route. Renders `<AppFrame><Outlet /></AppFrame>`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2605:+- Create: `apps/frontend/src/routes/_authed.tsx` — TanStack layout route. `beforeLoad` calls `fetchMe()` and redirects unauthenticated users to `/login`; renders `<AppFrame><Outlet /></AppFrame>`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2606: - Create: `apps/frontend/src/routes/_authed/vocs.tsx` — `createFileRoute('/_authed/vocs')` with validateSearch zod. Component selects shell based on `view`/`action`. Main = placeholder text.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2607: - Modify: `apps/frontend/src/routes/__root.tsx` — minimal; providers + `<Outlet>` only (no AppFrame).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2608:-- Relocate or re-parent: `apps/frontend/src/routes/admin/` — move under `_authed` so admin pages get AppFrame. If not done in C5, create a follow-up GitHub issue before closing this chunk.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2609:+- Move: `apps/frontend/src/routes/admin/managed-systems.tsx` → `apps/frontend/src/routes/_authed/admin/managed-systems.tsx`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2610:+- Move: `apps/frontend/src/routes/admin/analytics-areas.tsx` → `apps/frontend/src/routes/_authed/admin/analytics-areas.tsx`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2611:+- Move: `apps/frontend/src/routes/admin/placeholder.tsx` → `apps/frontend/src/routes/_authed/admin/placeholder.tsx`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2612:+- Move: `apps/frontend/src/routes/admin/*.test.tsx` → alongside relocated `_authed/admin/*` routes; update imports.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2614: - Auto-regen: `apps/frontend/src/routeTree.gen.ts` (TanStackRouterVite plugin handles on dev).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2615:-- Create: `apps/frontend/src/routes/__tests__/vocs.test.tsx` — navigating to `/_authed/vocs?view=inbox` resolves; invalid `?view=foo` rejected by zod; sidebar `+ New VOC` href = `/_authed/vocs?action=create`; `view=triage` renders WorkbenchShell.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2616:+- Create: `apps/frontend/src/routes/__tests__/vocs.test.tsx` — navigating to `/vocs?view=inbox` resolves; invalid `?view=foo` rejected by zod; sidebar `+ New VOC` href = `/vocs?action=create`; `view=triage` renders WorkbenchShell.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2617: - Delete: `apps/frontend/src/routes/dev-rich-editor.tsx` IF it was added in C2 and is no longer needed (or keep behind DEV flag).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2621: - Read first: `apps/frontend/src/routes/__root.tsx`, `apps/frontend/vite.config.ts`, `apps/frontend/src/routes/admin/managed-systems.tsx` (existing TanStack file-route pattern), `apps/frontend/src/lib/layout/AppFrame.tsx` (just created in C4b), `packages/ui/src/layout/` (shells).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2625:+- Constraint: no `Route.id` navigation. Run `grep -rn 'Route\\.id\\|from: .*Route\\.id\\|to: .*Route\\.id' apps/frontend/src/` and refactor any hits to literal `to:` path strings.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2644: - Sonnet dispatches read AGENTS.md hierarchy first (`apps/frontend/AGENTS.md` mandatory).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2649: - **AppFrame in `apps/frontend` NEVER becomes a 4th exported shell. Shell taxonomy = 3 (PageShell/ListShell/WorkbenchShell) per ADR-0020.**
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2660: - `@tiptap/react` in `packages/ui` — verify `apps/frontend` resolves it transitively via workspace link without explicit install; if pnpm strict-mode blocks it, add a peer dep declaration.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2689: - ADR-0020 taxonomy enforced: `packages/ui/src/layout/` exports exactly 3 shells (PageShell, ListShell, WorkbenchShell). AppFrame in `apps/frontend/src/lib/layout/` is NOT a 4th shell.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2740:+- Modify/audit: `apps/frontend/src/routes/admin/managed-systems.tsx`, `apps/frontend/src/routes/admin/analytics-areas.tsx`, `apps/frontend/src/routes/login.tsx`, `apps/frontend/src/routes/index.tsx` and any other route file referencing token classes — grep first, build rename map, then apply.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2741:+- Create: `apps/frontend/src/__tests__/token-class-coverage.test.ts` — grep/scan `.tsx` class strings and assert no `text|border|bg|ring|fill|stroke` token class references a Tailwind theme key that is not resolvable via `resolveConfig`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2742: - Modify: `apps/frontend/src/styles.css` — keep `@import "@fops/ui/styles/tokens.css"` + `semantic.css` + tailwind directives.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2748:+  `grep -rn '\(text\|border\|bg\|ring\|fill\|stroke\)-\(status\|surface\|accent\|severity\|reporter\|internal\|confidence\|focus\)-' apps/frontend/src/`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2792: - Modify: `apps/frontend/src/features/admin/permissions/request-access-button.tsx:115` — `variant="primary"` → `variant="default"` (or leave with primary alias).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2812: - Constraint: `@tiptap/react` lives in `packages/ui` — do NOT install it in `apps/frontend`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2814:+- Constraint: keep `apps/frontend/src/routes/dev-rich-editor.tsx` available after C2 so C3 can validate sanitizer-fail toast flow against the demo route; C5 may delete it only if no later checkpoint needs it.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2820: **Goal:** `<Toaster>` mounted in `__root.tsx`. `apiClient`, `errorMapper`, `useIdempotencyKey` land in `apps/frontend/src/lib/api/`. ALL codes in `ERROR_CODES` from `@fops/shared` covered with Korean copy and tone classification.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2823:-- Create: `apps/frontend/src/lib/api/errorMapper.ts` — maps `{ code, detail }` to `{ tone: 'error'|'warning'|'info', message: string, action?: { label, run } }`. **Catalog is generated by iterating `ERROR_CODES` from `@fops/shared`** — no manually typed list. Every code must map to a non-empty Korean message. Fallback for unknown codes: `{ tone: 'error', message: '일시적 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.' }`. Tone per category: `auth.*` → `error`, `permission.*` → `error`, `rate_limited.*` → `warning`, `validation.*` → `error`, `conflict.*` → `error` (except `conflict.stale_write` → `warning` with retry action), `not_found.*` → `error`, `internal.*` → `error`, `voc.*` → `error`, `rich_content.*` → `error`, `attachment.*` → `warning`, `reporter_facing_status.*` → `warning`. Required codes at minimum (from `packages/shared/src/errors/codes.ts`): `auth.session_invalid`, `auth.session_required`, `auth.session_expired`, `auth.workspace_mismatch`, `permission.denied`, `rate_limited.actor`, `rate_limited.ip`, `validation.failed`, `validation.malformed_request`, `validation.unknown_capability`, `conflict.idempotency_key_reuse`, `conflict.capability_already_granted`, `conflict.permission_request_duplicate`, `validation.malformed_idempotency_key`, `validation.sensitive_reason_required`, `validation.immutable_field`, `conflict.duplicate_slug`, `conflict.parent_archived`, `conflict.record_archived`, `not_found.record`, `internal.unexpected`, `voc.severity_not_user_settable`, `validation.unexpected_field`, `rich_content.disallowed_node`, `rich_content.external_image_forbidden`, `attachment.unsupported_pending_storage_slice`, `conflict.stale_write`, `voc.reporter_status_via_public_update_only`, `permission.scope_required`, `reporter_facing_status.invalid_transition`, `reporter_facing_status.gate_blocked`, `conflict.triage_already_committed`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2824:+- Create: `apps/frontend/src/lib/api/errorMapper.ts` — maps `{ code, detail }` to `{ tone: 'error'|'warning'|'info', message: string, action?: { label, run } }`. **Catalog is generated by iterating `ERROR_CODES` from `@fops/shared`** — no manually typed list. Every code must map to a non-empty Korean message. Export `GENERIC_ERROR_MESSAGE = '일시적 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.'` so tests compare to the fallback constant directly. Fallback for unknown codes: `{ tone: 'error', message: GENERIC_ERROR_MESSAGE }`. Tone per category: `auth.*` → `error`, `permission.*` → `error`, `rate_limited.*` → `warning`, `validation.*` → `error`, `conflict.*` → `error` (except `conflict.stale_write` → `warning` with retry action), `not_found.*` → `error`, `internal.*` → `error`, `voc.*` → `error`, `rich_content.*` → `error`, `attachment.*` → `warning`, `reporter_facing_status.*` → `warning`. Required codes at minimum (from `packages/shared/src/errors/codes.ts`): `auth.session_invalid`, `auth.session_required`, `auth.session_expired`, `auth.workspace_mismatch`, `permission.denied`, `rate_limited.actor`, `rate_limited.ip`, `validation.failed`, `validation.malformed_request`, `validation.unknown_capability`, `conflict.idempotency_key_reuse`, `conflict.capability_already_granted`, `conflict.permission_request_duplicate`, `validation.malformed_idempotency_key`, `validation.sensitive_reason_required`, `validation.immutable_field`, `conflict.duplicate_slug`, `conflict.parent_archived`, `conflict.record_archived`, `not_found.record`, `internal.unexpected`, `voc.severity_not_user_settable`, `validation.unexpected_field`, `rich_content.disallowed_node`, `rich_content.external_image_forbidden`, `attachment.unsupported_pending_storage_slice`, `conflict.stale_write`, `voc.reporter_status_via_public_update_only`, `permission.scope_required`, `reporter_facing_status.invalid_transition`, `reporter_facing_status.gate_blocked`, `conflict.triage_already_committed`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2825: - Create: `apps/frontend/src/lib/api/client.ts` — `apiClient(method, path, { body?, idempotencyKey?, ifMatch?, signal? })`. Auto-mint Idempotency-Key UUIDv4 on POST/PATCH/DELETE when not supplied. Attach `Authorization` from session store. Parse JSON. Non-2xx → throw `ApiError extends Error { code, detail, status, requestId }`. 304 → return `{ status: 304, etag }`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2826: - Create: `apps/frontend/src/lib/api/useIdempotencyKey.ts` — `useIdempotencyKey(ifMatchEtag?: string)`. Returns stable UUIDv4 per render-tree until consumed; `markConsumed()` mints fresh. **When `ifMatchEtag` changes value, the hook MUST automatically mint a fresh UUIDv4** — this prevents `conflict.idempotency_key_reuse` after a stale-write refetch (BE includes `ifMatch` in the idempotency hash per `apps/backend/src/modules/voc/routes.ts:225`, so a retry with a new `If-Match` value is a semantically different request that needs a new key).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2827: - Create: `apps/frontend/src/lib/api/types.ts` — `ApiErrorEnvelope` matching BE `errors/envelope.ts`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2828: - Modify: `apps/frontend/src/routes/__root.tsx` — mount `<Toaster position="bottom-center" />` from `sonner`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2829:-- Create: `apps/frontend/src/lib/api/__tests__/errorMapper.test.ts` — **iterate `ERROR_CODES` from `@fops/shared` and assert each maps to a non-empty Korean message** (not a manual catalog). This test auto-covers new codes added to `codes.ts` without test update.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2830:+- Create: `apps/frontend/src/lib/api/__tests__/errorMapper.test.ts` — **iterate `ERROR_CODES` from `@fops/shared` and assert each maps to a non-empty Korean message** (not a manual catalog). This test auto-covers new codes added to `codes.ts` without test update. Locked assertions: (1) every `ERROR_CODES` mapping has `tone` in literal set `{ 'error', 'warning', 'info' }`; (2) every code with prefix/member in `{ voc.*, rich_content.*, attachment.*, reporter_facing_status.*, conflict.stale_write, conflict.triage_already_committed, conflict.idempotency_key_reuse }` has Korean message not equal to exported `GENERIC_ERROR_MESSAGE`; (3) `conflict.stale_write` maps to `{ tone: 'warning', action: { label: <not undefined>, run: <fn> } }`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2831: - Create: `apps/frontend/src/lib/api/__tests__/client.test.ts` — mock fetch: POST mints Idempotency-Key, GET omits, Authorization attached, 422 throws ApiError, 304 returns ETag. Add test case: same `useIdempotencyKey` instance + changed `ifMatchEtag` → new key minted automatically.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2838:-**CHECKPOINT 2.5** — small playground demonstrating: Toaster position (bottom-center), tone variants (success / error / warning / info) with Korean copy, at least 3 representative error codes rendered as toasts (`conflict.stale_write` warning + retry action, `permission.denied` error, `rate_limited.ip` warning). AskUserQuestion: "토스트 UX + 에러 메시지 OK?"
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2839:+**CHECKPOINT 2.5** — playground HTML demonstrating: Toaster tones + Korean copy for 3+ representative codes (`conflict.stale_write` warning + retry action, `permission.denied` error, `rate_limited.ip` warning) + RichEditor demo rendering sanitizer-rejected content with toast surfaced via apiClient mock. Requires C2 `/dev-rich-editor` route to still exist when C3 lands. AskUserQuestion: "토스트 UX + 에러 메시지 OK?"
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2868: ## C4b — AppFrame in apps/frontend + useFullscreenPanel hook
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2870:-**Goal:** `<AppFrame>` in `apps/frontend/src/lib/layout/` composes Rail(52) + Sidebar(240/56) + (shell outlet) + DetailPanelSlot(440). AppFrame consumes one of the 3 shells as its inner outlet. It is NOT exported as a shell — it is the authenticated route frame. `useFullscreenPanel` hook ready for #20 to consume.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2871:+**Goal:** `<AppFrame>` in `apps/frontend/src/lib/layout/` composes Rail(52) + Sidebar(240/56) + (shell outlet) + the single global DetailPanelSlot(440). AppFrame consumes one of the 3 shells as its inner outlet. It is NOT exported as a shell — it is the authenticated route frame. `useFullscreenPanel` hook ready for #20 to consume.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2876: - Create: `apps/frontend/src/lib/layout/AppFrame.tsx` — flex row Rail(52) + Sidebar(240/56) + Main(flex-1, shell outlet) + DetailPanelSlot(440 conditional). Headers conform to 50px rhythm via ShellHeader from `packages/ui`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2877: - Create: `apps/frontend/src/lib/layout/AppRail.tsx` — 52px vertical, workspace switcher placeholder + lucide-react utility icons.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2878:-- Create: `apps/frontend/src/lib/layout/AppSidebar.tsx` — 240px nav list. Slice 3 entries: Inbox, My VOCs, Triage, + New VOC. Collapse button writes `localStorage.appSidebarCollapsed`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2879:-- Create: `apps/frontend/src/lib/layout/DetailPanelSlot.tsx` — fixed 440 right column. min 360 / max 520. Hidden when no content registered via `useDetailPanelSlot()`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2880:-- Create: `apps/frontend/src/lib/layout/useDetailPanelSlot.ts` — context-based slot register/clear hook.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2881:+- Create: `apps/frontend/src/lib/layout/AppSidebar.tsx` — 240px nav list. Slice 3 entries: Inbox, My VOCs, Triage, + New VOC. Collapse state uses SSR-safe initializer:
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2889:+- Create: `apps/frontend/src/lib/layout/DetailPanelSlot.tsx` — fixed 440 right column. min 360 / max 520. Hidden when no content registered via `useDetailPanelSlot()`. This is the single rendering surface for all shell `detailPanel` content.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2890:+- Create: `apps/frontend/src/lib/layout/useDetailPanelSlot.ts` — context-based slot register/clear hook. Forbid multiple registrants: throw in dev (and warn in prod) if called twice with overlapping lifetimes, using a ref to track active ownership.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2891: - Create: `apps/frontend/src/lib/panel/useFullscreenPanel.ts` — `[isFullscreen, toggle]`. Esc collapses. Route change clears.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2892:-- Create: `apps/frontend/src/lib/layout/__tests__/AppFrame.test.tsx` — Rail/Sidebar/Main present; sidebar collapse toggle writes localStorage; DetailPanelSlot collapses when empty.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2893:+- Create: `apps/frontend/src/lib/layout/__tests__/AppFrame.test.tsx` — Rail/Sidebar/Main present; sidebar first-paint width matches stored `localStorage.appSidebarCollapsed` before any user interaction; sidebar collapse toggle writes localStorage; DetailPanelSlot collapses when empty; multiple overlapping `useDetailPanelSlot()` registrants throw/warn.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2894: - Create: `apps/frontend/src/lib/panel/__tests__/useFullscreenPanel.test.tsx` — toggle flips boolean; Esc dispatches collapse; route change clears (mock router).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2900: - Constraint: AppFrame is NOT exported from `packages/ui` — it lives in `apps/frontend/src/lib/layout/` only.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2909:-- `apps/frontend/src/routes/_authed.tsx` — new TanStack layout route. Wraps children with `<AppFrame>`. Login + non-authed routes do NOT use this layout and do NOT render AppFrame.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2911:+- `apps/frontend/src/routes/_authed.tsx` — new TanStack pathless layout route. Includes a `beforeLoad` callback that calls `fetchMe()` (same auth pattern currently used in admin routes) and `redirect({ to: '/login' })` on `UnauthenticatedError`. Wraps children with `<AppFrame>`. Login + non-authed routes do NOT use this layout and do NOT render AppFrame.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2912:+- Per-route auth guards in admin pages are DELETED in C5 after `_authed.beforeLoad` centralizes the guard.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2914:+  - `apps/frontend/src/routes/admin/managed-systems.tsx` → `apps/frontend/src/routes/_authed/admin/managed-systems.tsx`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2915:+  - `apps/frontend/src/routes/admin/analytics-areas.tsx` → `apps/frontend/src/routes/_authed/admin/analytics-areas.tsx`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2916:+  - `apps/frontend/src/routes/admin/placeholder.tsx` → `apps/frontend/src/routes/_authed/admin/placeholder.tsx`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2917:+  - Test file imports updated: `apps/frontend/src/routes/admin/*.test.tsx` move alongside their routes.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2920:-- `/vocs` route = `apps/frontend/src/routes/_authed/vocs.tsx`. Per-view shell selection: `view=inbox|my` → `<ListShell>`, `view=triage` → `<WorkbenchShell>`, `action=create` → `<PageShell>` (default when no view/action = `<ListShell>`).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2921:+- `/vocs` route file = `apps/frontend/src/routes/_authed/vocs.tsx`. Public path string is `/vocs`; `_authed` is pathless. Per-view shell selection: `view=inbox|my` → `<ListShell>`, `view=triage` → `<WorkbenchShell>`, `action=create` → `<PageShell>` (default when no view/action = `<ListShell>`).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2925:-- Create: `apps/frontend/src/routes/_authed.tsx` — TanStack layout route. Renders `<AppFrame><Outlet /></AppFrame>`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2926:+- Create: `apps/frontend/src/routes/_authed.tsx` — TanStack layout route. `beforeLoad` calls `fetchMe()` and redirects unauthenticated users to `/login`; renders `<AppFrame><Outlet /></AppFrame>`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2927: - Create: `apps/frontend/src/routes/_authed/vocs.tsx` — `createFileRoute('/_authed/vocs')` with validateSearch zod. Component selects shell based on `view`/`action`. Main = placeholder text.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2928: - Modify: `apps/frontend/src/routes/__root.tsx` — minimal; providers + `<Outlet>` only (no AppFrame).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2929:-- Relocate or re-parent: `apps/frontend/src/routes/admin/` — move under `_authed` so admin pages get AppFrame. If not done in C5, create a follow-up GitHub issue before closing this chunk.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2930:+- Move: `apps/frontend/src/routes/admin/managed-systems.tsx` → `apps/frontend/src/routes/_authed/admin/managed-systems.tsx`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2931:+- Move: `apps/frontend/src/routes/admin/analytics-areas.tsx` → `apps/frontend/src/routes/_authed/admin/analytics-areas.tsx`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2932:+- Move: `apps/frontend/src/routes/admin/placeholder.tsx` → `apps/frontend/src/routes/_authed/admin/placeholder.tsx`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2933:+- Move: `apps/frontend/src/routes/admin/*.test.tsx` → alongside relocated `_authed/admin/*` routes; update imports.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2935: - Auto-regen: `apps/frontend/src/routeTree.gen.ts` (TanStackRouterVite plugin handles on dev).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2936:-- Create: `apps/frontend/src/routes/__tests__/vocs.test.tsx` — navigating to `/_authed/vocs?view=inbox` resolves; invalid `?view=foo` rejected by zod; sidebar `+ New VOC` href = `/_authed/vocs?action=create`; `view=triage` renders WorkbenchShell.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2937:+- Create: `apps/frontend/src/routes/__tests__/vocs.test.tsx` — navigating to `/vocs?view=inbox` resolves; invalid `?view=foo` rejected by zod; sidebar `+ New VOC` href = `/vocs?action=create`; `view=triage` renders WorkbenchShell.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2938: - Delete: `apps/frontend/src/routes/dev-rich-editor.tsx` IF it was added in C2 and is no longer needed (or keep behind DEV flag).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2942: - Read first: `apps/frontend/src/routes/__root.tsx`, `apps/frontend/vite.config.ts`, `apps/frontend/src/routes/admin/managed-systems.tsx` (existing TanStack file-route pattern), `apps/frontend/src/lib/layout/AppFrame.tsx` (just created in C4b), `packages/ui/src/layout/` (shells).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2946:+- Constraint: no `Route.id` navigation. Run `grep -rn 'Route\\.id\\|from: .*Route\\.id\\|to: .*Route\\.id' apps/frontend/src/` and refactor any hits to literal `to:` path strings.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2965: - Sonnet dispatches read AGENTS.md hierarchy first (`apps/frontend/AGENTS.md` mandatory).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2970: - **AppFrame in `apps/frontend` NEVER becomes a 4th exported shell. Shell taxonomy = 3 (PageShell/ListShell/WorkbenchShell) per ADR-0020.**
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:2981: - `@tiptap/react` in `packages/ui` — verify `apps/frontend` resolves it transitively via workspace link without explicit install; if pnpm strict-mode blocks it, add a peer dep declaration.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3032:+      {type:'modify', path:'apps/frontend/src/routes/{admin/managed-systems,admin/analytics-areas,login,index}.tsx  // token classname rename audit'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3033:+      {type:'create', path:'apps/frontend/src/__tests__/token-class-coverage.test.ts  // resolveConfig coverage for TSX token classes'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3034:       {type:'modify', path:'apps/frontend/src/styles.css  // @import tokens.css + semantic.css'}
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3068: - ADR-0020 taxonomy enforced: `packages/ui/src/layout/` exports exactly 3 shells (PageShell, ListShell, WorkbenchShell). AppFrame in `apps/frontend/src/lib/layout/` is NOT a 4th shell.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3119:+- Modify/audit: `apps/frontend/src/routes/admin/managed-systems.tsx`, `apps/frontend/src/routes/admin/analytics-areas.tsx`, `apps/frontend/src/routes/login.tsx`, `apps/frontend/src/routes/index.tsx` and any other route file referencing token classes — grep first, build rename map, then apply.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3120:+- Create: `apps/frontend/src/__tests__/token-class-coverage.test.ts` — grep/scan `.tsx` class strings and assert no `text|border|bg|ring|fill|stroke` token class references a Tailwind theme key that is not resolvable via `resolveConfig`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3121: - Modify: `apps/frontend/src/styles.css` — keep `@import "@fops/ui/styles/tokens.css"` + `semantic.css` + tailwind directives.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3127:+  `grep -rn '\(text\|border\|bg\|ring\|fill\|stroke\)-\(status\|surface\|accent\|severity\|reporter\|internal\|confidence\|focus\)-' apps/frontend/src/`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3171: - Modify: `apps/frontend/src/features/admin/permissions/request-access-button.tsx:115` — `variant="primary"` → `variant="default"` (or leave with primary alias).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3191: - Constraint: `@tiptap/react` lives in `packages/ui` — do NOT install it in `apps/frontend`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3193:+- Constraint: keep `apps/frontend/src/routes/dev-rich-editor.tsx` available after C2 so C3 can validate sanitizer-fail toast flow against the demo route; C5 may delete it only if no later checkpoint needs it.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3199: **Goal:** `<Toaster>` mounted in `__root.tsx`. `apiClient`, `errorMapper`, `useIdempotencyKey` land in `apps/frontend/src/lib/api/`. ALL codes in `ERROR_CODES` from `@fops/shared` covered with Korean copy and tone classification.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3202:-- Create: `apps/frontend/src/lib/api/errorMapper.ts` — maps `{ code, detail }` to `{ tone: 'error'|'warning'|'info', message: string, action?: { label, run } }`. **Catalog is generated by iterating `ERROR_CODES` from `@fops/shared`** — no manually typed list. Every code must map to a non-empty Korean message. Fallback for unknown codes: `{ tone: 'error', message: '일시적 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.' }`. Tone per category: `auth.*` → `error`, `permission.*` → `error`, `rate_limited.*` → `warning`, `validation.*` → `error`, `conflict.*` → `error` (except `conflict.stale_write` → `warning` with retry action), `not_found.*` → `error`, `internal.*` → `error`, `voc.*` → `error`, `rich_content.*` → `error`, `attachment.*` → `warning`, `reporter_facing_status.*` → `warning`. Required codes at minimum (from `packages/shared/src/errors/codes.ts`): `auth.session_invalid`, `auth.session_required`, `auth.session_expired`, `auth.workspace_mismatch`, `permission.denied`, `rate_limited.actor`, `rate_limited.ip`, `validation.failed`, `validation.malformed_request`, `validation.unknown_capability`, `conflict.idempotency_key_reuse`, `conflict.capability_already_granted`, `conflict.permission_request_duplicate`, `validation.malformed_idempotency_key`, `validation.sensitive_reason_required`, `validation.immutable_field`, `conflict.duplicate_slug`, `conflict.parent_archived`, `conflict.record_archived`, `not_found.record`, `internal.unexpected`, `voc.severity_not_user_settable`, `validation.unexpected_field`, `rich_content.disallowed_node`, `rich_content.external_image_forbidden`, `attachment.unsupported_pending_storage_slice`, `conflict.stale_write`, `voc.reporter_status_via_public_update_only`, `permission.scope_required`, `reporter_facing_status.invalid_transition`, `reporter_facing_status.gate_blocked`, `conflict.triage_already_committed`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3203:+- Create: `apps/frontend/src/lib/api/errorMapper.ts` — maps `{ code, detail }` to `{ tone: 'error'|'warning'|'info', message: string, action?: { label, run } }`. **Catalog is generated by iterating `ERROR_CODES` from `@fops/shared`** — no manually typed list. Every code must map to a non-empty Korean message. Export `GENERIC_ERROR_MESSAGE = '일시적 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.'` so tests compare to the fallback constant directly. Fallback for unknown codes: `{ tone: 'error', message: GENERIC_ERROR_MESSAGE }`. Tone per category: `auth.*` → `error`, `permission.*` → `error`, `rate_limited.*` → `warning`, `validation.*` → `error`, `conflict.*` → `error` (except `conflict.stale_write` → `warning` with retry action), `not_found.*` → `error`, `internal.*` → `error`, `voc.*` → `error`, `rich_content.*` → `error`, `attachment.*` → `warning`, `reporter_facing_status.*` → `warning`. Required codes at minimum (from `packages/shared/src/errors/codes.ts`): `auth.session_invalid`, `auth.session_required`, `auth.session_expired`, `auth.workspace_mismatch`, `permission.denied`, `rate_limited.actor`, `rate_limited.ip`, `validation.failed`, `validation.malformed_request`, `validation.unknown_capability`, `conflict.idempotency_key_reuse`, `conflict.capability_already_granted`, `conflict.permission_request_duplicate`, `validation.malformed_idempotency_key`, `validation.sensitive_reason_required`, `validation.immutable_field`, `conflict.duplicate_slug`, `conflict.parent_archived`, `conflict.record_archived`, `not_found.record`, `internal.unexpected`, `voc.severity_not_user_settable`, `validation.unexpected_field`, `rich_content.disallowed_node`, `rich_content.external_image_forbidden`, `attachment.unsupported_pending_storage_slice`, `conflict.stale_write`, `voc.reporter_status_via_public_update_only`, `permission.scope_required`, `reporter_facing_status.invalid_transition`, `reporter_facing_status.gate_blocked`, `conflict.triage_already_committed`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3204: - Create: `apps/frontend/src/lib/api/client.ts` — `apiClient(method, path, { body?, idempotencyKey?, ifMatch?, signal? })`. Auto-mint Idempotency-Key UUIDv4 on POST/PATCH/DELETE when not supplied. Attach `Authorization` from session store. Parse JSON. Non-2xx → throw `ApiError extends Error { code, detail, status, requestId }`. 304 → return `{ status: 304, etag }`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3205: - Create: `apps/frontend/src/lib/api/useIdempotencyKey.ts` — `useIdempotencyKey(ifMatchEtag?: string)`. Returns stable UUIDv4 per render-tree until consumed; `markConsumed()` mints fresh. **When `ifMatchEtag` changes value, the hook MUST automatically mint a fresh UUIDv4** — this prevents `conflict.idempotency_key_reuse` after a stale-write refetch (BE includes `ifMatch` in the idempotency hash per `apps/backend/src/modules/voc/routes.ts:225`, so a retry with a new `If-Match` value is a semantically different request that needs a new key).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3206: - Create: `apps/frontend/src/lib/api/types.ts` — `ApiErrorEnvelope` matching BE `errors/envelope.ts`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3207: - Modify: `apps/frontend/src/routes/__root.tsx` — mount `<Toaster position="bottom-center" />` from `sonner`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3208:-- Create: `apps/frontend/src/lib/api/__tests__/errorMapper.test.ts` — **iterate `ERROR_CODES` from `@fops/shared` and assert each maps to a non-empty Korean message** (not a manual catalog). This test auto-covers new codes added to `codes.ts` without test update.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3209:+- Create: `apps/frontend/src/lib/api/__tests__/errorMapper.test.ts` — **iterate `ERROR_CODES` from `@fops/shared` and assert each maps to a non-empty Korean message** (not a manual catalog). This test auto-covers new codes added to `codes.ts` without test update. Locked assertions: (1) every `ERROR_CODES` mapping has `tone` in literal set `{ 'error', 'warning', 'info' }`; (2) every code with prefix/member in `{ voc.*, rich_content.*, attachment.*, reporter_facing_status.*, conflict.stale_write, conflict.triage_already_committed, conflict.idempotency_key_reuse }` has Korean message not equal to exported `GENERIC_ERROR_MESSAGE`; (3) `conflict.stale_write` maps to `{ tone: 'warning', action: { label: <not undefined>, run: <fn> } }`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3210: - Create: `apps/frontend/src/lib/api/__tests__/client.test.ts` — mock fetch: POST mints Idempotency-Key, GET omits, Authorization attached, 422 throws ApiError, 304 returns ETag. Add test case: same `useIdempotencyKey` instance + changed `ifMatchEtag` → new key minted automatically.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3217:-**CHECKPOINT 2.5** — small playground demonstrating: Toaster position (bottom-center), tone variants (success / error / warning / info) with Korean copy, at least 3 representative error codes rendered as toasts (`conflict.stale_write` warning + retry action, `permission.denied` error, `rate_limited.ip` warning). AskUserQuestion: "토스트 UX + 에러 메시지 OK?"
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3218:+**CHECKPOINT 2.5** — playground HTML demonstrating: Toaster tones + Korean copy for 3+ representative codes (`conflict.stale_write` warning + retry action, `permission.denied` error, `rate_limited.ip` warning) + RichEditor demo rendering sanitizer-rejected content with toast surfaced via apiClient mock. Requires C2 `/dev-rich-editor` route to still exist when C3 lands. AskUserQuestion: "토스트 UX + 에러 메시지 OK?"
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3247: ## C4b — AppFrame in apps/frontend + useFullscreenPanel hook
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3249:-**Goal:** `<AppFrame>` in `apps/frontend/src/lib/layout/` composes Rail(52) + Sidebar(240/56) + (shell outlet) + DetailPanelSlot(440). AppFrame consumes one of the 3 shells as its inner outlet. It is NOT exported as a shell — it is the authenticated route frame. `useFullscreenPanel` hook ready for #20 to consume.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3250:+**Goal:** `<AppFrame>` in `apps/frontend/src/lib/layout/` composes Rail(52) + Sidebar(240/56) + (shell outlet) + the single global DetailPanelSlot(440). AppFrame consumes one of the 3 shells as its inner outlet. It is NOT exported as a shell — it is the authenticated route frame. `useFullscreenPanel` hook ready for #20 to consume.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3255: - Create: `apps/frontend/src/lib/layout/AppFrame.tsx` — flex row Rail(52) + Sidebar(240/56) + Main(flex-1, shell outlet) + DetailPanelSlot(440 conditional). Headers conform to 50px rhythm via ShellHeader from `packages/ui`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3256: - Create: `apps/frontend/src/lib/layout/AppRail.tsx` — 52px vertical, workspace switcher placeholder + lucide-react utility icons.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3257:-- Create: `apps/frontend/src/lib/layout/AppSidebar.tsx` — 240px nav list. Slice 3 entries: Inbox, My VOCs, Triage, + New VOC. Collapse button writes `localStorage.appSidebarCollapsed`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3258:-- Create: `apps/frontend/src/lib/layout/DetailPanelSlot.tsx` — fixed 440 right column. min 360 / max 520. Hidden when no content registered via `useDetailPanelSlot()`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3259:-- Create: `apps/frontend/src/lib/layout/useDetailPanelSlot.ts` — context-based slot register/clear hook.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3260:+- Create: `apps/frontend/src/lib/layout/AppSidebar.tsx` — 240px nav list. Slice 3 entries: Inbox, My VOCs, Triage, + New VOC. Collapse state uses SSR-safe initializer:
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3268:+- Create: `apps/frontend/src/lib/layout/DetailPanelSlot.tsx` — fixed 440 right column. min 360 / max 520. Hidden when no content registered via `useDetailPanelSlot()`. This is the single rendering surface for all shell `detailPanel` content.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3269:+- Create: `apps/frontend/src/lib/layout/useDetailPanelSlot.ts` — context-based slot register/clear hook. Forbid multiple registrants: throw in dev (and warn in prod) if called twice with overlapping lifetimes, using a ref to track active ownership.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3270: - Create: `apps/frontend/src/lib/panel/useFullscreenPanel.ts` — `[isFullscreen, toggle]`. Esc collapses. Route change clears.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3271:-- Create: `apps/frontend/src/lib/layout/__tests__/AppFrame.test.tsx` — Rail/Sidebar/Main present; sidebar collapse toggle writes localStorage; DetailPanelSlot collapses when empty.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3272:+- Create: `apps/frontend/src/lib/layout/__tests__/AppFrame.test.tsx` — Rail/Sidebar/Main present; sidebar first-paint width matches stored `localStorage.appSidebarCollapsed` before any user interaction; sidebar collapse toggle writes localStorage; DetailPanelSlot collapses when empty; multiple overlapping `useDetailPanelSlot()` registrants throw/warn.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3273: - Create: `apps/frontend/src/lib/panel/__tests__/useFullscreenPanel.test.tsx` — toggle flips boolean; Esc dispatches collapse; route change clears (mock router).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3279: - Constraint: AppFrame is NOT exported from `packages/ui` — it lives in `apps/frontend/src/lib/layout/` only.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3288:-- `apps/frontend/src/routes/_authed.tsx` — new TanStack layout route. Wraps children with `<AppFrame>`. Login + non-authed routes do NOT use this layout and do NOT render AppFrame.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3290:+- `apps/frontend/src/routes/_authed.tsx` — new TanStack pathless layout route. Includes a `beforeLoad` callback that calls `fetchMe()` (same auth pattern currently used in admin routes) and `redirect({ to: '/login' })` on `UnauthenticatedError`. Wraps children with `<AppFrame>`. Login + non-authed routes do NOT use this layout and do NOT render AppFrame.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3291:+- Per-route auth guards in admin pages are DELETED in C5 after `_authed.beforeLoad` centralizes the guard.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3293:+  - `apps/frontend/src/routes/admin/managed-systems.tsx` → `apps/frontend/src/routes/_authed/admin/managed-systems.tsx`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3294:+  - `apps/frontend/src/routes/admin/analytics-areas.tsx` → `apps/frontend/src/routes/_authed/admin/analytics-areas.tsx`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3295:+  - `apps/frontend/src/routes/admin/placeholder.tsx` → `apps/frontend/src/routes/_authed/admin/placeholder.tsx`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3296:+  - Test file imports updated: `apps/frontend/src/routes/admin/*.test.tsx` move alongside their routes.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3299:-- `/vocs` route = `apps/frontend/src/routes/_authed/vocs.tsx`. Per-view shell selection: `view=inbox|my` → `<ListShell>`, `view=triage` → `<WorkbenchShell>`, `action=create` → `<PageShell>` (default when no view/action = `<ListShell>`).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3300:+- `/vocs` route file = `apps/frontend/src/routes/_authed/vocs.tsx`. Public path string is `/vocs`; `_authed` is pathless. Per-view shell selection: `view=inbox|my` → `<ListShell>`, `view=triage` → `<WorkbenchShell>`, `action=create` → `<PageShell>` (default when no view/action = `<ListShell>`).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3304:-- Create: `apps/frontend/src/routes/_authed.tsx` — TanStack layout route. Renders `<AppFrame><Outlet /></AppFrame>`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3305:+- Create: `apps/frontend/src/routes/_authed.tsx` — TanStack layout route. `beforeLoad` calls `fetchMe()` and redirects unauthenticated users to `/login`; renders `<AppFrame><Outlet /></AppFrame>`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3306: - Create: `apps/frontend/src/routes/_authed/vocs.tsx` — `createFileRoute('/_authed/vocs')` with validateSearch zod. Component selects shell based on `view`/`action`. Main = placeholder text.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3307: - Modify: `apps/frontend/src/routes/__root.tsx` — minimal; providers + `<Outlet>` only (no AppFrame).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3308:-- Relocate or re-parent: `apps/frontend/src/routes/admin/` — move under `_authed` so admin pages get AppFrame. If not done in C5, create a follow-up GitHub issue before closing this chunk.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3309:+- Move: `apps/frontend/src/routes/admin/managed-systems.tsx` → `apps/frontend/src/routes/_authed/admin/managed-systems.tsx`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3310:+- Move: `apps/frontend/src/routes/admin/analytics-areas.tsx` → `apps/frontend/src/routes/_authed/admin/analytics-areas.tsx`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3311:+- Move: `apps/frontend/src/routes/admin/placeholder.tsx` → `apps/frontend/src/routes/_authed/admin/placeholder.tsx`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3312:+- Move: `apps/frontend/src/routes/admin/*.test.tsx` → alongside relocated `_authed/admin/*` routes; update imports.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3314: - Auto-regen: `apps/frontend/src/routeTree.gen.ts` (TanStackRouterVite plugin handles on dev).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3315:-- Create: `apps/frontend/src/routes/__tests__/vocs.test.tsx` — navigating to `/_authed/vocs?view=inbox` resolves; invalid `?view=foo` rejected by zod; sidebar `+ New VOC` href = `/_authed/vocs?action=create`; `view=triage` renders WorkbenchShell.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3316:+- Create: `apps/frontend/src/routes/__tests__/vocs.test.tsx` — navigating to `/vocs?view=inbox` resolves; invalid `?view=foo` rejected by zod; sidebar `+ New VOC` href = `/vocs?action=create`; `view=triage` renders WorkbenchShell.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3317: - Delete: `apps/frontend/src/routes/dev-rich-editor.tsx` IF it was added in C2 and is no longer needed (or keep behind DEV flag).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3321: - Read first: `apps/frontend/src/routes/__root.tsx`, `apps/frontend/vite.config.ts`, `apps/frontend/src/routes/admin/managed-systems.tsx` (existing TanStack file-route pattern), `apps/frontend/src/lib/layout/AppFrame.tsx` (just created in C4b), `packages/ui/src/layout/` (shells).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3325:+- Constraint: no `Route.id` navigation. Run `grep -rn 'Route\\.id\\|from: .*Route\\.id\\|to: .*Route\\.id' apps/frontend/src/` and refactor any hits to literal `to:` path strings.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3344: - Sonnet dispatches read AGENTS.md hierarchy first (`apps/frontend/AGENTS.md` mandatory).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3349: - **AppFrame in `apps/frontend` NEVER becomes a 4th exported shell. Shell taxonomy = 3 (PageShell/ListShell/WorkbenchShell) per ADR-0020.**
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3360: - `@tiptap/react` in `packages/ui` — verify `apps/frontend` resolves it transitively via workspace link without explicit install; if pnpm strict-mode blocks it, add a peer dep declaration.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3411:+      {type:'modify', path:'apps/frontend/src/routes/{admin/managed-systems,admin/analytics-areas,login,index}.tsx  // token classname rename audit'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3412:+      {type:'create', path:'apps/frontend/src/__tests__/token-class-coverage.test.ts  // resolveConfig coverage for TSX token classes'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3413:       {type:'modify', path:'apps/frontend/src/styles.css  // @import tokens.css + semantic.css'}
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3450: - ADR-0020 taxonomy enforced: `packages/ui/src/layout/` exports exactly 3 shells (PageShell, ListShell, WorkbenchShell). AppFrame in `apps/frontend/src/lib/layout/` is NOT a 4th shell.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3501:+- Modify/audit: `apps/frontend/src/routes/admin/managed-systems.tsx`, `apps/frontend/src/routes/admin/analytics-areas.tsx`, `apps/frontend/src/routes/login.tsx`, `apps/frontend/src/routes/index.tsx` and any other route file referencing token classes — grep first, build rename map, then apply.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3502:+- Create: `apps/frontend/src/__tests__/token-class-coverage.test.ts` — grep/scan `.tsx` class strings and assert no `text|border|bg|ring|fill|stroke` token class references a Tailwind theme key that is not resolvable via `resolveConfig`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3503: - Modify: `apps/frontend/src/styles.css` — keep `@import "@fops/ui/styles/tokens.css"` + `semantic.css` + tailwind directives.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3509:+  `grep -rn '\(text\|border\|bg\|ring\|fill\|stroke\)-\(status\|surface\|accent\|severity\|reporter\|internal\|confidence\|focus\)-' apps/frontend/src/`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3553: - Modify: `apps/frontend/src/features/admin/permissions/request-access-button.tsx:115` — `variant="primary"` → `variant="default"` (or leave with primary alias).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3573: - Constraint: `@tiptap/react` lives in `packages/ui` — do NOT install it in `apps/frontend`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3575:+- Constraint: keep `apps/frontend/src/routes/dev-rich-editor.tsx` available after C2 so C3 can validate sanitizer-fail toast flow against the demo route; C5 may delete it only if no later checkpoint needs it.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3581: **Goal:** `<Toaster>` mounted in `__root.tsx`. `apiClient`, `errorMapper`, `useIdempotencyKey` land in `apps/frontend/src/lib/api/`. ALL codes in `ERROR_CODES` from `@fops/shared` covered with Korean copy and tone classification.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3584:-- Create: `apps/frontend/src/lib/api/errorMapper.ts` — maps `{ code, detail }` to `{ tone: 'error'|'warning'|'info', message: string, action?: { label, run } }`. **Catalog is generated by iterating `ERROR_CODES` from `@fops/shared`** — no manually typed list. Every code must map to a non-empty Korean message. Fallback for unknown codes: `{ tone: 'error', message: '일시적 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.' }`. Tone per category: `auth.*` → `error`, `permission.*` → `error`, `rate_limited.*` → `warning`, `validation.*` → `error`, `conflict.*` → `error` (except `conflict.stale_write` → `warning` with retry action), `not_found.*` → `error`, `internal.*` → `error`, `voc.*` → `error`, `rich_content.*` → `error`, `attachment.*` → `warning`, `reporter_facing_status.*` → `warning`. Required codes at minimum (from `packages/shared/src/errors/codes.ts`): `auth.session_invalid`, `auth.session_required`, `auth.session_expired`, `auth.workspace_mismatch`, `permission.denied`, `rate_limited.actor`, `rate_limited.ip`, `validation.failed`, `validation.malformed_request`, `validation.unknown_capability`, `conflict.idempotency_key_reuse`, `conflict.capability_already_granted`, `conflict.permission_request_duplicate`, `validation.malformed_idempotency_key`, `validation.sensitive_reason_required`, `validation.immutable_field`, `conflict.duplicate_slug`, `conflict.parent_archived`, `conflict.record_archived`, `not_found.record`, `internal.unexpected`, `voc.severity_not_user_settable`, `validation.unexpected_field`, `rich_content.disallowed_node`, `rich_content.external_image_forbidden`, `attachment.unsupported_pending_storage_slice`, `conflict.stale_write`, `voc.reporter_status_via_public_update_only`, `permission.scope_required`, `reporter_facing_status.invalid_transition`, `reporter_facing_status.gate_blocked`, `conflict.triage_already_committed`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3585:+- Create: `apps/frontend/src/lib/api/errorMapper.ts` — maps `{ code, detail }` to `{ tone: 'error'|'warning'|'info', message: string, action?: { label, run } }`. **Catalog is generated by iterating `ERROR_CODES` from `@fops/shared`** — no manually typed list. Every code must map to a non-empty Korean message. Export `GENERIC_ERROR_MESSAGE = '일시적 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.'` so tests compare to the fallback constant directly. Fallback for unknown codes: `{ tone: 'error', message: GENERIC_ERROR_MESSAGE }`. Tone per category: `auth.*` → `error`, `permission.*` → `error`, `rate_limited.*` → `warning`, `validation.*` → `error`, `conflict.*` → `error` (except `conflict.stale_write` → `warning` with retry action), `not_found.*` → `error`, `internal.*` → `error`, `voc.*` → `error`, `rich_content.*` → `error`, `attachment.*` → `warning`, `reporter_facing_status.*` → `warning`. Required codes at minimum (from `packages/shared/src/errors/codes.ts`): `auth.session_invalid`, `auth.session_required`, `auth.session_expired`, `auth.workspace_mismatch`, `permission.denied`, `rate_limited.actor`, `rate_limited.ip`, `validation.failed`, `validation.malformed_request`, `validation.unknown_capability`, `conflict.idempotency_key_reuse`, `conflict.capability_already_granted`, `conflict.permission_request_duplicate`, `validation.malformed_idempotency_key`, `validation.sensitive_reason_required`, `validation.immutable_field`, `conflict.duplicate_slug`, `conflict.parent_archived`, `conflict.record_archived`, `not_found.record`, `internal.unexpected`, `voc.severity_not_user_settable`, `validation.unexpected_field`, `rich_content.disallowed_node`, `rich_content.external_image_forbidden`, `attachment.unsupported_pending_storage_slice`, `conflict.stale_write`, `voc.reporter_status_via_public_update_only`, `permission.scope_required`, `reporter_facing_status.invalid_transition`, `reporter_facing_status.gate_blocked`, `conflict.triage_already_committed`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3586: - Create: `apps/frontend/src/lib/api/client.ts` — `apiClient(method, path, { body?, idempotencyKey?, ifMatch?, signal? })`. Auto-mint Idempotency-Key UUIDv4 on POST/PATCH/DELETE when not supplied. Attach `Authorization` from session store. Parse JSON. Non-2xx → throw `ApiError extends Error { code, detail, status, requestId }`. 304 → return `{ status: 304, etag }`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3587: - Create: `apps/frontend/src/lib/api/useIdempotencyKey.ts` — `useIdempotencyKey(ifMatchEtag?: string)`. Returns stable UUIDv4 per render-tree until consumed; `markConsumed()` mints fresh. **When `ifMatchEtag` changes value, the hook MUST automatically mint a fresh UUIDv4** — this prevents `conflict.idempotency_key_reuse` after a stale-write refetch (BE includes `ifMatch` in the idempotency hash per `apps/backend/src/modules/voc/routes.ts:225`, so a retry with a new `If-Match` value is a semantically different request that needs a new key).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3588: - Create: `apps/frontend/src/lib/api/types.ts` — `ApiErrorEnvelope` matching BE `errors/envelope.ts`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3589: - Modify: `apps/frontend/src/routes/__root.tsx` — mount `<Toaster position="bottom-center" />` from `sonner`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3590:-- Create: `apps/frontend/src/lib/api/__tests__/errorMapper.test.ts` — **iterate `ERROR_CODES` from `@fops/shared` and assert each maps to a non-empty Korean message** (not a manual catalog). This test auto-covers new codes added to `codes.ts` without test update.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3591:+- Create: `apps/frontend/src/lib/api/__tests__/errorMapper.test.ts` — **iterate `ERROR_CODES` from `@fops/shared` and assert each maps to a non-empty Korean message** (not a manual catalog). This test auto-covers new codes added to `codes.ts` without test update. Locked assertions: (1) every `ERROR_CODES` mapping has `tone` in literal set `{ 'error', 'warning', 'info' }`; (2) every code with prefix/member in `{ voc.*, rich_content.*, attachment.*, reporter_facing_status.*, conflict.stale_write, conflict.triage_already_committed, conflict.idempotency_key_reuse }` has Korean message not equal to exported `GENERIC_ERROR_MESSAGE`; (3) `conflict.stale_write` maps to `{ tone: 'warning', action: { label: <not undefined>, run: <fn> } }`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3592: - Create: `apps/frontend/src/lib/api/__tests__/client.test.ts` — mock fetch: POST mints Idempotency-Key, GET omits, Authorization attached, 422 throws ApiError, 304 returns ETag. Add test case: same `useIdempotencyKey` instance + changed `ifMatchEtag` → new key minted automatically.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3599:-**CHECKPOINT 2.5** — small playground demonstrating: Toaster position (bottom-center), tone variants (success / error / warning / info) with Korean copy, at least 3 representative error codes rendered as toasts (`conflict.stale_write` warning + retry action, `permission.denied` error, `rate_limited.ip` warning). AskUserQuestion: "토스트 UX + 에러 메시지 OK?"
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3600:+**CHECKPOINT 2.5** — playground HTML demonstrating: Toaster tones + Korean copy for 3+ representative codes (`conflict.stale_write` warning + retry action, `permission.denied` error, `rate_limited.ip` warning) + RichEditor demo rendering sanitizer-rejected content with toast surfaced via apiClient mock. Requires C2 `/dev-rich-editor` route to still exist when C3 lands. AskUserQuestion: "토스트 UX + 에러 메시지 OK?"
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3629: ## C4b — AppFrame in apps/frontend + useFullscreenPanel hook
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3631:-**Goal:** `<AppFrame>` in `apps/frontend/src/lib/layout/` composes Rail(52) + Sidebar(240/56) + (shell outlet) + DetailPanelSlot(440). AppFrame consumes one of the 3 shells as its inner outlet. It is NOT exported as a shell — it is the authenticated route frame. `useFullscreenPanel` hook ready for #20 to consume.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3632:+**Goal:** `<AppFrame>` in `apps/frontend/src/lib/layout/` composes Rail(52) + Sidebar(240/56) + (shell outlet) + the single global DetailPanelSlot(440). AppFrame consumes one of the 3 shells as its inner outlet. It is NOT exported as a shell — it is the authenticated route frame. `useFullscreenPanel` hook ready for #20 to consume.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3637: - Create: `apps/frontend/src/lib/layout/AppFrame.tsx` — flex row Rail(52) + Sidebar(240/56) + Main(flex-1, shell outlet) + DetailPanelSlot(440 conditional). Headers conform to 50px rhythm via ShellHeader from `packages/ui`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3638: - Create: `apps/frontend/src/lib/layout/AppRail.tsx` — 52px vertical, workspace switcher placeholder + lucide-react utility icons.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3639:-- Create: `apps/frontend/src/lib/layout/AppSidebar.tsx` — 240px nav list. Slice 3 entries: Inbox, My VOCs, Triage, + New VOC. Collapse button writes `localStorage.appSidebarCollapsed`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3640:-- Create: `apps/frontend/src/lib/layout/DetailPanelSlot.tsx` — fixed 440 right column. min 360 / max 520. Hidden when no content registered via `useDetailPanelSlot()`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3641:-- Create: `apps/frontend/src/lib/layout/useDetailPanelSlot.ts` — context-based slot register/clear hook.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3642:+- Create: `apps/frontend/src/lib/layout/AppSidebar.tsx` — 240px nav list. Slice 3 entries: Inbox, My VOCs, Triage, + New VOC. Collapse state uses SSR-safe initializer:
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3650:+- Create: `apps/frontend/src/lib/layout/DetailPanelSlot.tsx` — fixed 440 right column. min 360 / max 520. Hidden when no content registered via `useDetailPanelSlot()`. This is the single rendering surface for all shell `detailPanel` content.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3651:+- Create: `apps/frontend/src/lib/layout/useDetailPanelSlot.ts` — context-based slot register/clear hook. Forbid multiple registrants: throw in dev (and warn in prod) if called twice with overlapping lifetimes, using a ref to track active ownership.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3652: - Create: `apps/frontend/src/lib/panel/useFullscreenPanel.ts` — `[isFullscreen, toggle]`. Esc collapses. Route change clears.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3653:-- Create: `apps/frontend/src/lib/layout/__tests__/AppFrame.test.tsx` — Rail/Sidebar/Main present; sidebar collapse toggle writes localStorage; DetailPanelSlot collapses when empty.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3654:+- Create: `apps/frontend/src/lib/layout/__tests__/AppFrame.test.tsx` — Rail/Sidebar/Main present; sidebar first-paint width matches stored `localStorage.appSidebarCollapsed` before any user interaction; sidebar collapse toggle writes localStorage; DetailPanelSlot collapses when empty; multiple overlapping `useDetailPanelSlot()` registrants throw/warn.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3655: - Create: `apps/frontend/src/lib/panel/__tests__/useFullscreenPanel.test.tsx` — toggle flips boolean; Esc dispatches collapse; route change clears (mock router).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3661: - Constraint: AppFrame is NOT exported from `packages/ui` — it lives in `apps/frontend/src/lib/layout/` only.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3670:-- `apps/frontend/src/routes/_authed.tsx` — new TanStack layout route. Wraps children with `<AppFrame>`. Login + non-authed routes do NOT use this layout and do NOT render AppFrame.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3672:+- `apps/frontend/src/routes/_authed.tsx` — new TanStack pathless layout route. Includes a `beforeLoad` callback that calls `fetchMe()` (same auth pattern currently used in admin routes) and `redirect({ to: '/login' })` on `UnauthenticatedError`. Wraps children with `<AppFrame>`. Login + non-authed routes do NOT use this layout and do NOT render AppFrame.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3673:+- Per-route auth guards in admin pages are DELETED in C5 after `_authed.beforeLoad` centralizes the guard.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3675:+  - `apps/frontend/src/routes/admin/managed-systems.tsx` → `apps/frontend/src/routes/_authed/admin/managed-systems.tsx`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3676:+  - `apps/frontend/src/routes/admin/analytics-areas.tsx` → `apps/frontend/src/routes/_authed/admin/analytics-areas.tsx`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3677:+  - `apps/frontend/src/routes/admin/placeholder.tsx` → `apps/frontend/src/routes/_authed/admin/placeholder.tsx`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3678:+  - Test file imports updated: `apps/frontend/src/routes/admin/*.test.tsx` move alongside their routes.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3681:-- `/vocs` route = `apps/frontend/src/routes/_authed/vocs.tsx`. Per-view shell selection: `view=inbox|my` → `<ListShell>`, `view=triage` → `<WorkbenchShell>`, `action=create` → `<PageShell>` (default when no view/action = `<ListShell>`).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3682:+- `/vocs` route file = `apps/frontend/src/routes/_authed/vocs.tsx`. Public path string is `/vocs`; `_authed` is pathless. Per-view shell selection: `view=inbox|my` → `<ListShell>`, `view=triage` → `<WorkbenchShell>`, `action=create` → `<PageShell>` (default when no view/action = `<ListShell>`).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3686:-- Create: `apps/frontend/src/routes/_authed.tsx` — TanStack layout route. Renders `<AppFrame><Outlet /></AppFrame>`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3687:+- Create: `apps/frontend/src/routes/_authed.tsx` — TanStack layout route. `beforeLoad` calls `fetchMe()` and redirects unauthenticated users to `/login`; renders `<AppFrame><Outlet /></AppFrame>`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3688: - Create: `apps/frontend/src/routes/_authed/vocs.tsx` — `createFileRoute('/_authed/vocs')` with validateSearch zod. Component selects shell based on `view`/`action`. Main = placeholder text.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3689: - Modify: `apps/frontend/src/routes/__root.tsx` — minimal; providers + `<Outlet>` only (no AppFrame).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3690:-- Relocate or re-parent: `apps/frontend/src/routes/admin/` — move under `_authed` so admin pages get AppFrame. If not done in C5, create a follow-up GitHub issue before closing this chunk.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3691:+- Move: `apps/frontend/src/routes/admin/managed-systems.tsx` → `apps/frontend/src/routes/_authed/admin/managed-systems.tsx`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3692:+- Move: `apps/frontend/src/routes/admin/analytics-areas.tsx` → `apps/frontend/src/routes/_authed/admin/analytics-areas.tsx`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3693:+- Move: `apps/frontend/src/routes/admin/placeholder.tsx` → `apps/frontend/src/routes/_authed/admin/placeholder.tsx`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3694:+- Move: `apps/frontend/src/routes/admin/*.test.tsx` → alongside relocated `_authed/admin/*` routes; update imports.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3696: - Auto-regen: `apps/frontend/src/routeTree.gen.ts` (TanStackRouterVite plugin handles on dev).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3697:-- Create: `apps/frontend/src/routes/__tests__/vocs.test.tsx` — navigating to `/_authed/vocs?view=inbox` resolves; invalid `?view=foo` rejected by zod; sidebar `+ New VOC` href = `/_authed/vocs?action=create`; `view=triage` renders WorkbenchShell.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3698:+- Create: `apps/frontend/src/routes/__tests__/vocs.test.tsx` — navigating to `/vocs?view=inbox` resolves; invalid `?view=foo` rejected by zod; sidebar `+ New VOC` href = `/vocs?action=create`; `view=triage` renders WorkbenchShell.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3699: - Delete: `apps/frontend/src/routes/dev-rich-editor.tsx` IF it was added in C2 and is no longer needed (or keep behind DEV flag).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3703: - Read first: `apps/frontend/src/routes/__root.tsx`, `apps/frontend/vite.config.ts`, `apps/frontend/src/routes/admin/managed-systems.tsx` (existing TanStack file-route pattern), `apps/frontend/src/lib/layout/AppFrame.tsx` (just created in C4b), `packages/ui/src/layout/` (shells).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3707:+- Constraint: no `Route.id` navigation. Run `grep -rn 'Route\\.id\\|from: .*Route\\.id\\|to: .*Route\\.id' apps/frontend/src/` and refactor any hits to literal `to:` path strings.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3726: - Sonnet dispatches read AGENTS.md hierarchy first (`apps/frontend/AGENTS.md` mandatory).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3731: - **AppFrame in `apps/frontend` NEVER becomes a 4th exported shell. Shell taxonomy = 3 (PageShell/ListShell/WorkbenchShell) per ADR-0020.**
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3742: - `@tiptap/react` in `packages/ui` — verify `apps/frontend` resolves it transitively via workspace link without explicit install; if pnpm strict-mode blocks it, add a peer dep declaration.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3793:+      {type:'modify', path:'apps/frontend/src/routes/{admin/managed-systems,admin/analytics-areas,login,index}.tsx  // token classname rename audit'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3794:+      {type:'create', path:'apps/frontend/src/__tests__/token-class-coverage.test.ts  // resolveConfig coverage for TSX token classes'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3795:       {type:'modify', path:'apps/frontend/src/styles.css  // @import tokens.css + semantic.css'}
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3817:       {type:'modify', path:'apps/frontend/src/features/admin/permissions/request-access-button.tsx:115  // variant primary→default'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3826: # apps/frontend — app-level only; NO direct @tiptap/* (consumed via @fops/ui)
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3839:     dispatch:'Sonnet. Read rich-editor.jsx + ADR-0011 + BE sanitizer.ts. Constraints: surface = opaque pass-through; StarterKit image:false; demo = local state only; @tiptap/* must NOT be installed in apps/frontend.',
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3850:-      {type:'create', path:'apps/frontend/src/lib/api/{client,errorMapper,useIdempotencyKey,types}.ts'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3851:+      {type:'create', path:'apps/frontend/src/lib/api/{client,errorMapper,useIdempotencyKey,types}.ts  // export GENERIC_ERROR_MESSAGE'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3852:       {type:'modify', path:'apps/frontend/src/routes/__root.tsx  // <Toaster position="bottom-center"/>'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3853:       {type:'create', path:'apps/frontend/src/lib/api/__tests__/{errorMapper,client}.test.ts'}
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3857:+    dispatch:'Sonnet. Read packages/shared/src/errors/codes.ts (iterate ERROR_CODES, do NOT hardcode list) + envelope.ts + voc routes.ts lines 200-260. Tests assert tone literal set, non-generic messages for VOC/rich/attachment/reporter/conflict special codes, and conflict.stale_write warning action. Checkpoint includes /dev-rich-editor sanitizer-reject toast via apiClient mock.',
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3884: - ADR-0020 taxonomy enforced: `packages/ui/src/layout/` exports exactly 3 shells (PageShell, ListShell, WorkbenchShell). AppFrame in `apps/frontend/src/lib/layout/` is NOT a 4th shell.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3935:+- Modify/audit: `apps/frontend/src/routes/admin/managed-systems.tsx`, `apps/frontend/src/routes/admin/analytics-areas.tsx`, `apps/frontend/src/routes/login.tsx`, `apps/frontend/src/routes/index.tsx` and any other route file referencing token classes — grep first, build rename map, then apply.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3936:+- Create: `apps/frontend/src/__tests__/token-class-coverage.test.ts` — grep/scan `.tsx` class strings and assert no `text|border|bg|ring|fill|stroke` token class references a Tailwind theme key that is not resolvable via `resolveConfig`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3937: - Modify: `apps/frontend/src/styles.css` — keep `@import "@fops/ui/styles/tokens.css"` + `semantic.css` + tailwind directives.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3943:+  `grep -rn '\(text\|border\|bg\|ring\|fill\|stroke\)-\(status\|surface\|accent\|severity\|reporter\|internal\|confidence\|focus\)-' apps/frontend/src/`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:3987: - Modify: `apps/frontend/src/features/admin/permissions/request-access-button.tsx:115` — `variant="primary"` → `variant="default"` (or leave with primary alias).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4007: - Constraint: `@tiptap/react` lives in `packages/ui` — do NOT install it in `apps/frontend`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4009:+- Constraint: keep `apps/frontend/src/routes/dev-rich-editor.tsx` available after C2 so C3 can validate sanitizer-fail toast flow against the demo route; C5 may delete it only if no later checkpoint needs it.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4015: **Goal:** `<Toaster>` mounted in `__root.tsx`. `apiClient`, `errorMapper`, `useIdempotencyKey` land in `apps/frontend/src/lib/api/`. ALL codes in `ERROR_CODES` from `@fops/shared` covered with Korean copy and tone classification.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4018:-- Create: `apps/frontend/src/lib/api/errorMapper.ts` — maps `{ code, detail }` to `{ tone: 'error'|'warning'|'info', message: string, action?: { label, run } }`. **Catalog is generated by iterating `ERROR_CODES` from `@fops/shared`** — no manually typed list. Every code must map to a non-empty Korean message. Fallback for unknown codes: `{ tone: 'error', message: '일시적 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.' }`. Tone per category: `auth.*` → `error`, `permission.*` → `error`, `rate_limited.*` → `warning`, `validation.*` → `error`, `conflict.*` → `error` (except `conflict.stale_write` → `warning` with retry action), `not_found.*` → `error`, `internal.*` → `error`, `voc.*` → `error`, `rich_content.*` → `error`, `attachment.*` → `warning`, `reporter_facing_status.*` → `warning`. Required codes at minimum (from `packages/shared/src/errors/codes.ts`): `auth.session_invalid`, `auth.session_required`, `auth.session_expired`, `auth.workspace_mismatch`, `permission.denied`, `rate_limited.actor`, `rate_limited.ip`, `validation.failed`, `validation.malformed_request`, `validation.unknown_capability`, `conflict.idempotency_key_reuse`, `conflict.capability_already_granted`, `conflict.permission_request_duplicate`, `validation.malformed_idempotency_key`, `validation.sensitive_reason_required`, `validation.immutable_field`, `conflict.duplicate_slug`, `conflict.parent_archived`, `conflict.record_archived`, `not_found.record`, `internal.unexpected`, `voc.severity_not_user_settable`, `validation.unexpected_field`, `rich_content.disallowed_node`, `rich_content.external_image_forbidden`, `attachment.unsupported_pending_storage_slice`, `conflict.stale_write`, `voc.reporter_status_via_public_update_only`, `permission.scope_required`, `reporter_facing_status.invalid_transition`, `reporter_facing_status.gate_blocked`, `conflict.triage_already_committed`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4019:+- Create: `apps/frontend/src/lib/api/errorMapper.ts` — maps `{ code, detail }` to `{ tone: 'error'|'warning'|'info', message: string, action?: { label, run } }`. **Catalog is generated by iterating `ERROR_CODES` from `@fops/shared`** — no manually typed list. Every code must map to a non-empty Korean message. Export `GENERIC_ERROR_MESSAGE = '일시적 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.'` so tests compare to the fallback constant directly. Fallback for unknown codes: `{ tone: 'error', message: GENERIC_ERROR_MESSAGE }`. Tone per category: `auth.*` → `error`, `permission.*` → `error`, `rate_limited.*` → `warning`, `validation.*` → `error`, `conflict.*` → `error` (except `conflict.stale_write` → `warning` with retry action), `not_found.*` → `error`, `internal.*` → `error`, `voc.*` → `error`, `rich_content.*` → `error`, `attachment.*` → `warning`, `reporter_facing_status.*` → `warning`. Required codes at minimum (from `packages/shared/src/errors/codes.ts`): `auth.session_invalid`, `auth.session_required`, `auth.session_expired`, `auth.workspace_mismatch`, `permission.denied`, `rate_limited.actor`, `rate_limited.ip`, `validation.failed`, `validation.malformed_request`, `validation.unknown_capability`, `conflict.idempotency_key_reuse`, `conflict.capability_already_granted`, `conflict.permission_request_duplicate`, `validation.malformed_idempotency_key`, `validation.sensitive_reason_required`, `validation.immutable_field`, `conflict.duplicate_slug`, `conflict.parent_archived`, `conflict.record_archived`, `not_found.record`, `internal.unexpected`, `voc.severity_not_user_settable`, `validation.unexpected_field`, `rich_content.disallowed_node`, `rich_content.external_image_forbidden`, `attachment.unsupported_pending_storage_slice`, `conflict.stale_write`, `voc.reporter_status_via_public_update_only`, `permission.scope_required`, `reporter_facing_status.invalid_transition`, `reporter_facing_status.gate_blocked`, `conflict.triage_already_committed`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4020: - Create: `apps/frontend/src/lib/api/client.ts` — `apiClient(method, path, { body?, idempotencyKey?, ifMatch?, signal? })`. Auto-mint Idempotency-Key UUIDv4 on POST/PATCH/DELETE when not supplied. Attach `Authorization` from session store. Parse JSON. Non-2xx → throw `ApiError extends Error { code, detail, status, requestId }`. 304 → return `{ status: 304, etag }`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4021: - Create: `apps/frontend/src/lib/api/useIdempotencyKey.ts` — `useIdempotencyKey(ifMatchEtag?: string)`. Returns stable UUIDv4 per render-tree until consumed; `markConsumed()` mints fresh. **When `ifMatchEtag` changes value, the hook MUST automatically mint a fresh UUIDv4** — this prevents `conflict.idempotency_key_reuse` after a stale-write refetch (BE includes `ifMatch` in the idempotency hash per `apps/backend/src/modules/voc/routes.ts:225`, so a retry with a new `If-Match` value is a semantically different request that needs a new key).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4022: - Create: `apps/frontend/src/lib/api/types.ts` — `ApiErrorEnvelope` matching BE `errors/envelope.ts`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4023: - Modify: `apps/frontend/src/routes/__root.tsx` — mount `<Toaster position="bottom-center" />` from `sonner`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4024:-- Create: `apps/frontend/src/lib/api/__tests__/errorMapper.test.ts` — **iterate `ERROR_CODES` from `@fops/shared` and assert each maps to a non-empty Korean message** (not a manual catalog). This test auto-covers new codes added to `codes.ts` without test update.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4025:+- Create: `apps/frontend/src/lib/api/__tests__/errorMapper.test.ts` — **iterate `ERROR_CODES` from `@fops/shared` and assert each maps to a non-empty Korean message** (not a manual catalog). This test auto-covers new codes added to `codes.ts` without test update. Locked assertions: (1) every `ERROR_CODES` mapping has `tone` in literal set `{ 'error', 'warning', 'info' }`; (2) every code with prefix/member in `{ voc.*, rich_content.*, attachment.*, reporter_facing_status.*, conflict.stale_write, conflict.triage_already_committed, conflict.idempotency_key_reuse }` has Korean message not equal to exported `GENERIC_ERROR_MESSAGE`; (3) `conflict.stale_write` maps to `{ tone: 'warning', action: { label: <not undefined>, run: <fn> } }`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4026: - Create: `apps/frontend/src/lib/api/__tests__/client.test.ts` — mock fetch: POST mints Idempotency-Key, GET omits, Authorization attached, 422 throws ApiError, 304 returns ETag. Add test case: same `useIdempotencyKey` instance + changed `ifMatchEtag` → new key minted automatically.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4033:-**CHECKPOINT 2.5** — small playground demonstrating: Toaster position (bottom-center), tone variants (success / error / warning / info) with Korean copy, at least 3 representative error codes rendered as toasts (`conflict.stale_write` warning + retry action, `permission.denied` error, `rate_limited.ip` warning). AskUserQuestion: "토스트 UX + 에러 메시지 OK?"
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4034:+**CHECKPOINT 2.5** — playground HTML demonstrating: Toaster tones + Korean copy for 3+ representative codes (`conflict.stale_write` warning + retry action, `permission.denied` error, `rate_limited.ip` warning) + RichEditor demo rendering sanitizer-rejected content with toast surfaced via apiClient mock. Requires C2 `/dev-rich-editor` route to still exist when C3 lands. AskUserQuestion: "토스트 UX + 에러 메시지 OK?"
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4063: ## C4b — AppFrame in apps/frontend + useFullscreenPanel hook
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4065:-**Goal:** `<AppFrame>` in `apps/frontend/src/lib/layout/` composes Rail(52) + Sidebar(240/56) + (shell outlet) + DetailPanelSlot(440). AppFrame consumes one of the 3 shells as its inner outlet. It is NOT exported as a shell — it is the authenticated route frame. `useFullscreenPanel` hook ready for #20 to consume.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4066:+**Goal:** `<AppFrame>` in `apps/frontend/src/lib/layout/` composes Rail(52) + Sidebar(240/56) + (shell outlet) + the single global DetailPanelSlot(440). AppFrame consumes one of the 3 shells as its inner outlet. It is NOT exported as a shell — it is the authenticated route frame. `useFullscreenPanel` hook ready for #20 to consume.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4071: - Create: `apps/frontend/src/lib/layout/AppFrame.tsx` — flex row Rail(52) + Sidebar(240/56) + Main(flex-1, shell outlet) + DetailPanelSlot(440 conditional). Headers conform to 50px rhythm via ShellHeader from `packages/ui`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4072: - Create: `apps/frontend/src/lib/layout/AppRail.tsx` — 52px vertical, workspace switcher placeholder + lucide-react utility icons.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4073:-- Create: `apps/frontend/src/lib/layout/AppSidebar.tsx` — 240px nav list. Slice 3 entries: Inbox, My VOCs, Triage, + New VOC. Collapse button writes `localStorage.appSidebarCollapsed`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4074:-- Create: `apps/frontend/src/lib/layout/DetailPanelSlot.tsx` — fixed 440 right column. min 360 / max 520. Hidden when no content registered via `useDetailPanelSlot()`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4075:-- Create: `apps/frontend/src/lib/layout/useDetailPanelSlot.ts` — context-based slot register/clear hook.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4076:+- Create: `apps/frontend/src/lib/layout/AppSidebar.tsx` — 240px nav list. Slice 3 entries: Inbox, My VOCs, Triage, + New VOC. Collapse state uses SSR-safe initializer:
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4084:+- Create: `apps/frontend/src/lib/layout/DetailPanelSlot.tsx` — fixed 440 right column. min 360 / max 520. Hidden when no content registered via `useDetailPanelSlot()`. This is the single rendering surface for all shell `detailPanel` content.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4085:+- Create: `apps/frontend/src/lib/layout/useDetailPanelSlot.ts` — context-based slot register/clear hook. Forbid multiple registrants: throw in dev (and warn in prod) if called twice with overlapping lifetimes, using a ref to track active ownership.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4086: - Create: `apps/frontend/src/lib/panel/useFullscreenPanel.ts` — `[isFullscreen, toggle]`. Esc collapses. Route change clears.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4087:-- Create: `apps/frontend/src/lib/layout/__tests__/AppFrame.test.tsx` — Rail/Sidebar/Main present; sidebar collapse toggle writes localStorage; DetailPanelSlot collapses when empty.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4088:+- Create: `apps/frontend/src/lib/layout/__tests__/AppFrame.test.tsx` — Rail/Sidebar/Main present; sidebar first-paint width matches stored `localStorage.appSidebarCollapsed` before any user interaction; sidebar collapse toggle writes localStorage; DetailPanelSlot collapses when empty; multiple overlapping `useDetailPanelSlot()` registrants throw/warn.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4089: - Create: `apps/frontend/src/lib/panel/__tests__/useFullscreenPanel.test.tsx` — toggle flips boolean; Esc dispatches collapse; route change clears (mock router).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4095: - Constraint: AppFrame is NOT exported from `packages/ui` — it lives in `apps/frontend/src/lib/layout/` only.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4104:-- `apps/frontend/src/routes/_authed.tsx` — new TanStack layout route. Wraps children with `<AppFrame>`. Login + non-authed routes do NOT use this layout and do NOT render AppFrame.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4106:+- `apps/frontend/src/routes/_authed.tsx` — new TanStack pathless layout route. Includes a `beforeLoad` callback that calls `fetchMe()` (same auth pattern currently used in admin routes) and `redirect({ to: '/login' })` on `UnauthenticatedError`. Wraps children with `<AppFrame>`. Login + non-authed routes do NOT use this layout and do NOT render AppFrame.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4107:+- Per-route auth guards in admin pages are DELETED in C5 after `_authed.beforeLoad` centralizes the guard.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4109:+  - `apps/frontend/src/routes/admin/managed-systems.tsx` → `apps/frontend/src/routes/_authed/admin/managed-systems.tsx`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4110:+  - `apps/frontend/src/routes/admin/analytics-areas.tsx` → `apps/frontend/src/routes/_authed/admin/analytics-areas.tsx`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4111:+  - `apps/frontend/src/routes/admin/placeholder.tsx` → `apps/frontend/src/routes/_authed/admin/placeholder.tsx`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4112:+  - Test file imports updated: `apps/frontend/src/routes/admin/*.test.tsx` move alongside their routes.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4115:-- `/vocs` route = `apps/frontend/src/routes/_authed/vocs.tsx`. Per-view shell selection: `view=inbox|my` → `<ListShell>`, `view=triage` → `<WorkbenchShell>`, `action=create` → `<PageShell>` (default when no view/action = `<ListShell>`).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4116:+- `/vocs` route file = `apps/frontend/src/routes/_authed/vocs.tsx`. Public path string is `/vocs`; `_authed` is pathless. Per-view shell selection: `view=inbox|my` → `<ListShell>`, `view=triage` → `<WorkbenchShell>`, `action=create` → `<PageShell>` (default when no view/action = `<ListShell>`).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4120:-- Create: `apps/frontend/src/routes/_authed.tsx` — TanStack layout route. Renders `<AppFrame><Outlet /></AppFrame>`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4121:+- Create: `apps/frontend/src/routes/_authed.tsx` — TanStack layout route. `beforeLoad` calls `fetchMe()` and redirects unauthenticated users to `/login`; renders `<AppFrame><Outlet /></AppFrame>`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4122: - Create: `apps/frontend/src/routes/_authed/vocs.tsx` — `createFileRoute('/_authed/vocs')` with validateSearch zod. Component selects shell based on `view`/`action`. Main = placeholder text.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4123: - Modify: `apps/frontend/src/routes/__root.tsx` — minimal; providers + `<Outlet>` only (no AppFrame).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4124:-- Relocate or re-parent: `apps/frontend/src/routes/admin/` — move under `_authed` so admin pages get AppFrame. If not done in C5, create a follow-up GitHub issue before closing this chunk.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4125:+- Move: `apps/frontend/src/routes/admin/managed-systems.tsx` → `apps/frontend/src/routes/_authed/admin/managed-systems.tsx`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4126:+- Move: `apps/frontend/src/routes/admin/analytics-areas.tsx` → `apps/frontend/src/routes/_authed/admin/analytics-areas.tsx`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4127:+- Move: `apps/frontend/src/routes/admin/placeholder.tsx` → `apps/frontend/src/routes/_authed/admin/placeholder.tsx`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4128:+- Move: `apps/frontend/src/routes/admin/*.test.tsx` → alongside relocated `_authed/admin/*` routes; update imports.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4130: - Auto-regen: `apps/frontend/src/routeTree.gen.ts` (TanStackRouterVite plugin handles on dev).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4131:-- Create: `apps/frontend/src/routes/__tests__/vocs.test.tsx` — navigating to `/_authed/vocs?view=inbox` resolves; invalid `?view=foo` rejected by zod; sidebar `+ New VOC` href = `/_authed/vocs?action=create`; `view=triage` renders WorkbenchShell.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4132:+- Create: `apps/frontend/src/routes/__tests__/vocs.test.tsx` — navigating to `/vocs?view=inbox` resolves; invalid `?view=foo` rejected by zod; sidebar `+ New VOC` href = `/vocs?action=create`; `view=triage` renders WorkbenchShell.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4133: - Delete: `apps/frontend/src/routes/dev-rich-editor.tsx` IF it was added in C2 and is no longer needed (or keep behind DEV flag).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4137: - Read first: `apps/frontend/src/routes/__root.tsx`, `apps/frontend/vite.config.ts`, `apps/frontend/src/routes/admin/managed-systems.tsx` (existing TanStack file-route pattern), `apps/frontend/src/lib/layout/AppFrame.tsx` (just created in C4b), `packages/ui/src/layout/` (shells).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4141:+- Constraint: no `Route.id` navigation. Run `grep -rn 'Route\\.id\\|from: .*Route\\.id\\|to: .*Route\\.id' apps/frontend/src/` and refactor any hits to literal `to:` path strings.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4160: - Sonnet dispatches read AGENTS.md hierarchy first (`apps/frontend/AGENTS.md` mandatory).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4165: - **AppFrame in `apps/frontend` NEVER becomes a 4th exported shell. Shell taxonomy = 3 (PageShell/ListShell/WorkbenchShell) per ADR-0020.**
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4176: - `@tiptap/react` in `packages/ui` — verify `apps/frontend` resolves it transitively via workspace link without explicit install; if pnpm strict-mode blocks it, add a peer dep declaration.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4227:+      {type:'modify', path:'apps/frontend/src/routes/{admin/managed-systems,admin/analytics-areas,login,index}.tsx  // token classname rename audit'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4228:+      {type:'create', path:'apps/frontend/src/__tests__/token-class-coverage.test.ts  // resolveConfig coverage for TSX token classes'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4229:       {type:'modify', path:'apps/frontend/src/styles.css  // @import tokens.css + semantic.css'}
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4251:       {type:'modify', path:'apps/frontend/src/features/admin/permissions/request-access-button.tsx:115  // variant primary→default'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4260: # apps/frontend — app-level only; NO direct @tiptap/* (consumed via @fops/ui)
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4273:     dispatch:'Sonnet. Read rich-editor.jsx + ADR-0011 + BE sanitizer.ts. Constraints: surface = opaque pass-through; StarterKit image:false; demo = local state only; @tiptap/* must NOT be installed in apps/frontend.',
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4284:-      {type:'create', path:'apps/frontend/src/lib/api/{client,errorMapper,useIdempotencyKey,types}.ts'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4285:+      {type:'create', path:'apps/frontend/src/lib/api/{client,errorMapper,useIdempotencyKey,types}.ts  // export GENERIC_ERROR_MESSAGE'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4286:       {type:'modify', path:'apps/frontend/src/routes/__root.tsx  // <Toaster position="bottom-center"/>'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4287:       {type:'create', path:'apps/frontend/src/lib/api/__tests__/{errorMapper,client}.test.ts'}
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4291:+    dispatch:'Sonnet. Read packages/shared/src/errors/codes.ts (iterate ERROR_CODES, do NOT hardcode list) + envelope.ts + voc routes.ts lines 200-260. Tests assert tone literal set, non-generic messages for VOC/rich/attachment/reporter/conflict special codes, and conflict.stale_write warning action. Checkpoint includes /dev-rich-editor sanitizer-reject toast via apiClient mock.',
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4321: - ADR-0020 taxonomy enforced: `packages/ui/src/layout/` exports exactly 3 shells (PageShell, ListShell, WorkbenchShell). AppFrame in `apps/frontend/src/lib/layout/` is NOT a 4th shell.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4372:+- Modify/audit: `apps/frontend/src/routes/admin/managed-systems.tsx`, `apps/frontend/src/routes/admin/analytics-areas.tsx`, `apps/frontend/src/routes/login.tsx`, `apps/frontend/src/routes/index.tsx` and any other route file referencing token classes — grep first, build rename map, then apply.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4373:+- Create: `apps/frontend/src/__tests__/token-class-coverage.test.ts` — grep/scan `.tsx` class strings and assert no `text|border|bg|ring|fill|stroke` token class references a Tailwind theme key that is not resolvable via `resolveConfig`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4374: - Modify: `apps/frontend/src/styles.css` — keep `@import "@fops/ui/styles/tokens.css"` + `semantic.css` + tailwind directives.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4380:+  `grep -rn '\(text\|border\|bg\|ring\|fill\|stroke\)-\(status\|surface\|accent\|severity\|reporter\|internal\|confidence\|focus\)-' apps/frontend/src/`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4424: - Modify: `apps/frontend/src/features/admin/permissions/request-access-button.tsx:115` — `variant="primary"` → `variant="default"` (or leave with primary alias).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4444: - Constraint: `@tiptap/react` lives in `packages/ui` — do NOT install it in `apps/frontend`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4446:+- Constraint: keep `apps/frontend/src/routes/dev-rich-editor.tsx` available after C2 so C3 can validate sanitizer-fail toast flow against the demo route; C5 may delete it only if no later checkpoint needs it.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4452: **Goal:** `<Toaster>` mounted in `__root.tsx`. `apiClient`, `errorMapper`, `useIdempotencyKey` land in `apps/frontend/src/lib/api/`. ALL codes in `ERROR_CODES` from `@fops/shared` covered with Korean copy and tone classification.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4455:-- Create: `apps/frontend/src/lib/api/errorMapper.ts` — maps `{ code, detail }` to `{ tone: 'error'|'warning'|'info', message: string, action?: { label, run } }`. **Catalog is generated by iterating `ERROR_CODES` from `@fops/shared`** — no manually typed list. Every code must map to a non-empty Korean message. Fallback for unknown codes: `{ tone: 'error', message: '일시적 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.' }`. Tone per category: `auth.*` → `error`, `permission.*` → `error`, `rate_limited.*` → `warning`, `validation.*` → `error`, `conflict.*` → `error` (except `conflict.stale_write` → `warning` with retry action), `not_found.*` → `error`, `internal.*` → `error`, `voc.*` → `error`, `rich_content.*` → `error`, `attachment.*` → `warning`, `reporter_facing_status.*` → `warning`. Required codes at minimum (from `packages/shared/src/errors/codes.ts`): `auth.session_invalid`, `auth.session_required`, `auth.session_expired`, `auth.workspace_mismatch`, `permission.denied`, `rate_limited.actor`, `rate_limited.ip`, `validation.failed`, `validation.malformed_request`, `validation.unknown_capability`, `conflict.idempotency_key_reuse`, `conflict.capability_already_granted`, `conflict.permission_request_duplicate`, `validation.malformed_idempotency_key`, `validation.sensitive_reason_required`, `validation.immutable_field`, `conflict.duplicate_slug`, `conflict.parent_archived`, `conflict.record_archived`, `not_found.record`, `internal.unexpected`, `voc.severity_not_user_settable`, `validation.unexpected_field`, `rich_content.disallowed_node`, `rich_content.external_image_forbidden`, `attachment.unsupported_pending_storage_slice`, `conflict.stale_write`, `voc.reporter_status_via_public_update_only`, `permission.scope_required`, `reporter_facing_status.invalid_transition`, `reporter_facing_status.gate_blocked`, `conflict.triage_already_committed`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4456:+- Create: `apps/frontend/src/lib/api/errorMapper.ts` — maps `{ code, detail }` to `{ tone: 'error'|'warning'|'info', message: string, action?: { label, run } }`. **Catalog is generated by iterating `ERROR_CODES` from `@fops/shared`** — no manually typed list. Every code must map to a non-empty Korean message. Export `GENERIC_ERROR_MESSAGE = '일시적 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.'` so tests compare to the fallback constant directly. Fallback for unknown codes: `{ tone: 'error', message: GENERIC_ERROR_MESSAGE }`. Tone per category: `auth.*` → `error`, `permission.*` → `error`, `rate_limited.*` → `warning`, `validation.*` → `error`, `conflict.*` → `error` (except `conflict.stale_write` → `warning` with retry action), `not_found.*` → `error`, `internal.*` → `error`, `voc.*` → `error`, `rich_content.*` → `error`, `attachment.*` → `warning`, `reporter_facing_status.*` → `warning`. Required codes at minimum (from `packages/shared/src/errors/codes.ts`): `auth.session_invalid`, `auth.session_required`, `auth.session_expired`, `auth.workspace_mismatch`, `permission.denied`, `rate_limited.actor`, `rate_limited.ip`, `validation.failed`, `validation.malformed_request`, `validation.unknown_capability`, `conflict.idempotency_key_reuse`, `conflict.capability_already_granted`, `conflict.permission_request_duplicate`, `validation.malformed_idempotency_key`, `validation.sensitive_reason_required`, `validation.immutable_field`, `conflict.duplicate_slug`, `conflict.parent_archived`, `conflict.record_archived`, `not_found.record`, `internal.unexpected`, `voc.severity_not_user_settable`, `validation.unexpected_field`, `rich_content.disallowed_node`, `rich_content.external_image_forbidden`, `attachment.unsupported_pending_storage_slice`, `conflict.stale_write`, `voc.reporter_status_via_public_update_only`, `permission.scope_required`, `reporter_facing_status.invalid_transition`, `reporter_facing_status.gate_blocked`, `conflict.triage_already_committed`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4457: - Create: `apps/frontend/src/lib/api/client.ts` — `apiClient(method, path, { body?, idempotencyKey?, ifMatch?, signal? })`. Auto-mint Idempotency-Key UUIDv4 on POST/PATCH/DELETE when not supplied. Attach `Authorization` from session store. Parse JSON. Non-2xx → throw `ApiError extends Error { code, detail, status, requestId }`. 304 → return `{ status: 304, etag }`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4458: - Create: `apps/frontend/src/lib/api/useIdempotencyKey.ts` — `useIdempotencyKey(ifMatchEtag?: string)`. Returns stable UUIDv4 per render-tree until consumed; `markConsumed()` mints fresh. **When `ifMatchEtag` changes value, the hook MUST automatically mint a fresh UUIDv4** — this prevents `conflict.idempotency_key_reuse` after a stale-write refetch (BE includes `ifMatch` in the idempotency hash per `apps/backend/src/modules/voc/routes.ts:225`, so a retry with a new `If-Match` value is a semantically different request that needs a new key).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4459: - Create: `apps/frontend/src/lib/api/types.ts` — `ApiErrorEnvelope` matching BE `errors/envelope.ts`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4460: - Modify: `apps/frontend/src/routes/__root.tsx` — mount `<Toaster position="bottom-center" />` from `sonner`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4461:-- Create: `apps/frontend/src/lib/api/__tests__/errorMapper.test.ts` — **iterate `ERROR_CODES` from `@fops/shared` and assert each maps to a non-empty Korean message** (not a manual catalog). This test auto-covers new codes added to `codes.ts` without test update.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4462:+- Create: `apps/frontend/src/lib/api/__tests__/errorMapper.test.ts` — **iterate `ERROR_CODES` from `@fops/shared` and assert each maps to a non-empty Korean message** (not a manual catalog). This test auto-covers new codes added to `codes.ts` without test update. Locked assertions: (1) every `ERROR_CODES` mapping has `tone` in literal set `{ 'error', 'warning', 'info' }`; (2) every code with prefix/member in `{ voc.*, rich_content.*, attachment.*, reporter_facing_status.*, conflict.stale_write, conflict.triage_already_committed, conflict.idempotency_key_reuse }` has Korean message not equal to exported `GENERIC_ERROR_MESSAGE`; (3) `conflict.stale_write` maps to `{ tone: 'warning', action: { label: <not undefined>, run: <fn> } }`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4463: - Create: `apps/frontend/src/lib/api/__tests__/client.test.ts` — mock fetch: POST mints Idempotency-Key, GET omits, Authorization attached, 422 throws ApiError, 304 returns ETag. Add test case: same `useIdempotencyKey` instance + changed `ifMatchEtag` → new key minted automatically.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4470:-**CHECKPOINT 2.5** — small playground demonstrating: Toaster position (bottom-center), tone variants (success / error / warning / info) with Korean copy, at least 3 representative error codes rendered as toasts (`conflict.stale_write` warning + retry action, `permission.denied` error, `rate_limited.ip` warning). AskUserQuestion: "토스트 UX + 에러 메시지 OK?"
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4471:+**CHECKPOINT 2.5** — playground HTML demonstrating: Toaster tones + Korean copy for 3+ representative codes (`conflict.stale_write` warning + retry action, `permission.denied` error, `rate_limited.ip` warning) + RichEditor demo rendering sanitizer-rejected content with toast surfaced via apiClient mock. Requires C2 `/dev-rich-editor` route to still exist when C3 lands. AskUserQuestion: "토스트 UX + 에러 메시지 OK?"
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4500: ## C4b — AppFrame in apps/frontend + useFullscreenPanel hook
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4502:-**Goal:** `<AppFrame>` in `apps/frontend/src/lib/layout/` composes Rail(52) + Sidebar(240/56) + (shell outlet) + DetailPanelSlot(440). AppFrame consumes one of the 3 shells as its inner outlet. It is NOT exported as a shell — it is the authenticated route frame. `useFullscreenPanel` hook ready for #20 to consume.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4503:+**Goal:** `<AppFrame>` in `apps/frontend/src/lib/layout/` composes Rail(52) + Sidebar(240/56) + (shell outlet) + the single global DetailPanelSlot(440). AppFrame consumes one of the 3 shells as its inner outlet. It is NOT exported as a shell — it is the authenticated route frame. `useFullscreenPanel` hook ready for #20 to consume.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4508: - Create: `apps/frontend/src/lib/layout/AppFrame.tsx` — flex row Rail(52) + Sidebar(240/56) + Main(flex-1, shell outlet) + DetailPanelSlot(440 conditional). Headers conform to 50px rhythm via ShellHeader from `packages/ui`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4509: - Create: `apps/frontend/src/lib/layout/AppRail.tsx` — 52px vertical, workspace switcher placeholder + lucide-react utility icons.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4510:-- Create: `apps/frontend/src/lib/layout/AppSidebar.tsx` — 240px nav list. Slice 3 entries: Inbox, My VOCs, Triage, + New VOC. Collapse button writes `localStorage.appSidebarCollapsed`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4511:-- Create: `apps/frontend/src/lib/layout/DetailPanelSlot.tsx` — fixed 440 right column. min 360 / max 520. Hidden when no content registered via `useDetailPanelSlot()`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4512:-- Create: `apps/frontend/src/lib/layout/useDetailPanelSlot.ts` — context-based slot register/clear hook.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4513:+- Create: `apps/frontend/src/lib/layout/AppSidebar.tsx` — 240px nav list. Slice 3 entries: Inbox, My VOCs, Triage, + New VOC. Collapse state uses SSR-safe initializer:
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4521:+- Create: `apps/frontend/src/lib/layout/DetailPanelSlot.tsx` — fixed 440 right column. min 360 / max 520. Hidden when no content registered via `useDetailPanelSlot()`. This is the single rendering surface for all shell `detailPanel` content.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4522:+- Create: `apps/frontend/src/lib/layout/useDetailPanelSlot.ts` — context-based slot register/clear hook. Forbid multiple registrants: throw in dev (and warn in prod) if called twice with overlapping lifetimes, using a ref to track active ownership.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4523: - Create: `apps/frontend/src/lib/panel/useFullscreenPanel.ts` — `[isFullscreen, toggle]`. Esc collapses. Route change clears.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4524:-- Create: `apps/frontend/src/lib/layout/__tests__/AppFrame.test.tsx` — Rail/Sidebar/Main present; sidebar collapse toggle writes localStorage; DetailPanelSlot collapses when empty.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4525:+- Create: `apps/frontend/src/lib/layout/__tests__/AppFrame.test.tsx` — Rail/Sidebar/Main present; sidebar first-paint width matches stored `localStorage.appSidebarCollapsed` before any user interaction; sidebar collapse toggle writes localStorage; DetailPanelSlot collapses when empty; multiple overlapping `useDetailPanelSlot()` registrants throw/warn.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4526: - Create: `apps/frontend/src/lib/panel/__tests__/useFullscreenPanel.test.tsx` — toggle flips boolean; Esc dispatches collapse; route change clears (mock router).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4532: - Constraint: AppFrame is NOT exported from `packages/ui` — it lives in `apps/frontend/src/lib/layout/` only.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4541:-- `apps/frontend/src/routes/_authed.tsx` — new TanStack layout route. Wraps children with `<AppFrame>`. Login + non-authed routes do NOT use this layout and do NOT render AppFrame.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4543:+- `apps/frontend/src/routes/_authed.tsx` — new TanStack pathless layout route. Includes a `beforeLoad` callback that calls `fetchMe()` (same auth pattern currently used in admin routes) and `redirect({ to: '/login' })` on `UnauthenticatedError`. Wraps children with `<AppFrame>`. Login + non-authed routes do NOT use this layout and do NOT render AppFrame.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4544:+- Per-route auth guards in admin pages are DELETED in C5 after `_authed.beforeLoad` centralizes the guard.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4546:+  - `apps/frontend/src/routes/admin/managed-systems.tsx` → `apps/frontend/src/routes/_authed/admin/managed-systems.tsx`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4547:+  - `apps/frontend/src/routes/admin/analytics-areas.tsx` → `apps/frontend/src/routes/_authed/admin/analytics-areas.tsx`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4548:+  - `apps/frontend/src/routes/admin/placeholder.tsx` → `apps/frontend/src/routes/_authed/admin/placeholder.tsx`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4549:+  - Test file imports updated: `apps/frontend/src/routes/admin/*.test.tsx` move alongside their routes.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4552:-- `/vocs` route = `apps/frontend/src/routes/_authed/vocs.tsx`. Per-view shell selection: `view=inbox|my` → `<ListShell>`, `view=triage` → `<WorkbenchShell>`, `action=create` → `<PageShell>` (default when no view/action = `<ListShell>`).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4553:+- `/vocs` route file = `apps/frontend/src/routes/_authed/vocs.tsx`. Public path string is `/vocs`; `_authed` is pathless. Per-view shell selection: `view=inbox|my` → `<ListShell>`, `view=triage` → `<WorkbenchShell>`, `action=create` → `<PageShell>` (default when no view/action = `<ListShell>`).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4557:-- Create: `apps/frontend/src/routes/_authed.tsx` — TanStack layout route. Renders `<AppFrame><Outlet /></AppFrame>`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4558:+- Create: `apps/frontend/src/routes/_authed.tsx` — TanStack layout route. `beforeLoad` calls `fetchMe()` and redirects unauthenticated users to `/login`; renders `<AppFrame><Outlet /></AppFrame>`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4559: - Create: `apps/frontend/src/routes/_authed/vocs.tsx` — `createFileRoute('/_authed/vocs')` with validateSearch zod. Component selects shell based on `view`/`action`. Main = placeholder text.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4560: - Modify: `apps/frontend/src/routes/__root.tsx` — minimal; providers + `<Outlet>` only (no AppFrame).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4561:-- Relocate or re-parent: `apps/frontend/src/routes/admin/` — move under `_authed` so admin pages get AppFrame. If not done in C5, create a follow-up GitHub issue before closing this chunk.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4562:+- Move: `apps/frontend/src/routes/admin/managed-systems.tsx` → `apps/frontend/src/routes/_authed/admin/managed-systems.tsx`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4563:+- Move: `apps/frontend/src/routes/admin/analytics-areas.tsx` → `apps/frontend/src/routes/_authed/admin/analytics-areas.tsx`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4564:+- Move: `apps/frontend/src/routes/admin/placeholder.tsx` → `apps/frontend/src/routes/_authed/admin/placeholder.tsx`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4565:+- Move: `apps/frontend/src/routes/admin/*.test.tsx` → alongside relocated `_authed/admin/*` routes; update imports.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4567: - Auto-regen: `apps/frontend/src/routeTree.gen.ts` (TanStackRouterVite plugin handles on dev).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4568:-- Create: `apps/frontend/src/routes/__tests__/vocs.test.tsx` — navigating to `/_authed/vocs?view=inbox` resolves; invalid `?view=foo` rejected by zod; sidebar `+ New VOC` href = `/_authed/vocs?action=create`; `view=triage` renders WorkbenchShell.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4569:+- Create: `apps/frontend/src/routes/__tests__/vocs.test.tsx` — navigating to `/vocs?view=inbox` resolves; invalid `?view=foo` rejected by zod; sidebar `+ New VOC` href = `/vocs?action=create`; `view=triage` renders WorkbenchShell.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4570: - Delete: `apps/frontend/src/routes/dev-rich-editor.tsx` IF it was added in C2 and is no longer needed (or keep behind DEV flag).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4574: - Read first: `apps/frontend/src/routes/__root.tsx`, `apps/frontend/vite.config.ts`, `apps/frontend/src/routes/admin/managed-systems.tsx` (existing TanStack file-route pattern), `apps/frontend/src/lib/layout/AppFrame.tsx` (just created in C4b), `packages/ui/src/layout/` (shells).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4578:+- Constraint: no `Route.id` navigation. Run `grep -rn 'Route\\.id\\|from: .*Route\\.id\\|to: .*Route\\.id' apps/frontend/src/` and refactor any hits to literal `to:` path strings.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4597: - Sonnet dispatches read AGENTS.md hierarchy first (`apps/frontend/AGENTS.md` mandatory).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4602: - **AppFrame in `apps/frontend` NEVER becomes a 4th exported shell. Shell taxonomy = 3 (PageShell/ListShell/WorkbenchShell) per ADR-0020.**
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4613: - `@tiptap/react` in `packages/ui` — verify `apps/frontend` resolves it transitively via workspace link without explicit install; if pnpm strict-mode blocks it, add a peer dep declaration.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4664:+      {type:'modify', path:'apps/frontend/src/routes/{admin/managed-systems,admin/analytics-areas,login,index}.tsx  // token classname rename audit'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4665:+      {type:'create', path:'apps/frontend/src/__tests__/token-class-coverage.test.ts  // resolveConfig coverage for TSX token classes'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4666:       {type:'modify', path:'apps/frontend/src/styles.css  // @import tokens.css + semantic.css'}
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4688:       {type:'modify', path:'apps/frontend/src/features/admin/permissions/request-access-button.tsx:115  // variant primary→default'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4697: # apps/frontend — app-level only; NO direct @tiptap/* (consumed via @fops/ui)
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4710:     dispatch:'Sonnet. Read rich-editor.jsx + ADR-0011 + BE sanitizer.ts. Constraints: surface = opaque pass-through; StarterKit image:false; demo = local state only; @tiptap/* must NOT be installed in apps/frontend.',
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4721:-      {type:'create', path:'apps/frontend/src/lib/api/{client,errorMapper,useIdempotencyKey,types}.ts'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4722:+      {type:'create', path:'apps/frontend/src/lib/api/{client,errorMapper,useIdempotencyKey,types}.ts  // export GENERIC_ERROR_MESSAGE'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4723:       {type:'modify', path:'apps/frontend/src/routes/__root.tsx  // <Toaster position="bottom-center"/>'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4724:       {type:'create', path:'apps/frontend/src/lib/api/__tests__/{errorMapper,client}.test.ts'}
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4728:+    dispatch:'Sonnet. Read packages/shared/src/errors/codes.ts (iterate ERROR_CODES, do NOT hardcode list) + envelope.ts + voc routes.ts lines 200-260. Tests assert tone literal set, non-generic messages for VOC/rich/attachment/reporter/conflict special codes, and conflict.stale_write warning action. Checkpoint includes /dev-rich-editor sanitizer-reject toast via apiClient mock.',
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4756:-    goal:'AppFrame in apps/frontend/src/lib/layout/ composes Rail+Sidebar+shell outlet+DetailPanelSlot. NOT a 4th shell — app-internal only. useFullscreenPanel hook.',
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4757:+    goal:'AppFrame in apps/frontend/src/lib/layout/ composes Rail+Sidebar+shell outlet+the single global DetailPanelSlot. SSR-safe sidebar collapse. NOT a 4th shell.',
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4759:       {type:'create', path:'apps/frontend/src/lib/layout/AppFrame.tsx  // NOT exported as shell; wraps one of 3 shells'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4760:       {type:'create', path:'apps/frontend/src/lib/layout/AppRail.tsx'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4761:-      {type:'create', path:'apps/frontend/src/lib/layout/AppSidebar.tsx  // collapse→localStorage'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4762:-      {type:'create', path:'apps/frontend/src/lib/layout/DetailPanelSlot.tsx  // 440px, min 360, max 520'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4763:-      {type:'create', path:'apps/frontend/src/lib/layout/useDetailPanelSlot.ts'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4764:+      {type:'create', path:'apps/frontend/src/lib/layout/AppSidebar.tsx  // SSR-safe localStorage initializer; first-paint width test'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4765:+      {type:'create', path:'apps/frontend/src/lib/layout/DetailPanelSlot.tsx  // single global 440px slot, min 360, max 520'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4766:+      {type:'create', path:'apps/frontend/src/lib/layout/useDetailPanelSlot.ts  // forbid overlapping registrants'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4767:       {type:'create', path:'apps/frontend/src/lib/panel/useFullscreenPanel.ts  // Esc collapses, route change clears'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4768:       {type:'create', path:'apps/frontend/src/lib/layout/__tests__/AppFrame.test.tsx'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4769:       {type:'create', path:'apps/frontend/src/lib/panel/__tests__/useFullscreenPanel.test.tsx'}
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4783:-      {type:'create', path:'apps/frontend/src/routes/_authed.tsx  // layout route: <AppFrame><Outlet/></AppFrame>'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4784:-      {type:'create', path:'apps/frontend/src/routes/_authed/vocs.tsx  // shell selection per view/action'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4785:+      {type:'create', path:'apps/frontend/src/routes/_authed.tsx  // beforeLoad fetchMe; redirect /login on UnauthenticatedError; <AppFrame><Outlet/></AppFrame>'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4786:+      {type:'create', path:'apps/frontend/src/routes/_authed/vocs.tsx  // public path /vocs; shell selection per view/action'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4787:       {type:'modify', path:'apps/frontend/src/routes/__root.tsx  // minimal: providers + <Outlet> only'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4788:-      {type:'modify', path:'apps/frontend/src/routes/admin/  // re-parent under _authed as PageShell (or file follow-up)'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4789:-      {type:'create', path:'apps/frontend/src/routes/__tests__/vocs.test.tsx  // shell per view + login NOT in AppFrame'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4790:+      {type:'move', path:'apps/frontend/src/routes/admin/{managed-systems,analytics-areas,placeholder}.tsx → apps/frontend/src/routes/_authed/admin/  // paths /admin/* unchanged; delete per-page auth guards'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4791:+      {type:'move', path:'apps/frontend/src/routes/admin/*.test.tsx → apps/frontend/src/routes/_authed/admin/  // update imports'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4792:+      {type:'create', path:'apps/frontend/src/routes/__tests__/vocs.test.tsx  // /vocs shell per view + login NOT in AppFrame + no Route.id nav'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4793:       {type:'delete', path:'apps/frontend/src/routes/dev-rich-editor.tsx  // if not kept behind DEV flag'}
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4835: - ADR-0020 taxonomy enforced: `packages/ui/src/layout/` exports exactly 3 shells (PageShell, ListShell, WorkbenchShell). AppFrame in `apps/frontend/src/lib/layout/` is NOT a 4th shell.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4886:+- Modify/audit: `apps/frontend/src/routes/admin/managed-systems.tsx`, `apps/frontend/src/routes/admin/analytics-areas.tsx`, `apps/frontend/src/routes/login.tsx`, `apps/frontend/src/routes/index.tsx` and any other route file referencing token classes — grep first, build rename map, then apply.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4887:+- Create: `apps/frontend/src/__tests__/token-class-coverage.test.ts` — grep/scan `.tsx` class strings and assert no `text|border|bg|ring|fill|stroke` token class references a Tailwind theme key that is not resolvable via `resolveConfig`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4888: - Modify: `apps/frontend/src/styles.css` — keep `@import "@fops/ui/styles/tokens.css"` + `semantic.css` + tailwind directives.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4894:+  `grep -rn '\(text\|border\|bg\|ring\|fill\|stroke\)-\(status\|surface\|accent\|severity\|reporter\|internal\|confidence\|focus\)-' apps/frontend/src/`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4938: - Modify: `apps/frontend/src/features/admin/permissions/request-access-button.tsx:115` — `variant="primary"` → `variant="default"` (or leave with primary alias).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4958: - Constraint: `@tiptap/react` lives in `packages/ui` — do NOT install it in `apps/frontend`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4960:+- Constraint: keep `apps/frontend/src/routes/dev-rich-editor.tsx` available after C2 so C3 can validate sanitizer-fail toast flow against the demo route; C5 may delete it only if no later checkpoint needs it.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4966: **Goal:** `<Toaster>` mounted in `__root.tsx`. `apiClient`, `errorMapper`, `useIdempotencyKey` land in `apps/frontend/src/lib/api/`. ALL codes in `ERROR_CODES` from `@fops/shared` covered with Korean copy and tone classification.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4969:-- Create: `apps/frontend/src/lib/api/errorMapper.ts` — maps `{ code, detail }` to `{ tone: 'error'|'warning'|'info', message: string, action?: { label, run } }`. **Catalog is generated by iterating `ERROR_CODES` from `@fops/shared`** — no manually typed list. Every code must map to a non-empty Korean message. Fallback for unknown codes: `{ tone: 'error', message: '일시적 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.' }`. Tone per category: `auth.*` → `error`, `permission.*` → `error`, `rate_limited.*` → `warning`, `validation.*` → `error`, `conflict.*` → `error` (except `conflict.stale_write` → `warning` with retry action), `not_found.*` → `error`, `internal.*` → `error`, `voc.*` → `error`, `rich_content.*` → `error`, `attachment.*` → `warning`, `reporter_facing_status.*` → `warning`. Required codes at minimum (from `packages/shared/src/errors/codes.ts`): `auth.session_invalid`, `auth.session_required`, `auth.session_expired`, `auth.workspace_mismatch`, `permission.denied`, `rate_limited.actor`, `rate_limited.ip`, `validation.failed`, `validation.malformed_request`, `validation.unknown_capability`, `conflict.idempotency_key_reuse`, `conflict.capability_already_granted`, `conflict.permission_request_duplicate`, `validation.malformed_idempotency_key`, `validation.sensitive_reason_required`, `validation.immutable_field`, `conflict.duplicate_slug`, `conflict.parent_archived`, `conflict.record_archived`, `not_found.record`, `internal.unexpected`, `voc.severity_not_user_settable`, `validation.unexpected_field`, `rich_content.disallowed_node`, `rich_content.external_image_forbidden`, `attachment.unsupported_pending_storage_slice`, `conflict.stale_write`, `voc.reporter_status_via_public_update_only`, `permission.scope_required`, `reporter_facing_status.invalid_transition`, `reporter_facing_status.gate_blocked`, `conflict.triage_already_committed`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4970:+- Create: `apps/frontend/src/lib/api/errorMapper.ts` — maps `{ code, detail }` to `{ tone: 'error'|'warning'|'info', message: string, action?: { label, run } }`. **Catalog is generated by iterating `ERROR_CODES` from `@fops/shared`** — no manually typed list. Every code must map to a non-empty Korean message. Export `GENERIC_ERROR_MESSAGE = '일시적 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.'` so tests compare to the fallback constant directly. Fallback for unknown codes: `{ tone: 'error', message: GENERIC_ERROR_MESSAGE }`. Tone per category: `auth.*` → `error`, `permission.*` → `error`, `rate_limited.*` → `warning`, `validation.*` → `error`, `conflict.*` → `error` (except `conflict.stale_write` → `warning` with retry action), `not_found.*` → `error`, `internal.*` → `error`, `voc.*` → `error`, `rich_content.*` → `error`, `attachment.*` → `warning`, `reporter_facing_status.*` → `warning`. Required codes at minimum (from `packages/shared/src/errors/codes.ts`): `auth.session_invalid`, `auth.session_required`, `auth.session_expired`, `auth.workspace_mismatch`, `permission.denied`, `rate_limited.actor`, `rate_limited.ip`, `validation.failed`, `validation.malformed_request`, `validation.unknown_capability`, `conflict.idempotency_key_reuse`, `conflict.capability_already_granted`, `conflict.permission_request_duplicate`, `validation.malformed_idempotency_key`, `validation.sensitive_reason_required`, `validation.immutable_field`, `conflict.duplicate_slug`, `conflict.parent_archived`, `conflict.record_archived`, `not_found.record`, `internal.unexpected`, `voc.severity_not_user_settable`, `validation.unexpected_field`, `rich_content.disallowed_node`, `rich_content.external_image_forbidden`, `attachment.unsupported_pending_storage_slice`, `conflict.stale_write`, `voc.reporter_status_via_public_update_only`, `permission.scope_required`, `reporter_facing_status.invalid_transition`, `reporter_facing_status.gate_blocked`, `conflict.triage_already_committed`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4971: - Create: `apps/frontend/src/lib/api/client.ts` — `apiClient(method, path, { body?, idempotencyKey?, ifMatch?, signal? })`. Auto-mint Idempotency-Key UUIDv4 on POST/PATCH/DELETE when not supplied. Attach `Authorization` from session store. Parse JSON. Non-2xx → throw `ApiError extends Error { code, detail, status, requestId }`. 304 → return `{ status: 304, etag }`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4972: - Create: `apps/frontend/src/lib/api/useIdempotencyKey.ts` — `useIdempotencyKey(ifMatchEtag?: string)`. Returns stable UUIDv4 per render-tree until consumed; `markConsumed()` mints fresh. **When `ifMatchEtag` changes value, the hook MUST automatically mint a fresh UUIDv4** — this prevents `conflict.idempotency_key_reuse` after a stale-write refetch (BE includes `ifMatch` in the idempotency hash per `apps/backend/src/modules/voc/routes.ts:225`, so a retry with a new `If-Match` value is a semantically different request that needs a new key).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4973: - Create: `apps/frontend/src/lib/api/types.ts` — `ApiErrorEnvelope` matching BE `errors/envelope.ts`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4974: - Modify: `apps/frontend/src/routes/__root.tsx` — mount `<Toaster position="bottom-center" />` from `sonner`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4975:-- Create: `apps/frontend/src/lib/api/__tests__/errorMapper.test.ts` — **iterate `ERROR_CODES` from `@fops/shared` and assert each maps to a non-empty Korean message** (not a manual catalog). This test auto-covers new codes added to `codes.ts` without test update.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4976:+- Create: `apps/frontend/src/lib/api/__tests__/errorMapper.test.ts` — **iterate `ERROR_CODES` from `@fops/shared` and assert each maps to a non-empty Korean message** (not a manual catalog). This test auto-covers new codes added to `codes.ts` without test update. Locked assertions: (1) every `ERROR_CODES` mapping has `tone` in literal set `{ 'error', 'warning', 'info' }`; (2) every code with prefix/member in `{ voc.*, rich_content.*, attachment.*, reporter_facing_status.*, conflict.stale_write, conflict.triage_already_committed, conflict.idempotency_key_reuse }` has Korean message not equal to exported `GENERIC_ERROR_MESSAGE`; (3) `conflict.stale_write` maps to `{ tone: 'warning', action: { label: <not undefined>, run: <fn> } }`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4977: - Create: `apps/frontend/src/lib/api/__tests__/client.test.ts` — mock fetch: POST mints Idempotency-Key, GET omits, Authorization attached, 422 throws ApiError, 304 returns ETag. Add test case: same `useIdempotencyKey` instance + changed `ifMatchEtag` → new key minted automatically.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4984:-**CHECKPOINT 2.5** — small playground demonstrating: Toaster position (bottom-center), tone variants (success / error / warning / info) with Korean copy, at least 3 representative error codes rendered as toasts (`conflict.stale_write` warning + retry action, `permission.denied` error, `rate_limited.ip` warning). AskUserQuestion: "토스트 UX + 에러 메시지 OK?"
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:4985:+**CHECKPOINT 2.5** — playground HTML demonstrating: Toaster tones + Korean copy for 3+ representative codes (`conflict.stale_write` warning + retry action, `permission.denied` error, `rate_limited.ip` warning) + RichEditor demo rendering sanitizer-rejected content with toast surfaced via apiClient mock. Requires C2 `/dev-rich-editor` route to still exist when C3 lands. AskUserQuestion: "토스트 UX + 에러 메시지 OK?"
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5014: ## C4b — AppFrame in apps/frontend + useFullscreenPanel hook
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5016:-**Goal:** `<AppFrame>` in `apps/frontend/src/lib/layout/` composes Rail(52) + Sidebar(240/56) + (shell outlet) + DetailPanelSlot(440). AppFrame consumes one of the 3 shells as its inner outlet. It is NOT exported as a shell — it is the authenticated route frame. `useFullscreenPanel` hook ready for #20 to consume.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5017:+**Goal:** `<AppFrame>` in `apps/frontend/src/lib/layout/` composes Rail(52) + Sidebar(240/56) + (shell outlet) + the single global DetailPanelSlot(440). AppFrame consumes one of the 3 shells as its inner outlet. It is NOT exported as a shell — it is the authenticated route frame. `useFullscreenPanel` hook ready for #20 to consume.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5022: - Create: `apps/frontend/src/lib/layout/AppFrame.tsx` — flex row Rail(52) + Sidebar(240/56) + Main(flex-1, shell outlet) + DetailPanelSlot(440 conditional). Headers conform to 50px rhythm via ShellHeader from `packages/ui`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5023: - Create: `apps/frontend/src/lib/layout/AppRail.tsx` — 52px vertical, workspace switcher placeholder + lucide-react utility icons.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5024:-- Create: `apps/frontend/src/lib/layout/AppSidebar.tsx` — 240px nav list. Slice 3 entries: Inbox, My VOCs, Triage, + New VOC. Collapse button writes `localStorage.appSidebarCollapsed`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5025:-- Create: `apps/frontend/src/lib/layout/DetailPanelSlot.tsx` — fixed 440 right column. min 360 / max 520. Hidden when no content registered via `useDetailPanelSlot()`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5026:-- Create: `apps/frontend/src/lib/layout/useDetailPanelSlot.ts` — context-based slot register/clear hook.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5027:+- Create: `apps/frontend/src/lib/layout/AppSidebar.tsx` — 240px nav list. Slice 3 entries: Inbox, My VOCs, Triage, + New VOC. Collapse state uses SSR-safe initializer:
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5035:+- Create: `apps/frontend/src/lib/layout/DetailPanelSlot.tsx` — fixed 440 right column. min 360 / max 520. Hidden when no content registered via `useDetailPanelSlot()`. This is the single rendering surface for all shell `detailPanel` content.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5036:+- Create: `apps/frontend/src/lib/layout/useDetailPanelSlot.ts` — context-based slot register/clear hook. Forbid multiple registrants: throw in dev (and warn in prod) if called twice with overlapping lifetimes, using a ref to track active ownership.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5037: - Create: `apps/frontend/src/lib/panel/useFullscreenPanel.ts` — `[isFullscreen, toggle]`. Esc collapses. Route change clears.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5038:-- Create: `apps/frontend/src/lib/layout/__tests__/AppFrame.test.tsx` — Rail/Sidebar/Main present; sidebar collapse toggle writes localStorage; DetailPanelSlot collapses when empty.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5039:+- Create: `apps/frontend/src/lib/layout/__tests__/AppFrame.test.tsx` — Rail/Sidebar/Main present; sidebar first-paint width matches stored `localStorage.appSidebarCollapsed` before any user interaction; sidebar collapse toggle writes localStorage; DetailPanelSlot collapses when empty; multiple overlapping `useDetailPanelSlot()` registrants throw/warn.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5040: - Create: `apps/frontend/src/lib/panel/__tests__/useFullscreenPanel.test.tsx` — toggle flips boolean; Esc dispatches collapse; route change clears (mock router).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5046: - Constraint: AppFrame is NOT exported from `packages/ui` — it lives in `apps/frontend/src/lib/layout/` only.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5055:-- `apps/frontend/src/routes/_authed.tsx` — new TanStack layout route. Wraps children with `<AppFrame>`. Login + non-authed routes do NOT use this layout and do NOT render AppFrame.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5057:+- `apps/frontend/src/routes/_authed.tsx` — new TanStack pathless layout route. Includes a `beforeLoad` callback that calls `fetchMe()` (same auth pattern currently used in admin routes) and `redirect({ to: '/login' })` on `UnauthenticatedError`. Wraps children with `<AppFrame>`. Login + non-authed routes do NOT use this layout and do NOT render AppFrame.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5058:+- Per-route auth guards in admin pages are DELETED in C5 after `_authed.beforeLoad` centralizes the guard.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5060:+  - `apps/frontend/src/routes/admin/managed-systems.tsx` → `apps/frontend/src/routes/_authed/admin/managed-systems.tsx`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5061:+  - `apps/frontend/src/routes/admin/analytics-areas.tsx` → `apps/frontend/src/routes/_authed/admin/analytics-areas.tsx`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5062:+  - `apps/frontend/src/routes/admin/placeholder.tsx` → `apps/frontend/src/routes/_authed/admin/placeholder.tsx`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5063:+  - Test file imports updated: `apps/frontend/src/routes/admin/*.test.tsx` move alongside their routes.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5066:-- `/vocs` route = `apps/frontend/src/routes/_authed/vocs.tsx`. Per-view shell selection: `view=inbox|my` → `<ListShell>`, `view=triage` → `<WorkbenchShell>`, `action=create` → `<PageShell>` (default when no view/action = `<ListShell>`).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5067:+- `/vocs` route file = `apps/frontend/src/routes/_authed/vocs.tsx`. Public path string is `/vocs`; `_authed` is pathless. Per-view shell selection: `view=inbox|my` → `<ListShell>`, `view=triage` → `<WorkbenchShell>`, `action=create` → `<PageShell>` (default when no view/action = `<ListShell>`).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5071:-- Create: `apps/frontend/src/routes/_authed.tsx` — TanStack layout route. Renders `<AppFrame><Outlet /></AppFrame>`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5072:+- Create: `apps/frontend/src/routes/_authed.tsx` — TanStack layout route. `beforeLoad` calls `fetchMe()` and redirects unauthenticated users to `/login`; renders `<AppFrame><Outlet /></AppFrame>`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5073: - Create: `apps/frontend/src/routes/_authed/vocs.tsx` — `createFileRoute('/_authed/vocs')` with validateSearch zod. Component selects shell based on `view`/`action`. Main = placeholder text.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5074: - Modify: `apps/frontend/src/routes/__root.tsx` — minimal; providers + `<Outlet>` only (no AppFrame).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5075:-- Relocate or re-parent: `apps/frontend/src/routes/admin/` — move under `_authed` so admin pages get AppFrame. If not done in C5, create a follow-up GitHub issue before closing this chunk.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5076:+- Move: `apps/frontend/src/routes/admin/managed-systems.tsx` → `apps/frontend/src/routes/_authed/admin/managed-systems.tsx`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5077:+- Move: `apps/frontend/src/routes/admin/analytics-areas.tsx` → `apps/frontend/src/routes/_authed/admin/analytics-areas.tsx`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5078:+- Move: `apps/frontend/src/routes/admin/placeholder.tsx` → `apps/frontend/src/routes/_authed/admin/placeholder.tsx`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5079:+- Move: `apps/frontend/src/routes/admin/*.test.tsx` → alongside relocated `_authed/admin/*` routes; update imports.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5081: - Auto-regen: `apps/frontend/src/routeTree.gen.ts` (TanStackRouterVite plugin handles on dev).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5082:-- Create: `apps/frontend/src/routes/__tests__/vocs.test.tsx` — navigating to `/_authed/vocs?view=inbox` resolves; invalid `?view=foo` rejected by zod; sidebar `+ New VOC` href = `/_authed/vocs?action=create`; `view=triage` renders WorkbenchShell.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5083:+- Create: `apps/frontend/src/routes/__tests__/vocs.test.tsx` — navigating to `/vocs?view=inbox` resolves; invalid `?view=foo` rejected by zod; sidebar `+ New VOC` href = `/vocs?action=create`; `view=triage` renders WorkbenchShell.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5084: - Delete: `apps/frontend/src/routes/dev-rich-editor.tsx` IF it was added in C2 and is no longer needed (or keep behind DEV flag).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5088: - Read first: `apps/frontend/src/routes/__root.tsx`, `apps/frontend/vite.config.ts`, `apps/frontend/src/routes/admin/managed-systems.tsx` (existing TanStack file-route pattern), `apps/frontend/src/lib/layout/AppFrame.tsx` (just created in C4b), `packages/ui/src/layout/` (shells).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5092:+- Constraint: no `Route.id` navigation. Run `grep -rn 'Route\\.id\\|from: .*Route\\.id\\|to: .*Route\\.id' apps/frontend/src/` and refactor any hits to literal `to:` path strings.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5111: - Sonnet dispatches read AGENTS.md hierarchy first (`apps/frontend/AGENTS.md` mandatory).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5116: - **AppFrame in `apps/frontend` NEVER becomes a 4th exported shell. Shell taxonomy = 3 (PageShell/ListShell/WorkbenchShell) per ADR-0020.**
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5127: - `@tiptap/react` in `packages/ui` — verify `apps/frontend` resolves it transitively via workspace link without explicit install; if pnpm strict-mode blocks it, add a peer dep declaration.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5178:+      {type:'modify', path:'apps/frontend/src/routes/{admin/managed-systems,admin/analytics-areas,login,index}.tsx  // token classname rename audit'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5179:+      {type:'create', path:'apps/frontend/src/__tests__/token-class-coverage.test.ts  // resolveConfig coverage for TSX token classes'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5180:       {type:'modify', path:'apps/frontend/src/styles.css  // @import tokens.css + semantic.css'}
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5202:       {type:'modify', path:'apps/frontend/src/features/admin/permissions/request-access-button.tsx:115  // variant primary→default'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5211: # apps/frontend — app-level only; NO direct @tiptap/* (consumed via @fops/ui)
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5224:     dispatch:'Sonnet. Read rich-editor.jsx + ADR-0011 + BE sanitizer.ts. Constraints: surface = opaque pass-through; StarterKit image:false; demo = local state only; @tiptap/* must NOT be installed in apps/frontend.',
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5235:-      {type:'create', path:'apps/frontend/src/lib/api/{client,errorMapper,useIdempotencyKey,types}.ts'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5236:+      {type:'create', path:'apps/frontend/src/lib/api/{client,errorMapper,useIdempotencyKey,types}.ts  // export GENERIC_ERROR_MESSAGE'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5237:       {type:'modify', path:'apps/frontend/src/routes/__root.tsx  // <Toaster position="bottom-center"/>'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5238:       {type:'create', path:'apps/frontend/src/lib/api/__tests__/{errorMapper,client}.test.ts'}
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5242:+    dispatch:'Sonnet. Read packages/shared/src/errors/codes.ts (iterate ERROR_CODES, do NOT hardcode list) + envelope.ts + voc routes.ts lines 200-260. Tests assert tone literal set, non-generic messages for VOC/rich/attachment/reporter/conflict special codes, and conflict.stale_write warning action. Checkpoint includes /dev-rich-editor sanitizer-reject toast via apiClient mock.',
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5270:-    goal:'AppFrame in apps/frontend/src/lib/layout/ composes Rail+Sidebar+shell outlet+DetailPanelSlot. NOT a 4th shell — app-internal only. useFullscreenPanel hook.',
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5271:+    goal:'AppFrame in apps/frontend/src/lib/layout/ composes Rail+Sidebar+shell outlet+the single global DetailPanelSlot. SSR-safe sidebar collapse. NOT a 4th shell.',
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5273:       {type:'create', path:'apps/frontend/src/lib/layout/AppFrame.tsx  // NOT exported as shell; wraps one of 3 shells'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5274:       {type:'create', path:'apps/frontend/src/lib/layout/AppRail.tsx'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5275:-      {type:'create', path:'apps/frontend/src/lib/layout/AppSidebar.tsx  // collapse→localStorage'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5276:-      {type:'create', path:'apps/frontend/src/lib/layout/DetailPanelSlot.tsx  // 440px, min 360, max 520'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5277:-      {type:'create', path:'apps/frontend/src/lib/layout/useDetailPanelSlot.ts'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5278:+      {type:'create', path:'apps/frontend/src/lib/layout/AppSidebar.tsx  // SSR-safe localStorage initializer; first-paint width test'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5279:+      {type:'create', path:'apps/frontend/src/lib/layout/DetailPanelSlot.tsx  // single global 440px slot, min 360, max 520'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5280:+      {type:'create', path:'apps/frontend/src/lib/layout/useDetailPanelSlot.ts  // forbid overlapping registrants'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5281:       {type:'create', path:'apps/frontend/src/lib/panel/useFullscreenPanel.ts  // Esc collapses, route change clears'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5282:       {type:'create', path:'apps/frontend/src/lib/layout/__tests__/AppFrame.test.tsx'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5283:       {type:'create', path:'apps/frontend/src/lib/panel/__tests__/useFullscreenPanel.test.tsx'}
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5297:-      {type:'create', path:'apps/frontend/src/routes/_authed.tsx  // layout route: <AppFrame><Outlet/></AppFrame>'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5298:-      {type:'create', path:'apps/frontend/src/routes/_authed/vocs.tsx  // shell selection per view/action'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5299:+      {type:'create', path:'apps/frontend/src/routes/_authed.tsx  // beforeLoad fetchMe; redirect /login on UnauthenticatedError; <AppFrame><Outlet/></AppFrame>'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5300:+      {type:'create', path:'apps/frontend/src/routes/_authed/vocs.tsx  // public path /vocs; shell selection per view/action'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5301:       {type:'modify', path:'apps/frontend/src/routes/__root.tsx  // minimal: providers + <Outlet> only'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5302:-      {type:'modify', path:'apps/frontend/src/routes/admin/  // re-parent under _authed as PageShell (or file follow-up)'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5303:-      {type:'create', path:'apps/frontend/src/routes/__tests__/vocs.test.tsx  // shell per view + login NOT in AppFrame'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5304:+      {type:'move', path:'apps/frontend/src/routes/admin/{managed-systems,analytics-areas,placeholder}.tsx → apps/frontend/src/routes/_authed/admin/  // paths /admin/* unchanged; delete per-page auth guards'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5305:+      {type:'move', path:'apps/frontend/src/routes/admin/*.test.tsx → apps/frontend/src/routes/_authed/admin/  // update imports'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5306:+      {type:'create', path:'apps/frontend/src/routes/__tests__/vocs.test.tsx  // /vocs shell per view + login NOT in AppFrame + no Route.id nav'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5307:       {type:'delete', path:'apps/frontend/src/routes/dev-rich-editor.tsx  // if not kept behind DEV flag'}
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5328:The requested patches are in place. I’m doing a narrow verification now: checking that only the two target files changed and scanning for stale “18 shadcn” or old `/ _authed` URL wording.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5347:report/2026-05-20-slice3-18-plan-playground.html:283:      {type:'create', path:'apps/frontend/src/routes/_authed.tsx  // beforeLoad fetchMe; redirect /login on UnauthenticatedError; <AppFrame><Outlet/></AppFrame>'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5348:report/2026-05-20-slice3-18-plan-playground.html:284:      {type:'create', path:'apps/frontend/src/routes/_authed/vocs.tsx  // public path /vocs; shell selection per view/action'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5349:report/2026-05-20-slice3-18-plan-playground.html:288:      {type:'create', path:'apps/frontend/src/routes/__tests__/vocs.test.tsx  // /vocs shell per view + login NOT in AppFrame + no Route.id nav'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5360:.review/SLICE-3-18-PLAN.md:296:- `apps/frontend/src/routes/_authed.tsx` — new TanStack pathless layout route. Includes a `beforeLoad` callback that calls `fetchMe()` (same auth pattern currently used in admin routes) and `redirect({ to: '/login' })` on `UnauthenticatedError`. Wraps children with `<AppFrame>`. Login + non-authed routes do NOT use this layout and do NOT render AppFrame.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5361:.review/SLICE-3-18-PLAN.md:297:- Per-route auth guards in admin pages are DELETED in C5 after `_authed.beforeLoad` centralizes the guard.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5362:.review/SLICE-3-18-PLAN.md:305:- `/vocs` route file = `apps/frontend/src/routes/_authed/vocs.tsx`. Public path string is `/vocs`; `_authed` is pathless. Per-view shell selection: `view=inbox|my` → `<ListShell>`, `view=triage` → `<WorkbenchShell>`, `action=create` → `<PageShell>` (default when no view/action = `<ListShell>`).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5364:.review/SLICE-3-18-PLAN.md:309:- Create: `apps/frontend/src/routes/_authed.tsx` — TanStack layout route. `beforeLoad` calls `fetchMe()` and redirects unauthenticated users to `/login`; renders `<AppFrame><Outlet /></AppFrame>`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5365:.review/SLICE-3-18-PLAN.md:310:- Create: `apps/frontend/src/routes/_authed/vocs.tsx` — `createFileRoute('/_authed/vocs')` with validateSearch zod. Component selects shell based on `view`/`action`. Main = placeholder text.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5367:.review/SLICE-3-18-PLAN.md:337:- Constraint: no `Route.id` navigation. Run `grep -rn 'Route\\.id\\|from: .*Route\\.id\\|to: .*Route\\.id' apps/frontend/src/` and refactor any hits to literal `to:` path strings.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5402: - ADR-0020 taxonomy enforced: `packages/ui/src/layout/` exports exactly 3 shells (PageShell, ListShell, WorkbenchShell). AppFrame in `apps/frontend/src/lib/layout/` is NOT a 4th shell.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5453:+- Modify/audit: `apps/frontend/src/routes/admin/managed-systems.tsx`, `apps/frontend/src/routes/admin/analytics-areas.tsx`, `apps/frontend/src/routes/login.tsx`, `apps/frontend/src/routes/index.tsx` and any other route file referencing token classes — grep first, build rename map, then apply.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5454:+- Create: `apps/frontend/src/__tests__/token-class-coverage.test.ts` — grep/scan `.tsx` class strings and assert no `text|border|bg|ring|fill|stroke` token class references a Tailwind theme key that is not resolvable via `resolveConfig`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5455: - Modify: `apps/frontend/src/styles.css` — keep `@import "@fops/ui/styles/tokens.css"` + `semantic.css` + tailwind directives.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5461:+  `grep -rn '\(text\|border\|bg\|ring\|fill\|stroke\)-\(status\|surface\|accent\|severity\|reporter\|internal\|confidence\|focus\)-' apps/frontend/src/`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5505: - Modify: `apps/frontend/src/features/admin/permissions/request-access-button.tsx:115` — `variant="primary"` → `variant="default"` (or leave with primary alias).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5525: - Constraint: `@tiptap/react` lives in `packages/ui` — do NOT install it in `apps/frontend`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5527:+- Constraint: keep `apps/frontend/src/routes/dev-rich-editor.tsx` available after C2 so C3 can validate sanitizer-fail toast flow against the demo route; C5 may delete it only if no later checkpoint needs it.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5533: **Goal:** `<Toaster>` mounted in `__root.tsx`. `apiClient`, `errorMapper`, `useIdempotencyKey` land in `apps/frontend/src/lib/api/`. ALL codes in `ERROR_CODES` from `@fops/shared` covered with Korean copy and tone classification.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5536:-- Create: `apps/frontend/src/lib/api/errorMapper.ts` — maps `{ code, detail }` to `{ tone: 'error'|'warning'|'info', message: string, action?: { label, run } }`. **Catalog is generated by iterating `ERROR_CODES` from `@fops/shared`** — no manually typed list. Every code must map to a non-empty Korean message. Fallback for unknown codes: `{ tone: 'error', message: '일시적 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.' }`. Tone per category: `auth.*` → `error`, `permission.*` → `error`, `rate_limited.*` → `warning`, `validation.*` → `error`, `conflict.*` → `error` (except `conflict.stale_write` → `warning` with retry action), `not_found.*` → `error`, `internal.*` → `error`, `voc.*` → `error`, `rich_content.*` → `error`, `attachment.*` → `warning`, `reporter_facing_status.*` → `warning`. Required codes at minimum (from `packages/shared/src/errors/codes.ts`): `auth.session_invalid`, `auth.session_required`, `auth.session_expired`, `auth.workspace_mismatch`, `permission.denied`, `rate_limited.actor`, `rate_limited.ip`, `validation.failed`, `validation.malformed_request`, `validation.unknown_capability`, `conflict.idempotency_key_reuse`, `conflict.capability_already_granted`, `conflict.permission_request_duplicate`, `validation.malformed_idempotency_key`, `validation.sensitive_reason_required`, `validation.immutable_field`, `conflict.duplicate_slug`, `conflict.parent_archived`, `conflict.record_archived`, `not_found.record`, `internal.unexpected`, `voc.severity_not_user_settable`, `validation.unexpected_field`, `rich_content.disallowed_node`, `rich_content.external_image_forbidden`, `attachment.unsupported_pending_storage_slice`, `conflict.stale_write`, `voc.reporter_status_via_public_update_only`, `permission.scope_required`, `reporter_facing_status.invalid_transition`, `reporter_facing_status.gate_blocked`, `conflict.triage_already_committed`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5537:+- Create: `apps/frontend/src/lib/api/errorMapper.ts` — maps `{ code, detail }` to `{ tone: 'error'|'warning'|'info', message: string, action?: { label, run } }`. **Catalog is generated by iterating `ERROR_CODES` from `@fops/shared`** — no manually typed list. Every code must map to a non-empty Korean message. Export `GENERIC_ERROR_MESSAGE = '일시적 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.'` so tests compare to the fallback constant directly. Fallback for unknown codes: `{ tone: 'error', message: GENERIC_ERROR_MESSAGE }`. Tone per category: `auth.*` → `error`, `permission.*` → `error`, `rate_limited.*` → `warning`, `validation.*` → `error`, `conflict.*` → `error` (except `conflict.stale_write` → `warning` with retry action), `not_found.*` → `error`, `internal.*` → `error`, `voc.*` → `error`, `rich_content.*` → `error`, `attachment.*` → `warning`, `reporter_facing_status.*` → `warning`. Required codes at minimum (from `packages/shared/src/errors/codes.ts`): `auth.session_invalid`, `auth.session_required`, `auth.session_expired`, `auth.workspace_mismatch`, `permission.denied`, `rate_limited.actor`, `rate_limited.ip`, `validation.failed`, `validation.malformed_request`, `validation.unknown_capability`, `conflict.idempotency_key_reuse`, `conflict.capability_already_granted`, `conflict.permission_request_duplicate`, `validation.malformed_idempotency_key`, `validation.sensitive_reason_required`, `validation.immutable_field`, `conflict.duplicate_slug`, `conflict.parent_archived`, `conflict.record_archived`, `not_found.record`, `internal.unexpected`, `voc.severity_not_user_settable`, `validation.unexpected_field`, `rich_content.disallowed_node`, `rich_content.external_image_forbidden`, `attachment.unsupported_pending_storage_slice`, `conflict.stale_write`, `voc.reporter_status_via_public_update_only`, `permission.scope_required`, `reporter_facing_status.invalid_transition`, `reporter_facing_status.gate_blocked`, `conflict.triage_already_committed`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5538: - Create: `apps/frontend/src/lib/api/client.ts` — `apiClient(method, path, { body?, idempotencyKey?, ifMatch?, signal? })`. Auto-mint Idempotency-Key UUIDv4 on POST/PATCH/DELETE when not supplied. Attach `Authorization` from session store. Parse JSON. Non-2xx → throw `ApiError extends Error { code, detail, status, requestId }`. 304 → return `{ status: 304, etag }`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5539: - Create: `apps/frontend/src/lib/api/useIdempotencyKey.ts` — `useIdempotencyKey(ifMatchEtag?: string)`. Returns stable UUIDv4 per render-tree until consumed; `markConsumed()` mints fresh. **When `ifMatchEtag` changes value, the hook MUST automatically mint a fresh UUIDv4** — this prevents `conflict.idempotency_key_reuse` after a stale-write refetch (BE includes `ifMatch` in the idempotency hash per `apps/backend/src/modules/voc/routes.ts:225`, so a retry with a new `If-Match` value is a semantically different request that needs a new key).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5540: - Create: `apps/frontend/src/lib/api/types.ts` — `ApiErrorEnvelope` matching BE `errors/envelope.ts`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5541: - Modify: `apps/frontend/src/routes/__root.tsx` — mount `<Toaster position="bottom-center" />` from `sonner`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5542:-- Create: `apps/frontend/src/lib/api/__tests__/errorMapper.test.ts` — **iterate `ERROR_CODES` from `@fops/shared` and assert each maps to a non-empty Korean message** (not a manual catalog). This test auto-covers new codes added to `codes.ts` without test update.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5543:+- Create: `apps/frontend/src/lib/api/__tests__/errorMapper.test.ts` — **iterate `ERROR_CODES` from `@fops/shared` and assert each maps to a non-empty Korean message** (not a manual catalog). This test auto-covers new codes added to `codes.ts` without test update. Locked assertions: (1) every `ERROR_CODES` mapping has `tone` in literal set `{ 'error', 'warning', 'info' }`; (2) every code with prefix/member in `{ voc.*, rich_content.*, attachment.*, reporter_facing_status.*, conflict.stale_write, conflict.triage_already_committed, conflict.idempotency_key_reuse }` has Korean message not equal to exported `GENERIC_ERROR_MESSAGE`; (3) `conflict.stale_write` maps to `{ tone: 'warning', action: { label: <not undefined>, run: <fn> } }`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5544: - Create: `apps/frontend/src/lib/api/__tests__/client.test.ts` — mock fetch: POST mints Idempotency-Key, GET omits, Authorization attached, 422 throws ApiError, 304 returns ETag. Add test case: same `useIdempotencyKey` instance + changed `ifMatchEtag` → new key minted automatically.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5551:-**CHECKPOINT 2.5** — small playground demonstrating: Toaster position (bottom-center), tone variants (success / error / warning / info) with Korean copy, at least 3 representative error codes rendered as toasts (`conflict.stale_write` warning + retry action, `permission.denied` error, `rate_limited.ip` warning). AskUserQuestion: "토스트 UX + 에러 메시지 OK?"
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5552:+**CHECKPOINT 2.5** — playground HTML demonstrating: Toaster tones + Korean copy for 3+ representative codes (`conflict.stale_write` warning + retry action, `permission.denied` error, `rate_limited.ip` warning) + RichEditor demo rendering sanitizer-rejected content with toast surfaced via apiClient mock. Requires C2 `/dev-rich-editor` route to still exist when C3 lands. AskUserQuestion: "토스트 UX + 에러 메시지 OK?"
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5581: ## C4b — AppFrame in apps/frontend + useFullscreenPanel hook
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5583:-**Goal:** `<AppFrame>` in `apps/frontend/src/lib/layout/` composes Rail(52) + Sidebar(240/56) + (shell outlet) + DetailPanelSlot(440). AppFrame consumes one of the 3 shells as its inner outlet. It is NOT exported as a shell — it is the authenticated route frame. `useFullscreenPanel` hook ready for #20 to consume.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5584:+**Goal:** `<AppFrame>` in `apps/frontend/src/lib/layout/` composes Rail(52) + Sidebar(240/56) + (shell outlet) + the single global DetailPanelSlot(440). AppFrame consumes one of the 3 shells as its inner outlet. It is NOT exported as a shell — it is the authenticated route frame. `useFullscreenPanel` hook ready for #20 to consume.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5589: - Create: `apps/frontend/src/lib/layout/AppFrame.tsx` — flex row Rail(52) + Sidebar(240/56) + Main(flex-1, shell outlet) + DetailPanelSlot(440 conditional). Headers conform to 50px rhythm via ShellHeader from `packages/ui`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5590: - Create: `apps/frontend/src/lib/layout/AppRail.tsx` — 52px vertical, workspace switcher placeholder + lucide-react utility icons.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5591:-- Create: `apps/frontend/src/lib/layout/AppSidebar.tsx` — 240px nav list. Slice 3 entries: Inbox, My VOCs, Triage, + New VOC. Collapse button writes `localStorage.appSidebarCollapsed`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5592:-- Create: `apps/frontend/src/lib/layout/DetailPanelSlot.tsx` — fixed 440 right column. min 360 / max 520. Hidden when no content registered via `useDetailPanelSlot()`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5593:-- Create: `apps/frontend/src/lib/layout/useDetailPanelSlot.ts` — context-based slot register/clear hook.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5594:+- Create: `apps/frontend/src/lib/layout/AppSidebar.tsx` — 240px nav list. Slice 3 entries: Inbox, My VOCs, Triage, + New VOC. Collapse state uses SSR-safe initializer:
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5602:+- Create: `apps/frontend/src/lib/layout/DetailPanelSlot.tsx` — fixed 440 right column. min 360 / max 520. Hidden when no content registered via `useDetailPanelSlot()`. This is the single rendering surface for all shell `detailPanel` content.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5603:+- Create: `apps/frontend/src/lib/layout/useDetailPanelSlot.ts` — context-based slot register/clear hook. Forbid multiple registrants: throw in dev (and warn in prod) if called twice with overlapping lifetimes, using a ref to track active ownership.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5604: - Create: `apps/frontend/src/lib/panel/useFullscreenPanel.ts` — `[isFullscreen, toggle]`. Esc collapses. Route change clears.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5605:-- Create: `apps/frontend/src/lib/layout/__tests__/AppFrame.test.tsx` — Rail/Sidebar/Main present; sidebar collapse toggle writes localStorage; DetailPanelSlot collapses when empty.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5606:+- Create: `apps/frontend/src/lib/layout/__tests__/AppFrame.test.tsx` — Rail/Sidebar/Main present; sidebar first-paint width matches stored `localStorage.appSidebarCollapsed` before any user interaction; sidebar collapse toggle writes localStorage; DetailPanelSlot collapses when empty; multiple overlapping `useDetailPanelSlot()` registrants throw/warn.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5607: - Create: `apps/frontend/src/lib/panel/__tests__/useFullscreenPanel.test.tsx` — toggle flips boolean; Esc dispatches collapse; route change clears (mock router).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5613: - Constraint: AppFrame is NOT exported from `packages/ui` — it lives in `apps/frontend/src/lib/layout/` only.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5622:-- `apps/frontend/src/routes/_authed.tsx` — new TanStack layout route. Wraps children with `<AppFrame>`. Login + non-authed routes do NOT use this layout and do NOT render AppFrame.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5624:+- `apps/frontend/src/routes/_authed.tsx` — new TanStack pathless layout route. Includes a `beforeLoad` callback that calls `fetchMe()` (same auth pattern currently used in admin routes) and `redirect({ to: '/login' })` on `UnauthenticatedError`. Wraps children with `<AppFrame>`. Login + non-authed routes do NOT use this layout and do NOT render AppFrame.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5625:+- Per-route auth guards in admin pages are DELETED in C5 after `_authed.beforeLoad` centralizes the guard.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5627:+  - `apps/frontend/src/routes/admin/managed-systems.tsx` → `apps/frontend/src/routes/_authed/admin/managed-systems.tsx`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5628:+  - `apps/frontend/src/routes/admin/analytics-areas.tsx` → `apps/frontend/src/routes/_authed/admin/analytics-areas.tsx`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5629:+  - `apps/frontend/src/routes/admin/placeholder.tsx` → `apps/frontend/src/routes/_authed/admin/placeholder.tsx`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5630:+  - Test file imports updated: `apps/frontend/src/routes/admin/*.test.tsx` move alongside their routes.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5633:-- `/vocs` route = `apps/frontend/src/routes/_authed/vocs.tsx`. Per-view shell selection: `view=inbox|my` → `<ListShell>`, `view=triage` → `<WorkbenchShell>`, `action=create` → `<PageShell>` (default when no view/action = `<ListShell>`).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5634:+- `/vocs` route file = `apps/frontend/src/routes/_authed/vocs.tsx`. Public path string is `/vocs`; `_authed` is pathless. Per-view shell selection: `view=inbox|my` → `<ListShell>`, `view=triage` → `<WorkbenchShell>`, `action=create` → `<PageShell>` (default when no view/action = `<ListShell>`).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5638:-- Create: `apps/frontend/src/routes/_authed.tsx` — TanStack layout route. Renders `<AppFrame><Outlet /></AppFrame>`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5639:+- Create: `apps/frontend/src/routes/_authed.tsx` — TanStack layout route. `beforeLoad` calls `fetchMe()` and redirects unauthenticated users to `/login`; renders `<AppFrame><Outlet /></AppFrame>`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5640: - Create: `apps/frontend/src/routes/_authed/vocs.tsx` — `createFileRoute('/_authed/vocs')` with validateSearch zod. Component selects shell based on `view`/`action`. Main = placeholder text.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5641: - Modify: `apps/frontend/src/routes/__root.tsx` — minimal; providers + `<Outlet>` only (no AppFrame).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5642:-- Relocate or re-parent: `apps/frontend/src/routes/admin/` — move under `_authed` so admin pages get AppFrame. If not done in C5, create a follow-up GitHub issue before closing this chunk.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5643:+- Move: `apps/frontend/src/routes/admin/managed-systems.tsx` → `apps/frontend/src/routes/_authed/admin/managed-systems.tsx`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5644:+- Move: `apps/frontend/src/routes/admin/analytics-areas.tsx` → `apps/frontend/src/routes/_authed/admin/analytics-areas.tsx`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5645:+- Move: `apps/frontend/src/routes/admin/placeholder.tsx` → `apps/frontend/src/routes/_authed/admin/placeholder.tsx`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5646:+- Move: `apps/frontend/src/routes/admin/*.test.tsx` → alongside relocated `_authed/admin/*` routes; update imports.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5648: - Auto-regen: `apps/frontend/src/routeTree.gen.ts` (TanStackRouterVite plugin handles on dev).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5649:-- Create: `apps/frontend/src/routes/__tests__/vocs.test.tsx` — navigating to `/_authed/vocs?view=inbox` resolves; invalid `?view=foo` rejected by zod; sidebar `+ New VOC` href = `/_authed/vocs?action=create`; `view=triage` renders WorkbenchShell.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5650:+- Create: `apps/frontend/src/routes/__tests__/vocs.test.tsx` — navigating to `/vocs?view=inbox` resolves; invalid `?view=foo` rejected by zod; sidebar `+ New VOC` href = `/vocs?action=create`; `view=triage` renders WorkbenchShell.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5651: - Delete: `apps/frontend/src/routes/dev-rich-editor.tsx` IF it was added in C2 and is no longer needed (or keep behind DEV flag).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5655: - Read first: `apps/frontend/src/routes/__root.tsx`, `apps/frontend/vite.config.ts`, `apps/frontend/src/routes/admin/managed-systems.tsx` (existing TanStack file-route pattern), `apps/frontend/src/lib/layout/AppFrame.tsx` (just created in C4b), `packages/ui/src/layout/` (shells).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5659:+- Constraint: no `Route.id` navigation. Run `grep -rn 'Route\\.id\\|from: .*Route\\.id\\|to: .*Route\\.id' apps/frontend/src/` and refactor any hits to literal `to:` path strings.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5678: - Sonnet dispatches read AGENTS.md hierarchy first (`apps/frontend/AGENTS.md` mandatory).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5683: - **AppFrame in `apps/frontend` NEVER becomes a 4th exported shell. Shell taxonomy = 3 (PageShell/ListShell/WorkbenchShell) per ADR-0020.**
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5694: - `@tiptap/react` in `packages/ui` — verify `apps/frontend` resolves it transitively via workspace link without explicit install; if pnpm strict-mode blocks it, add a peer dep declaration.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5745:+      {type:'modify', path:'apps/frontend/src/routes/{admin/managed-systems,admin/analytics-areas,login,index}.tsx  // token classname rename audit'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5746:+      {type:'create', path:'apps/frontend/src/__tests__/token-class-coverage.test.ts  // resolveConfig coverage for TSX token classes'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5747:       {type:'modify', path:'apps/frontend/src/styles.css  // @import tokens.css + semantic.css'}
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5769:       {type:'modify', path:'apps/frontend/src/features/admin/permissions/request-access-button.tsx:115  // variant primary→default'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5778: # apps/frontend — app-level only; NO direct @tiptap/* (consumed via @fops/ui)
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5791:     dispatch:'Sonnet. Read rich-editor.jsx + ADR-0011 + BE sanitizer.ts. Constraints: surface = opaque pass-through; StarterKit image:false; demo = local state only; @tiptap/* must NOT be installed in apps/frontend.',
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5802:-      {type:'create', path:'apps/frontend/src/lib/api/{client,errorMapper,useIdempotencyKey,types}.ts'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5803:+      {type:'create', path:'apps/frontend/src/lib/api/{client,errorMapper,useIdempotencyKey,types}.ts  // export GENERIC_ERROR_MESSAGE'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5804:       {type:'modify', path:'apps/frontend/src/routes/__root.tsx  // <Toaster position="bottom-center"/>'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5805:       {type:'create', path:'apps/frontend/src/lib/api/__tests__/{errorMapper,client}.test.ts'}
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5809:+    dispatch:'Sonnet. Read packages/shared/src/errors/codes.ts (iterate ERROR_CODES, do NOT hardcode list) + envelope.ts + voc routes.ts lines 200-260. Tests assert tone literal set, non-generic messages for VOC/rich/attachment/reporter/conflict special codes, and conflict.stale_write warning action. Checkpoint includes /dev-rich-editor sanitizer-reject toast via apiClient mock.',
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5837:-    goal:'AppFrame in apps/frontend/src/lib/layout/ composes Rail+Sidebar+shell outlet+DetailPanelSlot. NOT a 4th shell — app-internal only. useFullscreenPanel hook.',
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5838:+    goal:'AppFrame in apps/frontend/src/lib/layout/ composes Rail+Sidebar+shell outlet+the single global DetailPanelSlot. SSR-safe sidebar collapse. NOT a 4th shell.',
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5840:       {type:'create', path:'apps/frontend/src/lib/layout/AppFrame.tsx  // NOT exported as shell; wraps one of 3 shells'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5841:       {type:'create', path:'apps/frontend/src/lib/layout/AppRail.tsx'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5842:-      {type:'create', path:'apps/frontend/src/lib/layout/AppSidebar.tsx  // collapse→localStorage'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5843:-      {type:'create', path:'apps/frontend/src/lib/layout/DetailPanelSlot.tsx  // 440px, min 360, max 520'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5844:-      {type:'create', path:'apps/frontend/src/lib/layout/useDetailPanelSlot.ts'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5845:+      {type:'create', path:'apps/frontend/src/lib/layout/AppSidebar.tsx  // SSR-safe localStorage initializer; first-paint width test'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5846:+      {type:'create', path:'apps/frontend/src/lib/layout/DetailPanelSlot.tsx  // single global 440px slot, min 360, max 520'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5847:+      {type:'create', path:'apps/frontend/src/lib/layout/useDetailPanelSlot.ts  // forbid overlapping registrants'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5848:       {type:'create', path:'apps/frontend/src/lib/panel/useFullscreenPanel.ts  // Esc collapses, route change clears'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5849:       {type:'create', path:'apps/frontend/src/lib/layout/__tests__/AppFrame.test.tsx'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5850:       {type:'create', path:'apps/frontend/src/lib/panel/__tests__/useFullscreenPanel.test.tsx'}
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5864:-      {type:'create', path:'apps/frontend/src/routes/_authed.tsx  // layout route: <AppFrame><Outlet/></AppFrame>'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5865:-      {type:'create', path:'apps/frontend/src/routes/_authed/vocs.tsx  // shell selection per view/action'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5866:+      {type:'create', path:'apps/frontend/src/routes/_authed.tsx  // beforeLoad fetchMe; redirect /login on UnauthenticatedError; <AppFrame><Outlet/></AppFrame>'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5867:+      {type:'create', path:'apps/frontend/src/routes/_authed/vocs.tsx  // public path /vocs; shell selection per view/action'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5868:       {type:'modify', path:'apps/frontend/src/routes/__root.tsx  // minimal: providers + <Outlet> only'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5869:-      {type:'modify', path:'apps/frontend/src/routes/admin/  // re-parent under _authed as PageShell (or file follow-up)'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5870:-      {type:'create', path:'apps/frontend/src/routes/__tests__/vocs.test.tsx  // shell per view + login NOT in AppFrame'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5871:+      {type:'move', path:'apps/frontend/src/routes/admin/{managed-systems,analytics-areas,placeholder}.tsx → apps/frontend/src/routes/_authed/admin/  // paths /admin/* unchanged; delete per-page auth guards'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5872:+      {type:'move', path:'apps/frontend/src/routes/admin/*.test.tsx → apps/frontend/src/routes/_authed/admin/  // update imports'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5873:+      {type:'create', path:'apps/frontend/src/routes/__tests__/vocs.test.tsx  // /vocs shell per view + login NOT in AppFrame + no Route.id nav'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5874:       {type:'delete', path:'apps/frontend/src/routes/dev-rich-editor.tsx  // if not kept behind DEV flag'}
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5924: - ADR-0020 taxonomy enforced: `packages/ui/src/layout/` exports exactly 3 shells (PageShell, ListShell, WorkbenchShell). AppFrame in `apps/frontend/src/lib/layout/` is NOT a 4th shell.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5975:+- Modify/audit: `apps/frontend/src/routes/admin/managed-systems.tsx`, `apps/frontend/src/routes/admin/analytics-areas.tsx`, `apps/frontend/src/routes/login.tsx`, `apps/frontend/src/routes/index.tsx` and any other route file referencing token classes — grep first, build rename map, then apply.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5976:+- Create: `apps/frontend/src/__tests__/token-class-coverage.test.ts` — grep/scan `.tsx` class strings and assert no `text|border|bg|ring|fill|stroke` token class references a Tailwind theme key that is not resolvable via `resolveConfig`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5977: - Modify: `apps/frontend/src/styles.css` — keep `@import "@fops/ui/styles/tokens.css"` + `semantic.css` + tailwind directives.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:5983:+  `grep -rn '\(text\|border\|bg\|ring\|fill\|stroke\)-\(status\|surface\|accent\|severity\|reporter\|internal\|confidence\|focus\)-' apps/frontend/src/`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6027: - Modify: `apps/frontend/src/features/admin/permissions/request-access-button.tsx:115` — `variant="primary"` → `variant="default"` (or leave with primary alias).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6047: - Constraint: `@tiptap/react` lives in `packages/ui` — do NOT install it in `apps/frontend`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6049:+- Constraint: keep `apps/frontend/src/routes/dev-rich-editor.tsx` available after C2 so C3 can validate sanitizer-fail toast flow against the demo route; C5 may delete it only if no later checkpoint needs it.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6055: **Goal:** `<Toaster>` mounted in `__root.tsx`. `apiClient`, `errorMapper`, `useIdempotencyKey` land in `apps/frontend/src/lib/api/`. ALL codes in `ERROR_CODES` from `@fops/shared` covered with Korean copy and tone classification.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6058:-- Create: `apps/frontend/src/lib/api/errorMapper.ts` — maps `{ code, detail }` to `{ tone: 'error'|'warning'|'info', message: string, action?: { label, run } }`. **Catalog is generated by iterating `ERROR_CODES` from `@fops/shared`** — no manually typed list. Every code must map to a non-empty Korean message. Fallback for unknown codes: `{ tone: 'error', message: '일시적 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.' }`. Tone per category: `auth.*` → `error`, `permission.*` → `error`, `rate_limited.*` → `warning`, `validation.*` → `error`, `conflict.*` → `error` (except `conflict.stale_write` → `warning` with retry action), `not_found.*` → `error`, `internal.*` → `error`, `voc.*` → `error`, `rich_content.*` → `error`, `attachment.*` → `warning`, `reporter_facing_status.*` → `warning`. Required codes at minimum (from `packages/shared/src/errors/codes.ts`): `auth.session_invalid`, `auth.session_required`, `auth.session_expired`, `auth.workspace_mismatch`, `permission.denied`, `rate_limited.actor`, `rate_limited.ip`, `validation.failed`, `validation.malformed_request`, `validation.unknown_capability`, `conflict.idempotency_key_reuse`, `conflict.capability_already_granted`, `conflict.permission_request_duplicate`, `validation.malformed_idempotency_key`, `validation.sensitive_reason_required`, `validation.immutable_field`, `conflict.duplicate_slug`, `conflict.parent_archived`, `conflict.record_archived`, `not_found.record`, `internal.unexpected`, `voc.severity_not_user_settable`, `validation.unexpected_field`, `rich_content.disallowed_node`, `rich_content.external_image_forbidden`, `attachment.unsupported_pending_storage_slice`, `conflict.stale_write`, `voc.reporter_status_via_public_update_only`, `permission.scope_required`, `reporter_facing_status.invalid_transition`, `reporter_facing_status.gate_blocked`, `conflict.triage_already_committed`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6059:+- Create: `apps/frontend/src/lib/api/errorMapper.ts` — maps `{ code, detail }` to `{ tone: 'error'|'warning'|'info', message: string, action?: { label, run } }`. **Catalog is generated by iterating `ERROR_CODES` from `@fops/shared`** — no manually typed list. Every code must map to a non-empty Korean message. Export `GENERIC_ERROR_MESSAGE = '일시적 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.'` so tests compare to the fallback constant directly. Fallback for unknown codes: `{ tone: 'error', message: GENERIC_ERROR_MESSAGE }`. Tone per category: `auth.*` → `error`, `permission.*` → `error`, `rate_limited.*` → `warning`, `validation.*` → `error`, `conflict.*` → `error` (except `conflict.stale_write` → `warning` with retry action), `not_found.*` → `error`, `internal.*` → `error`, `voc.*` → `error`, `rich_content.*` → `error`, `attachment.*` → `warning`, `reporter_facing_status.*` → `warning`. Required codes at minimum (from `packages/shared/src/errors/codes.ts`): `auth.session_invalid`, `auth.session_required`, `auth.session_expired`, `auth.workspace_mismatch`, `permission.denied`, `rate_limited.actor`, `rate_limited.ip`, `validation.failed`, `validation.malformed_request`, `validation.unknown_capability`, `conflict.idempotency_key_reuse`, `conflict.capability_already_granted`, `conflict.permission_request_duplicate`, `validation.malformed_idempotency_key`, `validation.sensitive_reason_required`, `validation.immutable_field`, `conflict.duplicate_slug`, `conflict.parent_archived`, `conflict.record_archived`, `not_found.record`, `internal.unexpected`, `voc.severity_not_user_settable`, `validation.unexpected_field`, `rich_content.disallowed_node`, `rich_content.external_image_forbidden`, `attachment.unsupported_pending_storage_slice`, `conflict.stale_write`, `voc.reporter_status_via_public_update_only`, `permission.scope_required`, `reporter_facing_status.invalid_transition`, `reporter_facing_status.gate_blocked`, `conflict.triage_already_committed`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6060: - Create: `apps/frontend/src/lib/api/client.ts` — `apiClient(method, path, { body?, idempotencyKey?, ifMatch?, signal? })`. Auto-mint Idempotency-Key UUIDv4 on POST/PATCH/DELETE when not supplied. Attach `Authorization` from session store. Parse JSON. Non-2xx → throw `ApiError extends Error { code, detail, status, requestId }`. 304 → return `{ status: 304, etag }`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6061: - Create: `apps/frontend/src/lib/api/useIdempotencyKey.ts` — `useIdempotencyKey(ifMatchEtag?: string)`. Returns stable UUIDv4 per render-tree until consumed; `markConsumed()` mints fresh. **When `ifMatchEtag` changes value, the hook MUST automatically mint a fresh UUIDv4** — this prevents `conflict.idempotency_key_reuse` after a stale-write refetch (BE includes `ifMatch` in the idempotency hash per `apps/backend/src/modules/voc/routes.ts:225`, so a retry with a new `If-Match` value is a semantically different request that needs a new key).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6062: - Create: `apps/frontend/src/lib/api/types.ts` — `ApiErrorEnvelope` matching BE `errors/envelope.ts`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6063: - Modify: `apps/frontend/src/routes/__root.tsx` — mount `<Toaster position="bottom-center" />` from `sonner`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6064:-- Create: `apps/frontend/src/lib/api/__tests__/errorMapper.test.ts` — **iterate `ERROR_CODES` from `@fops/shared` and assert each maps to a non-empty Korean message** (not a manual catalog). This test auto-covers new codes added to `codes.ts` without test update.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6065:+- Create: `apps/frontend/src/lib/api/__tests__/errorMapper.test.ts` — **iterate `ERROR_CODES` from `@fops/shared` and assert each maps to a non-empty Korean message** (not a manual catalog). This test auto-covers new codes added to `codes.ts` without test update. Locked assertions: (1) every `ERROR_CODES` mapping has `tone` in literal set `{ 'error', 'warning', 'info' }`; (2) every code with prefix/member in `{ voc.*, rich_content.*, attachment.*, reporter_facing_status.*, conflict.stale_write, conflict.triage_already_committed, conflict.idempotency_key_reuse }` has Korean message not equal to exported `GENERIC_ERROR_MESSAGE`; (3) `conflict.stale_write` maps to `{ tone: 'warning', action: { label: <not undefined>, run: <fn> } }`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6066: - Create: `apps/frontend/src/lib/api/__tests__/client.test.ts` — mock fetch: POST mints Idempotency-Key, GET omits, Authorization attached, 422 throws ApiError, 304 returns ETag. Add test case: same `useIdempotencyKey` instance + changed `ifMatchEtag` → new key minted automatically.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6073:-**CHECKPOINT 2.5** — small playground demonstrating: Toaster position (bottom-center), tone variants (success / error / warning / info) with Korean copy, at least 3 representative error codes rendered as toasts (`conflict.stale_write` warning + retry action, `permission.denied` error, `rate_limited.ip` warning). AskUserQuestion: "토스트 UX + 에러 메시지 OK?"
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6074:+**CHECKPOINT 2.5** — playground HTML demonstrating: Toaster tones + Korean copy for 3+ representative codes (`conflict.stale_write` warning + retry action, `permission.denied` error, `rate_limited.ip` warning) + RichEditor demo rendering sanitizer-rejected content with toast surfaced via apiClient mock. Requires C2 `/dev-rich-editor` route to still exist when C3 lands. AskUserQuestion: "토스트 UX + 에러 메시지 OK?"
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6103: ## C4b — AppFrame in apps/frontend + useFullscreenPanel hook
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6105:-**Goal:** `<AppFrame>` in `apps/frontend/src/lib/layout/` composes Rail(52) + Sidebar(240/56) + (shell outlet) + DetailPanelSlot(440). AppFrame consumes one of the 3 shells as its inner outlet. It is NOT exported as a shell — it is the authenticated route frame. `useFullscreenPanel` hook ready for #20 to consume.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6106:+**Goal:** `<AppFrame>` in `apps/frontend/src/lib/layout/` composes Rail(52) + Sidebar(240/56) + (shell outlet) + the single global DetailPanelSlot(440). AppFrame consumes one of the 3 shells as its inner outlet. It is NOT exported as a shell — it is the authenticated route frame. `useFullscreenPanel` hook ready for #20 to consume.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6111: - Create: `apps/frontend/src/lib/layout/AppFrame.tsx` — flex row Rail(52) + Sidebar(240/56) + Main(flex-1, shell outlet) + DetailPanelSlot(440 conditional). Headers conform to 50px rhythm via ShellHeader from `packages/ui`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6112: - Create: `apps/frontend/src/lib/layout/AppRail.tsx` — 52px vertical, workspace switcher placeholder + lucide-react utility icons.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6113:-- Create: `apps/frontend/src/lib/layout/AppSidebar.tsx` — 240px nav list. Slice 3 entries: Inbox, My VOCs, Triage, + New VOC. Collapse button writes `localStorage.appSidebarCollapsed`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6114:-- Create: `apps/frontend/src/lib/layout/DetailPanelSlot.tsx` — fixed 440 right column. min 360 / max 520. Hidden when no content registered via `useDetailPanelSlot()`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6115:-- Create: `apps/frontend/src/lib/layout/useDetailPanelSlot.ts` — context-based slot register/clear hook.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6116:+- Create: `apps/frontend/src/lib/layout/AppSidebar.tsx` — 240px nav list. Slice 3 entries: Inbox, My VOCs, Triage, + New VOC. Collapse state uses SSR-safe initializer:
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6124:+- Create: `apps/frontend/src/lib/layout/DetailPanelSlot.tsx` — fixed 440 right column. min 360 / max 520. Hidden when no content registered via `useDetailPanelSlot()`. This is the single rendering surface for all shell `detailPanel` content.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6125:+- Create: `apps/frontend/src/lib/layout/useDetailPanelSlot.ts` — context-based slot register/clear hook. Forbid multiple registrants: throw in dev (and warn in prod) if called twice with overlapping lifetimes, using a ref to track active ownership.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6126: - Create: `apps/frontend/src/lib/panel/useFullscreenPanel.ts` — `[isFullscreen, toggle]`. Esc collapses. Route change clears.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6127:-- Create: `apps/frontend/src/lib/layout/__tests__/AppFrame.test.tsx` — Rail/Sidebar/Main present; sidebar collapse toggle writes localStorage; DetailPanelSlot collapses when empty.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6128:+- Create: `apps/frontend/src/lib/layout/__tests__/AppFrame.test.tsx` — Rail/Sidebar/Main present; sidebar first-paint width matches stored `localStorage.appSidebarCollapsed` before any user interaction; sidebar collapse toggle writes localStorage; DetailPanelSlot collapses when empty; multiple overlapping `useDetailPanelSlot()` registrants throw/warn.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6129: - Create: `apps/frontend/src/lib/panel/__tests__/useFullscreenPanel.test.tsx` — toggle flips boolean; Esc dispatches collapse; route change clears (mock router).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6135: - Constraint: AppFrame is NOT exported from `packages/ui` — it lives in `apps/frontend/src/lib/layout/` only.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6144:-- `apps/frontend/src/routes/_authed.tsx` — new TanStack layout route. Wraps children with `<AppFrame>`. Login + non-authed routes do NOT use this layout and do NOT render AppFrame.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6146:+- `apps/frontend/src/routes/_authed.tsx` — new TanStack pathless layout route. Includes a `beforeLoad` callback that calls `fetchMe()` (same auth pattern currently used in admin routes) and `redirect({ to: '/login' })` on `UnauthenticatedError`. Wraps children with `<AppFrame>`. Login + non-authed routes do NOT use this layout and do NOT render AppFrame.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6147:+- Per-route auth guards in admin pages are DELETED in C5 after `_authed.beforeLoad` centralizes the guard.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6149:+  - `apps/frontend/src/routes/admin/managed-systems.tsx` → `apps/frontend/src/routes/_authed/admin/managed-systems.tsx`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6150:+  - `apps/frontend/src/routes/admin/analytics-areas.tsx` → `apps/frontend/src/routes/_authed/admin/analytics-areas.tsx`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6151:+  - `apps/frontend/src/routes/admin/placeholder.tsx` → `apps/frontend/src/routes/_authed/admin/placeholder.tsx`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6152:+  - Test file imports updated: `apps/frontend/src/routes/admin/*.test.tsx` move alongside their routes.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6155:-- `/vocs` route = `apps/frontend/src/routes/_authed/vocs.tsx`. Per-view shell selection: `view=inbox|my` → `<ListShell>`, `view=triage` → `<WorkbenchShell>`, `action=create` → `<PageShell>` (default when no view/action = `<ListShell>`).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6156:+- `/vocs` route file = `apps/frontend/src/routes/_authed/vocs.tsx`. Public path string is `/vocs`; `_authed` is pathless. Per-view shell selection: `view=inbox|my` → `<ListShell>`, `view=triage` → `<WorkbenchShell>`, `action=create` → `<PageShell>` (default when no view/action = `<ListShell>`).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6160:-- Create: `apps/frontend/src/routes/_authed.tsx` — TanStack layout route. Renders `<AppFrame><Outlet /></AppFrame>`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6161:+- Create: `apps/frontend/src/routes/_authed.tsx` — TanStack layout route. `beforeLoad` calls `fetchMe()` and redirects unauthenticated users to `/login`; renders `<AppFrame><Outlet /></AppFrame>`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6162: - Create: `apps/frontend/src/routes/_authed/vocs.tsx` — `createFileRoute('/_authed/vocs')` with validateSearch zod. Component selects shell based on `view`/`action`. Main = placeholder text.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6163: - Modify: `apps/frontend/src/routes/__root.tsx` — minimal; providers + `<Outlet>` only (no AppFrame).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6164:-- Relocate or re-parent: `apps/frontend/src/routes/admin/` — move under `_authed` so admin pages get AppFrame. If not done in C5, create a follow-up GitHub issue before closing this chunk.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6165:+- Move: `apps/frontend/src/routes/admin/managed-systems.tsx` → `apps/frontend/src/routes/_authed/admin/managed-systems.tsx`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6166:+- Move: `apps/frontend/src/routes/admin/analytics-areas.tsx` → `apps/frontend/src/routes/_authed/admin/analytics-areas.tsx`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6167:+- Move: `apps/frontend/src/routes/admin/placeholder.tsx` → `apps/frontend/src/routes/_authed/admin/placeholder.tsx`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6168:+- Move: `apps/frontend/src/routes/admin/*.test.tsx` → alongside relocated `_authed/admin/*` routes; update imports.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6170: - Auto-regen: `apps/frontend/src/routeTree.gen.ts` (TanStackRouterVite plugin handles on dev).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6171:-- Create: `apps/frontend/src/routes/__tests__/vocs.test.tsx` — navigating to `/_authed/vocs?view=inbox` resolves; invalid `?view=foo` rejected by zod; sidebar `+ New VOC` href = `/_authed/vocs?action=create`; `view=triage` renders WorkbenchShell.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6172:+- Create: `apps/frontend/src/routes/__tests__/vocs.test.tsx` — navigating to `/vocs?view=inbox` resolves; invalid `?view=foo` rejected by zod; sidebar `+ New VOC` href = `/vocs?action=create`; `view=triage` renders WorkbenchShell.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6173: - Delete: `apps/frontend/src/routes/dev-rich-editor.tsx` IF it was added in C2 and is no longer needed (or keep behind DEV flag).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6177: - Read first: `apps/frontend/src/routes/__root.tsx`, `apps/frontend/vite.config.ts`, `apps/frontend/src/routes/admin/managed-systems.tsx` (existing TanStack file-route pattern), `apps/frontend/src/lib/layout/AppFrame.tsx` (just created in C4b), `packages/ui/src/layout/` (shells).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6181:+- Constraint: no `Route.id` navigation. Run `grep -rn 'Route\\.id\\|from: .*Route\\.id\\|to: .*Route\\.id' apps/frontend/src/` and refactor any hits to literal `to:` path strings.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6200: - Sonnet dispatches read AGENTS.md hierarchy first (`apps/frontend/AGENTS.md` mandatory).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6205: - **AppFrame in `apps/frontend` NEVER becomes a 4th exported shell. Shell taxonomy = 3 (PageShell/ListShell/WorkbenchShell) per ADR-0020.**
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6216: - `@tiptap/react` in `packages/ui` — verify `apps/frontend` resolves it transitively via workspace link without explicit install; if pnpm strict-mode blocks it, add a peer dep declaration.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6267:+      {type:'modify', path:'apps/frontend/src/routes/{admin/managed-systems,admin/analytics-areas,login,index}.tsx  // token classname rename audit'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6268:+      {type:'create', path:'apps/frontend/src/__tests__/token-class-coverage.test.ts  // resolveConfig coverage for TSX token classes'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6269:       {type:'modify', path:'apps/frontend/src/styles.css  // @import tokens.css + semantic.css'}
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6291:       {type:'modify', path:'apps/frontend/src/features/admin/permissions/request-access-button.tsx:115  // variant primary→default'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6300: # apps/frontend — app-level only; NO direct @tiptap/* (consumed via @fops/ui)
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6313:     dispatch:'Sonnet. Read rich-editor.jsx + ADR-0011 + BE sanitizer.ts. Constraints: surface = opaque pass-through; StarterKit image:false; demo = local state only; @tiptap/* must NOT be installed in apps/frontend.',
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6324:-      {type:'create', path:'apps/frontend/src/lib/api/{client,errorMapper,useIdempotencyKey,types}.ts'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6325:+      {type:'create', path:'apps/frontend/src/lib/api/{client,errorMapper,useIdempotencyKey,types}.ts  // export GENERIC_ERROR_MESSAGE'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6326:       {type:'modify', path:'apps/frontend/src/routes/__root.tsx  // <Toaster position="bottom-center"/>'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6327:       {type:'create', path:'apps/frontend/src/lib/api/__tests__/{errorMapper,client}.test.ts'}
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6331:+    dispatch:'Sonnet. Read packages/shared/src/errors/codes.ts (iterate ERROR_CODES, do NOT hardcode list) + envelope.ts + voc routes.ts lines 200-260. Tests assert tone literal set, non-generic messages for VOC/rich/attachment/reporter/conflict special codes, and conflict.stale_write warning action. Checkpoint includes /dev-rich-editor sanitizer-reject toast via apiClient mock.',
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6359:-    goal:'AppFrame in apps/frontend/src/lib/layout/ composes Rail+Sidebar+shell outlet+DetailPanelSlot. NOT a 4th shell — app-internal only. useFullscreenPanel hook.',
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6360:+    goal:'AppFrame in apps/frontend/src/lib/layout/ composes Rail+Sidebar+shell outlet+the single global DetailPanelSlot. SSR-safe sidebar collapse. NOT a 4th shell.',
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6362:       {type:'create', path:'apps/frontend/src/lib/layout/AppFrame.tsx  // NOT exported as shell; wraps one of 3 shells'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6363:       {type:'create', path:'apps/frontend/src/lib/layout/AppRail.tsx'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6364:-      {type:'create', path:'apps/frontend/src/lib/layout/AppSidebar.tsx  // collapse→localStorage'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6365:-      {type:'create', path:'apps/frontend/src/lib/layout/DetailPanelSlot.tsx  // 440px, min 360, max 520'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6366:-      {type:'create', path:'apps/frontend/src/lib/layout/useDetailPanelSlot.ts'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6367:+      {type:'create', path:'apps/frontend/src/lib/layout/AppSidebar.tsx  // SSR-safe localStorage initializer; first-paint width test'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6368:+      {type:'create', path:'apps/frontend/src/lib/layout/DetailPanelSlot.tsx  // single global 440px slot, min 360, max 520'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6369:+      {type:'create', path:'apps/frontend/src/lib/layout/useDetailPanelSlot.ts  // forbid overlapping registrants'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6370:       {type:'create', path:'apps/frontend/src/lib/panel/useFullscreenPanel.ts  // Esc collapses, route change clears'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6371:       {type:'create', path:'apps/frontend/src/lib/layout/__tests__/AppFrame.test.tsx'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6372:       {type:'create', path:'apps/frontend/src/lib/panel/__tests__/useFullscreenPanel.test.tsx'}
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6386:-      {type:'create', path:'apps/frontend/src/routes/_authed.tsx  // layout route: <AppFrame><Outlet/></AppFrame>'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6387:-      {type:'create', path:'apps/frontend/src/routes/_authed/vocs.tsx  // shell selection per view/action'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6388:+      {type:'create', path:'apps/frontend/src/routes/_authed.tsx  // beforeLoad fetchMe; redirect /login on UnauthenticatedError; <AppFrame><Outlet/></AppFrame>'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6389:+      {type:'create', path:'apps/frontend/src/routes/_authed/vocs.tsx  // public path /vocs; shell selection per view/action'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6390:       {type:'modify', path:'apps/frontend/src/routes/__root.tsx  // minimal: providers + <Outlet> only'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6391:-      {type:'modify', path:'apps/frontend/src/routes/admin/  // re-parent under _authed as PageShell (or file follow-up)'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6392:-      {type:'create', path:'apps/frontend/src/routes/__tests__/vocs.test.tsx  // shell per view + login NOT in AppFrame'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6393:+      {type:'move', path:'apps/frontend/src/routes/admin/{managed-systems,analytics-areas,placeholder}.tsx → apps/frontend/src/routes/_authed/admin/  // paths /admin/* unchanged; delete per-page auth guards'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6394:+      {type:'move', path:'apps/frontend/src/routes/admin/*.test.tsx → apps/frontend/src/routes/_authed/admin/  // update imports'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6395:+      {type:'create', path:'apps/frontend/src/routes/__tests__/vocs.test.tsx  // /vocs shell per view + login NOT in AppFrame + no Route.id nav'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6396:       {type:'delete', path:'apps/frontend/src/routes/dev-rich-editor.tsx  // if not kept behind DEV flag'}
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6445: - ADR-0020 taxonomy enforced: `packages/ui/src/layout/` exports exactly 3 shells (PageShell, ListShell, WorkbenchShell). AppFrame in `apps/frontend/src/lib/layout/` is NOT a 4th shell.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6496:+- Modify/audit: `apps/frontend/src/routes/admin/managed-systems.tsx`, `apps/frontend/src/routes/admin/analytics-areas.tsx`, `apps/frontend/src/routes/login.tsx`, `apps/frontend/src/routes/index.tsx` and any other route file referencing token classes — grep first, build rename map, then apply.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6497:+- Create: `apps/frontend/src/__tests__/token-class-coverage.test.ts` — grep/scan `.tsx` class strings and assert no `text|border|bg|ring|fill|stroke` token class references a Tailwind theme key that is not resolvable via `resolveConfig`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6498: - Modify: `apps/frontend/src/styles.css` — keep `@import "@fops/ui/styles/tokens.css"` + `semantic.css` + tailwind directives.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6504:+  `grep -rn '\(text\|border\|bg\|ring\|fill\|stroke\)-\(status\|surface\|accent\|severity\|reporter\|internal\|confidence\|focus\)-' apps/frontend/src/`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6548: - Modify: `apps/frontend/src/features/admin/permissions/request-access-button.tsx:115` — `variant="primary"` → `variant="default"` (or leave with primary alias).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6568: - Constraint: `@tiptap/react` lives in `packages/ui` — do NOT install it in `apps/frontend`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6570:+- Constraint: keep `apps/frontend/src/routes/dev-rich-editor.tsx` available after C2 so C3 can validate sanitizer-fail toast flow against the demo route; C5 may delete it only if no later checkpoint needs it.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6576: **Goal:** `<Toaster>` mounted in `__root.tsx`. `apiClient`, `errorMapper`, `useIdempotencyKey` land in `apps/frontend/src/lib/api/`. ALL codes in `ERROR_CODES` from `@fops/shared` covered with Korean copy and tone classification.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6579:-- Create: `apps/frontend/src/lib/api/errorMapper.ts` — maps `{ code, detail }` to `{ tone: 'error'|'warning'|'info', message: string, action?: { label, run } }`. **Catalog is generated by iterating `ERROR_CODES` from `@fops/shared`** — no manually typed list. Every code must map to a non-empty Korean message. Fallback for unknown codes: `{ tone: 'error', message: '일시적 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.' }`. Tone per category: `auth.*` → `error`, `permission.*` → `error`, `rate_limited.*` → `warning`, `validation.*` → `error`, `conflict.*` → `error` (except `conflict.stale_write` → `warning` with retry action), `not_found.*` → `error`, `internal.*` → `error`, `voc.*` → `error`, `rich_content.*` → `error`, `attachment.*` → `warning`, `reporter_facing_status.*` → `warning`. Required codes at minimum (from `packages/shared/src/errors/codes.ts`): `auth.session_invalid`, `auth.session_required`, `auth.session_expired`, `auth.workspace_mismatch`, `permission.denied`, `rate_limited.actor`, `rate_limited.ip`, `validation.failed`, `validation.malformed_request`, `validation.unknown_capability`, `conflict.idempotency_key_reuse`, `conflict.capability_already_granted`, `conflict.permission_request_duplicate`, `validation.malformed_idempotency_key`, `validation.sensitive_reason_required`, `validation.immutable_field`, `conflict.duplicate_slug`, `conflict.parent_archived`, `conflict.record_archived`, `not_found.record`, `internal.unexpected`, `voc.severity_not_user_settable`, `validation.unexpected_field`, `rich_content.disallowed_node`, `rich_content.external_image_forbidden`, `attachment.unsupported_pending_storage_slice`, `conflict.stale_write`, `voc.reporter_status_via_public_update_only`, `permission.scope_required`, `reporter_facing_status.invalid_transition`, `reporter_facing_status.gate_blocked`, `conflict.triage_already_committed`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6580:+- Create: `apps/frontend/src/lib/api/errorMapper.ts` — maps `{ code, detail }` to `{ tone: 'error'|'warning'|'info', message: string, action?: { label, run } }`. **Catalog is generated by iterating `ERROR_CODES` from `@fops/shared`** — no manually typed list. Every code must map to a non-empty Korean message. Export `GENERIC_ERROR_MESSAGE = '일시적 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.'` so tests compare to the fallback constant directly. Fallback for unknown codes: `{ tone: 'error', message: GENERIC_ERROR_MESSAGE }`. Tone per category: `auth.*` → `error`, `permission.*` → `error`, `rate_limited.*` → `warning`, `validation.*` → `error`, `conflict.*` → `error` (except `conflict.stale_write` → `warning` with retry action), `not_found.*` → `error`, `internal.*` → `error`, `voc.*` → `error`, `rich_content.*` → `error`, `attachment.*` → `warning`, `reporter_facing_status.*` → `warning`. Required codes at minimum (from `packages/shared/src/errors/codes.ts`): `auth.session_invalid`, `auth.session_required`, `auth.session_expired`, `auth.workspace_mismatch`, `permission.denied`, `rate_limited.actor`, `rate_limited.ip`, `validation.failed`, `validation.malformed_request`, `validation.unknown_capability`, `conflict.idempotency_key_reuse`, `conflict.capability_already_granted`, `conflict.permission_request_duplicate`, `validation.malformed_idempotency_key`, `validation.sensitive_reason_required`, `validation.immutable_field`, `conflict.duplicate_slug`, `conflict.parent_archived`, `conflict.record_archived`, `not_found.record`, `internal.unexpected`, `voc.severity_not_user_settable`, `validation.unexpected_field`, `rich_content.disallowed_node`, `rich_content.external_image_forbidden`, `attachment.unsupported_pending_storage_slice`, `conflict.stale_write`, `voc.reporter_status_via_public_update_only`, `permission.scope_required`, `reporter_facing_status.invalid_transition`, `reporter_facing_status.gate_blocked`, `conflict.triage_already_committed`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6581: - Create: `apps/frontend/src/lib/api/client.ts` — `apiClient(method, path, { body?, idempotencyKey?, ifMatch?, signal? })`. Auto-mint Idempotency-Key UUIDv4 on POST/PATCH/DELETE when not supplied. Attach `Authorization` from session store. Parse JSON. Non-2xx → throw `ApiError extends Error { code, detail, status, requestId }`. 304 → return `{ status: 304, etag }`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6582: - Create: `apps/frontend/src/lib/api/useIdempotencyKey.ts` — `useIdempotencyKey(ifMatchEtag?: string)`. Returns stable UUIDv4 per render-tree until consumed; `markConsumed()` mints fresh. **When `ifMatchEtag` changes value, the hook MUST automatically mint a fresh UUIDv4** — this prevents `conflict.idempotency_key_reuse` after a stale-write refetch (BE includes `ifMatch` in the idempotency hash per `apps/backend/src/modules/voc/routes.ts:225`, so a retry with a new `If-Match` value is a semantically different request that needs a new key).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6583: - Create: `apps/frontend/src/lib/api/types.ts` — `ApiErrorEnvelope` matching BE `errors/envelope.ts`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6584: - Modify: `apps/frontend/src/routes/__root.tsx` — mount `<Toaster position="bottom-center" />` from `sonner`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6585:-- Create: `apps/frontend/src/lib/api/__tests__/errorMapper.test.ts` — **iterate `ERROR_CODES` from `@fops/shared` and assert each maps to a non-empty Korean message** (not a manual catalog). This test auto-covers new codes added to `codes.ts` without test update.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6586:+- Create: `apps/frontend/src/lib/api/__tests__/errorMapper.test.ts` — **iterate `ERROR_CODES` from `@fops/shared` and assert each maps to a non-empty Korean message** (not a manual catalog). This test auto-covers new codes added to `codes.ts` without test update. Locked assertions: (1) every `ERROR_CODES` mapping has `tone` in literal set `{ 'error', 'warning', 'info' }`; (2) every code with prefix/member in `{ voc.*, rich_content.*, attachment.*, reporter_facing_status.*, conflict.stale_write, conflict.triage_already_committed, conflict.idempotency_key_reuse }` has Korean message not equal to exported `GENERIC_ERROR_MESSAGE`; (3) `conflict.stale_write` maps to `{ tone: 'warning', action: { label: <not undefined>, run: <fn> } }`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6587: - Create: `apps/frontend/src/lib/api/__tests__/client.test.ts` — mock fetch: POST mints Idempotency-Key, GET omits, Authorization attached, 422 throws ApiError, 304 returns ETag. Add test case: same `useIdempotencyKey` instance + changed `ifMatchEtag` → new key minted automatically.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6594:-**CHECKPOINT 2.5** — small playground demonstrating: Toaster position (bottom-center), tone variants (success / error / warning / info) with Korean copy, at least 3 representative error codes rendered as toasts (`conflict.stale_write` warning + retry action, `permission.denied` error, `rate_limited.ip` warning). AskUserQuestion: "토스트 UX + 에러 메시지 OK?"
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6595:+**CHECKPOINT 2.5** — playground HTML demonstrating: Toaster tones + Korean copy for 3+ representative codes (`conflict.stale_write` warning + retry action, `permission.denied` error, `rate_limited.ip` warning) + RichEditor demo rendering sanitizer-rejected content with toast surfaced via apiClient mock. Requires C2 `/dev-rich-editor` route to still exist when C3 lands. AskUserQuestion: "토스트 UX + 에러 메시지 OK?"
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6624: ## C4b — AppFrame in apps/frontend + useFullscreenPanel hook
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6626:-**Goal:** `<AppFrame>` in `apps/frontend/src/lib/layout/` composes Rail(52) + Sidebar(240/56) + (shell outlet) + DetailPanelSlot(440). AppFrame consumes one of the 3 shells as its inner outlet. It is NOT exported as a shell — it is the authenticated route frame. `useFullscreenPanel` hook ready for #20 to consume.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6627:+**Goal:** `<AppFrame>` in `apps/frontend/src/lib/layout/` composes Rail(52) + Sidebar(240/56) + (shell outlet) + the single global DetailPanelSlot(440). AppFrame consumes one of the 3 shells as its inner outlet. It is NOT exported as a shell — it is the authenticated route frame. `useFullscreenPanel` hook ready for #20 to consume.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6632: - Create: `apps/frontend/src/lib/layout/AppFrame.tsx` — flex row Rail(52) + Sidebar(240/56) + Main(flex-1, shell outlet) + DetailPanelSlot(440 conditional). Headers conform to 50px rhythm via ShellHeader from `packages/ui`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6633: - Create: `apps/frontend/src/lib/layout/AppRail.tsx` — 52px vertical, workspace switcher placeholder + lucide-react utility icons.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6634:-- Create: `apps/frontend/src/lib/layout/AppSidebar.tsx` — 240px nav list. Slice 3 entries: Inbox, My VOCs, Triage, + New VOC. Collapse button writes `localStorage.appSidebarCollapsed`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6635:-- Create: `apps/frontend/src/lib/layout/DetailPanelSlot.tsx` — fixed 440 right column. min 360 / max 520. Hidden when no content registered via `useDetailPanelSlot()`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6636:-- Create: `apps/frontend/src/lib/layout/useDetailPanelSlot.ts` — context-based slot register/clear hook.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6637:+- Create: `apps/frontend/src/lib/layout/AppSidebar.tsx` — 240px nav list. Slice 3 entries: Inbox, My VOCs, Triage, + New VOC. Collapse state uses SSR-safe initializer:
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6645:+- Create: `apps/frontend/src/lib/layout/DetailPanelSlot.tsx` — fixed 440 right column. min 360 / max 520. Hidden when no content registered via `useDetailPanelSlot()`. This is the single rendering surface for all shell `detailPanel` content.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6646:+- Create: `apps/frontend/src/lib/layout/useDetailPanelSlot.ts` — context-based slot register/clear hook. Forbid multiple registrants: throw in dev (and warn in prod) if called twice with overlapping lifetimes, using a ref to track active ownership.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6647: - Create: `apps/frontend/src/lib/panel/useFullscreenPanel.ts` — `[isFullscreen, toggle]`. Esc collapses. Route change clears.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6648:-- Create: `apps/frontend/src/lib/layout/__tests__/AppFrame.test.tsx` — Rail/Sidebar/Main present; sidebar collapse toggle writes localStorage; DetailPanelSlot collapses when empty.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6649:+- Create: `apps/frontend/src/lib/layout/__tests__/AppFrame.test.tsx` — Rail/Sidebar/Main present; sidebar first-paint width matches stored `localStorage.appSidebarCollapsed` before any user interaction; sidebar collapse toggle writes localStorage; DetailPanelSlot collapses when empty; multiple overlapping `useDetailPanelSlot()` registrants throw/warn.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6650: - Create: `apps/frontend/src/lib/panel/__tests__/useFullscreenPanel.test.tsx` — toggle flips boolean; Esc dispatches collapse; route change clears (mock router).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6656: - Constraint: AppFrame is NOT exported from `packages/ui` — it lives in `apps/frontend/src/lib/layout/` only.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6665:-- `apps/frontend/src/routes/_authed.tsx` — new TanStack layout route. Wraps children with `<AppFrame>`. Login + non-authed routes do NOT use this layout and do NOT render AppFrame.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6667:+- `apps/frontend/src/routes/_authed.tsx` — new TanStack pathless layout route. Includes a `beforeLoad` callback that calls `fetchMe()` (same auth pattern currently used in admin routes) and `redirect({ to: '/login' })` on `UnauthenticatedError`. Wraps children with `<AppFrame>`. Login + non-authed routes do NOT use this layout and do NOT render AppFrame.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6668:+- Per-route auth guards in admin pages are DELETED in C5 after `_authed.beforeLoad` centralizes the guard.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6670:+  - `apps/frontend/src/routes/admin/managed-systems.tsx` → `apps/frontend/src/routes/_authed/admin/managed-systems.tsx`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6671:+  - `apps/frontend/src/routes/admin/analytics-areas.tsx` → `apps/frontend/src/routes/_authed/admin/analytics-areas.tsx`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6672:+  - `apps/frontend/src/routes/admin/placeholder.tsx` → `apps/frontend/src/routes/_authed/admin/placeholder.tsx`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6673:+  - Test file imports updated: `apps/frontend/src/routes/admin/*.test.tsx` move alongside their routes.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6676:-- `/vocs` route = `apps/frontend/src/routes/_authed/vocs.tsx`. Per-view shell selection: `view=inbox|my` → `<ListShell>`, `view=triage` → `<WorkbenchShell>`, `action=create` → `<PageShell>` (default when no view/action = `<ListShell>`).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6677:+- `/vocs` route file = `apps/frontend/src/routes/_authed/vocs.tsx`. Public path string is `/vocs`; `_authed` is pathless. Per-view shell selection: `view=inbox|my` → `<ListShell>`, `view=triage` → `<WorkbenchShell>`, `action=create` → `<PageShell>` (default when no view/action = `<ListShell>`).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6681:-- Create: `apps/frontend/src/routes/_authed.tsx` — TanStack layout route. Renders `<AppFrame><Outlet /></AppFrame>`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6682:+- Create: `apps/frontend/src/routes/_authed.tsx` — TanStack layout route. `beforeLoad` calls `fetchMe()` and redirects unauthenticated users to `/login`; renders `<AppFrame><Outlet /></AppFrame>`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6683: - Create: `apps/frontend/src/routes/_authed/vocs.tsx` — `createFileRoute('/_authed/vocs')` with validateSearch zod. Component selects shell based on `view`/`action`. Main = placeholder text.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6684: - Modify: `apps/frontend/src/routes/__root.tsx` — minimal; providers + `<Outlet>` only (no AppFrame).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6685:-- Relocate or re-parent: `apps/frontend/src/routes/admin/` — move under `_authed` so admin pages get AppFrame. If not done in C5, create a follow-up GitHub issue before closing this chunk.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6686:+- Move: `apps/frontend/src/routes/admin/managed-systems.tsx` → `apps/frontend/src/routes/_authed/admin/managed-systems.tsx`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6687:+- Move: `apps/frontend/src/routes/admin/analytics-areas.tsx` → `apps/frontend/src/routes/_authed/admin/analytics-areas.tsx`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6688:+- Move: `apps/frontend/src/routes/admin/placeholder.tsx` → `apps/frontend/src/routes/_authed/admin/placeholder.tsx`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6689:+- Move: `apps/frontend/src/routes/admin/*.test.tsx` → alongside relocated `_authed/admin/*` routes; update imports.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6691: - Auto-regen: `apps/frontend/src/routeTree.gen.ts` (TanStackRouterVite plugin handles on dev).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6692:-- Create: `apps/frontend/src/routes/__tests__/vocs.test.tsx` — navigating to `/_authed/vocs?view=inbox` resolves; invalid `?view=foo` rejected by zod; sidebar `+ New VOC` href = `/_authed/vocs?action=create`; `view=triage` renders WorkbenchShell.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6693:+- Create: `apps/frontend/src/routes/__tests__/vocs.test.tsx` — navigating to `/vocs?view=inbox` resolves; invalid `?view=foo` rejected by zod; sidebar `+ New VOC` href = `/vocs?action=create`; `view=triage` renders WorkbenchShell.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6694: - Delete: `apps/frontend/src/routes/dev-rich-editor.tsx` IF it was added in C2 and is no longer needed (or keep behind DEV flag).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6698: - Read first: `apps/frontend/src/routes/__root.tsx`, `apps/frontend/vite.config.ts`, `apps/frontend/src/routes/admin/managed-systems.tsx` (existing TanStack file-route pattern), `apps/frontend/src/lib/layout/AppFrame.tsx` (just created in C4b), `packages/ui/src/layout/` (shells).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6702:+- Constraint: no `Route.id` navigation. Run `grep -rn 'Route\\.id\\|from: .*Route\\.id\\|to: .*Route\\.id' apps/frontend/src/` and refactor any hits to literal `to:` path strings.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6721: - Sonnet dispatches read AGENTS.md hierarchy first (`apps/frontend/AGENTS.md` mandatory).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6726: - **AppFrame in `apps/frontend` NEVER becomes a 4th exported shell. Shell taxonomy = 3 (PageShell/ListShell/WorkbenchShell) per ADR-0020.**
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6737: - `@tiptap/react` in `packages/ui` — verify `apps/frontend` resolves it transitively via workspace link without explicit install; if pnpm strict-mode blocks it, add a peer dep declaration.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6788:+      {type:'modify', path:'apps/frontend/src/routes/{admin/managed-systems,admin/analytics-areas,login,index}.tsx  // token classname rename audit'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6789:+      {type:'create', path:'apps/frontend/src/__tests__/token-class-coverage.test.ts  // resolveConfig coverage for TSX token classes'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6790:       {type:'modify', path:'apps/frontend/src/styles.css  // @import tokens.css + semantic.css'}
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6812:       {type:'modify', path:'apps/frontend/src/features/admin/permissions/request-access-button.tsx:115  // variant primary→default'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6821: # apps/frontend — app-level only; NO direct @tiptap/* (consumed via @fops/ui)
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6834:     dispatch:'Sonnet. Read rich-editor.jsx + ADR-0011 + BE sanitizer.ts. Constraints: surface = opaque pass-through; StarterKit image:false; demo = local state only; @tiptap/* must NOT be installed in apps/frontend.',
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6845:-      {type:'create', path:'apps/frontend/src/lib/api/{client,errorMapper,useIdempotencyKey,types}.ts'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6846:+      {type:'create', path:'apps/frontend/src/lib/api/{client,errorMapper,useIdempotencyKey,types}.ts  // export GENERIC_ERROR_MESSAGE'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6847:       {type:'modify', path:'apps/frontend/src/routes/__root.tsx  // <Toaster position="bottom-center"/>'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6848:       {type:'create', path:'apps/frontend/src/lib/api/__tests__/{errorMapper,client}.test.ts'}
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6852:+    dispatch:'Sonnet. Read packages/shared/src/errors/codes.ts (iterate ERROR_CODES, do NOT hardcode list) + envelope.ts + voc routes.ts lines 200-260. Tests assert tone literal set, non-generic messages for VOC/rich/attachment/reporter/conflict special codes, and conflict.stale_write warning action. Checkpoint includes /dev-rich-editor sanitizer-reject toast via apiClient mock.',
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6880:-    goal:'AppFrame in apps/frontend/src/lib/layout/ composes Rail+Sidebar+shell outlet+DetailPanelSlot. NOT a 4th shell — app-internal only. useFullscreenPanel hook.',
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6881:+    goal:'AppFrame in apps/frontend/src/lib/layout/ composes Rail+Sidebar+shell outlet+the single global DetailPanelSlot. SSR-safe sidebar collapse. NOT a 4th shell.',
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6883:       {type:'create', path:'apps/frontend/src/lib/layout/AppFrame.tsx  // NOT exported as shell; wraps one of 3 shells'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6884:       {type:'create', path:'apps/frontend/src/lib/layout/AppRail.tsx'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6885:-      {type:'create', path:'apps/frontend/src/lib/layout/AppSidebar.tsx  // collapse→localStorage'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6886:-      {type:'create', path:'apps/frontend/src/lib/layout/DetailPanelSlot.tsx  // 440px, min 360, max 520'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6887:-      {type:'create', path:'apps/frontend/src/lib/layout/useDetailPanelSlot.ts'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6888:+      {type:'create', path:'apps/frontend/src/lib/layout/AppSidebar.tsx  // SSR-safe localStorage initializer; first-paint width test'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6889:+      {type:'create', path:'apps/frontend/src/lib/layout/DetailPanelSlot.tsx  // single global 440px slot, min 360, max 520'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6890:+      {type:'create', path:'apps/frontend/src/lib/layout/useDetailPanelSlot.ts  // forbid overlapping registrants'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6891:       {type:'create', path:'apps/frontend/src/lib/panel/useFullscreenPanel.ts  // Esc collapses, route change clears'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6892:       {type:'create', path:'apps/frontend/src/lib/layout/__tests__/AppFrame.test.tsx'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6893:       {type:'create', path:'apps/frontend/src/lib/panel/__tests__/useFullscreenPanel.test.tsx'}
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6907:-      {type:'create', path:'apps/frontend/src/routes/_authed.tsx  // layout route: <AppFrame><Outlet/></AppFrame>'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6908:-      {type:'create', path:'apps/frontend/src/routes/_authed/vocs.tsx  // shell selection per view/action'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6909:+      {type:'create', path:'apps/frontend/src/routes/_authed.tsx  // beforeLoad fetchMe; redirect /login on UnauthenticatedError; <AppFrame><Outlet/></AppFrame>'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6910:+      {type:'create', path:'apps/frontend/src/routes/_authed/vocs.tsx  // public path /vocs; shell selection per view/action'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6911:       {type:'modify', path:'apps/frontend/src/routes/__root.tsx  // minimal: providers + <Outlet> only'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6912:-      {type:'modify', path:'apps/frontend/src/routes/admin/  // re-parent under _authed as PageShell (or file follow-up)'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6913:-      {type:'create', path:'apps/frontend/src/routes/__tests__/vocs.test.tsx  // shell per view + login NOT in AppFrame'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6914:+      {type:'move', path:'apps/frontend/src/routes/admin/{managed-systems,analytics-areas,placeholder}.tsx → apps/frontend/src/routes/_authed/admin/  // paths /admin/* unchanged; delete per-page auth guards'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6915:+      {type:'move', path:'apps/frontend/src/routes/admin/*.test.tsx → apps/frontend/src/routes/_authed/admin/  // update imports'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6916:+      {type:'create', path:'apps/frontend/src/routes/__tests__/vocs.test.tsx  // /vocs shell per view + login NOT in AppFrame + no Route.id nav'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6917:       {type:'delete', path:'apps/frontend/src/routes/dev-rich-editor.tsx  // if not kept behind DEV flag'}
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:6976: - ADR-0020 taxonomy enforced: `packages/ui/src/layout/` exports exactly 3 shells (PageShell, ListShell, WorkbenchShell). AppFrame in `apps/frontend/src/lib/layout/` is NOT a 4th shell.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7027:+- Modify/audit: `apps/frontend/src/routes/admin/managed-systems.tsx`, `apps/frontend/src/routes/admin/analytics-areas.tsx`, `apps/frontend/src/routes/login.tsx`, `apps/frontend/src/routes/index.tsx` and any other route file referencing token classes — grep first, build rename map, then apply.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7028:+- Create: `apps/frontend/src/__tests__/token-class-coverage.test.ts` — grep/scan `.tsx` class strings and assert no `text|border|bg|ring|fill|stroke` token class references a Tailwind theme key that is not resolvable via `resolveConfig`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7029: - Modify: `apps/frontend/src/styles.css` — keep `@import "@fops/ui/styles/tokens.css"` + `semantic.css` + tailwind directives.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7035:+  `grep -rn '\(text\|border\|bg\|ring\|fill\|stroke\)-\(status\|surface\|accent\|severity\|reporter\|internal\|confidence\|focus\)-' apps/frontend/src/`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7079: - Modify: `apps/frontend/src/features/admin/permissions/request-access-button.tsx:115` — `variant="primary"` → `variant="default"` (or leave with primary alias).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7099: - Constraint: `@tiptap/react` lives in `packages/ui` — do NOT install it in `apps/frontend`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7101:+- Constraint: keep `apps/frontend/src/routes/dev-rich-editor.tsx` available after C2 so C3 can validate sanitizer-fail toast flow against the demo route; C5 may delete it only if no later checkpoint needs it.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7107: **Goal:** `<Toaster>` mounted in `__root.tsx`. `apiClient`, `errorMapper`, `useIdempotencyKey` land in `apps/frontend/src/lib/api/`. ALL codes in `ERROR_CODES` from `@fops/shared` covered with Korean copy and tone classification.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7110:-- Create: `apps/frontend/src/lib/api/errorMapper.ts` — maps `{ code, detail }` to `{ tone: 'error'|'warning'|'info', message: string, action?: { label, run } }`. **Catalog is generated by iterating `ERROR_CODES` from `@fops/shared`** — no manually typed list. Every code must map to a non-empty Korean message. Fallback for unknown codes: `{ tone: 'error', message: '일시적 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.' }`. Tone per category: `auth.*` → `error`, `permission.*` → `error`, `rate_limited.*` → `warning`, `validation.*` → `error`, `conflict.*` → `error` (except `conflict.stale_write` → `warning` with retry action), `not_found.*` → `error`, `internal.*` → `error`, `voc.*` → `error`, `rich_content.*` → `error`, `attachment.*` → `warning`, `reporter_facing_status.*` → `warning`. Required codes at minimum (from `packages/shared/src/errors/codes.ts`): `auth.session_invalid`, `auth.session_required`, `auth.session_expired`, `auth.workspace_mismatch`, `permission.denied`, `rate_limited.actor`, `rate_limited.ip`, `validation.failed`, `validation.malformed_request`, `validation.unknown_capability`, `conflict.idempotency_key_reuse`, `conflict.capability_already_granted`, `conflict.permission_request_duplicate`, `validation.malformed_idempotency_key`, `validation.sensitive_reason_required`, `validation.immutable_field`, `conflict.duplicate_slug`, `conflict.parent_archived`, `conflict.record_archived`, `not_found.record`, `internal.unexpected`, `voc.severity_not_user_settable`, `validation.unexpected_field`, `rich_content.disallowed_node`, `rich_content.external_image_forbidden`, `attachment.unsupported_pending_storage_slice`, `conflict.stale_write`, `voc.reporter_status_via_public_update_only`, `permission.scope_required`, `reporter_facing_status.invalid_transition`, `reporter_facing_status.gate_blocked`, `conflict.triage_already_committed`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7111:+- Create: `apps/frontend/src/lib/api/errorMapper.ts` — maps `{ code, detail }` to `{ tone: 'error'|'warning'|'info', message: string, action?: { label, run } }`. **Catalog is generated by iterating `ERROR_CODES` from `@fops/shared`** — no manually typed list. Every code must map to a non-empty Korean message. Export `GENERIC_ERROR_MESSAGE = '일시적 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.'` so tests compare to the fallback constant directly. Fallback for unknown codes: `{ tone: 'error', message: GENERIC_ERROR_MESSAGE }`. Tone per category: `auth.*` → `error`, `permission.*` → `error`, `rate_limited.*` → `warning`, `validation.*` → `error`, `conflict.*` → `error` (except `conflict.stale_write` → `warning` with retry action), `not_found.*` → `error`, `internal.*` → `error`, `voc.*` → `error`, `rich_content.*` → `error`, `attachment.*` → `warning`, `reporter_facing_status.*` → `warning`. Required codes at minimum (from `packages/shared/src/errors/codes.ts`): `auth.session_invalid`, `auth.session_required`, `auth.session_expired`, `auth.workspace_mismatch`, `permission.denied`, `rate_limited.actor`, `rate_limited.ip`, `validation.failed`, `validation.malformed_request`, `validation.unknown_capability`, `conflict.idempotency_key_reuse`, `conflict.capability_already_granted`, `conflict.permission_request_duplicate`, `validation.malformed_idempotency_key`, `validation.sensitive_reason_required`, `validation.immutable_field`, `conflict.duplicate_slug`, `conflict.parent_archived`, `conflict.record_archived`, `not_found.record`, `internal.unexpected`, `voc.severity_not_user_settable`, `validation.unexpected_field`, `rich_content.disallowed_node`, `rich_content.external_image_forbidden`, `attachment.unsupported_pending_storage_slice`, `conflict.stale_write`, `voc.reporter_status_via_public_update_only`, `permission.scope_required`, `reporter_facing_status.invalid_transition`, `reporter_facing_status.gate_blocked`, `conflict.triage_already_committed`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7112: - Create: `apps/frontend/src/lib/api/client.ts` — `apiClient(method, path, { body?, idempotencyKey?, ifMatch?, signal? })`. Auto-mint Idempotency-Key UUIDv4 on POST/PATCH/DELETE when not supplied. Attach `Authorization` from session store. Parse JSON. Non-2xx → throw `ApiError extends Error { code, detail, status, requestId }`. 304 → return `{ status: 304, etag }`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7113: - Create: `apps/frontend/src/lib/api/useIdempotencyKey.ts` — `useIdempotencyKey(ifMatchEtag?: string)`. Returns stable UUIDv4 per render-tree until consumed; `markConsumed()` mints fresh. **When `ifMatchEtag` changes value, the hook MUST automatically mint a fresh UUIDv4** — this prevents `conflict.idempotency_key_reuse` after a stale-write refetch (BE includes `ifMatch` in the idempotency hash per `apps/backend/src/modules/voc/routes.ts:225`, so a retry with a new `If-Match` value is a semantically different request that needs a new key).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7114: - Create: `apps/frontend/src/lib/api/types.ts` — `ApiErrorEnvelope` matching BE `errors/envelope.ts`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7115: - Modify: `apps/frontend/src/routes/__root.tsx` — mount `<Toaster position="bottom-center" />` from `sonner`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7116:-- Create: `apps/frontend/src/lib/api/__tests__/errorMapper.test.ts` — **iterate `ERROR_CODES` from `@fops/shared` and assert each maps to a non-empty Korean message** (not a manual catalog). This test auto-covers new codes added to `codes.ts` without test update.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7117:+- Create: `apps/frontend/src/lib/api/__tests__/errorMapper.test.ts` — **iterate `ERROR_CODES` from `@fops/shared` and assert each maps to a non-empty Korean message** (not a manual catalog). This test auto-covers new codes added to `codes.ts` without test update. Locked assertions: (1) every `ERROR_CODES` mapping has `tone` in literal set `{ 'error', 'warning', 'info' }`; (2) every code with prefix/member in `{ voc.*, rich_content.*, attachment.*, reporter_facing_status.*, conflict.stale_write, conflict.triage_already_committed, conflict.idempotency_key_reuse }` has Korean message not equal to exported `GENERIC_ERROR_MESSAGE`; (3) `conflict.stale_write` maps to `{ tone: 'warning', action: { label: <not undefined>, run: <fn> } }`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7118: - Create: `apps/frontend/src/lib/api/__tests__/client.test.ts` — mock fetch: POST mints Idempotency-Key, GET omits, Authorization attached, 422 throws ApiError, 304 returns ETag. Add test case: same `useIdempotencyKey` instance + changed `ifMatchEtag` → new key minted automatically.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7125:-**CHECKPOINT 2.5** — small playground demonstrating: Toaster position (bottom-center), tone variants (success / error / warning / info) with Korean copy, at least 3 representative error codes rendered as toasts (`conflict.stale_write` warning + retry action, `permission.denied` error, `rate_limited.ip` warning). AskUserQuestion: "토스트 UX + 에러 메시지 OK?"
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7126:+**CHECKPOINT 2.5** — playground HTML demonstrating: Toaster tones + Korean copy for 3+ representative codes (`conflict.stale_write` warning + retry action, `permission.denied` error, `rate_limited.ip` warning) + RichEditor demo rendering sanitizer-rejected content with toast surfaced via apiClient mock. Requires C2 `/dev-rich-editor` route to still exist when C3 lands. AskUserQuestion: "토스트 UX + 에러 메시지 OK?"
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7155: ## C4b — AppFrame in apps/frontend + useFullscreenPanel hook
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7157:-**Goal:** `<AppFrame>` in `apps/frontend/src/lib/layout/` composes Rail(52) + Sidebar(240/56) + (shell outlet) + DetailPanelSlot(440). AppFrame consumes one of the 3 shells as its inner outlet. It is NOT exported as a shell — it is the authenticated route frame. `useFullscreenPanel` hook ready for #20 to consume.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7158:+**Goal:** `<AppFrame>` in `apps/frontend/src/lib/layout/` composes Rail(52) + Sidebar(240/56) + (shell outlet) + the single global DetailPanelSlot(440). AppFrame consumes one of the 3 shells as its inner outlet. It is NOT exported as a shell — it is the authenticated route frame. `useFullscreenPanel` hook ready for #20 to consume.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7163: - Create: `apps/frontend/src/lib/layout/AppFrame.tsx` — flex row Rail(52) + Sidebar(240/56) + Main(flex-1, shell outlet) + DetailPanelSlot(440 conditional). Headers conform to 50px rhythm via ShellHeader from `packages/ui`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7164: - Create: `apps/frontend/src/lib/layout/AppRail.tsx` — 52px vertical, workspace switcher placeholder + lucide-react utility icons.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7165:-- Create: `apps/frontend/src/lib/layout/AppSidebar.tsx` — 240px nav list. Slice 3 entries: Inbox, My VOCs, Triage, + New VOC. Collapse button writes `localStorage.appSidebarCollapsed`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7166:-- Create: `apps/frontend/src/lib/layout/DetailPanelSlot.tsx` — fixed 440 right column. min 360 / max 520. Hidden when no content registered via `useDetailPanelSlot()`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7167:-- Create: `apps/frontend/src/lib/layout/useDetailPanelSlot.ts` — context-based slot register/clear hook.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7168:+- Create: `apps/frontend/src/lib/layout/AppSidebar.tsx` — 240px nav list. Slice 3 entries: Inbox, My VOCs, Triage, + New VOC. Collapse state uses SSR-safe initializer:
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7176:+- Create: `apps/frontend/src/lib/layout/DetailPanelSlot.tsx` — fixed 440 right column. min 360 / max 520. Hidden when no content registered via `useDetailPanelSlot()`. This is the single rendering surface for all shell `detailPanel` content.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7177:+- Create: `apps/frontend/src/lib/layout/useDetailPanelSlot.ts` — context-based slot register/clear hook. Forbid multiple registrants: throw in dev (and warn in prod) if called twice with overlapping lifetimes, using a ref to track active ownership.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7178: - Create: `apps/frontend/src/lib/panel/useFullscreenPanel.ts` — `[isFullscreen, toggle]`. Esc collapses. Route change clears.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7179:-- Create: `apps/frontend/src/lib/layout/__tests__/AppFrame.test.tsx` — Rail/Sidebar/Main present; sidebar collapse toggle writes localStorage; DetailPanelSlot collapses when empty.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7180:+- Create: `apps/frontend/src/lib/layout/__tests__/AppFrame.test.tsx` — Rail/Sidebar/Main present; sidebar first-paint width matches stored `localStorage.appSidebarCollapsed` before any user interaction; sidebar collapse toggle writes localStorage; DetailPanelSlot collapses when empty; multiple overlapping `useDetailPanelSlot()` registrants throw/warn.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7181: - Create: `apps/frontend/src/lib/panel/__tests__/useFullscreenPanel.test.tsx` — toggle flips boolean; Esc dispatches collapse; route change clears (mock router).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7187: - Constraint: AppFrame is NOT exported from `packages/ui` — it lives in `apps/frontend/src/lib/layout/` only.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7196:-- `apps/frontend/src/routes/_authed.tsx` — new TanStack layout route. Wraps children with `<AppFrame>`. Login + non-authed routes do NOT use this layout and do NOT render AppFrame.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7198:+- `apps/frontend/src/routes/_authed.tsx` — new TanStack pathless layout route. Includes a `beforeLoad` callback that calls `fetchMe()` (same auth pattern currently used in admin routes) and `redirect({ to: '/login' })` on `UnauthenticatedError`. Wraps children with `<AppFrame>`. Login + non-authed routes do NOT use this layout and do NOT render AppFrame.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7199:+- Per-route auth guards in admin pages are DELETED in C5 after `_authed.beforeLoad` centralizes the guard.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7201:+  - `apps/frontend/src/routes/admin/managed-systems.tsx` → `apps/frontend/src/routes/_authed/admin/managed-systems.tsx`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7202:+  - `apps/frontend/src/routes/admin/analytics-areas.tsx` → `apps/frontend/src/routes/_authed/admin/analytics-areas.tsx`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7203:+  - `apps/frontend/src/routes/admin/placeholder.tsx` → `apps/frontend/src/routes/_authed/admin/placeholder.tsx`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7204:+  - Test file imports updated: `apps/frontend/src/routes/admin/*.test.tsx` move alongside their routes.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7207:-- `/vocs` route = `apps/frontend/src/routes/_authed/vocs.tsx`. Per-view shell selection: `view=inbox|my` → `<ListShell>`, `view=triage` → `<WorkbenchShell>`, `action=create` → `<PageShell>` (default when no view/action = `<ListShell>`).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7208:+- `/vocs` route file = `apps/frontend/src/routes/_authed/vocs.tsx`. Public path string is `/vocs`; `_authed` is pathless. Per-view shell selection: `view=inbox|my` → `<ListShell>`, `view=triage` → `<WorkbenchShell>`, `action=create` → `<PageShell>` (default when no view/action = `<ListShell>`).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7212:-- Create: `apps/frontend/src/routes/_authed.tsx` — TanStack layout route. Renders `<AppFrame><Outlet /></AppFrame>`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7213:+- Create: `apps/frontend/src/routes/_authed.tsx` — TanStack layout route. `beforeLoad` calls `fetchMe()` and redirects unauthenticated users to `/login`; renders `<AppFrame><Outlet /></AppFrame>`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7214: - Create: `apps/frontend/src/routes/_authed/vocs.tsx` — `createFileRoute('/_authed/vocs')` with validateSearch zod. Component selects shell based on `view`/`action`. Main = placeholder text.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7215: - Modify: `apps/frontend/src/routes/__root.tsx` — minimal; providers + `<Outlet>` only (no AppFrame).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7216:-- Relocate or re-parent: `apps/frontend/src/routes/admin/` — move under `_authed` so admin pages get AppFrame. If not done in C5, create a follow-up GitHub issue before closing this chunk.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7217:+- Move: `apps/frontend/src/routes/admin/managed-systems.tsx` → `apps/frontend/src/routes/_authed/admin/managed-systems.tsx`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7218:+- Move: `apps/frontend/src/routes/admin/analytics-areas.tsx` → `apps/frontend/src/routes/_authed/admin/analytics-areas.tsx`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7219:+- Move: `apps/frontend/src/routes/admin/placeholder.tsx` → `apps/frontend/src/routes/_authed/admin/placeholder.tsx`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7220:+- Move: `apps/frontend/src/routes/admin/*.test.tsx` → alongside relocated `_authed/admin/*` routes; update imports.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7222: - Auto-regen: `apps/frontend/src/routeTree.gen.ts` (TanStackRouterVite plugin handles on dev).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7223:-- Create: `apps/frontend/src/routes/__tests__/vocs.test.tsx` — navigating to `/_authed/vocs?view=inbox` resolves; invalid `?view=foo` rejected by zod; sidebar `+ New VOC` href = `/_authed/vocs?action=create`; `view=triage` renders WorkbenchShell.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7224:+- Create: `apps/frontend/src/routes/__tests__/vocs.test.tsx` — navigating to `/vocs?view=inbox` resolves; invalid `?view=foo` rejected by zod; sidebar `+ New VOC` href = `/vocs?action=create`; `view=triage` renders WorkbenchShell.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7225: - Delete: `apps/frontend/src/routes/dev-rich-editor.tsx` IF it was added in C2 and is no longer needed (or keep behind DEV flag).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7229: - Read first: `apps/frontend/src/routes/__root.tsx`, `apps/frontend/vite.config.ts`, `apps/frontend/src/routes/admin/managed-systems.tsx` (existing TanStack file-route pattern), `apps/frontend/src/lib/layout/AppFrame.tsx` (just created in C4b), `packages/ui/src/layout/` (shells).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7233:+- Constraint: no `Route.id` navigation. Run `grep -rn 'Route\\.id\\|from: .*Route\\.id\\|to: .*Route\\.id' apps/frontend/src/` and refactor any hits to literal `to:` path strings.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7252: - Sonnet dispatches read AGENTS.md hierarchy first (`apps/frontend/AGENTS.md` mandatory).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7257: - **AppFrame in `apps/frontend` NEVER becomes a 4th exported shell. Shell taxonomy = 3 (PageShell/ListShell/WorkbenchShell) per ADR-0020.**
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7268: - `@tiptap/react` in `packages/ui` — verify `apps/frontend` resolves it transitively via workspace link without explicit install; if pnpm strict-mode blocks it, add a peer dep declaration.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7319:+      {type:'modify', path:'apps/frontend/src/routes/{admin/managed-systems,admin/analytics-areas,login,index}.tsx  // token classname rename audit'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7320:+      {type:'create', path:'apps/frontend/src/__tests__/token-class-coverage.test.ts  // resolveConfig coverage for TSX token classes'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7321:       {type:'modify', path:'apps/frontend/src/styles.css  // @import tokens.css + semantic.css'}
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7343:       {type:'modify', path:'apps/frontend/src/features/admin/permissions/request-access-button.tsx:115  // variant primary→default'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7352: # apps/frontend — app-level only; NO direct @tiptap/* (consumed via @fops/ui)
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7365:     dispatch:'Sonnet. Read rich-editor.jsx + ADR-0011 + BE sanitizer.ts. Constraints: surface = opaque pass-through; StarterKit image:false; demo = local state only; @tiptap/* must NOT be installed in apps/frontend.',
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7376:-      {type:'create', path:'apps/frontend/src/lib/api/{client,errorMapper,useIdempotencyKey,types}.ts'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7377:+      {type:'create', path:'apps/frontend/src/lib/api/{client,errorMapper,useIdempotencyKey,types}.ts  // export GENERIC_ERROR_MESSAGE'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7378:       {type:'modify', path:'apps/frontend/src/routes/__root.tsx  // <Toaster position="bottom-center"/>'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7379:       {type:'create', path:'apps/frontend/src/lib/api/__tests__/{errorMapper,client}.test.ts'}
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7383:+    dispatch:'Sonnet. Read packages/shared/src/errors/codes.ts (iterate ERROR_CODES, do NOT hardcode list) + envelope.ts + voc routes.ts lines 200-260. Tests assert tone literal set, non-generic messages for VOC/rich/attachment/reporter/conflict special codes, and conflict.stale_write warning action. Checkpoint includes /dev-rich-editor sanitizer-reject toast via apiClient mock.',
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7411:-    goal:'AppFrame in apps/frontend/src/lib/layout/ composes Rail+Sidebar+shell outlet+DetailPanelSlot. NOT a 4th shell — app-internal only. useFullscreenPanel hook.',
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7412:+    goal:'AppFrame in apps/frontend/src/lib/layout/ composes Rail+Sidebar+shell outlet+the single global DetailPanelSlot. SSR-safe sidebar collapse. NOT a 4th shell.',
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7414:       {type:'create', path:'apps/frontend/src/lib/layout/AppFrame.tsx  // NOT exported as shell; wraps one of 3 shells'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7415:       {type:'create', path:'apps/frontend/src/lib/layout/AppRail.tsx'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7416:-      {type:'create', path:'apps/frontend/src/lib/layout/AppSidebar.tsx  // collapse→localStorage'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7417:-      {type:'create', path:'apps/frontend/src/lib/layout/DetailPanelSlot.tsx  // 440px, min 360, max 520'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7418:-      {type:'create', path:'apps/frontend/src/lib/layout/useDetailPanelSlot.ts'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7419:+      {type:'create', path:'apps/frontend/src/lib/layout/AppSidebar.tsx  // SSR-safe localStorage initializer; first-paint width test'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7420:+      {type:'create', path:'apps/frontend/src/lib/layout/DetailPanelSlot.tsx  // single global 440px slot, min 360, max 520'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7421:+      {type:'create', path:'apps/frontend/src/lib/layout/useDetailPanelSlot.ts  // forbid overlapping registrants'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7422:       {type:'create', path:'apps/frontend/src/lib/panel/useFullscreenPanel.ts  // Esc collapses, route change clears'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7423:       {type:'create', path:'apps/frontend/src/lib/layout/__tests__/AppFrame.test.tsx'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7424:       {type:'create', path:'apps/frontend/src/lib/panel/__tests__/useFullscreenPanel.test.tsx'}
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7438:-      {type:'create', path:'apps/frontend/src/routes/_authed.tsx  // layout route: <AppFrame><Outlet/></AppFrame>'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7439:-      {type:'create', path:'apps/frontend/src/routes/_authed/vocs.tsx  // shell selection per view/action'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7440:+      {type:'create', path:'apps/frontend/src/routes/_authed.tsx  // beforeLoad fetchMe; redirect /login on UnauthenticatedError; <AppFrame><Outlet/></AppFrame>'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7441:+      {type:'create', path:'apps/frontend/src/routes/_authed/vocs.tsx  // public path /vocs; shell selection per view/action'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7442:       {type:'modify', path:'apps/frontend/src/routes/__root.tsx  // minimal: providers + <Outlet> only'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7443:-      {type:'modify', path:'apps/frontend/src/routes/admin/  // re-parent under _authed as PageShell (or file follow-up)'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7444:-      {type:'create', path:'apps/frontend/src/routes/__tests__/vocs.test.tsx  // shell per view + login NOT in AppFrame'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7445:+      {type:'move', path:'apps/frontend/src/routes/admin/{managed-systems,analytics-areas,placeholder}.tsx → apps/frontend/src/routes/_authed/admin/  // paths /admin/* unchanged; delete per-page auth guards'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7446:+      {type:'move', path:'apps/frontend/src/routes/admin/*.test.tsx → apps/frontend/src/routes/_authed/admin/  // update imports'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7447:+      {type:'create', path:'apps/frontend/src/routes/__tests__/vocs.test.tsx  // /vocs shell per view + login NOT in AppFrame + no Route.id nav'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7448:       {type:'delete', path:'apps/frontend/src/routes/dev-rich-editor.tsx  // if not kept behind DEV flag'}
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7492: - ADR-0020 taxonomy enforced: `packages/ui/src/layout/` exports exactly 3 shells (PageShell, ListShell, WorkbenchShell). AppFrame in `apps/frontend/src/lib/layout/` is NOT a 4th shell.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7543:+- Modify/audit: `apps/frontend/src/routes/admin/managed-systems.tsx`, `apps/frontend/src/routes/admin/analytics-areas.tsx`, `apps/frontend/src/routes/login.tsx`, `apps/frontend/src/routes/index.tsx` and any other route file referencing token classes — grep first, build rename map, then apply.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7544:+- Create: `apps/frontend/src/__tests__/token-class-coverage.test.ts` — grep/scan `.tsx` class strings and assert no `text|border|bg|ring|fill|stroke` token class references a Tailwind theme key that is not resolvable via `resolveConfig`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7545: - Modify: `apps/frontend/src/styles.css` — keep `@import "@fops/ui/styles/tokens.css"` + `semantic.css` + tailwind directives.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7551:+  `grep -rn '\(text\|border\|bg\|ring\|fill\|stroke\)-\(status\|surface\|accent\|severity\|reporter\|internal\|confidence\|focus\)-' apps/frontend/src/`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7595: - Modify: `apps/frontend/src/features/admin/permissions/request-access-button.tsx:115` — `variant="primary"` → `variant="default"` (or leave with primary alias).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7615: - Constraint: `@tiptap/react` lives in `packages/ui` — do NOT install it in `apps/frontend`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7617:+- Constraint: keep `apps/frontend/src/routes/dev-rich-editor.tsx` available after C2 so C3 can validate sanitizer-fail toast flow against the demo route; C5 may delete it only if no later checkpoint needs it.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7623: **Goal:** `<Toaster>` mounted in `__root.tsx`. `apiClient`, `errorMapper`, `useIdempotencyKey` land in `apps/frontend/src/lib/api/`. ALL codes in `ERROR_CODES` from `@fops/shared` covered with Korean copy and tone classification.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7626:-- Create: `apps/frontend/src/lib/api/errorMapper.ts` — maps `{ code, detail }` to `{ tone: 'error'|'warning'|'info', message: string, action?: { label, run } }`. **Catalog is generated by iterating `ERROR_CODES` from `@fops/shared`** — no manually typed list. Every code must map to a non-empty Korean message. Fallback for unknown codes: `{ tone: 'error', message: '일시적 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.' }`. Tone per category: `auth.*` → `error`, `permission.*` → `error`, `rate_limited.*` → `warning`, `validation.*` → `error`, `conflict.*` → `error` (except `conflict.stale_write` → `warning` with retry action), `not_found.*` → `error`, `internal.*` → `error`, `voc.*` → `error`, `rich_content.*` → `error`, `attachment.*` → `warning`, `reporter_facing_status.*` → `warning`. Required codes at minimum (from `packages/shared/src/errors/codes.ts`): `auth.session_invalid`, `auth.session_required`, `auth.session_expired`, `auth.workspace_mismatch`, `permission.denied`, `rate_limited.actor`, `rate_limited.ip`, `validation.failed`, `validation.malformed_request`, `validation.unknown_capability`, `conflict.idempotency_key_reuse`, `conflict.capability_already_granted`, `conflict.permission_request_duplicate`, `validation.malformed_idempotency_key`, `validation.sensitive_reason_required`, `validation.immutable_field`, `conflict.duplicate_slug`, `conflict.parent_archived`, `conflict.record_archived`, `not_found.record`, `internal.unexpected`, `voc.severity_not_user_settable`, `validation.unexpected_field`, `rich_content.disallowed_node`, `rich_content.external_image_forbidden`, `attachment.unsupported_pending_storage_slice`, `conflict.stale_write`, `voc.reporter_status_via_public_update_only`, `permission.scope_required`, `reporter_facing_status.invalid_transition`, `reporter_facing_status.gate_blocked`, `conflict.triage_already_committed`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7627:+- Create: `apps/frontend/src/lib/api/errorMapper.ts` — maps `{ code, detail }` to `{ tone: 'error'|'warning'|'info', message: string, action?: { label, run } }`. **Catalog is generated by iterating `ERROR_CODES` from `@fops/shared`** — no manually typed list. Every code must map to a non-empty Korean message. Export `GENERIC_ERROR_MESSAGE = '일시적 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.'` so tests compare to the fallback constant directly. Fallback for unknown codes: `{ tone: 'error', message: GENERIC_ERROR_MESSAGE }`. Tone per category: `auth.*` → `error`, `permission.*` → `error`, `rate_limited.*` → `warning`, `validation.*` → `error`, `conflict.*` → `error` (except `conflict.stale_write` → `warning` with retry action), `not_found.*` → `error`, `internal.*` → `error`, `voc.*` → `error`, `rich_content.*` → `error`, `attachment.*` → `warning`, `reporter_facing_status.*` → `warning`. Required codes at minimum (from `packages/shared/src/errors/codes.ts`): `auth.session_invalid`, `auth.session_required`, `auth.session_expired`, `auth.workspace_mismatch`, `permission.denied`, `rate_limited.actor`, `rate_limited.ip`, `validation.failed`, `validation.malformed_request`, `validation.unknown_capability`, `conflict.idempotency_key_reuse`, `conflict.capability_already_granted`, `conflict.permission_request_duplicate`, `validation.malformed_idempotency_key`, `validation.sensitive_reason_required`, `validation.immutable_field`, `conflict.duplicate_slug`, `conflict.parent_archived`, `conflict.record_archived`, `not_found.record`, `internal.unexpected`, `voc.severity_not_user_settable`, `validation.unexpected_field`, `rich_content.disallowed_node`, `rich_content.external_image_forbidden`, `attachment.unsupported_pending_storage_slice`, `conflict.stale_write`, `voc.reporter_status_via_public_update_only`, `permission.scope_required`, `reporter_facing_status.invalid_transition`, `reporter_facing_status.gate_blocked`, `conflict.triage_already_committed`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7628: - Create: `apps/frontend/src/lib/api/client.ts` — `apiClient(method, path, { body?, idempotencyKey?, ifMatch?, signal? })`. Auto-mint Idempotency-Key UUIDv4 on POST/PATCH/DELETE when not supplied. Attach `Authorization` from session store. Parse JSON. Non-2xx → throw `ApiError extends Error { code, detail, status, requestId }`. 304 → return `{ status: 304, etag }`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7629: - Create: `apps/frontend/src/lib/api/useIdempotencyKey.ts` — `useIdempotencyKey(ifMatchEtag?: string)`. Returns stable UUIDv4 per render-tree until consumed; `markConsumed()` mints fresh. **When `ifMatchEtag` changes value, the hook MUST automatically mint a fresh UUIDv4** — this prevents `conflict.idempotency_key_reuse` after a stale-write refetch (BE includes `ifMatch` in the idempotency hash per `apps/backend/src/modules/voc/routes.ts:225`, so a retry with a new `If-Match` value is a semantically different request that needs a new key).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7630: - Create: `apps/frontend/src/lib/api/types.ts` — `ApiErrorEnvelope` matching BE `errors/envelope.ts`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7631: - Modify: `apps/frontend/src/routes/__root.tsx` — mount `<Toaster position="bottom-center" />` from `sonner`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7632:-- Create: `apps/frontend/src/lib/api/__tests__/errorMapper.test.ts` — **iterate `ERROR_CODES` from `@fops/shared` and assert each maps to a non-empty Korean message** (not a manual catalog). This test auto-covers new codes added to `codes.ts` without test update.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7633:+- Create: `apps/frontend/src/lib/api/__tests__/errorMapper.test.ts` — **iterate `ERROR_CODES` from `@fops/shared` and assert each maps to a non-empty Korean message** (not a manual catalog). This test auto-covers new codes added to `codes.ts` without test update. Locked assertions: (1) every `ERROR_CODES` mapping has `tone` in literal set `{ 'error', 'warning', 'info' }`; (2) every code with prefix/member in `{ voc.*, rich_content.*, attachment.*, reporter_facing_status.*, conflict.stale_write, conflict.triage_already_committed, conflict.idempotency_key_reuse }` has Korean message not equal to exported `GENERIC_ERROR_MESSAGE`; (3) `conflict.stale_write` maps to `{ tone: 'warning', action: { label: <not undefined>, run: <fn> } }`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7634: - Create: `apps/frontend/src/lib/api/__tests__/client.test.ts` — mock fetch: POST mints Idempotency-Key, GET omits, Authorization attached, 422 throws ApiError, 304 returns ETag. Add test case: same `useIdempotencyKey` instance + changed `ifMatchEtag` → new key minted automatically.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7641:-**CHECKPOINT 2.5** — small playground demonstrating: Toaster position (bottom-center), tone variants (success / error / warning / info) with Korean copy, at least 3 representative error codes rendered as toasts (`conflict.stale_write` warning + retry action, `permission.denied` error, `rate_limited.ip` warning). AskUserQuestion: "토스트 UX + 에러 메시지 OK?"
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7642:+**CHECKPOINT 2.5** — playground HTML demonstrating: Toaster tones + Korean copy for 3+ representative codes (`conflict.stale_write` warning + retry action, `permission.denied` error, `rate_limited.ip` warning) + RichEditor demo rendering sanitizer-rejected content with toast surfaced via apiClient mock. Requires C2 `/dev-rich-editor` route to still exist when C3 lands. AskUserQuestion: "토스트 UX + 에러 메시지 OK?"
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7671: ## C4b — AppFrame in apps/frontend + useFullscreenPanel hook
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7673:-**Goal:** `<AppFrame>` in `apps/frontend/src/lib/layout/` composes Rail(52) + Sidebar(240/56) + (shell outlet) + DetailPanelSlot(440). AppFrame consumes one of the 3 shells as its inner outlet. It is NOT exported as a shell — it is the authenticated route frame. `useFullscreenPanel` hook ready for #20 to consume.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7674:+**Goal:** `<AppFrame>` in `apps/frontend/src/lib/layout/` composes Rail(52) + Sidebar(240/56) + (shell outlet) + the single global DetailPanelSlot(440). AppFrame consumes one of the 3 shells as its inner outlet. It is NOT exported as a shell — it is the authenticated route frame. `useFullscreenPanel` hook ready for #20 to consume.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7679: - Create: `apps/frontend/src/lib/layout/AppFrame.tsx` — flex row Rail(52) + Sidebar(240/56) + Main(flex-1, shell outlet) + DetailPanelSlot(440 conditional). Headers conform to 50px rhythm via ShellHeader from `packages/ui`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7680: - Create: `apps/frontend/src/lib/layout/AppRail.tsx` — 52px vertical, workspace switcher placeholder + lucide-react utility icons.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7681:-- Create: `apps/frontend/src/lib/layout/AppSidebar.tsx` — 240px nav list. Slice 3 entries: Inbox, My VOCs, Triage, + New VOC. Collapse button writes `localStorage.appSidebarCollapsed`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7682:-- Create: `apps/frontend/src/lib/layout/DetailPanelSlot.tsx` — fixed 440 right column. min 360 / max 520. Hidden when no content registered via `useDetailPanelSlot()`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7683:-- Create: `apps/frontend/src/lib/layout/useDetailPanelSlot.ts` — context-based slot register/clear hook.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7684:+- Create: `apps/frontend/src/lib/layout/AppSidebar.tsx` — 240px nav list. Slice 3 entries: Inbox, My VOCs, Triage, + New VOC. Collapse state uses SSR-safe initializer:
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7692:+- Create: `apps/frontend/src/lib/layout/DetailPanelSlot.tsx` — fixed 440 right column. min 360 / max 520. Hidden when no content registered via `useDetailPanelSlot()`. This is the single rendering surface for all shell `detailPanel` content.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7693:+- Create: `apps/frontend/src/lib/layout/useDetailPanelSlot.ts` — context-based slot register/clear hook. Forbid multiple registrants: throw in dev (and warn in prod) if called twice with overlapping lifetimes, using a ref to track active ownership.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7694: - Create: `apps/frontend/src/lib/panel/useFullscreenPanel.ts` — `[isFullscreen, toggle]`. Esc collapses. Route change clears.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7695:-- Create: `apps/frontend/src/lib/layout/__tests__/AppFrame.test.tsx` — Rail/Sidebar/Main present; sidebar collapse toggle writes localStorage; DetailPanelSlot collapses when empty.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7696:+- Create: `apps/frontend/src/lib/layout/__tests__/AppFrame.test.tsx` — Rail/Sidebar/Main present; sidebar first-paint width matches stored `localStorage.appSidebarCollapsed` before any user interaction; sidebar collapse toggle writes localStorage; DetailPanelSlot collapses when empty; multiple overlapping `useDetailPanelSlot()` registrants throw/warn.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7697: - Create: `apps/frontend/src/lib/panel/__tests__/useFullscreenPanel.test.tsx` — toggle flips boolean; Esc dispatches collapse; route change clears (mock router).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7703: - Constraint: AppFrame is NOT exported from `packages/ui` — it lives in `apps/frontend/src/lib/layout/` only.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7712:-- `apps/frontend/src/routes/_authed.tsx` — new TanStack layout route. Wraps children with `<AppFrame>`. Login + non-authed routes do NOT use this layout and do NOT render AppFrame.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7714:+- `apps/frontend/src/routes/_authed.tsx` — new TanStack pathless layout route. Includes a `beforeLoad` callback that calls `fetchMe()` (same auth pattern currently used in admin routes) and `redirect({ to: '/login' })` on `UnauthenticatedError`. Wraps children with `<AppFrame>`. Login + non-authed routes do NOT use this layout and do NOT render AppFrame.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7715:+- Per-route auth guards in admin pages are DELETED in C5 after `_authed.beforeLoad` centralizes the guard.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7717:+  - `apps/frontend/src/routes/admin/managed-systems.tsx` → `apps/frontend/src/routes/_authed/admin/managed-systems.tsx`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7718:+  - `apps/frontend/src/routes/admin/analytics-areas.tsx` → `apps/frontend/src/routes/_authed/admin/analytics-areas.tsx`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7719:+  - `apps/frontend/src/routes/admin/placeholder.tsx` → `apps/frontend/src/routes/_authed/admin/placeholder.tsx`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7720:+  - Test file imports updated: `apps/frontend/src/routes/admin/*.test.tsx` move alongside their routes.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7723:-- `/vocs` route = `apps/frontend/src/routes/_authed/vocs.tsx`. Per-view shell selection: `view=inbox|my` → `<ListShell>`, `view=triage` → `<WorkbenchShell>`, `action=create` → `<PageShell>` (default when no view/action = `<ListShell>`).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7724:+- `/vocs` route file = `apps/frontend/src/routes/_authed/vocs.tsx`. Public path string is `/vocs`; `_authed` is pathless. Per-view shell selection: `view=inbox|my` → `<ListShell>`, `view=triage` → `<WorkbenchShell>`, `action=create` → `<PageShell>` (default when no view/action = `<ListShell>`).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7728:-- Create: `apps/frontend/src/routes/_authed.tsx` — TanStack layout route. Renders `<AppFrame><Outlet /></AppFrame>`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7729:+- Create: `apps/frontend/src/routes/_authed.tsx` — TanStack layout route. `beforeLoad` calls `fetchMe()` and redirects unauthenticated users to `/login`; renders `<AppFrame><Outlet /></AppFrame>`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7730: - Create: `apps/frontend/src/routes/_authed/vocs.tsx` — `createFileRoute('/_authed/vocs')` with validateSearch zod. Component selects shell based on `view`/`action`. Main = placeholder text.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7731: - Modify: `apps/frontend/src/routes/__root.tsx` — minimal; providers + `<Outlet>` only (no AppFrame).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7732:-- Relocate or re-parent: `apps/frontend/src/routes/admin/` — move under `_authed` so admin pages get AppFrame. If not done in C5, create a follow-up GitHub issue before closing this chunk.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7733:+- Move: `apps/frontend/src/routes/admin/managed-systems.tsx` → `apps/frontend/src/routes/_authed/admin/managed-systems.tsx`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7734:+- Move: `apps/frontend/src/routes/admin/analytics-areas.tsx` → `apps/frontend/src/routes/_authed/admin/analytics-areas.tsx`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7735:+- Move: `apps/frontend/src/routes/admin/placeholder.tsx` → `apps/frontend/src/routes/_authed/admin/placeholder.tsx`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7736:+- Move: `apps/frontend/src/routes/admin/*.test.tsx` → alongside relocated `_authed/admin/*` routes; update imports.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7738: - Auto-regen: `apps/frontend/src/routeTree.gen.ts` (TanStackRouterVite plugin handles on dev).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7739:-- Create: `apps/frontend/src/routes/__tests__/vocs.test.tsx` — navigating to `/_authed/vocs?view=inbox` resolves; invalid `?view=foo` rejected by zod; sidebar `+ New VOC` href = `/_authed/vocs?action=create`; `view=triage` renders WorkbenchShell.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7740:+- Create: `apps/frontend/src/routes/__tests__/vocs.test.tsx` — navigating to `/vocs?view=inbox` resolves; invalid `?view=foo` rejected by zod; sidebar `+ New VOC` href = `/vocs?action=create`; `view=triage` renders WorkbenchShell.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7741: - Delete: `apps/frontend/src/routes/dev-rich-editor.tsx` IF it was added in C2 and is no longer needed (or keep behind DEV flag).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7745: - Read first: `apps/frontend/src/routes/__root.tsx`, `apps/frontend/vite.config.ts`, `apps/frontend/src/routes/admin/managed-systems.tsx` (existing TanStack file-route pattern), `apps/frontend/src/lib/layout/AppFrame.tsx` (just created in C4b), `packages/ui/src/layout/` (shells).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7749:+- Constraint: no `Route.id` navigation. Run `grep -rn 'Route\\.id\\|from: .*Route\\.id\\|to: .*Route\\.id' apps/frontend/src/` and refactor any hits to literal `to:` path strings.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7768: - Sonnet dispatches read AGENTS.md hierarchy first (`apps/frontend/AGENTS.md` mandatory).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7773: - **AppFrame in `apps/frontend` NEVER becomes a 4th exported shell. Shell taxonomy = 3 (PageShell/ListShell/WorkbenchShell) per ADR-0020.**
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7784: - `@tiptap/react` in `packages/ui` — verify `apps/frontend` resolves it transitively via workspace link without explicit install; if pnpm strict-mode blocks it, add a peer dep declaration.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7835:+      {type:'modify', path:'apps/frontend/src/routes/{admin/managed-systems,admin/analytics-areas,login,index}.tsx  // token classname rename audit'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7836:+      {type:'create', path:'apps/frontend/src/__tests__/token-class-coverage.test.ts  // resolveConfig coverage for TSX token classes'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7837:       {type:'modify', path:'apps/frontend/src/styles.css  // @import tokens.css + semantic.css'}
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7859:       {type:'modify', path:'apps/frontend/src/features/admin/permissions/request-access-button.tsx:115  // variant primary→default'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7868: # apps/frontend — app-level only; NO direct @tiptap/* (consumed via @fops/ui)
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7881:     dispatch:'Sonnet. Read rich-editor.jsx + ADR-0011 + BE sanitizer.ts. Constraints: surface = opaque pass-through; StarterKit image:false; demo = local state only; @tiptap/* must NOT be installed in apps/frontend.',
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7892:-      {type:'create', path:'apps/frontend/src/lib/api/{client,errorMapper,useIdempotencyKey,types}.ts'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7893:+      {type:'create', path:'apps/frontend/src/lib/api/{client,errorMapper,useIdempotencyKey,types}.ts  // export GENERIC_ERROR_MESSAGE'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7894:       {type:'modify', path:'apps/frontend/src/routes/__root.tsx  // <Toaster position="bottom-center"/>'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7895:       {type:'create', path:'apps/frontend/src/lib/api/__tests__/{errorMapper,client}.test.ts'}
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7899:+    dispatch:'Sonnet. Read packages/shared/src/errors/codes.ts (iterate ERROR_CODES, do NOT hardcode list) + envelope.ts + voc routes.ts lines 200-260. Tests assert tone literal set, non-generic messages for VOC/rich/attachment/reporter/conflict special codes, and conflict.stale_write warning action. Checkpoint includes /dev-rich-editor sanitizer-reject toast via apiClient mock.',
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7927:-    goal:'AppFrame in apps/frontend/src/lib/layout/ composes Rail+Sidebar+shell outlet+DetailPanelSlot. NOT a 4th shell — app-internal only. useFullscreenPanel hook.',
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7928:+    goal:'AppFrame in apps/frontend/src/lib/layout/ composes Rail+Sidebar+shell outlet+the single global DetailPanelSlot. SSR-safe sidebar collapse. NOT a 4th shell.',
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7930:       {type:'create', path:'apps/frontend/src/lib/layout/AppFrame.tsx  // NOT exported as shell; wraps one of 3 shells'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7931:       {type:'create', path:'apps/frontend/src/lib/layout/AppRail.tsx'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7932:-      {type:'create', path:'apps/frontend/src/lib/layout/AppSidebar.tsx  // collapse→localStorage'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7933:-      {type:'create', path:'apps/frontend/src/lib/layout/DetailPanelSlot.tsx  // 440px, min 360, max 520'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7934:-      {type:'create', path:'apps/frontend/src/lib/layout/useDetailPanelSlot.ts'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7935:+      {type:'create', path:'apps/frontend/src/lib/layout/AppSidebar.tsx  // SSR-safe localStorage initializer; first-paint width test'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7936:+      {type:'create', path:'apps/frontend/src/lib/layout/DetailPanelSlot.tsx  // single global 440px slot, min 360, max 520'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7937:+      {type:'create', path:'apps/frontend/src/lib/layout/useDetailPanelSlot.ts  // forbid overlapping registrants'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7938:       {type:'create', path:'apps/frontend/src/lib/panel/useFullscreenPanel.ts  // Esc collapses, route change clears'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7939:       {type:'create', path:'apps/frontend/src/lib/layout/__tests__/AppFrame.test.tsx'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7940:       {type:'create', path:'apps/frontend/src/lib/panel/__tests__/useFullscreenPanel.test.tsx'}
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7954:-      {type:'create', path:'apps/frontend/src/routes/_authed.tsx  // layout route: <AppFrame><Outlet/></AppFrame>'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7955:-      {type:'create', path:'apps/frontend/src/routes/_authed/vocs.tsx  // shell selection per view/action'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7956:+      {type:'create', path:'apps/frontend/src/routes/_authed.tsx  // beforeLoad fetchMe; redirect /login on UnauthenticatedError; <AppFrame><Outlet/></AppFrame>'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7957:+      {type:'create', path:'apps/frontend/src/routes/_authed/vocs.tsx  // public path /vocs; shell selection per view/action'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7958:       {type:'modify', path:'apps/frontend/src/routes/__root.tsx  // minimal: providers + <Outlet> only'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7959:-      {type:'modify', path:'apps/frontend/src/routes/admin/  // re-parent under _authed as PageShell (or file follow-up)'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7960:-      {type:'create', path:'apps/frontend/src/routes/__tests__/vocs.test.tsx  // shell per view + login NOT in AppFrame'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7961:+      {type:'move', path:'apps/frontend/src/routes/admin/{managed-systems,analytics-areas,placeholder}.tsx → apps/frontend/src/routes/_authed/admin/  // paths /admin/* unchanged; delete per-page auth guards'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7962:+      {type:'move', path:'apps/frontend/src/routes/admin/*.test.tsx → apps/frontend/src/routes/_authed/admin/  // update imports'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7963:+      {type:'create', path:'apps/frontend/src/routes/__tests__/vocs.test.tsx  // /vocs shell per view + login NOT in AppFrame + no Route.id nav'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:7964:       {type:'delete', path:'apps/frontend/src/routes/dev-rich-editor.tsx  // if not kept behind DEV flag'}
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8015: - ADR-0020 taxonomy enforced: `packages/ui/src/layout/` exports exactly 3 shells (PageShell, ListShell, WorkbenchShell). AppFrame in `apps/frontend/src/lib/layout/` is NOT a 4th shell.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8066:+- Modify/audit: `apps/frontend/src/routes/admin/managed-systems.tsx`, `apps/frontend/src/routes/admin/analytics-areas.tsx`, `apps/frontend/src/routes/login.tsx`, `apps/frontend/src/routes/index.tsx` and any other route file referencing token classes — grep first, build rename map, then apply.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8067:+- Create: `apps/frontend/src/__tests__/token-class-coverage.test.ts` — grep/scan `.tsx` class strings and assert no `text|border|bg|ring|fill|stroke` token class references a Tailwind theme key that is not resolvable via `resolveConfig`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8068: - Modify: `apps/frontend/src/styles.css` — keep `@import "@fops/ui/styles/tokens.css"` + `semantic.css` + tailwind directives.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8074:+  `grep -rn '\(text\|border\|bg\|ring\|fill\|stroke\)-\(status\|surface\|accent\|severity\|reporter\|internal\|confidence\|focus\)-' apps/frontend/src/`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8118: - Modify: `apps/frontend/src/features/admin/permissions/request-access-button.tsx:115` — `variant="primary"` → `variant="default"` (or leave with primary alias).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8138: - Constraint: `@tiptap/react` lives in `packages/ui` — do NOT install it in `apps/frontend`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8140:+- Constraint: keep `apps/frontend/src/routes/dev-rich-editor.tsx` available after C2 so C3 can validate sanitizer-fail toast flow against the demo route; C5 may delete it only if no later checkpoint needs it.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8146: **Goal:** `<Toaster>` mounted in `__root.tsx`. `apiClient`, `errorMapper`, `useIdempotencyKey` land in `apps/frontend/src/lib/api/`. ALL codes in `ERROR_CODES` from `@fops/shared` covered with Korean copy and tone classification.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8149:-- Create: `apps/frontend/src/lib/api/errorMapper.ts` — maps `{ code, detail }` to `{ tone: 'error'|'warning'|'info', message: string, action?: { label, run } }`. **Catalog is generated by iterating `ERROR_CODES` from `@fops/shared`** — no manually typed list. Every code must map to a non-empty Korean message. Fallback for unknown codes: `{ tone: 'error', message: '일시적 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.' }`. Tone per category: `auth.*` → `error`, `permission.*` → `error`, `rate_limited.*` → `warning`, `validation.*` → `error`, `conflict.*` → `error` (except `conflict.stale_write` → `warning` with retry action), `not_found.*` → `error`, `internal.*` → `error`, `voc.*` → `error`, `rich_content.*` → `error`, `attachment.*` → `warning`, `reporter_facing_status.*` → `warning`. Required codes at minimum (from `packages/shared/src/errors/codes.ts`): `auth.session_invalid`, `auth.session_required`, `auth.session_expired`, `auth.workspace_mismatch`, `permission.denied`, `rate_limited.actor`, `rate_limited.ip`, `validation.failed`, `validation.malformed_request`, `validation.unknown_capability`, `conflict.idempotency_key_reuse`, `conflict.capability_already_granted`, `conflict.permission_request_duplicate`, `validation.malformed_idempotency_key`, `validation.sensitive_reason_required`, `validation.immutable_field`, `conflict.duplicate_slug`, `conflict.parent_archived`, `conflict.record_archived`, `not_found.record`, `internal.unexpected`, `voc.severity_not_user_settable`, `validation.unexpected_field`, `rich_content.disallowed_node`, `rich_content.external_image_forbidden`, `attachment.unsupported_pending_storage_slice`, `conflict.stale_write`, `voc.reporter_status_via_public_update_only`, `permission.scope_required`, `reporter_facing_status.invalid_transition`, `reporter_facing_status.gate_blocked`, `conflict.triage_already_committed`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8150:+- Create: `apps/frontend/src/lib/api/errorMapper.ts` — maps `{ code, detail }` to `{ tone: 'error'|'warning'|'info', message: string, action?: { label, run } }`. **Catalog is generated by iterating `ERROR_CODES` from `@fops/shared`** — no manually typed list. Every code must map to a non-empty Korean message. Export `GENERIC_ERROR_MESSAGE = '일시적 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.'` so tests compare to the fallback constant directly. Fallback for unknown codes: `{ tone: 'error', message: GENERIC_ERROR_MESSAGE }`. Tone per category: `auth.*` → `error`, `permission.*` → `error`, `rate_limited.*` → `warning`, `validation.*` → `error`, `conflict.*` → `error` (except `conflict.stale_write` → `warning` with retry action), `not_found.*` → `error`, `internal.*` → `error`, `voc.*` → `error`, `rich_content.*` → `error`, `attachment.*` → `warning`, `reporter_facing_status.*` → `warning`. Required codes at minimum (from `packages/shared/src/errors/codes.ts`): `auth.session_invalid`, `auth.session_required`, `auth.session_expired`, `auth.workspace_mismatch`, `permission.denied`, `rate_limited.actor`, `rate_limited.ip`, `validation.failed`, `validation.malformed_request`, `validation.unknown_capability`, `conflict.idempotency_key_reuse`, `conflict.capability_already_granted`, `conflict.permission_request_duplicate`, `validation.malformed_idempotency_key`, `validation.sensitive_reason_required`, `validation.immutable_field`, `conflict.duplicate_slug`, `conflict.parent_archived`, `conflict.record_archived`, `not_found.record`, `internal.unexpected`, `voc.severity_not_user_settable`, `validation.unexpected_field`, `rich_content.disallowed_node`, `rich_content.external_image_forbidden`, `attachment.unsupported_pending_storage_slice`, `conflict.stale_write`, `voc.reporter_status_via_public_update_only`, `permission.scope_required`, `reporter_facing_status.invalid_transition`, `reporter_facing_status.gate_blocked`, `conflict.triage_already_committed`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8151: - Create: `apps/frontend/src/lib/api/client.ts` — `apiClient(method, path, { body?, idempotencyKey?, ifMatch?, signal? })`. Auto-mint Idempotency-Key UUIDv4 on POST/PATCH/DELETE when not supplied. Attach `Authorization` from session store. Parse JSON. Non-2xx → throw `ApiError extends Error { code, detail, status, requestId }`. 304 → return `{ status: 304, etag }`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8152: - Create: `apps/frontend/src/lib/api/useIdempotencyKey.ts` — `useIdempotencyKey(ifMatchEtag?: string)`. Returns stable UUIDv4 per render-tree until consumed; `markConsumed()` mints fresh. **When `ifMatchEtag` changes value, the hook MUST automatically mint a fresh UUIDv4** — this prevents `conflict.idempotency_key_reuse` after a stale-write refetch (BE includes `ifMatch` in the idempotency hash per `apps/backend/src/modules/voc/routes.ts:225`, so a retry with a new `If-Match` value is a semantically different request that needs a new key).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8153: - Create: `apps/frontend/src/lib/api/types.ts` — `ApiErrorEnvelope` matching BE `errors/envelope.ts`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8154: - Modify: `apps/frontend/src/routes/__root.tsx` — mount `<Toaster position="bottom-center" />` from `sonner`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8155:-- Create: `apps/frontend/src/lib/api/__tests__/errorMapper.test.ts` — **iterate `ERROR_CODES` from `@fops/shared` and assert each maps to a non-empty Korean message** (not a manual catalog). This test auto-covers new codes added to `codes.ts` without test update.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8156:+- Create: `apps/frontend/src/lib/api/__tests__/errorMapper.test.ts` — **iterate `ERROR_CODES` from `@fops/shared` and assert each maps to a non-empty Korean message** (not a manual catalog). This test auto-covers new codes added to `codes.ts` without test update. Locked assertions: (1) every `ERROR_CODES` mapping has `tone` in literal set `{ 'error', 'warning', 'info' }`; (2) every code with prefix/member in `{ voc.*, rich_content.*, attachment.*, reporter_facing_status.*, conflict.stale_write, conflict.triage_already_committed, conflict.idempotency_key_reuse }` has Korean message not equal to exported `GENERIC_ERROR_MESSAGE`; (3) `conflict.stale_write` maps to `{ tone: 'warning', action: { label: <not undefined>, run: <fn> } }`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8157: - Create: `apps/frontend/src/lib/api/__tests__/client.test.ts` — mock fetch: POST mints Idempotency-Key, GET omits, Authorization attached, 422 throws ApiError, 304 returns ETag. Add test case: same `useIdempotencyKey` instance + changed `ifMatchEtag` → new key minted automatically.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8164:-**CHECKPOINT 2.5** — small playground demonstrating: Toaster position (bottom-center), tone variants (success / error / warning / info) with Korean copy, at least 3 representative error codes rendered as toasts (`conflict.stale_write` warning + retry action, `permission.denied` error, `rate_limited.ip` warning). AskUserQuestion: "토스트 UX + 에러 메시지 OK?"
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8165:+**CHECKPOINT 2.5** — playground HTML demonstrating: Toaster tones + Korean copy for 3+ representative codes (`conflict.stale_write` warning + retry action, `permission.denied` error, `rate_limited.ip` warning) + RichEditor demo rendering sanitizer-rejected content with toast surfaced via apiClient mock. Requires C2 `/dev-rich-editor` route to still exist when C3 lands. AskUserQuestion: "토스트 UX + 에러 메시지 OK?"
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8194: ## C4b — AppFrame in apps/frontend + useFullscreenPanel hook
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8196:-**Goal:** `<AppFrame>` in `apps/frontend/src/lib/layout/` composes Rail(52) + Sidebar(240/56) + (shell outlet) + DetailPanelSlot(440). AppFrame consumes one of the 3 shells as its inner outlet. It is NOT exported as a shell — it is the authenticated route frame. `useFullscreenPanel` hook ready for #20 to consume.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8197:+**Goal:** `<AppFrame>` in `apps/frontend/src/lib/layout/` composes Rail(52) + Sidebar(240/56) + (shell outlet) + the single global DetailPanelSlot(440). AppFrame consumes one of the 3 shells as its inner outlet. It is NOT exported as a shell — it is the authenticated route frame. `useFullscreenPanel` hook ready for #20 to consume.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8202: - Create: `apps/frontend/src/lib/layout/AppFrame.tsx` — flex row Rail(52) + Sidebar(240/56) + Main(flex-1, shell outlet) + DetailPanelSlot(440 conditional). Headers conform to 50px rhythm via ShellHeader from `packages/ui`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8203: - Create: `apps/frontend/src/lib/layout/AppRail.tsx` — 52px vertical, workspace switcher placeholder + lucide-react utility icons.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8204:-- Create: `apps/frontend/src/lib/layout/AppSidebar.tsx` — 240px nav list. Slice 3 entries: Inbox, My VOCs, Triage, + New VOC. Collapse button writes `localStorage.appSidebarCollapsed`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8205:-- Create: `apps/frontend/src/lib/layout/DetailPanelSlot.tsx` — fixed 440 right column. min 360 / max 520. Hidden when no content registered via `useDetailPanelSlot()`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8206:-- Create: `apps/frontend/src/lib/layout/useDetailPanelSlot.ts` — context-based slot register/clear hook.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8207:+- Create: `apps/frontend/src/lib/layout/AppSidebar.tsx` — 240px nav list. Slice 3 entries: Inbox, My VOCs, Triage, + New VOC. Collapse state uses SSR-safe initializer:
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8215:+- Create: `apps/frontend/src/lib/layout/DetailPanelSlot.tsx` — fixed 440 right column. min 360 / max 520. Hidden when no content registered via `useDetailPanelSlot()`. This is the single rendering surface for all shell `detailPanel` content.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8216:+- Create: `apps/frontend/src/lib/layout/useDetailPanelSlot.ts` — context-based slot register/clear hook. Forbid multiple registrants: throw in dev (and warn in prod) if called twice with overlapping lifetimes, using a ref to track active ownership.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8217: - Create: `apps/frontend/src/lib/panel/useFullscreenPanel.ts` — `[isFullscreen, toggle]`. Esc collapses. Route change clears.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8218:-- Create: `apps/frontend/src/lib/layout/__tests__/AppFrame.test.tsx` — Rail/Sidebar/Main present; sidebar collapse toggle writes localStorage; DetailPanelSlot collapses when empty.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8219:+- Create: `apps/frontend/src/lib/layout/__tests__/AppFrame.test.tsx` — Rail/Sidebar/Main present; sidebar first-paint width matches stored `localStorage.appSidebarCollapsed` before any user interaction; sidebar collapse toggle writes localStorage; DetailPanelSlot collapses when empty; multiple overlapping `useDetailPanelSlot()` registrants throw/warn.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8220: - Create: `apps/frontend/src/lib/panel/__tests__/useFullscreenPanel.test.tsx` — toggle flips boolean; Esc dispatches collapse; route change clears (mock router).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8226: - Constraint: AppFrame is NOT exported from `packages/ui` — it lives in `apps/frontend/src/lib/layout/` only.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8235:-- `apps/frontend/src/routes/_authed.tsx` — new TanStack layout route. Wraps children with `<AppFrame>`. Login + non-authed routes do NOT use this layout and do NOT render AppFrame.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8237:+- `apps/frontend/src/routes/_authed.tsx` — new TanStack pathless layout route. Includes a `beforeLoad` callback that calls `fetchMe()` (same auth pattern currently used in admin routes) and `redirect({ to: '/login' })` on `UnauthenticatedError`. Wraps children with `<AppFrame>`. Login + non-authed routes do NOT use this layout and do NOT render AppFrame.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8238:+- Per-route auth guards in admin pages are DELETED in C5 after `_authed.beforeLoad` centralizes the guard.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8240:+  - `apps/frontend/src/routes/admin/managed-systems.tsx` → `apps/frontend/src/routes/_authed/admin/managed-systems.tsx`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8241:+  - `apps/frontend/src/routes/admin/analytics-areas.tsx` → `apps/frontend/src/routes/_authed/admin/analytics-areas.tsx`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8242:+  - `apps/frontend/src/routes/admin/placeholder.tsx` → `apps/frontend/src/routes/_authed/admin/placeholder.tsx`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8243:+  - Test file imports updated: `apps/frontend/src/routes/admin/*.test.tsx` move alongside their routes.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8246:-- `/vocs` route = `apps/frontend/src/routes/_authed/vocs.tsx`. Per-view shell selection: `view=inbox|my` → `<ListShell>`, `view=triage` → `<WorkbenchShell>`, `action=create` → `<PageShell>` (default when no view/action = `<ListShell>`).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8247:+- `/vocs` route file = `apps/frontend/src/routes/_authed/vocs.tsx`. Public path string is `/vocs`; `_authed` is pathless. Per-view shell selection: `view=inbox|my` → `<ListShell>`, `view=triage` → `<WorkbenchShell>`, `action=create` → `<PageShell>` (default when no view/action = `<ListShell>`).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8251:-- Create: `apps/frontend/src/routes/_authed.tsx` — TanStack layout route. Renders `<AppFrame><Outlet /></AppFrame>`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8252:+- Create: `apps/frontend/src/routes/_authed.tsx` — TanStack layout route. `beforeLoad` calls `fetchMe()` and redirects unauthenticated users to `/login`; renders `<AppFrame><Outlet /></AppFrame>`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8253: - Create: `apps/frontend/src/routes/_authed/vocs.tsx` — `createFileRoute('/_authed/vocs')` with validateSearch zod. Component selects shell based on `view`/`action`. Main = placeholder text.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8254: - Modify: `apps/frontend/src/routes/__root.tsx` — minimal; providers + `<Outlet>` only (no AppFrame).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8255:-- Relocate or re-parent: `apps/frontend/src/routes/admin/` — move under `_authed` so admin pages get AppFrame. If not done in C5, create a follow-up GitHub issue before closing this chunk.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8256:+- Move: `apps/frontend/src/routes/admin/managed-systems.tsx` → `apps/frontend/src/routes/_authed/admin/managed-systems.tsx`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8257:+- Move: `apps/frontend/src/routes/admin/analytics-areas.tsx` → `apps/frontend/src/routes/_authed/admin/analytics-areas.tsx`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8258:+- Move: `apps/frontend/src/routes/admin/placeholder.tsx` → `apps/frontend/src/routes/_authed/admin/placeholder.tsx`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8259:+- Move: `apps/frontend/src/routes/admin/*.test.tsx` → alongside relocated `_authed/admin/*` routes; update imports.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8261: - Auto-regen: `apps/frontend/src/routeTree.gen.ts` (TanStackRouterVite plugin handles on dev).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8262:-- Create: `apps/frontend/src/routes/__tests__/vocs.test.tsx` — navigating to `/_authed/vocs?view=inbox` resolves; invalid `?view=foo` rejected by zod; sidebar `+ New VOC` href = `/_authed/vocs?action=create`; `view=triage` renders WorkbenchShell.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8263:+- Create: `apps/frontend/src/routes/__tests__/vocs.test.tsx` — navigating to `/vocs?view=inbox` resolves; invalid `?view=foo` rejected by zod; sidebar `+ New VOC` href = `/vocs?action=create`; `view=triage` renders WorkbenchShell.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8264: - Delete: `apps/frontend/src/routes/dev-rich-editor.tsx` IF it was added in C2 and is no longer needed (or keep behind DEV flag).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8268: - Read first: `apps/frontend/src/routes/__root.tsx`, `apps/frontend/vite.config.ts`, `apps/frontend/src/routes/admin/managed-systems.tsx` (existing TanStack file-route pattern), `apps/frontend/src/lib/layout/AppFrame.tsx` (just created in C4b), `packages/ui/src/layout/` (shells).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8272:+- Constraint: no `Route.id` navigation. Run `grep -rn 'Route\\.id\\|from: .*Route\\.id\\|to: .*Route\\.id' apps/frontend/src/` and refactor any hits to literal `to:` path strings.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8291: - Sonnet dispatches read AGENTS.md hierarchy first (`apps/frontend/AGENTS.md` mandatory).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8296: - **AppFrame in `apps/frontend` NEVER becomes a 4th exported shell. Shell taxonomy = 3 (PageShell/ListShell/WorkbenchShell) per ADR-0020.**
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8307: - `@tiptap/react` in `packages/ui` — verify `apps/frontend` resolves it transitively via workspace link without explicit install; if pnpm strict-mode blocks it, add a peer dep declaration.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8358:+      {type:'modify', path:'apps/frontend/src/routes/{admin/managed-systems,admin/analytics-areas,login,index}.tsx  // token classname rename audit'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8359:+      {type:'create', path:'apps/frontend/src/__tests__/token-class-coverage.test.ts  // resolveConfig coverage for TSX token classes'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8360:       {type:'modify', path:'apps/frontend/src/styles.css  // @import tokens.css + semantic.css'}
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8382:       {type:'modify', path:'apps/frontend/src/features/admin/permissions/request-access-button.tsx:115  // variant primary→default'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8391: # apps/frontend — app-level only; NO direct @tiptap/* (consumed via @fops/ui)
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8404:     dispatch:'Sonnet. Read rich-editor.jsx + ADR-0011 + BE sanitizer.ts. Constraints: surface = opaque pass-through; StarterKit image:false; demo = local state only; @tiptap/* must NOT be installed in apps/frontend.',
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8415:-      {type:'create', path:'apps/frontend/src/lib/api/{client,errorMapper,useIdempotencyKey,types}.ts'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8416:+      {type:'create', path:'apps/frontend/src/lib/api/{client,errorMapper,useIdempotencyKey,types}.ts  // export GENERIC_ERROR_MESSAGE'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8417:       {type:'modify', path:'apps/frontend/src/routes/__root.tsx  // <Toaster position="bottom-center"/>'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8418:       {type:'create', path:'apps/frontend/src/lib/api/__tests__/{errorMapper,client}.test.ts'}
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8422:+    dispatch:'Sonnet. Read packages/shared/src/errors/codes.ts (iterate ERROR_CODES, do NOT hardcode list) + envelope.ts + voc routes.ts lines 200-260. Tests assert tone literal set, non-generic messages for VOC/rich/attachment/reporter/conflict special codes, and conflict.stale_write warning action. Checkpoint includes /dev-rich-editor sanitizer-reject toast via apiClient mock.',
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8450:-    goal:'AppFrame in apps/frontend/src/lib/layout/ composes Rail+Sidebar+shell outlet+DetailPanelSlot. NOT a 4th shell — app-internal only. useFullscreenPanel hook.',
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8451:+    goal:'AppFrame in apps/frontend/src/lib/layout/ composes Rail+Sidebar+shell outlet+the single global DetailPanelSlot. SSR-safe sidebar collapse. NOT a 4th shell.',
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8453:       {type:'create', path:'apps/frontend/src/lib/layout/AppFrame.tsx  // NOT exported as shell; wraps one of 3 shells'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8454:       {type:'create', path:'apps/frontend/src/lib/layout/AppRail.tsx'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8455:-      {type:'create', path:'apps/frontend/src/lib/layout/AppSidebar.tsx  // collapse→localStorage'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8456:-      {type:'create', path:'apps/frontend/src/lib/layout/DetailPanelSlot.tsx  // 440px, min 360, max 520'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8457:-      {type:'create', path:'apps/frontend/src/lib/layout/useDetailPanelSlot.ts'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8458:+      {type:'create', path:'apps/frontend/src/lib/layout/AppSidebar.tsx  // SSR-safe localStorage initializer; first-paint width test'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8459:+      {type:'create', path:'apps/frontend/src/lib/layout/DetailPanelSlot.tsx  // single global 440px slot, min 360, max 520'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8460:+      {type:'create', path:'apps/frontend/src/lib/layout/useDetailPanelSlot.ts  // forbid overlapping registrants'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8461:       {type:'create', path:'apps/frontend/src/lib/panel/useFullscreenPanel.ts  // Esc collapses, route change clears'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8462:       {type:'create', path:'apps/frontend/src/lib/layout/__tests__/AppFrame.test.tsx'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8463:       {type:'create', path:'apps/frontend/src/lib/panel/__tests__/useFullscreenPanel.test.tsx'}
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8477:-      {type:'create', path:'apps/frontend/src/routes/_authed.tsx  // layout route: <AppFrame><Outlet/></AppFrame>'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8478:-      {type:'create', path:'apps/frontend/src/routes/_authed/vocs.tsx  // shell selection per view/action'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8479:+      {type:'create', path:'apps/frontend/src/routes/_authed.tsx  // beforeLoad fetchMe; redirect /login on UnauthenticatedError; <AppFrame><Outlet/></AppFrame>'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8480:+      {type:'create', path:'apps/frontend/src/routes/_authed/vocs.tsx  // public path /vocs; shell selection per view/action'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8481:       {type:'modify', path:'apps/frontend/src/routes/__root.tsx  // minimal: providers + <Outlet> only'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8482:-      {type:'modify', path:'apps/frontend/src/routes/admin/  // re-parent under _authed as PageShell (or file follow-up)'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8483:-      {type:'create', path:'apps/frontend/src/routes/__tests__/vocs.test.tsx  // shell per view + login NOT in AppFrame'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8484:+      {type:'move', path:'apps/frontend/src/routes/admin/{managed-systems,analytics-areas,placeholder}.tsx → apps/frontend/src/routes/_authed/admin/  // paths /admin/* unchanged; delete per-page auth guards'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8485:+      {type:'move', path:'apps/frontend/src/routes/admin/*.test.tsx → apps/frontend/src/routes/_authed/admin/  // update imports'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8486:+      {type:'create', path:'apps/frontend/src/routes/__tests__/vocs.test.tsx  // /vocs shell per view + login NOT in AppFrame + no Route.id nav'},
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REINFORCE-2-codex.md:8487:       {type:'delete', path:'apps/frontend/src/routes/dev-rich-editor.tsx  // if not kept behind DEV flag'}
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:22:7. `apps/frontend/src/routes/__root.tsx` and `apps/frontend/vite.config.ts` (TanStack Router setup)
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:23:8. `apps/frontend/AGENTS.md` (FE rules — extraction, dumb-prop, packages/ui export)
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:80:I’m pulling structured summaries and line-numbered excerpts from the plan plus the referenced source/docs. I’ll also try `gh issue view 18`; if auth/network blocks it, I’ll fall back to the plan’s locked decisions as requested.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:135:71:- Modify: `apps/frontend/src/features/admin/permissions/request-access-button.tsx:115` — `variant="primary"` → `variant="default"` (or leave with primary alias).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:136:72:- Modify: `apps/frontend/src/styles.css` — keep `@import "@fops/ui/styles/tokens.css"` + `semantic.css` + tailwind directives.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:138:76:- Read first: `docs/design-prototype/styles.css`, `packages/ui/src/styles/{tokens,semantic}.css`, `packages/ui/tailwind.preset.ts`, `packages/ui/src/components/Button.tsx`, `packages/ui/src/components/{ManagedSystemPicker,AnalyticsAreaPicker}.tsx`, `apps/frontend/src/components-test-pickers.test.tsx`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:149:103:- Create: `apps/frontend/src/routes/dev-rich-editor.tsx` — temporary demo route (keep behind `import.meta.env.DEV` guard or delete in Final). Renders RichEditor + RichContentRenderer side by side, with surface picker + mode toggle.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:156:121:**Goal:** `<Toaster>` mounted in `__root.tsx`. `apiClient`, `errorMapper`, `useIdempotencyKey` land in `apps/frontend/src/lib/api/`. All Slice 3 ADR-0012 codes covered with Korean copy.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:157:124:- Create: `apps/frontend/src/lib/api/errorMapper.ts` — function mapping `{ code, detail }` to `{ tone: 'error'|'warning'|'info', message: string, action?: { label, run } }`. Catalog covers: validation.failed, voc.severity_not_user_settable, voc.reporter_status_via_public_update_only, validation.unexpected_field, rich_content.disallowed_node, rich_content.external_image_forbidden, attachment.unsupported_pending_storage_slice, conflict.stale_write, conflict.triage_already_committed, conflict.parent_archived, conflict.record_archived, conflict.idempotency_key_reuse, not_found.record, permission.denied, permission.scope_required, reporter_facing_status.invalid_transition, reporter_facing_status.gate_blocked, rate_limited.actor. Korean copy.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:158:125:- Create: `apps/frontend/src/lib/api/client.ts` — `apiClient(method, path, { body?, idempotencyKey?, ifMatch?, signal? })`. Auto-mint Idempotency-Key UUIDv4 on POST/PATCH/DELETE when not supplied. Attach `Authorization` from session store. Parse JSON. Non-2xx → throw `ApiError extends Error { code, detail, status, requestId }`. 304 → return `{ status: 304, etag }`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:159:126:- Create: `apps/frontend/src/lib/api/useIdempotencyKey.ts` — `useIdempotencyKey()` returns stable UUIDv4 per render-tree until consumed; `markConsumed()` mints fresh.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:160:128:- Modify: `apps/frontend/src/routes/__root.tsx` — mount `<Toaster position="bottom-center" />` from `sonner`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:161:129:- Create: `apps/frontend/src/lib/api/__tests__/errorMapper.test.ts` — enumerate every code in catalog.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:162:130:- Create: `apps/frontend/src/lib/api/__tests__/client.test.ts` — mock fetch: POST mints Idempotency-Key, GET omits, Authorization attached, 422 throws ApiError, 304 returns ETag.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:170:149:- Create: `apps/frontend/src/lib/layout/AppShell.tsx` — flex row Rail(52) + Sidebar(240/56) + Main(flex-1) + DetailPanelSlot(440 conditional). Headers 50px.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:171:155:- Create: `apps/frontend/src/lib/layout/__tests__/AppShell.test.tsx` — Rail/Sidebar/Main present; sidebar collapse toggle writes localStorage; DetailPanelSlot collapses when empty.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:172:156:- Create: `apps/frontend/src/lib/panel/__tests__/useFullscreenPanel.test.tsx` — toggle flips boolean; Esc dispatches collapse; route change clears (mock router).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:177:173:- Create: `apps/frontend/src/routes/vocs.tsx` — `createFileRoute('/vocs')` with validateSearch zod. Component renders `<AppShell>` + sidebar items linking to `?view=inbox|my|triage` + `?action=create`. Main = `<p>VOC routes land in #19/#20/#21 — current view: {view ?? action}</p>`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:178:174:- Modify: `apps/frontend/src/routes/__root.tsx` — wrap children with `<AppShell>` for authed routes (or wrap inside vocs.tsx only — decide in dispatch).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:179:175:- Auto-regen: `apps/frontend/src/routeTree.gen.ts` (TanStackRouterVite plugin handles on dev).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:180:176:- Create: `apps/frontend/src/routes/__tests__/vocs.test.tsx` — navigating to `/vocs?view=inbox` resolves; invalid `?view=foo` rejected by zod; sidebar `+ New VOC` href = `/vocs?action=create`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:181:177:- Delete: `apps/frontend/src/routes/dev-rich-editor.tsx` IF it was added in C2 and is no longer needed (or keep behind DEV flag).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:182:192:- Read first: `apps/frontend/src/routes/__root.tsx`, `apps/frontend/vite.config.ts`, `apps/frontend/src/routes/admin/managed-systems.tsx` (existing TanStack file-route pattern).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:192:226:- Sonnet dispatches read AGENTS.md hierarchy first (`apps/frontend/AGENTS.md` mandatory).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1012:/bin/zsh -lc 'rg -n "createRootRoute|Outlet|Router|AppShell|auth|login|TanStack|router|routeTree|alias|@fops|vite|extract|dumb|packages/ui|export|component|rule" apps/frontend/src/routes/__root.tsx apps/frontend/vite.config.ts apps/frontend/AGENTS.md' in /Users/hyojung/Desktop/2026/FeedbackOps
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1014:apps/frontend/src/routes/__root.tsx:1:import { Outlet, createRootRoute } from '@tanstack/react-router';
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1015:apps/frontend/src/routes/__root.tsx:3:export const Route = createRootRoute({
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1016:apps/frontend/src/routes/__root.tsx:4:  component: RootLayout,
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1017:apps/frontend/src/routes/__root.tsx:10:      <Outlet />
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1018:apps/frontend/AGENTS.md:6:- Use `docs/frontend/ui-design-system.md` for component behavior and layout contracts.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1019:apps/frontend/AGENTS.md:7:- Use `docs/frontend/component-inventory.md` before creating a new shared component.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1020:apps/frontend/AGENTS.md:18:- Keep components feature-local until a second real feature needs the same behavior; then promote stable reusable components to `packages/ui`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1021:apps/frontend/AGENTS.md:27:- Use Role Level labels: Admin, Developer, and User. Backend capability checks remain authoritative.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1022:apps/frontend/AGENTS.md:32:- Do not build repeated UI patterns directly inside screens. Create or reuse a feature-local component first, then compose it in the screen.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1023:apps/frontend/AGENTS.md:33:- Before creating a new component, check `packages/ui`, the feature's existing components, and `docs/frontend/component-inventory.md`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1024:apps/frontend/AGENTS.md:34:- Use existing wrappers under `packages/ui/src/ui` before importing shadcn/Radix primitives directly.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1025:apps/frontend/vite.config.ts:2:import { TanStackRouterVite } from '@tanstack/router-plugin/vite';
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1026:apps/frontend/vite.config.ts:3:import react from '@vitejs/plugin-react';
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1027:apps/frontend/vite.config.ts:4:import { defineConfig } from 'vite';
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1028:apps/frontend/vite.config.ts:6:export default defineConfig({
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1029:apps/frontend/vite.config.ts:7:  plugins: [TanStackRouterVite(), react()],
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1030:apps/frontend/vite.config.ts:9:    alias: {
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1031:apps/frontend/vite.config.ts:18:      // Slice 1 #3: auth endpoints + the /me identity probe live at root.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1032:apps/frontend/vite.config.ts:19:      '/auth': 'http://127.0.0.1:3011',
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1049:4:> Stack: React 18 + TypeScript 5 + Tailwind 3 + shadcn/ui (production), TipTap (rich content, per ADR-0002 / ADR-0011), TanStack Router (production route shell — see `apps/frontend/src/routes/`).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1055:58:| R-VOC-INBOX | `/vocs?view=inbox` | `apps/frontend/src/features/voc/routes/InboxRoute.tsx` → `<VocInboxScreen>` | `view=inbox` | `managedSystem=:msId\|all`, `selected=:vocId`, `tab=untriaged\|high\|unassigned\|similar\|no-link`, `filter.severity=…`, `filter.reporterStatus=…`, `filter.owner=assigned\|unassigned`, `sort=createdAt:desc\|severity:asc\|status:asc` | `<VocDetailPanel>` when `selected=` resolves | Skeleton rows (10) in `<VocList>`; detail panel skeleton sections | "큐가 비었습니다" — `<EmptyState>` with `+ New VOC` CTA | Toast on list fetch fail; `<ErrorState>` row with retry | If actor has no VOC read capability for any MS in scope → render `<PermissionBlockedPanel state="blocked_not_requestable">` instead of the list |
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1056:60:| R-VOC-TRIAGE | `/vocs?view=triage` | `apps/frontend/src/features/voc/routes/TriageRoute.tsx` → `<VocTriageScreen>` | `view=triage` | `triage=unassigned\|untriaged\|high\|waiting`, `managedSystem=:msId\|all`, `selected=:vocId` | `<TriagePanel>` (always — single-pane decision flow) | Skeleton expanded rows + panel skeleton | "모든 VOC를 triage 처리했습니다" — `<TriageEmpty>` | Toast on per-action failure; rollback optimistic state | Requires VOC triage capability (Admin or same-MS Developer). Out-of-scope VOCs surface a `<PermissionBlockedPanel state="summary_visible">` peek above the queue per backend `out_of_scope_summary` envelope. |
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1071:109:| `<TriageQueueRow>` (expanded 96px row) | `<TriageRow>` in `features/voc/components/triage/` | none | `voc: TriageQueueItem`, `selected`, `onSelect` | default · selected · stale (when optimistic-removed elsewhere) |
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1074:113:| Triage undo toast | `<UndoToast>` in `packages/ui/src/feedback/` | shadcn `<Toast>` from `sonner` (per `apps/frontend/AGENTS.md` "use installed libraries" rule) | `message`, `actionLabel: '실행 취소'`, `onAction`, `duration: 4000` | visible · dismissing |
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1103:167:| `<CommandMenu>` | `<CommandMenu>` in `apps/frontend/src/lib/command-menu/` | shadcn `<Command>` (cmdk wrapper) | `open`, `onClose`, `onNavigate`, `onScopeChange`, `commands: CommandDescriptor[]` (resolved server-side per `interaction-patterns.md` §Command menu) | open · closed · filtered · empty |
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1257:apps/backend/src/modules/voc/routes.ts:215:      // fresh If-Match (e.g. after a 409 stale_write → refetch → retry)
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1378:  'conflict.stale_write',
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1410:/bin/zsh -lc "sed -n '1,45p' apps/frontend/src/routes/__root.tsx && sed -n '1,45p' apps/frontend/vite.config.ts" in /Users/hyojung/Desktop/2026/FeedbackOps
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1507:      // fresh If-Match (e.g. after a 409 stale_write → refetch → retry)
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1609:| Headers | `Content-Type: application/json`, `Idempotency-Key: <uuidv4>` (required from frontend — prevents double-submit on Create), session cookie (`fops_session`, HttpOnly + SameSite=Lax — set by `POST /auth/mock-login` or production OIDC handler) |
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1618:Tailwind config lives in `apps/frontend/tailwind.config.ts`. **CSS custom properties from `docs/design-prototype/styles.css` port verbatim**; Tailwind config exposes them as kebab-case theme keys.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1744:- Create: `apps/frontend/src/routes/dev-rich-editor.tsx` — temporary demo route (keep behind `import.meta.env.DEV` guard or delete in Final). Renders RichEditor + RichContentRenderer side by side, with surface picker + mode toggle.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1753:# apps/frontend
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1770:    55	# apps/frontend
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1786:    71	- Modify: `apps/frontend/src/features/admin/permissions/request-access-button.tsx:115` — `variant="primary"` → `variant="default"` (or leave with primary alias).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1787:    72	- Modify: `apps/frontend/src/styles.css` — keep `@import "@fops/ui/styles/tokens.css"` + `semantic.css` + tailwind directives.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1804:   103	- Create: `apps/frontend/src/routes/dev-rich-editor.tsx` — temporary demo route (keep behind `import.meta.env.DEV` guard or delete in Final). Renders RichEditor + RichContentRenderer side by side, with surface picker + mode toggle.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1810:   121	**Goal:** `<Toaster>` mounted in `__root.tsx`. `apiClient`, `errorMapper`, `useIdempotencyKey` land in `apps/frontend/src/lib/api/`. All Slice 3 ADR-0012 codes covered with Korean copy.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1813:   124	- Create: `apps/frontend/src/lib/api/errorMapper.ts` — function mapping `{ code, detail }` to `{ tone: 'error'|'warning'|'info', message: string, action?: { label, run } }`. Catalog covers: validation.failed, voc.severity_not_user_settable, voc.reporter_status_via_public_update_only, validation.unexpected_field, rich_content.disallowed_node, rich_content.external_image_forbidden, attachment.unsupported_pending_storage_slice, conflict.stale_write, conflict.triage_already_committed, conflict.parent_archived, conflict.record_archived, conflict.idempotency_key_reuse, not_found.record, permission.denied, permission.scope_required, reporter_facing_status.invalid_transition, reporter_facing_status.gate_blocked, rate_limited.actor. Korean copy.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1814:   125	- Create: `apps/frontend/src/lib/api/client.ts` — `apiClient(method, path, { body?, idempotencyKey?, ifMatch?, signal? })`. Auto-mint Idempotency-Key UUIDv4 on POST/PATCH/DELETE when not supplied. Attach `Authorization` from session store. Parse JSON. Non-2xx → throw `ApiError extends Error { code, detail, status, requestId }`. 304 → return `{ status: 304, etag }`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1815:   126	- Create: `apps/frontend/src/lib/api/useIdempotencyKey.ts` — `useIdempotencyKey()` returns stable UUIDv4 per render-tree until consumed; `markConsumed()` mints fresh.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1816:   127	- Create: `apps/frontend/src/lib/api/types.ts` — `ApiErrorEnvelope` matching BE `errors/envelope.ts`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1817:   128	- Modify: `apps/frontend/src/routes/__root.tsx` — mount `<Toaster position="bottom-center" />` from `sonner`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1818:   129	- Create: `apps/frontend/src/lib/api/__tests__/errorMapper.test.ts` — enumerate every code in catalog.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1819:   130	- Create: `apps/frontend/src/lib/api/__tests__/client.test.ts` — mock fetch: POST mints Idempotency-Key, GET omits, Authorization attached, 422 throws ApiError, 304 returns ETag.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1825:   149	- Create: `apps/frontend/src/lib/layout/AppShell.tsx` — flex row Rail(52) + Sidebar(240/56) + Main(flex-1) + DetailPanelSlot(440 conditional). Headers 50px.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1826:   150	- Create: `apps/frontend/src/lib/layout/AppRail.tsx` — 52px vertical, workspace switcher placeholder + lucide-react utility icons.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1827:   151	- Create: `apps/frontend/src/lib/layout/AppSidebar.tsx` — 240px nav list. Slice 3 entries: Inbox, My VOCs, Triage, + New VOC. Collapse button writes `localStorage.appSidebarCollapsed`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1828:   152	- Create: `apps/frontend/src/lib/layout/DetailPanelSlot.tsx` — fixed 440 right column. min 360 / max 520. Hidden when no content registered via `useDetailPanelSlot()`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1829:   153	- Create: `apps/frontend/src/lib/layout/useDetailPanelSlot.ts` — context-based slot register/clear hook.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1830:   154	- Create: `apps/frontend/src/lib/panel/useFullscreenPanel.ts` — `[isFullscreen, toggle]`. Esc collapses. Route change clears.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1831:   155	- Create: `apps/frontend/src/lib/layout/__tests__/AppShell.test.tsx` — Rail/Sidebar/Main present; sidebar collapse toggle writes localStorage; DetailPanelSlot collapses when empty.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1832:   156	- Create: `apps/frontend/src/lib/panel/__tests__/useFullscreenPanel.test.tsx` — toggle flips boolean; Esc dispatches collapse; route change clears (mock router).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1849:   173	- Create: `apps/frontend/src/routes/vocs.tsx` — `createFileRoute('/vocs')` with validateSearch zod. Component renders `<AppShell>` + sidebar items linking to `?view=inbox|my|triage` + `?action=create`. Main = `<p>VOC routes land in #19/#20/#21 — current view: {view ?? action}</p>`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1850:   174	- Modify: `apps/frontend/src/routes/__root.tsx` — wrap children with `<AppShell>` for authed routes (or wrap inside vocs.tsx only — decide in dispatch).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1851:   175	- Auto-regen: `apps/frontend/src/routeTree.gen.ts` (TanStackRouterVite plugin handles on dev).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1852:   176	- Create: `apps/frontend/src/routes/__tests__/vocs.test.tsx` — navigating to `/vocs?view=inbox` resolves; invalid `?view=foo` rejected by zod; sidebar `+ New VOC` href = `/vocs?action=create`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1853:   177	- Delete: `apps/frontend/src/routes/dev-rich-editor.tsx` IF it was added in C2 and is no longer needed (or keep behind DEV flag).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1872:   226	- Sonnet dispatches read AGENTS.md hierarchy first (`apps/frontend/AGENTS.md` mandatory).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1963:**Issue:** C4 builds only `AppShell` in `apps/frontend/src/lib/layout/`, but ADR-0020 requires every route to classify as `PageShell`, `ListShell`, or `WorkbenchShell` and says `packages/ui/src/layout/` must export exactly those three shell components (`docs/adr/0020-shell-taxonomy-three-route-shells-and-50px-header-rhythm.md:15`, `docs/adr/0020-shell-taxonomy-three-route-shells-and-50px-header-rhythm.md:48`).  
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1969:**Issue:** C5 says to wrap `__root.tsx` with `AppShell` for authed routes “or wrap inside vocs.tsx only — decide in dispatch.” Existing root is a simple global wrapper with `<Outlet />` (`apps/frontend/src/routes/__root.tsx:3`).  
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1975:**Issue:** `RichEditor.tsx` lives in `packages/ui`, but `@tiptap/react`, `@tiptap/starter-kit`, `@tiptap/extension-link`, `@tiptap/extension-underline`, and `@tiptap/extension-placeholder` are installed only in `apps/frontend`.  
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1977:**Suggested fix:** Move all TipTap runtime deps used by `packages/ui/src/rich-content/*` into `@fops/ui` dependencies. Keep only app-owned deps in `apps/frontend`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:1993:**Issue:** The backend includes `If-Match` in the idempotency hash and warns that a fresh `If-Match` requires a fresh key (`apps/backend/src/modules/voc/routes.ts:214`). The plan exposes `ifMatch?` and a stable `useIdempotencyKey`, but does not define when the key is consumed/refreshed after stale-write refetch.  
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:2051:**Issue:** C4 builds only `AppShell` in `apps/frontend/src/lib/layout/`, but ADR-0020 requires every route to classify as `PageShell`, `ListShell`, or `WorkbenchShell` and says `packages/ui/src/layout/` must export exactly those three shell components (`docs/adr/0020-shell-taxonomy-three-route-shells-and-50px-header-rhythm.md:15`, `docs/adr/0020-shell-taxonomy-three-route-shells-and-50px-header-rhythm.md:48`).  
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:2057:**Issue:** C5 says to wrap `__root.tsx` with `AppShell` for authed routes “or wrap inside vocs.tsx only — decide in dispatch.” Existing root is a simple global wrapper with `<Outlet />` (`apps/frontend/src/routes/__root.tsx:3`).  
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:2063:**Issue:** `RichEditor.tsx` lives in `packages/ui`, but `@tiptap/react`, `@tiptap/starter-kit`, `@tiptap/extension-link`, `@tiptap/extension-underline`, and `@tiptap/extension-placeholder` are installed only in `apps/frontend`.  
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:2065:**Suggested fix:** Move all TipTap runtime deps used by `packages/ui/src/rich-content/*` into `@fops/ui` dependencies. Keep only app-owned deps in `apps/frontend`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-PLAN-REVIEW-codex.md:2081:**Issue:** The backend includes `If-Match` in the idempotency hash and warns that a fresh `If-Match` requires a fresh key (`apps/backend/src/modules/voc/routes.ts:214`). The plan exposes `ifMatch?` and a stable `useIdempotencyKey`, but does not define when the key is consumed/refreshed after stale-write refetch.  
+.review/CHUNK-6-DEVIATIONS.md:13:**Files modified:** `apps/frontend/src/features/voc/hooks/__tests__/useVocEditDescriptionMutation.test.ts`
+.review/CHUNK-6-DEVIATIONS.md:25:**Issue:** Accessing `form.formState.isDirty` only inside `handleCancel` (a callback) creates a stale closure — react-hook-form's proxy-based `formState` only subscribes the component to re-renders when the property is accessed in the render path.
+.review/CHUNK-6-DEVIATIONS.md:39:**Fix:** Added `@testing-library/user-event ^14.6.1` to `apps/frontend/package.json` devDependencies.
+.review/CHUNK-6-DEVIATIONS.md:41:**Files modified:** `apps/frontend/package.json`, `pnpm-lock.yaml`
+.review/CHUNK-6-DEVIATIONS.md:55:**Files affected (not C6.2 introduced):** `apps/frontend/src/features/voc/components/create/AttachmentDropzone.tsx`
+.review/CHUNK-6-DEVIATIONS.md:73:### D-C6.3-1: stale_write/permission.denied integration tests use TriagePanel directly (not VocTriageScreen)
+.review/CHUNK-6-DEVIATIONS.md:75:**Found during:** GREEN phase — integration tests for stale_write and permission.denied re-insert path.
+.review/CHUNK-6-DEVIATIONS.md:83:**Files modified:** `apps/frontend/src/features/voc/__tests__/integration/voc-triage-flow.integration.test.tsx`
+.review/CHUNK-6-DEVIATIONS.md:135:### D-REV1-8: EditDescriptionModal stale_write now invalidates query
+.review/CHUNK-6-DEVIATIONS.md:141:**Issue:** `conflict.stale_write` only toasted; the modal's `voc.updated_at` (If-Match baseline) stayed stale, causing retry loops.
+.review/CHUNK-6-DEVIATIONS.md:143:**Fix:** On `conflict.stale_write`, call `queryClient.invalidateQueries({ queryKey: ['voc', voc.id] })`. The existing `useEffect` keyed on `[voc.id, voc.updated_at]` then re-populates form defaults from the refreshed VOC envelope on the next render. Toast message changed to "VOC가 변경되었습니다. 새로 불러왔습니다. 다시 시도해 주세요." to communicate the refresh to the user. Modal stays open with user's edits preserved.
+.review/CHUNK-6-DEVIATIONS.md:176:- `apps/frontend/src/features/voc/components/detail/__tests__/ReporterStatusChangeBlock.test.tsx`
+.review/CHUNK-6-DEVIATIONS.md:177:- `apps/frontend/src/features/voc/hooks/__tests__/useReporterStatusTransitions.test.ts`
+.review/CHUNK-6-DEVIATIONS.md:183:**Origin:** codex REV-1 finding #5 explicitly asked for a real `VocTriageScreen` integration test, not a `TriagePanel`-direct one (the original C6.3 stale_write/permission tests bypassed `VocTriageScreen`, exactly where the restore-id bug lived).
+.review/CHUNK-6-DEVIATIONS.md:185:**Added:** `apps/frontend/src/features/voc/components/triage/__tests__/VocTriageScreen.errorRollback.test.tsx`.
+.review/CHUNK-6-DEVIATIONS.md:187:Both tests render the full `VocTriageScreen`, click confirm on VOC_A, wait for the auto-advance to VOC_B, then release a deferred PATCH error (409 stale_write / 403 permission.denied). They assert that VOC_A reappears in the queue and VOC_B remains — the failure mode that the prior C6.3 tests could not catch.
+.review/CHUNK-6-DEVIATIONS.md:195:### D-REV2-G2: EditDescriptionModal stale_write reload via action button (no auto-reset)
+.review/CHUNK-6-DEVIATIONS.md:199:**Issue:** `useEffect([voc.id, voc.updated_at])` unconditionally `form.reset(...)`d when the refetch landed. A user typing between the 409 toast and the refetch completion had their edits clobbered.
+.review/CHUNK-6-DEVIATIONS.md:202:- Removed the `voc.updated_at` dependency from the reset effect — auto-reset now only fires when `voc.id` changes (i.e., the modal is being reused for a different VOC entirely).
+.review/CHUNK-6-DEVIATIONS.md:203:- On `conflict.stale_write` the toast carries an action button `다시 불러오기` that explicitly resets the form to the refetched defaults.
+.review/CHUNK-6-DEVIATIONS.md:206:**Files modified:** `apps/frontend/src/features/voc/components/detail/EditDescriptionModal.tsx`.
+.review/CHUNK-6-DEVIATIONS.md:208:**RED → GREEN test:** `apps/frontend/src/features/voc/components/detail/__tests__/EditDescriptionModal.staleWriteReload.test.tsx` — (a) edits survive a mid-flight refetch; (b) the action button resets to the refetched defaults.
+.review/CHUNK-6-DEVIATIONS.md:212:### D-REV2-G5: TriageRoute capability gate via /me/permissions/check (not role label)
+.review/CHUNK-6-DEVIATIONS.md:223:**Files modified:** `apps/frontend/src/features/voc/routes/TriageRoute.tsx`, `apps/frontend/src/features/voc/routes/__tests__/TriageRoute.test.tsx` (mocks usePermissionCheck instead of role_level), `apps/frontend/src/features/voc/hooks/useVocList.ts` (added `enabled?: boolean`).
+.review/CHUNK-6-DEVIATIONS.md:225:**RED → GREEN test:** `apps/frontend/src/features/voc/routes/__tests__/TriageRoute.capability.test.tsx` — 3 cases: blocked actor sees PermissionBlockedPanel; approved actor sees the queue; blocked actor's useVocList is invoked with `enabled: false`.
+.review/CHUNK-6-DEVIATIONS.md:236:**Issue:** `handleReloadFromVoc` reset the form synchronously from `vocRef.current`. After the stale_write 409, the modal invalidates `['voc', id]` but the refetch is async. If the user clicked 다시 불러오기 before the refetch landed, `vocRef.current` was still the OLD `voc` prop (the parent hasn't re-rendered with the refetched data yet), and the form was reset to the stale values — the very state the user was trying to leave.
+.review/CHUNK-6-DEVIATIONS.md:240:**Files modified:** `apps/frontend/src/features/voc/components/detail/EditDescriptionModal.tsx`.
+.review/CHUNK-6-DEVIATIONS.md:242:**RED → GREEN test:** `apps/frontend/src/features/voc/components/detail/__tests__/EditDescriptionModal.reloadAwaitsRefetch.test.tsx` — pre-seeds the QueryClient with V1, intercepts `refetchQueries` to swap the cache to V2 only when released, asserts the action handler (a) calls `refetchQueries` with `['voc', id]`, (b) does NOT reset until the refetch resolves, and (c) resets to V2 fields after release (despite the parent still passing V1 as the `voc` prop).
+.review/CHUNK-6-DEVIATIONS.md:246:## REV-4 (codex Cycle 4) — Cluster Y P1 fix: refetch-failure surface error + no stale PATCH
+.review/CHUNK-6-DEVIATIONS.md:248:### D-REV4-P1: refetch failure in compensateFn now surfaces toast and stops stale PATCH
+.review/CHUNK-6-DEVIATIONS.md:252:**Issue:** When the first PATCH response lacks a fresh `updated_at` (empty body), `compensateFn` refetches the VOC. The catch block silently swallowed refetch errors and fell through to `executeCompensatingPatch` with the original stale `If-Match` — guaranteed to 409. Additionally, `undoLast` called `void compensate()` fire-and-forget. If `compensateFn` threw (either from refetch failure or from the compensating PATCH itself), the rejection became unhandled with no user-facing feedback.
+.review/CHUNK-6-DEVIATIONS.md:255:1. **`TriagePanel.tsx` catch block**: when refetch throws, surface `toast.error('VOC를 새로 불러올 수 없습니다. 잠시 후 다시 시도해 주세요.')`, tag the error with `__refetchFailure: true`, and re-throw. This stops `executeCompensatingPatch` from running with a stale `If-Match`.
+.review/CHUNK-6-DEVIATIONS.md:260:- `apps/frontend/src/features/voc/components/triage/TriagePanel.tsx`
+.review/CHUNK-6-DEVIATIONS.md:261:- `apps/frontend/src/features/voc/hooks/useUndoableMutation.ts`
+.review/CHUNK-6-DEVIATIONS.md:263:**RED → GREEN test:** `apps/frontend/src/features/voc/components/triage/__tests__/TriagePanel.refetchFailure.test.tsx` — 3 cases: (1) refetch fails → toast + no compensating PATCH + no unhandled rejection; (2) refetch succeeds, compensating PATCH 409s → toast; (3) happy path → `onOptimisticRestore` called, no error toast.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:32:7. `apps/frontend/src/lib/layout/{AppFrame,AppRail,AppSidebar}.tsx` — frame composition
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:33:8. `apps/frontend/src/lib/api/{client,errorMapper,useIdempotencyKey,types,index}.ts` — api primitives
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:34:9. `apps/frontend/src/routes/_authed.tsx` + `_authed/vocs.tsx` + `_authed/admin/*.tsx` — route shells
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:36:11. `apps/frontend/AGENTS.md` (FE extraction rules — two-consumer rule, dumb-prop, packages/ui export)
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:37:12. `apps/frontend/CONTEXT.md`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:50:23. `apps/frontend/src/lib/api/errorMapper.ts` (CATALOG) vs the above two
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:51:24. `apps/frontend/src/lib/api/client.ts` (headers list) vs BE expectation
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:52:25. `apps/frontend/src/lib/api/types.ts` (ApiErrorEnvelope) vs `packages/shared/src/errors/codes.ts`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:186:/bin/zsh -lc "node -e \"const fs=require('fs'); const files=['apps/frontend/src/lib/api/client.ts','apps/frontend/src/lib/api/errorMapper.ts','apps/frontend/src/lib/api/types.ts','apps/frontend/src/lib/api/useIdempotencyKey.ts','apps/backend/src/modules/voc/routes.ts','apps/backend/src/lib/errors/envelope.ts','apps/backend/src/lib/errors/registry.ts','packages/shared/src/errors/codes.ts','packages/shared/src/vocs/index.ts','apps/backend/src/modules/voc/repo/idempotency.ts','apps/backend/src/lib/etag.ts']; const rx=/export|ErrorCode|code:|error|headers|Idempotency|idempotency|If-Match|If-None-Match|ETag|etag|RateLimit|rate-limit|router\\.|\\.get\\(|\\.post\\(|\\.patch\\(|\\.delete\\(|@fops\\/shared|z\\.|schema|parse|Envelope|fetch|Content-Type|Accept|Authorization|X-/i; for (const f of files){console.log('\\n## '+f); if("'!fs.existsSync(f)){console.log('"'MISSING'); continue} fs.readFileSync(f,'utf8').split('\\n').forEach((l,i)=>{if(rx.test(l)) console.log((i+1)+': '+l.slice(0,220))})}\"" in /Users/hyojung/Desktop/2026/FeedbackOps
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:189:## apps/frontend/src/lib/api/client.ts
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:218:## apps/frontend/src/lib/api/errorMapper.ts
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:257:150:   if (envelope.code === 'conflict.stale_write' && opts?.onRetry) {
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:261:## apps/frontend/src/lib/api/types.ts
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:275:## apps/frontend/src/lib/api/useIdempotencyKey.ts
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:369:215:       // fresh If-Match (e.g. after a 409 stale_write → refetch → retry)
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:551:apps/backend/src/modules/permissions/AGENTS.md
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:586:apps/frontend/CONTEXT.md
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:603:apps/frontend/AGENTS.md
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:621:apps/frontend/src/routes/__tests__/vocs.test.tsx
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:622:apps/frontend/src/features/surveys/AGENTS.md
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:623:apps/frontend/src/features/tasks/AGENTS.md
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:624:apps/frontend/src/routes/_authed/vocs.tsx
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:625:apps/frontend/src/features/voc/AGENTS.md
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:626:apps/frontend/src/features/home/AGENTS.md
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:627:apps/frontend/src/features/admin/AGENTS.md
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:630:apps/frontend/src/features/integration/AGENTS.md
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:631:apps/frontend/src/features/my-work/AGENTS.md
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:632:apps/frontend/src/lib/layout/AppSidebar.tsx
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:633:apps/frontend/src/lib/layout/AppFrame.tsx
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:634:apps/frontend/src/lib/layout/AppRail.tsx
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:635:apps/frontend/src/lib/layout/__tests__/AppSidebar.test.tsx
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:636:apps/frontend/src/lib/layout/__tests__/AppFrame.test.tsx
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:1067:/bin/zsh -lc "nl -ba packages/shared/src/errors/codes.ts | sed -n '1,90p'; printf '\\n--- errorMapper ---\\n'; nl -ba apps/frontend/src/lib/api/errorMapper.ts | sed -n '1,180p'; printf '\\n--- api tests? ---\\n'; nl -ba apps/frontend/src/lib/api/__tests__/errorMapper.test.ts | sed -n '1,220p'" in /Users/hyojung/Desktop/2026/FeedbackOps
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:1117:    49	  'conflict.stale_write',
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:1228:    81	  'conflict.stale_write': {
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:1297:   150	  if (envelope.code === 'conflict.stale_write' && opts?.onRetry) {
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:1321:    14	  'conflict.stale_write',
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:1359:    52	  it('conflict.stale_write maps to warning + retry action when onRetry provided', () => {
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:1362:    55	      { code: 'conflict.stale_write', message: '' },
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:1389:const fs=require('fs'); const files=['packages/ui/src/index.ts','packages/ui/src/components/Button.tsx','packages/ui/src/components/ManagedSystemPicker.tsx','packages/ui/src/components/AnalyticsAreaPicker.tsx','packages/ui/src/layout/PageShell.tsx','packages/ui/src/layout/ListShell.tsx','packages/ui/src/layout/WorkbenchShell.tsx','packages/ui/src/layout/ShellHeader.tsx','packages/ui/src/layout/useDetailPanelSlot.ts','apps/frontend/src/lib/layout/AppFrame.tsx','apps/frontend/src/lib/layout/AppRail.tsx','apps/frontend/src/lib/layout/AppSidebar.tsx','apps/frontend/AGENTS.md','packages/ui/CONTEXT.md','docs/frontend/specs/voc.md']; const rx=/export|interface|type |function|const |children|render|slot|Shell|Picker|Combobox|items|options|value|onValueChange|selected|PageShell|ListShell|WorkbenchShell|AppFrame|AppRail|AppSidebar|two-consumer|consumer|extract|@fops\\/ui|component inventory|VOC|RichEditor|RichContent/i; for (const f of files){console.log('\\n## '+f); if("'!fs.existsSync(f)){console.log('"'MISSING'); continue} fs.readFileSync(f,'utf8').split('\\n').forEach((l,i)=>{if(rx.test(l)) console.log((i+1)+': '+l.slice(0,240))})}
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:1587:16:  * AppFrame in apps/frontend/src/lib/layout/ provides the context. If a shell renders outside
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:1593:## apps/frontend/src/lib/layout/AppFrame.tsx
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:1630:## apps/frontend/src/lib/layout/AppRail.tsx
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:1641:## apps/frontend/src/lib/layout/AppSidebar.tsx
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:1659:## apps/frontend/AGENTS.md
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:1670:4: > Stack: React 18 + TypeScript 5 + Tailwind 3 + shadcn/ui (production), TipTap (rich content, per ADR-0002 / ADR-0011), TanStack Router (production route shell — see `apps/frontend/src/routes/`).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:1686:47: | Frontend module guide | `apps/frontend/AGENTS.md`, `apps/frontend/src/features/voc/AGENTS.md` (TBD — write at S3-006 prologue) |
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:1687:54: Production uses TanStack Router (`apps/frontend/src/routes/`) with query-param state. The prototype's `#route=voc&view=inbox&selected=...` maps to `/vocs?view=inbox&selected=...`.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:1688:58: | R-VOC-INBOX | `/vocs?view=inbox` | `apps/frontend/src/features/voc/routes/InboxRoute.tsx` → `<VocInboxScreen>` | `view=inbox` | `managedSystem=:msId\|all`, `selected=:vocId`, `tab=untriaged\|high\|unassigned\|similar\|no-link`, `filter.se
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:1690:60: | R-VOC-TRIAGE | `/vocs?view=triage` | `apps/frontend/src/features/voc/routes/TriageRoute.tsx` → `<VocTriageScreen>` | `view=triage` | `triage=unassigned\|untriaged\|high\|waiting`, `managedSystem=:msId\|all`, `selected=:vocId` | `<TriagePa
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:1691:61: | R-VOC-CREATE | `/vocs?action=create` | `apps/frontend/src/features/voc/routes/CreateRoute.tsx` → `<VocCreateScreen>` | `action=create` | `managedSystem=:msId` (seeds picker), `prefill=…` (future) | none (full-page form) | Skeleton form | 
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:1697:78: Production tree under `apps/frontend/src/features/voc/`. Shared primitives live in `packages/ui/src/` (extracted only after a second feature consumer exists, per `apps/frontend/AGENTS.md`).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:1713:109: | `<TriageQueueRow>` (expanded 96px row) | `<TriageRow>` in `features/voc/components/triage/` | none | `voc: TriageQueueItem`, `selected`, `onSelect` | default · selected · stale (when optimistic-removed elsewhere) |
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:1741:156: | `<PermissionBlockedPanel state category reason requiredScope summary>` | `<PermissionBlockedPanel>` in `packages/ui/src/permissions/` | shadcn `<Alert>` (custom layout) | `state: 'request_access' \| 'summary_visible' \| 'denied' \| 'block
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:1808:363: `<PermissionBlockedPanel state="request_access">` CTA navigates to `/admin/permissions/requests?action=create&capability=read_finding&scope=<requiredScope>&source_entity=VOC:<vocId>&return=<currentUrl>`. Slice 3 does not ship in-product per
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:1819:403: 3. If user selects a forbidden status (only possible via keyboard or stale data), a red `<Callout>` explains `voc.next_reporter_states.forbidden[next]` (e.g. "결과 확인 전에 해결됨으로 바꿀 수 없습니다.").
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:1846:560: 3. If state === 'request_access': render CTA, on click navigate to /admin/permissions/requests?action=create with prefill.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:1922:/bin/zsh -lc "nl -ba packages/ui/src/components/ManagedSystemPicker.tsx | sed -n '1,130p'; printf '\\n--- AA ---\\n'; nl -ba packages/ui/src/components/AnalyticsAreaPicker.tsx | sed -n '1,120p'; printf '\\n--- route vocs ---\\n'; nl -ba apps/frontend/src/routes/_authed/vocs.tsx | sed -n '1,220p'; printf '\\n--- authed ---\\n'; nl -ba apps/frontend/src/routes/_authed.tsx | sed -n '1,180p'; printf '\\n--- admin ms ---\\n'; nl -ba apps/frontend/src/routes/_authed/admin/managed-systems.tsx | sed -n '1,160p'; printf '\\n--- admin aa ---\\n'; nl -ba apps/frontend/src/routes/_authed/admin/analytics-areas.tsx | sed -n '1,180p'" in /Users/hyojung/Desktop/2026/FeedbackOps
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2259:    13	import { PermissionGate } from '../../../features/admin/permissions/permission-gate.js';
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2421:    13	import { PermissionGate } from '../../../features/admin/permissions/permission-gate.js';
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2595:/bin/zsh -lc "nl -ba apps/frontend/src/routes/_authed/admin/analytics-areas.tsx | sed -n '180,360p'; printf '\\n--- ms rest ---\\n'; nl -ba apps/frontend/src/routes/_authed/admin/managed-systems.tsx | sed -n '160,360p'" in /Users/hyojung/Desktop/2026/FeedbackOps
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2873:/bin/zsh -lc "rg -n \"interface (CreateVoc|PatchVoc|Voc|PublicUpdate|ReporterReply|InternalComment|VocDetail|VocList)|type (CreateVoc|PatchVoc|Voc|PublicUpdate|ReporterReply|InternalComment|VocDetail|VocList)|description_rich_content|body_rich_content|@fops/shared|ApiErrorEnvelope|ErrorEnvelope|rate_limited|Idempotency-Key|If-Match|If-None-Match|etag|x-request-id\" apps/frontend/src apps/frontend/src/lib/api packages/ui/src -g '*.ts' -g '*.tsx'" in /Users/hyojung/Desktop/2026/FeedbackOps
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2875:apps/frontend/src/lib/api/client.ts:1:import { ApiError, type ApiErrorEnvelope } from './types';
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2876:apps/frontend/src/lib/api/client.ts:15:  etag: string | undefined;
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2877:apps/frontend/src/lib/api/client.ts:19:// PUT is intentionally excluded: the locked API contract auto-mints Idempotency-Key
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2878:apps/frontend/src/lib/api/client.ts:34:    headers['Idempotency-Key'] = opts.idempotencyKey ?? mintInlineKey();
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2879:apps/frontend/src/lib/api/client.ts:36:  if (opts.ifMatch) headers['If-Match'] = opts.ifMatch;
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2880:apps/frontend/src/lib/api/client.ts:37:  if (opts.ifNoneMatch) headers['If-None-Match'] = opts.ifNoneMatch;
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2881:apps/frontend/src/lib/api/client.ts:50:  const etag = res.headers.get('etag') ?? undefined;
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2882:apps/frontend/src/lib/api/client.ts:51:  const requestId = res.headers.get('x-request-id') ?? undefined;
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2883:apps/frontend/src/lib/api/client.ts:54:    return { status: 304, data: undefined as T, etag, requestId };
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2884:apps/frontend/src/lib/api/client.ts:61:    const envelope: ApiErrorEnvelope =
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2885:apps/frontend/src/lib/api/client.ts:63:        ? (data as ApiErrorEnvelope)
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2886:apps/frontend/src/lib/api/client.ts:68:  return { status: res.status, data: data as T, etag, requestId };
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2887:apps/frontend/src/lib/api/types.ts:1:import type { ErrorCode } from '@fops/shared';
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2888:apps/frontend/src/lib/api/types.ts:3:export interface ApiErrorEnvelope {
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2889:apps/frontend/src/lib/api/types.ts:17:    public readonly envelope: ApiErrorEnvelope,
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2890:apps/frontend/src/lib/api/errorMapper.ts:1:import { ERROR_CODES, type ErrorCode } from '@fops/shared';
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2891:apps/frontend/src/lib/api/errorMapper.ts:2:import type { ApiErrorEnvelope, MappedError, Tone } from './types';
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2892:apps/frontend/src/lib/api/errorMapper.ts:31:  // rate_limited.*
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2893:apps/frontend/src/lib/api/errorMapper.ts:32:  'rate_limited.actor': {
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2894:apps/frontend/src/lib/api/errorMapper.ts:36:  'rate_limited.ip': {
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2895:apps/frontend/src/lib/api/errorMapper.ts:47:    message: 'Idempotency-Key가 잘못된 형식입니다. 새로고침 후 다시 시도해 주세요.',
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2896:apps/frontend/src/lib/api/errorMapper.ts:134:  envelope: ApiErrorEnvelope,
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2897:apps/frontend/src/lib/api/__tests__/client.test.ts:43:  it('POST attaches auto-minted Idempotency-Key UUID', async () => {
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2898:apps/frontend/src/lib/api/__tests__/client.test.ts:48:    expect(headers['Idempotency-Key']).toBeTruthy();
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2899:apps/frontend/src/lib/api/__tests__/client.test.ts:49:    expect((headers['Idempotency-Key'] as string).length).toBeGreaterThanOrEqual(10);
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2900:apps/frontend/src/lib/api/__tests__/client.test.ts:52:  it('GET omits Idempotency-Key', async () => {
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2901:apps/frontend/src/lib/api/__tests__/client.test.ts:57:    expect(headers['Idempotency-Key']).toBeUndefined();
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2902:apps/frontend/src/lib/api/__tests__/client.test.ts:60:  it('PATCH attaches If-Match when provided', async () => {
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2903:apps/frontend/src/lib/api/__tests__/client.test.ts:65:    expect(headers['If-Match']).toBe('W/"abc"');
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2904:apps/frontend/src/lib/api/__tests__/client.test.ts:90:  it('304 returns etag without throwing', async () => {
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2905:apps/frontend/src/lib/api/__tests__/client.test.ts:91:    const fetchMock = mockFetch({ ok: true, status: 304, headers: { etag: 'W/"abc"' } });
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2906:apps/frontend/src/lib/api/__tests__/client.test.ts:95:    expect(res.etag).toBe('W/"abc"');
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2907:apps/frontend/src/lib/api/__tests__/client.test.ts:98:  it('PUT does not auto-attach Idempotency-Key', async () => {
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2908:apps/frontend/src/lib/api/__tests__/client.test.ts:103:    expect(headers['Idempotency-Key']).toBeUndefined();
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2909:apps/frontend/src/lib/api/useIdempotencyKey.ts:19: * Stable Idempotency-Key per call site. Re-mints automatically when `ifMatchEtag` changes
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2910:apps/frontend/src/lib/api/useIdempotencyKey.ts:20: * (BE rule: idempotency hash includes If-Match; same key + new etag → conflict.idempotency_key_reuse).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2911:apps/frontend/src/lib/api/useIdempotencyKey.ts:27:  // Single ref holds { etag, key } together to allow synchronous derivation during render.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2912:apps/frontend/src/lib/api/useIdempotencyKey.ts:28:  const ref = useRef<{ etag: string | undefined; key: string }>({
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2913:apps/frontend/src/lib/api/useIdempotencyKey.ts:29:    etag: ifMatchEtag,
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2914:apps/frontend/src/lib/api/useIdempotencyKey.ts:33:  // Synchronous derivation: if etag changed, mint a new key before returning.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2915:apps/frontend/src/lib/api/useIdempotencyKey.ts:34:  if (ref.current.etag !== ifMatchEtag) {
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2916:apps/frontend/src/lib/api/useIdempotencyKey.ts:35:    ref.current = { etag: ifMatchEtag, key: mintKey() };
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2917:apps/frontend/src/lib/api/useIdempotencyKey.ts:43:    ref.current = { etag: ref.current.etag, key: mintKey() };
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2918:apps/frontend/src/lib/api/client.ts:1:import { ApiError, type ApiErrorEnvelope } from './types';
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2919:apps/frontend/src/lib/api/client.ts:15:  etag: string | undefined;
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2920:apps/frontend/src/lib/api/client.ts:19:// PUT is intentionally excluded: the locked API contract auto-mints Idempotency-Key
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2921:apps/frontend/src/lib/api/client.ts:34:    headers['Idempotency-Key'] = opts.idempotencyKey ?? mintInlineKey();
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2922:apps/frontend/src/lib/api/client.ts:36:  if (opts.ifMatch) headers['If-Match'] = opts.ifMatch;
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2923:apps/frontend/src/lib/api/client.ts:37:  if (opts.ifNoneMatch) headers['If-None-Match'] = opts.ifNoneMatch;
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2924:apps/frontend/src/lib/api/client.ts:50:  const etag = res.headers.get('etag') ?? undefined;
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2925:apps/frontend/src/lib/api/client.ts:51:  const requestId = res.headers.get('x-request-id') ?? undefined;
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2926:apps/frontend/src/lib/api/client.ts:54:    return { status: 304, data: undefined as T, etag, requestId };
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2927:apps/frontend/src/lib/api/client.ts:61:    const envelope: ApiErrorEnvelope =
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2928:apps/frontend/src/lib/api/client.ts:63:        ? (data as ApiErrorEnvelope)
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2929:apps/frontend/src/lib/api/client.ts:68:  return { status: res.status, data: data as T, etag, requestId };
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2930:apps/frontend/src/lib/api/__tests__/useIdempotencyKey.test.ts:8:      ({ etag }: { etag?: string }) => useIdempotencyKey(etag),
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2931:apps/frontend/src/lib/api/__tests__/useIdempotencyKey.test.ts:9:      { initialProps: { etag: 'W/"v1"' } },
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2932:apps/frontend/src/lib/api/__tests__/useIdempotencyKey.test.ts:12:    rerender({ etag: 'W/"v1"' });
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2933:apps/frontend/src/lib/api/__tests__/useIdempotencyKey.test.ts:18:      ({ etag }: { etag?: string }) => useIdempotencyKey(etag),
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2934:apps/frontend/src/lib/api/__tests__/useIdempotencyKey.test.ts:19:      { initialProps: { etag: 'W/"v1"' } },
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2935:apps/frontend/src/lib/api/__tests__/useIdempotencyKey.test.ts:22:    rerender({ etag: 'W/"v2"' });
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2936:apps/frontend/src/lib/api/__tests__/useIdempotencyKey.test.ts:29:      ({ etag }: { etag?: string }) => useIdempotencyKey(etag),
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2937:apps/frontend/src/lib/api/__tests__/useIdempotencyKey.test.ts:30:      { initialProps: { etag: 'W/"v1"' } },
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2938:apps/frontend/src/lib/api/__tests__/useIdempotencyKey.test.ts:33:    // Switch etag and immediately read key — no async wait.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2939:apps/frontend/src/lib/api/__tests__/useIdempotencyKey.test.ts:34:    rerender({ etag: 'W/"v2"' });
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2940:apps/frontend/src/lib/api/__tests__/useIdempotencyKey.test.ts:37:    // Confirm key is stable on subsequent re-renders with same etag
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2941:apps/frontend/src/lib/api/__tests__/useIdempotencyKey.test.ts:38:    rerender({ etag: 'W/"v2"' });
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2942:apps/frontend/src/lib/api/__tests__/client.test.ts:43:  it('POST attaches auto-minted Idempotency-Key UUID', async () => {
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2943:apps/frontend/src/lib/api/__tests__/client.test.ts:48:    expect(headers['Idempotency-Key']).toBeTruthy();
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2944:apps/frontend/src/lib/api/__tests__/client.test.ts:49:    expect((headers['Idempotency-Key'] as string).length).toBeGreaterThanOrEqual(10);
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2945:apps/frontend/src/lib/api/__tests__/client.test.ts:52:  it('GET omits Idempotency-Key', async () => {
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2946:apps/frontend/src/lib/api/__tests__/client.test.ts:57:    expect(headers['Idempotency-Key']).toBeUndefined();
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2947:apps/frontend/src/lib/api/__tests__/client.test.ts:60:  it('PATCH attaches If-Match when provided', async () => {
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2948:apps/frontend/src/lib/api/__tests__/client.test.ts:65:    expect(headers['If-Match']).toBe('W/"abc"');
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2949:apps/frontend/src/lib/api/__tests__/client.test.ts:90:  it('304 returns etag without throwing', async () => {
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2950:apps/frontend/src/lib/api/__tests__/client.test.ts:91:    const fetchMock = mockFetch({ ok: true, status: 304, headers: { etag: 'W/"abc"' } });
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2951:apps/frontend/src/lib/api/__tests__/client.test.ts:95:    expect(res.etag).toBe('W/"abc"');
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2952:apps/frontend/src/lib/api/__tests__/client.test.ts:98:  it('PUT does not auto-attach Idempotency-Key', async () => {
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2953:apps/frontend/src/lib/api/__tests__/client.test.ts:103:    expect(headers['Idempotency-Key']).toBeUndefined();
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2954:apps/frontend/src/lib/api/__tests__/useIdempotencyKey.test.ts:8:      ({ etag }: { etag?: string }) => useIdempotencyKey(etag),
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2955:apps/frontend/src/lib/api/__tests__/useIdempotencyKey.test.ts:9:      { initialProps: { etag: 'W/"v1"' } },
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2956:apps/frontend/src/lib/api/__tests__/useIdempotencyKey.test.ts:12:    rerender({ etag: 'W/"v1"' });
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2957:apps/frontend/src/lib/api/__tests__/useIdempotencyKey.test.ts:18:      ({ etag }: { etag?: string }) => useIdempotencyKey(etag),
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2958:apps/frontend/src/lib/api/__tests__/useIdempotencyKey.test.ts:19:      { initialProps: { etag: 'W/"v1"' } },
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2959:apps/frontend/src/lib/api/__tests__/useIdempotencyKey.test.ts:22:    rerender({ etag: 'W/"v2"' });
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2960:apps/frontend/src/lib/api/__tests__/useIdempotencyKey.test.ts:29:      ({ etag }: { etag?: string }) => useIdempotencyKey(etag),
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2961:apps/frontend/src/lib/api/__tests__/useIdempotencyKey.test.ts:30:      { initialProps: { etag: 'W/"v1"' } },
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2962:apps/frontend/src/lib/api/__tests__/useIdempotencyKey.test.ts:33:    // Switch etag and immediately read key — no async wait.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2963:apps/frontend/src/lib/api/__tests__/useIdempotencyKey.test.ts:34:    rerender({ etag: 'W/"v2"' });
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2964:apps/frontend/src/lib/api/__tests__/useIdempotencyKey.test.ts:37:    // Confirm key is stable on subsequent re-renders with same etag
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2965:apps/frontend/src/lib/api/__tests__/useIdempotencyKey.test.ts:38:    rerender({ etag: 'W/"v2"' });
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2966:apps/frontend/src/routes/dev-rich-editor.tsx:6:import type { ApiErrorEnvelope } from '../lib/api/types';
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2967:apps/frontend/src/routes/dev-rich-editor.tsx:15:/** Dev-only: fire a fake ApiErrorEnvelope through errorMapper → sonner toast. */
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2968:apps/frontend/src/routes/dev-rich-editor.tsx:16:function triggerToast(envelope: ApiErrorEnvelope, onRetry?: () => void) {
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2969:apps/frontend/src/lib/api/__tests__/errorMapper.test.ts:1:import { ERROR_CODES, type ErrorCode } from '@fops/shared';
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2970:apps/frontend/src/lib/api/__tests__/errorMapper.test.ts:1:import { ERROR_CODES, type ErrorCode } from '@fops/shared';
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2971:apps/frontend/src/lib/api/types.ts:1:import type { ErrorCode } from '@fops/shared';
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2972:apps/frontend/src/lib/api/types.ts:3:export interface ApiErrorEnvelope {
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2973:apps/frontend/src/lib/api/types.ts:17:    public readonly envelope: ApiErrorEnvelope,
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2974:apps/frontend/src/lib/api/errorMapper.ts:1:import { ERROR_CODES, type ErrorCode } from '@fops/shared';
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2975:apps/frontend/src/lib/api/errorMapper.ts:2:import type { ApiErrorEnvelope, MappedError, Tone } from './types';
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2976:apps/frontend/src/lib/api/errorMapper.ts:31:  // rate_limited.*
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2977:apps/frontend/src/lib/api/errorMapper.ts:32:  'rate_limited.actor': {
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2978:apps/frontend/src/lib/api/errorMapper.ts:36:  'rate_limited.ip': {
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2979:apps/frontend/src/lib/api/errorMapper.ts:47:    message: 'Idempotency-Key가 잘못된 형식입니다. 새로고침 후 다시 시도해 주세요.',
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2980:apps/frontend/src/lib/api/errorMapper.ts:134:  envelope: ApiErrorEnvelope,
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2981:apps/frontend/src/lib/api/useIdempotencyKey.ts:19: * Stable Idempotency-Key per call site. Re-mints automatically when `ifMatchEtag` changes
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2982:apps/frontend/src/lib/api/useIdempotencyKey.ts:20: * (BE rule: idempotency hash includes If-Match; same key + new etag → conflict.idempotency_key_reuse).
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2983:apps/frontend/src/lib/api/useIdempotencyKey.ts:27:  // Single ref holds { etag, key } together to allow synchronous derivation during render.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2984:apps/frontend/src/lib/api/useIdempotencyKey.ts:28:  const ref = useRef<{ etag: string | undefined; key: string }>({
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2985:apps/frontend/src/lib/api/useIdempotencyKey.ts:29:    etag: ifMatchEtag,
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2986:apps/frontend/src/lib/api/useIdempotencyKey.ts:33:  // Synchronous derivation: if etag changed, mint a new key before returning.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2987:apps/frontend/src/lib/api/useIdempotencyKey.ts:34:  if (ref.current.etag !== ifMatchEtag) {
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2988:apps/frontend/src/lib/api/useIdempotencyKey.ts:35:    ref.current = { etag: ifMatchEtag, key: mintKey() };
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2989:apps/frontend/src/lib/api/useIdempotencyKey.ts:43:    ref.current = { etag: ref.current.etag, key: mintKey() };
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2990:apps/frontend/src/routes/_authed/vocs.tsx:27:type VocSearch = z.infer<typeof vocSearchSchema>;
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2991:apps/frontend/src/lib/api.ts:97:export interface ApiErrorEnvelope {
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2992:apps/frontend/src/lib/api.ts:105:  readonly envelope: ApiErrorEnvelope;
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2993:apps/frontend/src/lib/api.ts:106:  constructor(status: number, envelope: ApiErrorEnvelope) {
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2994:apps/frontend/src/lib/api.ts:122:      'Idempotency-Key': options.idempotencyKey,
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2995:apps/frontend/src/lib/api.ts:132:  let envelope: ApiErrorEnvelope = { code: 'internal.unexpected', message: 'request failed' };
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2996:apps/frontend/src/lib/api.ts:134:    envelope = (await res.json()) as ApiErrorEnvelope;
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2997:apps/frontend/src/lib/api.ts:198:  let envelope: ApiErrorEnvelope = { code: 'internal.unexpected', message: 'request failed' };
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2998:apps/frontend/src/lib/api.ts:200:    envelope = (await res.json()) as ApiErrorEnvelope;
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:2999:apps/frontend/src/lib/api.ts:227:  if (options?.idempotencyKey) headers['Idempotency-Key'] = options.idempotencyKey;
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:3000:apps/frontend/src/lib/api.ts:247:  if (options?.idempotencyKey) headers['Idempotency-Key'] = options.idempotencyKey;
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:3001:apps/frontend/src/lib/api.ts:266:  if (options?.idempotencyKey) headers['Idempotency-Key'] = options.idempotencyKey;
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:3002:apps/frontend/src/lib/api.ts:324:  if (options?.idempotencyKey) headers['Idempotency-Key'] = options.idempotencyKey;
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:3003:apps/frontend/src/lib/api.ts:344:  if (options?.idempotencyKey) headers['Idempotency-Key'] = options.idempotencyKey;
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:3004:apps/frontend/src/lib/api.ts:363:  if (options?.idempotencyKey) headers['Idempotency-Key'] = options.idempotencyKey;
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:3005:apps/frontend/src/features/admin/permissions/request-access-button.tsx:3:// Generates a stable `Idempotency-Key` per logical intent — the key is
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:3006:apps/frontend/src/features/admin/permissions/request-access-button.tsx:40:  // Bumping `attempt` rotates the memoized Idempotency-Key, which we do
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:3007:apps/frontend/src/features/admin/permissions/__tests__/request-access-button.test.tsx:2://   - POSTs to /permission-requests with an Idempotency-Key UUIDv4 header.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:3008:apps/frontend/src/features/admin/permissions/__tests__/request-access-button.test.tsx:39:  test('on click → POST /permission-requests with Idempotency-Key UUID + body', async () => {
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:3009:apps/frontend/src/features/admin/permissions/__tests__/request-access-button.test.tsx:61:    expect(headers['Idempotency-Key']).toMatch(UUID_REGEX);
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:3010:apps/frontend/src/features/admin/permissions/__tests__/request-access-button.test.tsx:97:  // F-002: per ADR-0015:71-90 the Idempotency-Key represents the same
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:3011:apps/frontend/src/features/admin/permissions/__tests__/request-access-button.test.tsx:102:  test('two concurrent clicks for the same capability send the same Idempotency-Key', async () => {
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:3012:apps/frontend/src/features/admin/permissions/__tests__/request-access-button.test.tsx:138:      expect(a.headers['Idempotency-Key']).toBe(b.headers['Idempotency-Key']);
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:3013:apps/frontend/src/features/admin/permissions/__tests__/request-access-button.test.tsx:142:    expect(first.headers['Idempotency-Key']).toMatch(UUID_REGEX);
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:3020:/bin/zsh -lc "nl -ba apps/frontend/src/lib/api.ts | sed -n '80,150p'; printf '\\n--- later voc/api routes? ---\\n'; nl -ba apps/frontend/src/lib/api.ts | sed -n '150,390p'; printf '\\n--- new api index ---\\n'; nl -ba apps/frontend/src/lib/api/index.ts | sed -n '1,120p'" in /Users/hyojung/Desktop/2026/FeedbackOps
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:3124:   179	  updated_at: string;
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:3232:   287	  updated_at: string;
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:3325:   380	  const res = await fetch(`/me/permissions/check?${params.toString()}`, init);
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:3327:   382	  if (!res.ok) throw new Error(`/me/permissions/check failed: ${res.status}`);
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:3762:apps/backend/src/modules/auth/session-service.ts:297:     * touch `last_seen_at`. Intended for the `@fastify/rate-limit`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:3799:apps/backend/src/modules/permissions/routes.ts:25:  rateLimitConfig?: {
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:3800:apps/backend/src/modules/permissions/routes.ts:52:  const { sessionService, checkService, requestService, workspaceId, rateLimitConfig } = opts;
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:3801:apps/backend/src/modules/permissions/routes.ts:58:  // ADR-0015 mutation tier does not apply (GET). The global per-Actor limit
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:3802:apps/backend/src/modules/permissions/routes.ts:140:    ...(rateLimitConfig ? { config: { rateLimit: rateLimitConfig.mutation as never } } : {}),
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:3957:apps/backend/src/modules/permissions/routes.ts:25:  rateLimitConfig?: {
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:3958:apps/backend/src/modules/permissions/routes.ts:52:  const { sessionService, checkService, requestService, workspaceId, rateLimitConfig } = opts;
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:3959:apps/backend/src/modules/permissions/routes.ts:58:  // ADR-0015 mutation tier does not apply (GET). The global per-Actor limit
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:3960:apps/backend/src/modules/permissions/routes.ts:140:    ...(rateLimitConfig ? { config: { rateLimit: rateLimitConfig.mutation as never } } : {}),
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:3969:apps/backend/src/modules/auth/session-service.ts:297:     * touch `last_seen_at`. Intended for the `@fastify/rate-limit`
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:3976:/bin/zsh -lc "nl -ba apps/backend/src/server.ts | sed -n '144,166p'; printf '\\n--- client lines ---\\n'; nl -ba apps/frontend/src/lib/api/client.ts | sed -n '12,70p'; printf '\\n--- api types new ---\\n'; nl -ba apps/frontend/src/lib/api/types.ts | sed -n '1,45p'" in /Users/hyojung/Desktop/2026/FeedbackOps
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:4011:    20	// only for POST/PATCH/DELETE. Include PUT explicitly if a future endpoint opts in.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:4012:    21	const MUTATION_METHODS = new Set(['POST', 'PATCH', 'DELETE']);
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:4597:/bin/zsh -lc "nl -ba apps/frontend/AGENTS.md | sed -n '1,90p'; printf '\\n--- packages ui agents ---\\n'; nl -ba packages/ui/AGENTS.md | sed -n '1,130p'" in /Users/hyojung/Desktop/2026/FeedbackOps
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:4608:    10	- Use `apps/frontend/src/features/*/AGENTS.md` for route-specific ownership before adding screens.
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:4676:const mapper=fs.readFileSync('apps/frontend/src/lib/api/errorMapper.ts','utf8'); const missing=codes.filter(c=>"'!mapper.includes(`'"'"'${c}'"'"'`)); console.log({count:codes.length,missing});
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:4804:`packages/ui/src/index.ts:8`, `apps/frontend/src/routes/_authed/admin/analytics-areas.tsx:337`  
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:4805:Issue: the component is exported publicly, but the only route-level “consumer” is `_unusedPickerImport`, explicitly added to silence no-consumer complaints. This violates the two-consumer rule in `apps/frontend/AGENTS.md:18` and `packages/ui/AGENTS.md:22`.  
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:4816:`apps/frontend/src/lib/api/index.ts:1`, `apps/frontend/src/lib/api.ts:97`, `apps/frontend/src/routes/_authed/admin/managed-systems.tsx:14`  
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:4817:Issue: #18 adds `apps/frontend/src/lib/api/*`, but current routes still import the older `apps/frontend/src/lib/api.ts`, which owns DTOs, fetch wrappers, and its own `ApiError`.  
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:4841:`apps/frontend/src/lib/api/types.ts:3`, `apps/frontend/src/lib/api.ts:97`, `packages/shared/src/errors/codes.ts:68`  
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:4847:`apps/backend/src/server.ts:156`, `apps/backend/src/server.ts:161`, `apps/frontend/src/lib/api/client.ts:50`  
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:4882:`packages/ui/src/index.ts:8`, `apps/frontend/src/routes/_authed/admin/analytics-areas.tsx:337`  
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:4883:Issue: the component is exported publicly, but the only route-level “consumer” is `_unusedPickerImport`, explicitly added to silence no-consumer complaints. This violates the two-consumer rule in `apps/frontend/AGENTS.md:18` and `packages/ui/AGENTS.md:22`.  
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:4894:`apps/frontend/src/lib/api/index.ts:1`, `apps/frontend/src/lib/api.ts:97`, `apps/frontend/src/routes/_authed/admin/managed-systems.tsx:14`  
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:4895:Issue: #18 adds `apps/frontend/src/lib/api/*`, but current routes still import the older `apps/frontend/src/lib/api.ts`, which owns DTOs, fetch wrappers, and its own `ApiError`.  
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:4919:`apps/frontend/src/lib/api/types.ts:3`, `apps/frontend/src/lib/api.ts:97`, `packages/shared/src/errors/codes.ts:68`  
+.review/archive/slice-3-fe-foundation/SLICE-3-18-REVIEW-CYCLE-3-component-fe-be.md:4925:`apps/backend/src/server.ts:156`, `apps/backend/src/server.ts:161`, `apps/frontend/src/lib/api/client.ts:50`  
+
+hook: PostToolUse Failed
+hook: PostToolUse
+hook: PostToolUse Failed
+exec
+/bin/zsh -lc "nl -ba apps/backend/migrations/0019_entity_link_detach.sql && node -e \"const fs=require('fs'); const p='apps/backend/migrations/meta/0019_snapshot.json'; const j=JSON.parse(fs.readFileSync(p,'utf8')); const t=j.tables['core.entity_links']; console.log(JSON.stringify({columns:t.columns, indexes:t.indexes, foreignKeys:t.foreignKeys}, null, 2));\"" in /Users/hyojung/Desktop/2026/wt-113-entity-link-detach
+ succeeded in 0ms:
+     1	-- Issue #113: Slice 4.2 entity link soft detach lifecycle.
+     2	-- Adds detach metadata to core.entity_links and grants fops_app UPDATE only.
+     3	-- Hard delete remains unavailable to the app role; canonical link history is
+     4	-- preserved by transitioning active links to status='detached'.
+     5	
+     6	ALTER TABLE "core"."entity_links"
+     7	  ADD COLUMN IF NOT EXISTS "detached_by" uuid REFERENCES "core"."actors"("id"),
+     8	  ADD COLUMN IF NOT EXISTS "detach_reason" text,
+     9	  ADD COLUMN IF NOT EXISTS "detached_at" timestamptz;
+    10	--> statement-breakpoint
+    11	
+    12	GRANT UPDATE ON "core"."entity_links" TO fops_app;
+{
+  "columns": {
+    "id": {
+      "name": "id",
+      "type": "uuid",
+      "primaryKey": true,
+      "notNull": true,
+      "default": "gen_random_uuid()"
+    },
+    "workspace_id": {
+      "name": "workspace_id",
+      "type": "uuid",
+      "primaryKey": false,
+      "notNull": true
+    },
+    "source_type": {
+      "name": "source_type",
+      "type": "text",
+      "primaryKey": false,
+      "notNull": true
+    },
+    "source_id": {
+      "name": "source_id",
+      "type": "uuid",
+      "primaryKey": false,
+      "notNull": true
+    },
+    "target_type": {
+      "name": "target_type",
+      "type": "text",
+      "primaryKey": false,
+      "notNull": true
+    },
+    "target_id": {
+      "name": "target_id",
+      "type": "uuid",
+      "primaryKey": false,
+      "notNull": true
+    },
+    "relation_type": {
+      "name": "relation_type",
+      "type": "text",
+      "primaryKey": false,
+      "notNull": true
+    },
+    "visibility": {
+      "name": "visibility",
+      "type": "text",
+      "primaryKey": false,
+      "notNull": true,
+      "default": "'internal_only'"
+    },
+    "status": {
+      "name": "status",
+      "type": "text",
+      "primaryKey": false,
+      "notNull": true,
+      "default": "'active'"
+    },
+    "managed_system_id": {
+      "name": "managed_system_id",
+      "type": "uuid",
+      "primaryKey": false,
+      "notNull": true
+    },
+    "created_by": {
+      "name": "created_by",
+      "type": "uuid",
+      "primaryKey": false,
+      "notNull": true
+    },
+    "created_at": {
+      "name": "created_at",
+      "type": "timestamp with time zone",
+      "primaryKey": false,
+      "notNull": true,
+      "default": "now()"
+    },
+    "updated_at": {
+      "name": "updated_at",
+      "type": "timestamp with time zone",
+      "primaryKey": false,
+      "notNull": false
+    },
+    "detached_by": {
+      "name": "detached_by",
+      "type": "uuid",
+      "primaryKey": false,
+      "notNull": false
+    },
+    "detach_reason": {
+      "name": "detach_reason",
+      "type": "text",
+      "primaryKey": false,
+      "notNull": false
+    },
+    "detached_at": {
+      "name": "detached_at",
+      "type": "timestamp with time zone",
+      "primaryKey": false,
+      "notNull": false
+    }
+  },
+  "indexes": {
+    "entity_links_active_unique_idx": {
+      "name": "entity_links_active_unique_idx",
+      "columns": [
+        {
+          "expression": "workspace_id",
+          "isExpression": false,
+          "asc": true,
+          "nulls": "last"
+        },
+        {
+          "expression": "source_type",
+          "isExpression": false,
+          "asc": true,
+          "nulls": "last"
+        },
+        {
+          "expression": "source_id",
+          "isExpression": false,
+          "asc": true,
+          "nulls": "last"
+        },
+        {
+          "expression": "target_type",
+          "isExpression": false,
+          "asc": true,
+          "nulls": "last"
+        },
+        {
+          "expression": "target_id",
+          "isExpression": false,
+          "asc": true,
+          "nulls": "last"
+        },
+        {
+          "expression": "relation_type",
+          "isExpression": false,
+          "asc": true,
+          "nulls": "last"
+        }
+      ],
+      "isUnique": true,
+      "where": "\"core\".\"entity_links\".\"status\" = 'active'",
+      "concurrently": false,
+      "method": "btree",
+      "with": {}
+    },
+    "entity_links_active_source_idx": {
+      "name": "entity_links_active_source_idx",
+      "columns": [
+        {
+          "expression": "workspace_id",
+          "isExpression": false,
+          "asc": true,
+          "nulls": "last"
+        },
+        {
+          "expression": "source_type",
+          "isExpression": false,
+          "asc": true,
+          "nulls": "last"
+        },
+        {
+          "expression": "source_id",
+          "isExpression": false,
+          "asc": true,
+          "nulls": "last"
+        }
+      ],
+      "isUnique": false,
+      "where": "\"core\".\"entity_links\".\"status\" = 'active'",
+      "concurrently": false,
+      "method": "btree",
+      "with": {}
+    },
+    "entity_links_active_target_idx": {
+      "name": "entity_links_active_target_idx",
+      "columns": [
+        {
+          "expression": "workspace_id",
+          "isExpression": false,
+          "asc": true,
+          "nulls": "last"
+        },
+        {
+          "expression": "target_type",
+          "isExpression": false,
+          "asc": true,
+          "nulls": "last"
+        },
+        {
+          "expression": "target_id",
+          "isExpression": false,
+          "asc": true,
+          "nulls": "last"
+        }
+      ],
+      "isUnique": false,
+      "where": "\"core\".\"entity_links\".\"status\" = 'active'",
+      "concurrently": false,
+      "method": "btree",
+      "with": {}
+    },
+    "entity_links_workspace_ms_status_idx": {
+      "name": "entity_links_workspace_ms_status_idx",
+      "columns": [
+        {
+          "expression": "workspace_id",
+          "isExpression": false,
+          "asc": true,
+          "nulls": "last"
+        },
+        {
+          "expression": "managed_system_id",
+          "isExpression": false,
+          "asc": true,
+          "nulls": "last"
+        },
+        {
+          "expression": "status",
+          "isExpression": false,
+          "asc": true,
+          "nulls": "last"
+        }
+      ],
+      "isUnique": false,
+      "concurrently": false,
+      "method": "btree",
+      "with": {}
+    }
+  },
+  "foreignKeys": {
+    "entity_links_workspace_id_workspaces_id_fk": {
+      "name": "entity_links_workspace_id_workspaces_id_fk",
+      "tableFrom": "entity_links",
+      "tableTo": "workspaces",
+      "schemaTo": "core",
+      "columnsFrom": [
+        "workspace_id"
+      ],
+      "columnsTo": [
+        "id"
+      ],
+      "onDelete": "no action",
+      "onUpdate": "no action"
+    },
+    "entity_links_managed_system_id_managed_systems_id_fk": {
+      "name": "entity_links_managed_system_id_managed_systems_id_fk",
+      "tableFrom": "entity_links",
+      "tableTo": "managed_systems",
+      "schemaTo": "core",
+      "columnsFrom": [
+        "managed_system_id"
+      ],
+      "columnsTo": [
+        "id"
+      ],
+      "onDelete": "no action",
+      "onUpdate": "no action"
+    },
+    "entity_links_created_by_actors_id_fk": {
+      "name": "entity_links_created_by_actors_id_fk",
+      "tableFrom": "entity_links",
+      "tableTo": "actors",
+      "schemaTo": "core",
+      "columnsFrom": [
+        "created_by"
+      ],
+      "columnsTo": [
+        "id"
+      ],
+      "onDelete": "no action",
+      "onUpdate": "no action"
+    },
+    "entity_links_detached_by_actors_id_fk": {
+      "name": "entity_links_detached_by_actors_id_fk",
+      "tableFrom": "entity_links",
+      "tableTo": "actors",
+      "schemaTo": "core",
+      "columnsFrom": [
+        "detached_by"
+      ],
+      "columnsTo": [
+        "id"
+      ],
+      "onDelete": "no action",
+      "onUpdate": "no action"
+    }
+  }
+}
+
+hook: PostToolUse
+hook: PostToolUse Failed
+hook: PostToolUse Failed
+codex
+So far I don’t see scope escape, hard delete in production, or an index mutation. I’m doing one final pass for hidden contract mismatches: error mapping, VOC detail’s data source, and snapshot/journal shape against 0018.
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse Failed
+hook: PreToolUse Failed
+hook: PreToolUse Failed
+exec
+/bin/zsh -lc "nl -ba apps/backend/src/lib/errors.ts | sed -n '1,220p'" in /Users/hyojung/Desktop/2026/wt-113-entity-link-detach
+ succeeded in 0ms:
+     1	// Backend-side helpers for the ADR-0012 error envelope. Maps `code` family to
+     2	// HTTP status per the table in ADR-0012:25-34. Controllers throw an HttpError
+     3	// or call `sendError` from a handler; application services raise the same
+     4	// instance and a Fastify error handler renders the envelope.
+     5	
+     6	import type { ErrorCode } from '@fops/shared';
+     7	import type { FastifyReply } from 'fastify';
+     8	
+     9	const STATUS_BY_PREFIX: ReadonlyArray<[string, number]> = [
+    10	  ['auth.workspace_mismatch', 403],
+    11	  ['auth.', 401],
+    12	  ['permission.', 403],
+    13	  ['not_found.', 404],
+    14	  ['conflict.', 409],
+    15	  ['validation.', 422],
+    16	  ['voc.', 422],
+    17	  ['rich_content.', 422],
+    18	  ['attachment.', 422],
+    19	  ['reporter_facing_status.', 422],
+    20	  ['rate_limited.', 429],
+    21	  ['internal.', 500],
+    22	  ['upstream.', 502],
+    23	  // PLAN-22 C3a: object-store unavailable bubbles as 502 per OQ-2 default.
+    24	  ['storage.', 502],
+    25	  // PLAN-22 C3a: stub-path marker until C3b lands real implementation.
+    26	  ['not_implemented.', 501],
+    27	];
+    28	
+    29	export function statusForCode(code: ErrorCode): number {
+    30	  for (const [prefix, status] of STATUS_BY_PREFIX) {
+    31	    if (code.startsWith(prefix)) return status;
+    32	  }
+    33	  return 500;
+    34	}
+    35	
+    36	export type DetailField = {
+    37	  path: ReadonlyArray<string | number>;
+    38	  code: string;
+    39	  message?: string;
+    40	};
+    41	
+    42	export type DetailShape =
+    43	  | {
+    44	      fields: DetailField[];
+    45	      hint?: string | undefined;
+    46	      max_bytes?: number;
+    47	      mime_type?: string;
+    48	      reason?: string | null;
+    49	      detail?: { reason: string | null };
+    50	    }
+    51	  | { retry_after_seconds: number }
+    52	  | { resource_id?: string; resource_type?: string }
+    53	  | { capability: string }
+    54	  | { reason: string }
+    55	  | {
+    56	      requiredScope?: string[];
+    57	      requestable_permission: {
+    58	        permission: string;
+    59	        managed_system_id?: string | null;
+    60	        reason_required?: boolean;
+    61	      };
+    62	    }
+    63	  | { current_updated_at: string }
+    64	  | { current_triage_state: string }
+    65	  | undefined;
+    66	
+    67	export class HttpError extends Error {
+    68	  readonly code: ErrorCode;
+    69	  readonly detail?: Exclude<DetailShape, undefined>;
+    70	  constructor(code: ErrorCode, message: string, detail?: DetailShape) {
+    71	    super(message);
+    72	    this.code = code;
+    73	    if (detail !== undefined) this.detail = detail;
+    74	  }
+    75	}
+    76	
+    77	export function sendError(
+    78	  reply: FastifyReply,
+    79	  code: ErrorCode,
+    80	  message: string,
+    81	  detail?: DetailShape,
+    82	): FastifyReply {
+    83	  const body: Record<string, unknown> = { code, message };
+    84	  if (detail !== undefined) body.detail = detail;
+    85	  return reply.code(statusForCode(code)).send(body);
+    86	}
+    87	
+    88	// Slim down Zod issue payloads before they reach a client. Review HTTP-M-1:
+    89	// raw `ZodIssue` arrays leak internal field paths, discriminator codes, and
+    90	// in some Zod versions an `input` snapshot. ADR-0012:25-34 expects a stable
+    91	// `{ code, message, detail }` contract; the `detail.fields` array should
+    92	// expose only the path + error code the client needs to identify which
+    93	// field failed validation.
+    94	export type ZodIssueShape = { path?: unknown; code?: unknown };
+    95	export function fieldsFromZodIssues(issues: ReadonlyArray<ZodIssueShape>): Array<{
+    96	  path: ReadonlyArray<string | number>;
+    97	  code: string;
+    98	}> {
+    99	  return issues.map((iss) => ({
+   100	    path: Array.isArray(iss.path) ? (iss.path as Array<string | number>) : [],
+   101	    code: typeof iss.code === 'string' ? iss.code : 'invalid',
+   102	  }));
+   103	}
+
+hook: PostToolUse
+hook: PreToolUse Failed
+exec
+/bin/zsh -lc "rg -n \"selectActiveLinksForEndpoint|listLinks\\(|entityLinksService\\.listLinks|links\" apps/backend/src/modules/voc apps/backend/src/modules/entity-links apps/backend/src/server.ts" in /Users/hyojung/Desktop/2026/wt-113-entity-link-detach
+ succeeded in 0ms:
+apps/backend/src/server.ts:35:import { createEntityLinksService, entityLinksRoutes } from './modules/entity-links/index.js';
+apps/backend/src/modules/entity-links/service.ts:12:  selectActiveLinksForEndpoint,
+apps/backend/src/modules/entity-links/service.ts:158:  async function listLinks(args: {
+apps/backend/src/modules/entity-links/service.ts:184:    const rows = await selectActiveLinksForEndpoint(
+apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts:1:// POST/GET/PATCH /entity-links integration tests — Slice 4.1 #112 + Slice 4.2 #113.
+apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts:4:// required because core.entity_links is append-only to fops_app.
+apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts:28:const SLUG_PREFIX = 'it-links';
+apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts:30:describe.skipIf(!runIntegration)('POST/GET /entity-links (#112)', () => {
+apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts:77:      `delete from core.entity_links
+apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts:131:      url: '/entity-links',
+apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts:148:      url: `/entity-links/${linkId}`,
+apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts:167:      `select count(*)::int as n from core.entity_links
+apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts:234:      `select count(*)::int as n from core.entity_links
+apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts:285:      url: `/entity-links?source_type=voc&source_id=${sourceVoc.id}`,
+apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts:302:  it('VOC detail returns active outbound related_to links on the Links tab payload', async () => {
+apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts:314:    const body = res.json<{ links?: Array<{ id: string; visibility_state: string }> }>();
+apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts:316:      body.links?.some((link) => link.id === linkId && link.visibility_state === 'allowed'),
+apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts:339:        from core.entity_links
+apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts:366:  it('after detach, GET /entity-links and VOC detail Links tab omit the detached link', async () => {
+apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts:377:      url: `/entity-links?source_type=voc&source_id=${sourceVoc.id}`,
+apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts:391:    const body = detail.json<{ links?: Array<{ id: string }> }>();
+apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts:392:    expect(body.links?.some((link) => link.id === linkId)).toBe(false);
+apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts:457:        from core.entity_links
+apps/backend/src/modules/entity-links/repo.ts:95:    INSERT INTO core.entity_links (
+apps/backend/src/modules/entity-links/repo.ts:135:    FROM core.entity_links
+apps/backend/src/modules/entity-links/repo.ts:149:export async function selectActiveLinksForEndpoint(
+apps/backend/src/modules/entity-links/repo.ts:173:    FROM core.entity_links
+apps/backend/src/modules/entity-links/repo.ts:191:    FROM core.entity_links
+apps/backend/src/modules/entity-links/repo.ts:210:    UPDATE core.entity_links
+apps/backend/src/modules/entity-links/routes.ts:35:    url: '/entity-links',
+apps/backend/src/modules/entity-links/routes.ts:70:    url: '/entity-links',
+apps/backend/src/modules/entity-links/routes.ts:97:      const items = await entityLinksService.listLinks({
+apps/backend/src/modules/entity-links/routes.ts:112:    url: '/entity-links/:id',
+apps/backend/src/modules/voc/AGENTS.md:18:- VOC links to Findings, Tasks, and other entities through `entity_links`.
+apps/backend/src/modules/voc/AGENTS.md:19:- Convenience projections are allowed only when canonical history remains in `entity_links`.
+apps/backend/src/modules/voc/read-service.ts:30:import type { EntityLinksService } from '../entity-links/index.js';
+apps/backend/src/modules/voc/read-service.ts:520:    const links = await deps.entityLinksService.listLinks({
+apps/backend/src/modules/voc/read-service.ts:575:      links,
+apps/backend/src/modules/voc/read-service.ts:718:    const links = await deps.entityLinksService.listLinks({
+apps/backend/src/modules/voc/read-service.ts:769:      links,
+apps/backend/src/modules/voc/__tests__/create-voc.integration.test.ts:829:    // Seed an attachment + first VOC creation links it.
+
+hook: PostToolUse
+exec
+/bin/zsh -lc "nl -ba apps/backend/src/modules/voc/read-service.ts | sed -n '1,260p' && nl -ba apps/backend/src/modules/voc/repo-read.ts | sed -n '1,260p'" in /Users/hyojung/Desktop/2026/wt-113-entity-link-detach
+ succeeded in 0ms:
+     1	// apps/backend/src/modules/voc/read-service.ts
+     2	//
+     3	// Read application service for the VOC module.
+     4	// Owns view semantics, scope resolution orchestration, access-matrix decisions,
+     5	// and envelope assembly. No route handlers. No DB queries — everything goes
+     6	// through repo-read.ts (C1) + cursor.ts.
+     7	//
+     8	// Access matrix (codex BLOCKER fix):
+     9	//   msInReadScope || isReporter          → FULL envelope
+    10	//   !msInReadScope && !isReporter && msInEffectiveScope → SUMMARY envelope
+    11	//   !msInReadScope && !isReporter && !msInEffectiveScope → 404 not_found.record
+    12	//
+    13	// ETag (Slice 3): weak W/"<voc.updated_at-ISO>". Conversation tables immutable
+    14	// until #16 lands. TODO(#16): compose with max(conv.created_at) once #16 ships.
+    15	
+    16	import { z } from 'zod';
+    17	
+    18	import type {
+    19	  ConversationEntry,
+    20	  GetConversationQuery,
+    21	  LinkedAttachment,
+    22	  ListVocsQuery,
+    23	  VocDetailEnvelope,
+    24	  VocListItem,
+    25	  VocSummaryEnvelope,
+    26	} from '@fops/shared';
+    27	import type { Db } from '../../db/client.js';
+    28	import type { Tx } from '../../db/tx.js';
+    29	import { HttpError } from '../../lib/errors.js';
+    30	import type { EntityLinksService } from '../entity-links/index.js';
+    31	import type { CheckService } from '../permissions/check-service.js';
+    32	
+    33	import { decodeCursor, encodeCursor } from './cursor.js';
+    34	import type { ConversationRow, Scope, VocReadRow } from './repo-read.js';
+    35	import * as repoRead from './repo-read.js';
+    36	import { type ReporterFacingStatus, nextReporterStates } from './transitions.js';
+    37	
+    38	// ── Public interface ─────────────────────────────────────────────────────────
+    39	
+    40	export interface VocReadServiceDeps {
+    41	  db: Db;
+    42	  checkService: CheckService;
+    43	  entityLinksService: EntityLinksService;
+    44	}
+    45	
+    46	export interface ReadActorContext {
+    47	  actor_id: string;
+    48	  workspace_id: string;
+    49	  role_level: 'admin' | 'developer' | 'user';
+    50	}
+    51	
+    52	// ── Inline conversation cursor (conversation-specific; separate from VOC list cursor) ──
+    53	
+    54	interface ConversationCursor {
+    55	  createdAt: string;
+    56	  id: string;
+    57	}
+    58	
+    59	function encodeConversationCursor(c: ConversationCursor): string {
+    60	  return Buffer.from(JSON.stringify(c), 'utf8').toString('base64');
+    61	}
+    62	
+    63	// WHY (M5): zod schema validates cursor field types (not just presence) to
+    64	// prevent malformed UUID/datetime strings from reaching SQL and causing 500s.
+    65	// offset: true allows both Z and +HH:MM suffixes (postgres text → ISO conversion
+    66	// produces +00:00 which requires this option).
+    67	const conversationCursorSchema = z.object({
+    68	  createdAt: z.string().datetime({ offset: true, message: 'createdAt must be an ISO datetime' }),
+    69	  id: z.string().uuid({ message: 'id must be a UUID' }),
+    70	});
+    71	
+    72	function decodeConversationCursor(raw: string): ConversationCursor {
+    73	  const fail = () =>
+    74	    new HttpError('validation.failed', 'invalid cursor', {
+    75	      fields: [{ path: ['cursor'], code: 'invalid_cursor' }],
+    76	    });
+    77	  let json: string;
+    78	  try {
+    79	    json = Buffer.from(raw, 'base64').toString('utf8');
+    80	  } catch {
+    81	    throw fail();
+    82	  }
+    83	  let parsed: unknown;
+    84	  try {
+    85	    parsed = JSON.parse(json);
+    86	  } catch {
+    87	    throw fail();
+    88	  }
+    89	  // WHY (M5): validate field types, not just presence — malformed dates/UUIDs
+    90	  // would reach SQL and cause 500 errors on the timestamptz/uuid casts.
+    91	  const result = conversationCursorSchema.safeParse(parsed);
+    92	  if (!result.success) {
+    93	    throw fail();
+    94	  }
+    95	  return result.data;
+    96	}
+    97	
+    98	// ── Row mappers ──────────────────────────────────────────────────────────────
+    99	
+   100	function mapRowToListItem(row: VocReadRow, attachmentCount = 0): VocListItem {
+   101	  return {
+   102	    id: row.id,
+   103	    display_id: row.displayId,
+   104	    title: row.title,
+   105	    primary_managed_system_id: row.primaryManagedSystemId,
+   106	    analytics_area_id: row.analyticsAreaId,
+   107	    reporter_id: row.reporterId,
+   108	    owner_user_id: row.ownerUserId,
+   109	    owner_team_id: row.ownerTeamId,
+   110	    severity: row.severity,
+   111	    reporter_facing_status: row.reporterFacingStatus as VocListItem['reporter_facing_status'],
+   112	    triage_state: row.triageState as VocListItem['triage_state'],
+   113	    source_context: row.sourceContext as VocListItem['source_context'],
+   114	    created_at: row.createdAt.toISOString(),
+   115	    updated_at: row.updatedAt.toISOString(),
+   116	    similar_count: 0,
+   117	    // PLAN-22 §Bug-1: populated by listVocs via bulk subquery.
+   118	    attachment_count: attachmentCount,
+   119	  };
+   120	}
+   121	
+   122	// PLAN-22 §Bug-1: read-row → wire-shape mapper for linked attachments.
+   123	function mapAttachmentRow(row: import('./repo-read.js').LinkedAttachmentReadRow): LinkedAttachment {
+   124	  return {
+   125	    id: row.id,
+   126	    name: row.name,
+   127	    size_bytes: row.size_bytes,
+   128	    mime_type: row.mime_type,
+   129	    uploaded_by_actor_id: row.uploaded_by_actor_id,
+   130	    created_at: row.created_at.toISOString(),
+   131	    linked_at: row.linked_at.toISOString(),
+   132	  };
+   133	}
+   134	
+   135	function mapConversationRow(
+   136	  row: ConversationRow,
+   137	  attachments: LinkedAttachment[] = [],
+   138	): ConversationEntry {
+   139	  const entry: ConversationEntry = {
+   140	    id: row.id,
+   141	    kind: row.kind,
+   142	    actor_id: row.actorId,
+   143	    body_rich_content: row.bodyRichContent,
+   144	    created_at: row.createdAt.toISOString(),
+   145	    visibility: row.visibility,
+   146	    // PLAN-22 §Bug-1: per-entry attachments; [] when none.
+   147	    attachments,
+   148	  };
+   149	  if (row.kind === 'public_update') {
+   150	    entry.reporter_facing_status_before = row.reporterFacingStatusBefore;
+   151	    entry.reporter_facing_status_after = row.reporterFacingStatusAfter;
+   152	    entry.skip_public_update = row.skipPublicUpdate;
+   153	    entry.skip_reason = row.skipReason ?? null;
+   154	  }
+   155	  return entry;
+   156	}
+   157	
+   158	// PLAN-22 §Bug-1: helper that takes a list of conversation rows + bulk
+   159	// attachment map (comment_id → rows) and emits ConversationEntry[] with
+   160	// per-entry `attachments[]` populated.
+   161	function mapConversationRowsWithAttachments(
+   162	  rows: ConversationRow[],
+   163	  attachmentsByCommentId: Map<string, import('./repo-read.js').LinkedAttachmentReadRow[]>,
+   164	): ConversationEntry[] {
+   165	  return rows.map((row) => {
+   166	    const linked = attachmentsByCommentId.get(row.id) ?? [];
+   167	    return mapConversationRow(row, linked.map(mapAttachmentRow));
+   168	  });
+   169	}
+   170	
+   171	// ── Scope helpers ────────────────────────────────────────────────────────────
+   172	
+   173	function msInScope(scope: Scope, msId: string): boolean {
+   174	  if (scope.kind === 'all') return true;
+   175	  return scope.managedSystemIds.includes(msId);
+   176	}
+   177	
+   178	function intersectScopes(a: Scope, b: Scope): Scope {
+   179	  if (a.kind === 'all' && b.kind === 'all') return { kind: 'all' };
+   180	  const aIds = a.kind === 'all' ? null : a.managedSystemIds;
+   181	  const bIds = b.kind === 'all' ? null : b.managedSystemIds;
+   182	  if (aIds === null && bIds !== null) return { kind: 'scoped', managedSystemIds: bIds };
+   183	  if (bIds === null && aIds !== null) return { kind: 'scoped', managedSystemIds: aIds };
+   184	  if (aIds !== null && bIds !== null) {
+   185	    const bSet = new Set(bIds);
+   186	    return { kind: 'scoped', managedSystemIds: aIds.filter((id) => bSet.has(id)) };
+   187	  }
+   188	  return { kind: 'all' };
+   189	}
+   190	
+   191	// ── Service factory ──────────────────────────────────────────────────────────
+   192	
+   193	export function createVocReadService(deps: VocReadServiceDeps) {
+   194	  // ── listVocs ───────────────────────────────────────────────────────────────
+   195	
+   196	  async function listVocs(args: {
+   197	    actor: ReadActorContext;
+   198	    query: ListVocsQuery;
+   199	  }): Promise<{
+   200	    items: VocListItem[];
+   201	    page: { cursor?: string; has_more: boolean };
+   202	    out_of_scope_summary?: { count: number; severity_distribution: Record<string, number> };
+   203	  }> {
+   204	    const { actor, query } = args;
+   205	    const { view, managed_system_id, tab, limit } = query;
+   206	    const filterSeverity = query['filter.severity'];
+   207	    const filterReporterFacingStatus = query['filter.reporter_facing_status'];
+   208	    const filterOwner = query['filter.owner'];
+   209	
+   210	    // ── 1. View=triage: reject query.sort (server-pinned sort) ──────────────
+   211	    if (view === 'triage' && query.sort !== undefined) {
+   212	      throw new HttpError('validation.failed', 'sort param not allowed for view=triage', {
+   213	        fields: [{ path: ['sort'], code: 'invalid' }],
+   214	      });
+   215	    }
+   216	
+   217	    // ── 2. Tab filter cross-view validation ──────────────────────────────────
+   218	    if (tab === 'waiting' && view !== 'triage') {
+   219	      throw new HttpError('validation.failed', 'tab=waiting is only valid for view=triage', {
+   220	        fields: [{ path: ['tab'], code: 'invalid_for_view' }],
+   221	      });
+   222	    }
+   223	
+   224	    // ── 3. Determine sort key and direction ──────────────────────────────────
+   225	    // For triage view, use internal 'triage_pinned' sort.
+   226	    // For other views, default to 'created_at:desc' if sort not specified.
+   227	    let sortKey: string;
+   228	    let sortDir: 'asc' | 'desc';
+   229	
+   230	    if (view === 'triage') {
+   231	      sortKey = 'triage_pinned';
+   232	      sortDir = 'asc'; // triage_pinned uses ASC direction internally (it has its own multi-key sort)
+   233	    } else {
+   234	      const rawSort = query.sort ?? 'created_at:desc';
+   235	      // triage_pinned is not in the listVocsQuerySchema sort enum so this
+   236	    // branch is unreachable at runtime — guard kept for belt-and-suspenders.
+   237	      sortKey = rawSort;
+   238	      sortDir = rawSort.endsWith(':asc') ? 'asc' : 'desc';
+   239	    }
+   240	
+   241	    // ── 4. Decode cursor ──────────────────────────────────────────────────────
+   242	    let decodedCursor: { sv: string | number; id: string } | undefined;
+   243	    if (query.cursor) {
+   244	      const cursor = decodeCursor(query.cursor, sortKey, sortDir);
+   245	      decodedCursor = { sv: cursor.sv, id: cursor.id };
+   246	    }
+   247	
+   248	    // ── 5. view=my: reject managed_system_id='all' ────────────────────────────
+   249	    if (view === 'my' && managed_system_id === 'all') {
+   250	      throw new HttpError('validation.failed', 'managed_system_id=all not allowed for view=my', {
+   251	        fields: [{ path: ['managed_system_id'], code: 'invalid' }],
+   252	      });
+   253	    }
+   254	
+   255	    // ── 6. Resolve scopes (skip triageScope for non-triage views) ─────────────
+   256	    let readScope: Scope;
+   257	    let effectiveScope: Scope;
+   258	    let triageScope: Scope | undefined;
+   259	
+   260	    if (view === 'triage') {
+     1	// apps/backend/src/modules/voc/repo-read.ts
+     2	//
+     3	// Read repo layer for the VOC module. Pure SQL/drizzle reads on voc.* tables.
+     4	// No route handlers, no service-layer logic.
+     5	//
+     6	// Cross-module dependency note:
+     7	//   Scope resolution (actorEffectiveScope / actorReadScope / actorTriageScope)
+     8	//   reads permission.permission_grants. Per AGENTS.md layer rules, repos may
+     9	//   not reach into tables owned by another module. We delegate to
+    10	//   permissions/scope-service.ts which owns that cross-module read. This file
+    11	//   calls actorScopeForCapability() from scope-service.ts; it MUST NOT import
+    12	//   from permission.ts schema directly.
+    13	
+    14	import { sql } from 'drizzle-orm';
+    15	
+    16	import type { Db } from '../../db/client.js';
+    17	import { entityLinks } from '../../db/schema/core.js';
+    18	import {
+    19	  vocInternalComments,
+    20	  vocPermissionDecisionsSeedFixture,
+    21	  vocPublicUpdates,
+    22	  vocReporterReplies,
+    23	  vocs,
+    24	} from '../../db/schema/voc.js';
+    25	import type { Tx } from '../../db/tx.js';
+    26	import { allManagedSystemIds } from '../core/managed-systems/read-projections.js';
+    27	import type { Scope, ScopeActorContext } from '../permissions/scope-service.js';
+    28	import { actorScopeForCapability } from '../permissions/scope-service.js';
+    29	import { SEVERITY_ORDINAL, SORT_CONFIG } from './cursor.js';
+    30	
+    31	// Re-export Scope so callers only need one import.
+    32	export type { Scope };
+    33	
+    34	// ── Actor context ─────────────────────────────────────────────────────────────
+    35	
+    36	export interface ActorContextLite {
+    37	  actor_id: string;
+    38	  workspace_id: string;
+    39	  role_level: 'admin' | 'developer' | 'user';
+    40	}
+    41	
+    42	// ── Scope resolvers ───────────────────────────────────────────────────────────
+    43	
+    44	/**
+    45	 * Effective scope: union of voc.read and voc.triage grants for the actor.
+    46	 * Admin role → 'all'. MS-scoped grants → union of both capability MS lists.
+    47	 *
+    48	 * WHY: using undefined (any capability) let future non-VOC capabilities
+    49	 * widen VOC summary visibility, creating an unintended existence-probe
+    50	 * surface. Restricting to voc.read ∪ voc.triage bounds the effective
+    51	 * scope to capabilities that are semantically relevant to VOC reads (M1).
+    52	 *
+    53	 * Used for out_of_scope_summary visibility and detail-existence-probe defense.
+    54	 */
+    55	export async function actorEffectiveScope(
+    56	  db: Db | Tx,
+    57	  actor: ActorContextLite,
+    58	): Promise<Scope> {
+    59	  if (actor.role_level === 'admin') {
+    60	    return { kind: 'all' };
+    61	  }
+    62	  const [readScope, triageScope] = await Promise.all([
+    63	    actorScopeForCapability(db, actor as ScopeActorContext, 'voc.read'),
+    64	    actorScopeForCapability(db, actor as ScopeActorContext, 'voc.triage'),
+    65	  ]);
+    66	  // Union: if either is 'all', effective scope is 'all'.
+    67	  if (readScope.kind === 'all' || triageScope.kind === 'all') {
+    68	    return { kind: 'all' };
+    69	  }
+    70	  const unionIds = [...new Set([...readScope.managedSystemIds, ...triageScope.managedSystemIds])];
+    71	  return { kind: 'scoped', managedSystemIds: unionIds };
+    72	}
+    73	
+    74	/**
+    75	 * voc.read scope. Admin → 'all'. Otherwise: workspace-wide voc.read grant →
+    76	 * 'all'; MS-scoped voc.read grants → scoped list. Empty list → scoped:[].
+    77	 */
+    78	export async function actorReadScope(
+    79	  db: Db | Tx,
+    80	  actor: ActorContextLite,
+    81	): Promise<Scope> {
+    82	  return actorScopeForCapability(db, actor as ScopeActorContext, 'voc.read');
+    83	}
+    84	
+    85	/** voc.triage scope. Same shape as actorReadScope; admin → 'all'. */
+    86	export async function actorTriageScope(
+    87	  db: Db | Tx,
+    88	  actor: ActorContextLite,
+    89	): Promise<Scope> {
+    90	  return actorScopeForCapability(db, actor as ScopeActorContext, 'voc.triage');
+    91	}
+    92	
+    93	// ── SQL array helpers ─────────────────────────────────────────────────────────
+    94	// Drizzle's sql`` tag serializes JS arrays as postgres row/record literals, not
+    95	// postgres array literals. To safely use ANY($arr::uuid[]), we build
+    96	// ARRAY[v1, v2, ...]::uuid[] with individual parameterised slots.
+    97	// This avoids string interpolation of user-supplied values.
+    98	
+    99	function sqlUuidArray(ids: string[]): ReturnType<typeof sql> {
+   100	  if (ids.length === 0) return sql`ARRAY[]::uuid[]`;
+   101	  const items = ids.map((id) => sql`${id}::uuid`);
+   102	  return sql`ARRAY[${sql.join(items, sql`, `)}]::uuid[]`;
+   103	}
+   104	
+   105	function sqlTextArray(values: string[]): ReturnType<typeof sql> {
+   106	  if (values.length === 0) return sql`ARRAY[]::text[]`;
+   107	  const items = values.map((v) => sql`${v}::text`);
+   108	  return sql`ARRAY[${sql.join(items, sql`, `)}]::text[]`;
+   109	}
+   110	
+   111	// ── VocReadRow ────────────────────────────────────────────────────────────────
+   112	
+   113	export interface VocReadRow {
+   114	  id: string;
+   115	  displayId: string;
+   116	  title: string;
+   117	  workspaceId: string;
+   118	  primaryManagedSystemId: string;
+   119	  analyticsAreaId: string | null;
+   120	  reporterId: string;
+   121	  ownerUserId: string | null;
+   122	  ownerTeamId: string | null;
+   123	  severity: 'low' | 'medium' | 'high' | 'critical' | null;
+   124	  reporterFacingStatus: string;
+   125	  triageState: string;
+   126	  triageStateReviewPostponedAt: Date | null;
+   127	  sourceContext: string;
+   128	  descriptionRichContent: unknown;
+   129	  createdAt: Date;
+   130	  updatedAt: Date;
+   131	}
+   132	
+   133	// ── listVocsForRead ──────────────────────────────────────────────────────────
+   134	
+   135	export interface ListVocsRepoArgs {
+   136	  workspaceId: string;
+   137	  scopeFilter: Scope;
+   138	  view: 'inbox' | 'my' | 'triage';
+   139	  actorIdForMyFilter?: string; // required when view='my'
+   140	  tab?: 'untriaged' | 'high' | 'unassigned' | 'similar' | 'no-link' | 'waiting';
+   141	  filterSeverity?: ('low' | 'medium' | 'high' | 'critical')[];
+   142	  filterReporterFacingStatus?: string[];
+   143	  filterOwner?: 'assigned' | 'unassigned';
+   144	  sort: 'created_at:desc' | 'created_at:asc' | 'severity:asc' | 'severity:desc' | 'reporter_facing_status:asc' | 'triage_pinned';
+   145	  cursor?: { sv: string | number; id: string };
+   146	  limit: number;
+   147	}
+   148	
+   149	// Utility: normalise raw postgres row dates.
+   150	function toDate(v: Date | string): Date {
+   151	  return v instanceof Date ? v : new Date(v);
+   152	}
+   153	function toDateOrNull(v: Date | string | null | undefined): Date | null {
+   154	  if (v === null || v === undefined) return null;
+   155	  return v instanceof Date ? v : new Date(v);
+   156	}
+   157	
+   158	function mapVocRow(row: Record<string, unknown>): VocReadRow {
+   159	  return {
+   160	    id: row.id as string,
+   161	    displayId: row.display_id as string,
+   162	    title: row.title as string,
+   163	    workspaceId: row.workspace_id as string,
+   164	    primaryManagedSystemId: row.primary_managed_system_id as string,
+   165	    analyticsAreaId: (row.analytics_area_id as string | null) ?? null,
+   166	    reporterId: row.reporter_id as string,
+   167	    ownerUserId: (row.owner_user_id as string | null) ?? null,
+   168	    ownerTeamId: (row.owner_team_id as string | null) ?? null,
+   169	    severity: (row.severity as 'low' | 'medium' | 'high' | 'critical' | null) ?? null,
+   170	    reporterFacingStatus: row.reporter_facing_status as string,
+   171	    triageState: row.triage_state as string,
+   172	    triageStateReviewPostponedAt: toDateOrNull(row.triage_state_review_postponed_at as Date | string | null | undefined),
+   173	    sourceContext: row.source_context as string,
+   174	    // For list rows, descriptionRichContent is null (heavy column not fetched).
+   175	    descriptionRichContent: row.description_rich_content ?? null,
+   176	    createdAt: toDate(row.created_at as Date | string),
+   177	    updatedAt: toDate(row.updated_at as Date | string),
+   178	  };
+   179	}
+   180	
+   181	// Severity ordinal CASE expression for SQL (ordinal 1..4 for low..critical;
+   182	// NULL is excluded from CASE so it evaluates to SQL NULL).
+   183	// WHY: using ELSE 0 made nulls sort first in DESC (0 < any ordinal).
+   184	// Fix (M6): use a separate IS NULL flag so nulls always sort last in both
+   185	// ASC and DESC: ORDER BY (severity IS NULL) ASC, severity_ord ASC|DESC.
+   186	// The IS NULL flag (false=0, true=1) sorts NULLs to the end of any direction.
+   187	const SEVERITY_ORDINAL_CASE = sql<number>`
+   188	  CASE severity
+   189	    WHEN 'low'      THEN 1
+   190	    WHEN 'medium'   THEN 2
+   191	    WHEN 'high'     THEN 3
+   192	    WHEN 'critical' THEN 4
+   193	    ELSE NULL
+   194	  END`;
+   195	
+   196	export async function listVocsForRead(
+   197	  db: Db | Tx,
+   198	  args: ListVocsRepoArgs,
+   199	): Promise<{ rows: VocReadRow[]; hasMore: boolean; nextCursor: { sv: string | number; id: string } | null }> {
+   200	  const { workspaceId, scopeFilter, view, actorIdForMyFilter, tab, filterSeverity, filterReporterFacingStatus, filterOwner, sort, cursor, limit } = args;
+   201	
+   202	  // Short-circuit: empty scoped list → no rows possible, skip DB query.
+   203	  if (scopeFilter.kind === 'scoped' && scopeFilter.managedSystemIds.length === 0) {
+   204	    return { rows: [], hasMore: false, nextCursor: null };
+   205	  }
+   206	
+   207	  // tab='similar' → WHERE false (Slice 3; cluster service not available).
+   208	  if (tab === 'similar') {
+   209	    return { rows: [], hasMore: false, nextCursor: null };
+   210	  }
+   211	
+   212	  // Build the WHERE clauses via raw SQL fragments.
+   213	  // All values are bound via parameterised sql`` tags — never string-interpolated.
+   214	  const wheres: ReturnType<typeof sql>[] = [
+   215	    sql`workspace_id = ${workspaceId}`,
+   216	    sql`archived_at IS NULL`,
+   217	  ];
+   218	
+   219	  // Scope filter.
+   220	  if (scopeFilter.kind === 'scoped') {
+   221	    wheres.push(sql`primary_managed_system_id = ANY(${sqlUuidArray(scopeFilter.managedSystemIds)})`);
+   222	  }
+   223	
+   224	  // View-specific filters.
+   225	  if (view === 'my') {
+   226	    if (!actorIdForMyFilter) throw new Error('actorIdForMyFilter required for view=my');
+   227	    wheres.push(sql`reporter_id = ${actorIdForMyFilter}`);
+   228	  } else if (view === 'triage') {
+   229	    wheres.push(sql`triage_state IN ('untriaged','needs_more_information')`);
+   230	  }
+   231	
+   232	  // Tab filters.
+   233	  if (tab === 'untriaged') {
+   234	    wheres.push(sql`triage_state = 'untriaged'`);
+   235	  } else if (tab === 'high') {
+   236	    wheres.push(sql`severity = 'high'`);
+   237	  } else if (tab === 'unassigned') {
+   238	    wheres.push(sql`owner_user_id IS NULL AND owner_team_id IS NULL`);
+   239	  } else if (tab === 'waiting') {
+   240	    // Only valid for triage view; no extra clause beyond the triage_state filter
+   241	    // since service layer validates view=triage for this tab.
+   242	    wheres.push(sql`triage_state = 'untriaged' AND triage_state_review_postponed_at IS NOT NULL`);
+   243	  } else if (tab === 'no-link') {
+   244	    wheres.push(sql`NOT EXISTS (
+   245	      SELECT 1
+   246	      FROM ${entityLinks} el
+   247	      WHERE el.workspace_id = ${workspaceId}
+   248	        AND el.status = 'active'
+   249	        AND (
+   250	          (el.source_type = 'voc' AND el.source_id = ${vocs.id})
+   251	          OR (el.target_type = 'voc' AND el.target_id = ${vocs.id})
+   252	        )
+   253	    )`);
+   254	  }
+   255	
+   256	  // Scalar column filters.
+   257	  if (filterSeverity && filterSeverity.length > 0) {
+   258	    wheres.push(sql`severity = ANY(${sqlTextArray(filterSeverity)})`);
+   259	  }
+   260	  if (filterReporterFacingStatus && filterReporterFacingStatus.length > 0) {
+
+hook: PostToolUse
+hook: PostToolUse Failed
+exec
+/bin/zsh -lc "nl -ba apps/backend/migrations/0018_entity_links.sql | sed -n '1,220p' && nl -ba apps/backend/migrations/meta/_journal.json | sed -n '120,155p'" in /Users/hyojung/Desktop/2026/wt-113-entity-link-detach
+ succeeded in 0ms:
+     1	-- Issue #112: Slice 4.1 entity_links VOC↔VOC related_to tracer.
+     2	-- Establishes core.entity_links as the canonical polymorphic loose-coupling
+     3	-- join table. This slice creates only active VOC -> VOC related_to links;
+     4	-- later slices expand relation/status handling and detach transitions.
+     5	
+     6	CREATE TABLE IF NOT EXISTS "core"."entity_links" (
+     7	  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+     8	  "workspace_id" uuid NOT NULL REFERENCES "core"."workspaces"("id"),
+     9	  "source_type" text NOT NULL,
+    10	  "source_id" uuid NOT NULL,
+    11	  "target_type" text NOT NULL,
+    12	  "target_id" uuid NOT NULL,
+    13	  "relation_type" text NOT NULL,
+    14	  "visibility" text NOT NULL DEFAULT 'internal_only',
+    15	  "status" text NOT NULL DEFAULT 'active',
+    16	  "managed_system_id" uuid NOT NULL REFERENCES "core"."managed_systems"("id"),
+    17	  "created_by" uuid NOT NULL REFERENCES "core"."actors"("id"),
+    18	  "created_at" timestamptz NOT NULL DEFAULT now(),
+    19	  "updated_at" timestamptz,
+    20	  CONSTRAINT "entity_links_relation_type_check"
+    21	    CHECK ("relation_type" IN ('related_to')),
+    22	  CONSTRAINT "entity_links_visibility_check"
+    23	    CHECK ("visibility" IN ('internal_only','summary_visible','visible_to_reporter','admin_only')),
+    24	  CONSTRAINT "entity_links_status_check"
+    25	    CHECK ("status" IN ('active','stale','detached','revoked')),
+    26	  CONSTRAINT "entity_links_source_type_check"
+    27	    CHECK ("source_type" IN ('voc')),
+    28	  CONSTRAINT "entity_links_target_type_check"
+    29	    CHECK ("target_type" IN ('voc')),
+    30	  CONSTRAINT "entity_links_not_self_check"
+    31	    CHECK (NOT ("source_type" = "target_type" AND "source_id" = "target_id"))
+    32	);
+    33	--> statement-breakpoint
+    34	
+    35	CREATE UNIQUE INDEX IF NOT EXISTS "entity_links_active_unique_idx"
+    36	  ON "core"."entity_links"
+    37	  ("workspace_id", "source_type", "source_id", "target_type", "target_id", "relation_type")
+    38	  WHERE "status" = 'active';
+    39	--> statement-breakpoint
+    40	
+    41	CREATE INDEX IF NOT EXISTS "entity_links_active_source_idx"
+    42	  ON "core"."entity_links" ("workspace_id", "source_type", "source_id")
+    43	  WHERE "status" = 'active';
+    44	--> statement-breakpoint
+    45	
+    46	CREATE INDEX IF NOT EXISTS "entity_links_active_target_idx"
+    47	  ON "core"."entity_links" ("workspace_id", "target_type", "target_id")
+    48	  WHERE "status" = 'active';
+    49	--> statement-breakpoint
+    50	
+    51	CREATE INDEX IF NOT EXISTS "entity_links_workspace_ms_status_idx"
+    52	  ON "core"."entity_links" ("workspace_id", "managed_system_id", "status");
+    53	--> statement-breakpoint
+    54	
+    55	GRANT INSERT, SELECT ON "core"."entity_links" TO fops_app;
+   120	      "when": 1780440000000,
+   121	      "tag": "0016_voc_attachments_grants",
+   122	      "breakpoints": false
+   123	    },
+   124	    {
+   125	      "idx": 17,
+   126	      "version": "7",
+   127	      "when": 1780540000000,
+   128	      "tag": "0017_voc_per_workspace_display_counter",
+   129	      "breakpoints": true
+   130	    },
+   131	    {
+   132	      "idx": 18,
+   133	      "version": "7",
+   134	      "when": 1781533641945,
+   135	      "tag": "0018_entity_links",
+   136	      "breakpoints": true
+   137	    },
+   138	    {
+   139	      "idx": 19,
+   140	      "version": "7",
+   141	      "when": 1781534641945,
+   142	      "tag": "0019_entity_link_detach",
+   143	      "breakpoints": true
+   144	    }
+   145	  ]
+   146	}
+
+hook: PostToolUse
+hook: PostToolUse Failed
+hook: PostToolUse Failed
+hook: PostToolUse Failed
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse Failed
+hook: PreToolUse Failed
+hook: PreToolUse Failed
+hook: PreToolUse Failed
+exec
+/bin/zsh -lc "nl -ba apps/backend/src/modules/voc/read-service.ts | sed -n '500,590p'" in /Users/hyojung/Desktop/2026/wt-113-entity-link-detach
+ succeeded in 0ms:
+   500	    // ── FULL path (msInReadScope || isReporter) ────────────────────────────
+   501	
+   502	    // ── 5. Load inline conversation (first 50 entries) ───────────────────────
+   503	    const convResult = await repoRead.selectConversationPage(deps.db, {
+   504	      workspaceId: actor.workspace_id,
+   505	      vocId,
+   506	      actorId: actor.actor_id,
+   507	      canTriage,
+   508	      isReporter,
+   509	      limit: 50,
+   510	    });
+   511	
+   512	    // ── 5b. PLAN-22 §Bug-1: VOC-body attachments + per-comment attachments ──
+   513	    // Fetched in parallel — one query for VOC-body attachments, one bulk
+   514	    // query for ALL inline comment-attached rows (no N+1).
+   515	    const commentIds = convResult.entries.map((e) => e.id);
+   516	    const [vocAttRows, commentAttachmentsMap] = await Promise.all([
+   517	      repoRead.selectVocAttachments(deps.db, actor.workspace_id, vocId),
+   518	      repoRead.selectAttachmentsForComments(deps.db, actor.workspace_id, commentIds),
+   519	    ]);
+   520	    const links = await deps.entityLinksService.listLinks({
+   521	      actor,
+   522	      endpoint: { type: 'voc', id: vocId },
+   523	    });
+   524	
+   525	    const conversationTimeline = mapConversationRowsWithAttachments(
+   526	      convResult.entries,
+   527	      commentAttachmentsMap,
+   528	    );
+   529	    let convNextCursor: string | undefined;
+   530	    if (convResult.hasMore && convResult.nextCursor) {
+   531	      convNextCursor = encodeConversationCursor(convResult.nextCursor);
+   532	    }
+   533	
+   534	    // ── 6. Next reporter states ──────────────────────────────────────────────
+   535	    const nextStates = await nextReporterStates(
+   536	      row.reporterFacingStatus as ReporterFacingStatus,
+   537	      deps.db,
+   538	    );
+   539	
+   540	    // ── 7. Permission decisions seed ─────────────────────────────────────────
+   541	    const permissionDecisionsSeed = await repoRead.selectPermissionDecisionsSeed(deps.db, actor.workspace_id, vocId);
+   542	
+   543	    const permissionDecisions: Record<string, unknown> =
+   544	      permissionDecisionsSeed !== null && typeof permissionDecisionsSeed === 'object'
+   545	        ? (permissionDecisionsSeed as Record<string, unknown>)
+   546	        : {};
+   547	
+   548	    // ── 8. Compose full envelope ─────────────────────────────────────────────
+   549	    const envelope: VocDetailEnvelope = {
+   550	      id: row.id,
+   551	      display_id: row.displayId,
+   552	      title: row.title,
+   553	      primary_managed_system_id: primaryMs,
+   554	      analytics_area_id: row.analyticsAreaId,
+   555	      reporter_id: row.reporterId,
+   556	      owner_user_id: row.ownerUserId,
+   557	      owner_team_id: row.ownerTeamId,
+   558	      severity: row.severity,
+   559	      reporter_facing_status: row.reporterFacingStatus as VocDetailEnvelope['reporter_facing_status'],
+   560	      triage_state: row.triageState as VocDetailEnvelope['triage_state'],
+   561	      source_context: row.sourceContext as VocDetailEnvelope['source_context'],
+   562	      created_at: row.createdAt.toISOString(),
+   563	      updated_at: row.updatedAt.toISOString(),
+   564	      similar_count: 0,
+   565	      // PLAN-22 §Bug-1: detail row also carries attachment_count (matches the
+   566	      // shared schema which extends vocListItemSchema).
+   567	      attachment_count: vocAttRows.length,
+   568	      description_rich_content: row.descriptionRichContent,
+   569	      next_actions: [],
+   570	      next_reporter_states: {
+   571	        allowed: nextStates.allowed,
+   572	        forbidden: nextStates.forbidden as Record<VocDetailEnvelope['reporter_facing_status'], string>,
+   573	      },
+   574	      linked_execution: { findingRef: null, taskRef: null },
+   575	      links,
+   576	      conversation_timeline: conversationTimeline,
+   577	      // conversation_page.cursor uses exactOptionalPropertyTypes: build without key when absent.
+   578	      conversation_page: convNextCursor !== undefined
+   579	        ? { cursor: convNextCursor, has_more: convResult.hasMore }
+   580	        : { has_more: convResult.hasMore },
+   581	      permission_decisions: permissionDecisions,
+   582	      // PLAN-22 §Bug-1: VOC-body linked attachments.
+   583	      attachments: vocAttRows.map(mapAttachmentRow),
+   584	    };
+   585	
+   586	    return { kind: 'full', envelope, etag };
+   587	  }
+   588	
+   589	  // ── getConversation ───────────────────────────────────────────────────────
+   590	
+
+hook: PostToolUse
+exec
+/bin/zsh -lc "nl -ba apps/backend/src/modules/voc/read-service.ts | sed -n '700,780p'" in /Users/hyojung/Desktop/2026/wt-113-entity-link-detach
+ succeeded in 0ms:
+   700	    // Inline conversation (first 50 entries).
+   701	    const convResult = await repoRead.selectConversationPage(tx, {
+   702	      workspaceId: actor.workspace_id,
+   703	      vocId,
+   704	      actorId: actor.actor_id,
+   705	      canTriage,
+   706	      isReporter,
+   707	      limit: 50,
+   708	    });
+   709	
+   710	    // PLAN-22 §Bug-1: VOC-body + per-comment attachments, hydrated inside tx
+   711	    // so the post-write envelope reflects link rows written in the same tx
+   712	    // (e.g. a public_update that just attached files).
+   713	    const commentIds = convResult.entries.map((e) => e.id);
+   714	    const [vocAttRows, commentAttachmentsMap] = await Promise.all([
+   715	      repoRead.selectVocAttachments(tx, actor.workspace_id, vocId),
+   716	      repoRead.selectAttachmentsForComments(tx, actor.workspace_id, commentIds),
+   717	    ]);
+   718	    const links = await deps.entityLinksService.listLinks({
+   719	      actor,
+   720	      endpoint: { type: 'voc', id: vocId },
+   721	    });
+   722	
+   723	    const conversationTimeline = mapConversationRowsWithAttachments(
+   724	      convResult.entries,
+   725	      commentAttachmentsMap,
+   726	    );
+   727	    let convNextCursor: string | undefined;
+   728	    if (convResult.hasMore && convResult.nextCursor) {
+   729	      convNextCursor = encodeConversationCursor(convResult.nextCursor);
+   730	    }
+   731	
+   732	    // Next reporter states.
+   733	    const nextStates = await nextReporterStates(
+   734	      row.reporterFacingStatus as ReporterFacingStatus,
+   735	      tx,
+   736	    );
+   737	
+   738	    // Permission decisions seed.
+   739	    const permissionDecisionsSeed = await repoRead.selectPermissionDecisionsSeed(tx, actor.workspace_id, vocId);
+   740	    const permissionDecisions: Record<string, unknown> =
+   741	      permissionDecisionsSeed !== null && typeof permissionDecisionsSeed === 'object'
+   742	        ? (permissionDecisionsSeed as Record<string, unknown>)
+   743	        : {};
+   744	
+   745	    return {
+   746	      id: row.id,
+   747	      display_id: row.displayId,
+   748	      title: row.title,
+   749	      primary_managed_system_id: primaryMs,
+   750	      analytics_area_id: row.analyticsAreaId,
+   751	      reporter_id: row.reporterId,
+   752	      owner_user_id: row.ownerUserId,
+   753	      owner_team_id: row.ownerTeamId,
+   754	      severity: row.severity,
+   755	      reporter_facing_status: row.reporterFacingStatus as VocDetailEnvelope['reporter_facing_status'],
+   756	      triage_state: row.triageState as VocDetailEnvelope['triage_state'],
+   757	      source_context: row.sourceContext as VocDetailEnvelope['source_context'],
+   758	      created_at: row.createdAt.toISOString(),
+   759	      updated_at: row.updatedAt.toISOString(),
+   760	      similar_count: 0,
+   761	      attachment_count: vocAttRows.length,
+   762	      description_rich_content: row.descriptionRichContent,
+   763	      next_actions: [],
+   764	      next_reporter_states: {
+   765	        allowed: nextStates.allowed,
+   766	        forbidden: nextStates.forbidden as Record<VocDetailEnvelope['reporter_facing_status'], string>,
+   767	      },
+   768	      linked_execution: { findingRef: null, taskRef: null },
+   769	      links,
+   770	      conversation_timeline: conversationTimeline,
+   771	      conversation_page: convNextCursor !== undefined
+   772	        ? { cursor: convNextCursor, has_more: convResult.hasMore }
+   773	        : { has_more: convResult.hasMore },
+   774	      permission_decisions: permissionDecisions,
+   775	      attachments: vocAttRows.map(mapAttachmentRow),
+   776	    };
+   777	  }
+   778	
+   779	  return { listVocs, getVocDetail, getConversation, composeDetailEnvelope };
+   780	}
+
+hook: PostToolUse
+exec
+/bin/zsh -lc "nl -ba apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts | sed -n '60,470p'" in /Users/hyojung/Desktop/2026/wt-113-entity-link-detach
+ succeeded in 0ms:
+    60	  });
+    61	
+    62	  beforeEach(async () => {
+    63	    await dbHandle.pool.query('delete from core.rate_limits');
+    64	    await cleanupEntityLinkFixtures();
+    65	  });
+    66	
+    67	  afterAll(async () => {
+    68	    await cleanupEntityLinkFixtures();
+    69	    await app?.close();
+    70	    await dbHandle?.close();
+    71	    await migrateHandle?.close();
+    72	  });
+    73	
+    74	  async function cleanupEntityLinkFixtures(): Promise<void> {
+    75	    if (!migrateHandle) return;
+    76	    await migrateHandle.pool.query(
+    77	      `delete from core.entity_links
+    78	        where workspace_id = $1
+    79	          and managed_system_id in (
+    80	            select id from core.managed_systems where workspace_id = $1 and slug like $2
+    81	          )`,
+    82	      [WORKSPACE_ID, `${SLUG_PREFIX}%`],
+    83	    );
+    84	    await migrateHandle.pool.query(
+    85	      `delete from core.audit_log
+    86	        where workspace_id = $1
+    87	          and event_type in ('entity_link.created', 'entity_link.detached')`,
+    88	      [WORKSPACE_ID],
+    89	    );
+    90	    await cleanupReadTestTables(dbHandle, WORKSPACE_ID, SLUG_PREFIX);
+    91	  }
+    92	
+    93	  async function seedVocPair(): Promise<{
+    94	    msA: string;
+    95	    msB: string;
+    96	    sourceVoc: { id: string };
+    97	    targetVoc: { id: string };
+    98	  }> {
+    99	    const msA = await insertMsDirectly(
+   100	      dbHandle,
+   101	      WORKSPACE_ID,
+   102	      `${uid(SLUG_PREFIX)}-a`,
+   103	      'Links MS-A',
+   104	    );
+   105	    const msB = await insertMsDirectly(
+   106	      dbHandle,
+   107	      WORKSPACE_ID,
+   108	      `${uid(SLUG_PREFIX)}-b`,
+   109	      'Links MS-B',
+   110	    );
+   111	    const sourceVoc = await insertVocDirectly(
+   112	      dbHandle,
+   113	      WORKSPACE_ID,
+   114	      msA,
+   115	      reporterId,
+   116	      'Link Source VOC',
+   117	    );
+   118	    const targetVoc = await insertVocDirectly(
+   119	      dbHandle,
+   120	      WORKSPACE_ID,
+   121	      msB,
+   122	      reporterId,
+   123	      'Link Target VOC',
+   124	    );
+   125	    return { msA, msB, sourceVoc, targetVoc };
+   126	  }
+   127	
+   128	  async function postEntityLink(cookie: string, sourceId: string, targetId: string, extra = {}) {
+   129	    return app.inject({
+   130	      method: 'POST',
+   131	      url: '/entity-links',
+   132	      headers: {
+   133	        cookie: `${SESSION_COOKIE_NAME}=${cookie}`,
+   134	        'content-type': 'application/json',
+   135	      },
+   136	      payload: {
+   137	        source: { type: 'voc', id: sourceId },
+   138	        target: { type: 'voc', id: targetId },
+   139	        relation_type: 'related_to',
+   140	        ...extra,
+   141	      },
+   142	    });
+   143	  }
+   144	
+   145	  async function patchEntityLink(cookie: string, linkId: string, payload: Record<string, unknown>) {
+   146	    return await app.inject({
+   147	      method: 'PATCH',
+   148	      url: `/entity-links/${linkId}`,
+   149	      headers: {
+   150	        cookie: `${SESSION_COOKIE_NAME}=${cookie}`,
+   151	        'content-type': 'application/json',
+   152	      },
+   153	      payload,
+   154	    });
+   155	  }
+   156	
+   157	  it('POST creates an active VOC↔VOC related_to link and audit row', async () => {
+   158	    const { msA, sourceVoc, targetVoc } = await seedVocPair();
+   159	
+   160	    const res = await postEntityLink(adminCookie, sourceVoc.id, targetVoc.id);
+   161	    expect(res.statusCode).toBe(201);
+   162	    const body = res.json<{ id: string; visibility_state: string; managed_system_id: string }>();
+   163	    expect(body.visibility_state).toBe('allowed');
+   164	    expect(body.managed_system_id).toBe(msA);
+   165	
+   166	    const linkRows = await dbHandle.pool.query<{ n: number }>(
+   167	      `select count(*)::int as n from core.entity_links
+   168	        where id = $1 and status = 'active' and relation_type = 'related_to'`,
+   169	      [body.id],
+   170	    );
+   171	    expect(linkRows.rows[0]?.n).toBe(1);
+   172	
+   173	    const auditRows = await dbHandle.pool.query<{ detail: Record<string, unknown> }>(
+   174	      `select detail from core.audit_log
+   175	        where event_type = 'entity_link.created' and subject_id = $1`,
+   176	      [body.id],
+   177	    );
+   178	    expect(auditRows.rowCount).toBe(1);
+   179	    expect(auditRows.rows[0]?.detail).toMatchObject({
+   180	      link_id: body.id,
+   181	      relation_type: 'related_to',
+   182	      visibility: 'internal_only',
+   183	    });
+   184	  });
+   185	
+   186	  it('POST returns 404 when actor lacks scope on the target VOC', async () => {
+   187	    const { msA, sourceVoc, targetVoc } = await seedVocPair();
+   188	    const { id: devId, externalId } = await insertDevActor(
+   189	      dbHandle,
+   190	      WORKSPACE_ID,
+   191	      uid('target404'),
+   192	    );
+   193	    await grantCapability(dbHandle, WORKSPACE_ID, devId, 'voc.read', msA, adminActorId);
+   194	    const devCookie = await loginAs(app, externalId);
+   195	
+   196	    const res = await postEntityLink(devCookie, sourceVoc.id, targetVoc.id);
+   197	    expect(res.statusCode).toBe(404);
+   198	  });
+   199	
+   200	  it('POST rejects self-link', async () => {
+   201	    const { sourceVoc } = await seedVocPair();
+   202	    const res = await postEntityLink(adminCookie, sourceVoc.id, sourceVoc.id);
+   203	    expect(res.statusCode).toBe(422);
+   204	    expect(res.json<{ code: string }>().code).toBe('validation.failed');
+   205	  });
+   206	
+   207	  it('POST rejects unsupported relation_type, source_type, target_type, and visibility', async () => {
+   208	    const { sourceVoc, targetVoc } = await seedVocPair();
+   209	    const cases = [
+   210	      { relation_type: 'evidence_of' },
+   211	      { source: { type: 'finding', id: sourceVoc.id } },
+   212	      { target: { type: 'task', id: targetVoc.id } },
+   213	      { visibility: 'summary_visible' },
+   214	    ];
+   215	
+   216	    for (const extra of cases) {
+   217	      const res = await postEntityLink(adminCookie, sourceVoc.id, targetVoc.id, extra);
+   218	      expect(res.statusCode).toBe(422);
+   219	      expect(res.json<{ code: string }>().code).toBe('validation.failed');
+   220	    }
+   221	  });
+   222	
+   223	  it('POST duplicate returns the existing active link without duplicating', async () => {
+   224	    const { sourceVoc, targetVoc } = await seedVocPair();
+   225	    const first = await postEntityLink(adminCookie, sourceVoc.id, targetVoc.id);
+   226	    expect(first.statusCode).toBe(201);
+   227	    const firstId = first.json<{ id: string }>().id;
+   228	
+   229	    const second = await postEntityLink(adminCookie, sourceVoc.id, targetVoc.id);
+   230	    expect(second.statusCode).toBe(200);
+   231	    expect(second.json<{ id: string }>().id).toBe(firstId);
+   232	
+   233	    const count = await dbHandle.pool.query<{ n: number }>(
+   234	      `select count(*)::int as n from core.entity_links
+   235	        where source_id = $1 and target_id = $2 and status = 'active'`,
+   236	      [sourceVoc.id, targetVoc.id],
+   237	    );
+   238	    expect(count.rows[0]?.n).toBe(1);
+   239	  });
+   240	
+   241	  it('GET by source returns allowed rows and hidden stubs for out-of-scope targets', async () => {
+   242	    const msA = await insertMsDirectly(
+   243	      dbHandle,
+   244	      WORKSPACE_ID,
+   245	      `${uid(SLUG_PREFIX)}-geta`,
+   246	      'Links GET MS-A',
+   247	    );
+   248	    const msB = await insertMsDirectly(
+   249	      dbHandle,
+   250	      WORKSPACE_ID,
+   251	      `${uid(SLUG_PREFIX)}-getb`,
+   252	      'Links GET MS-B',
+   253	    );
+   254	    const sourceVoc = await insertVocDirectly(
+   255	      dbHandle,
+   256	      WORKSPACE_ID,
+   257	      msA,
+   258	      reporterId,
+   259	      'GET Source VOC',
+   260	    );
+   261	    const allowedTarget = await insertVocDirectly(
+   262	      dbHandle,
+   263	      WORKSPACE_ID,
+   264	      msA,
+   265	      reporterId,
+   266	      'GET Allowed Target',
+   267	    );
+   268	    const hiddenTarget = await insertVocDirectly(
+   269	      dbHandle,
+   270	      WORKSPACE_ID,
+   271	      msB,
+   272	      reporterId,
+   273	      'GET Hidden Target',
+   274	    );
+   275	
+   276	    await postEntityLink(adminCookie, sourceVoc.id, allowedTarget.id);
+   277	    await postEntityLink(adminCookie, sourceVoc.id, hiddenTarget.id);
+   278	
+   279	    const { id: devId, externalId } = await insertDevActor(dbHandle, WORKSPACE_ID, uid('getsrc'));
+   280	    await grantCapability(dbHandle, WORKSPACE_ID, devId, 'voc.read', msA, adminActorId);
+   281	    const devCookie = await loginAs(app, externalId);
+   282	
+   283	    const res = await app.inject({
+   284	      method: 'GET',
+   285	      url: `/entity-links?source_type=voc&source_id=${sourceVoc.id}`,
+   286	      headers: { cookie: `${SESSION_COOKIE_NAME}=${devCookie}` },
+   287	    });
+   288	    expect(res.statusCode).toBe(200);
+   289	    const body = res.json<{ items: Array<Record<string, unknown>> }>();
+   290	    expect(body.items).toHaveLength(2);
+   291	    expect(
+   292	      body.items.some(
+   293	        (item) => item.visibility_state === 'allowed' && item.target_id === allowedTarget.id,
+   294	      ),
+   295	    ).toBe(true);
+   296	    const hidden = body.items.find((item) => item.visibility_state === 'hidden');
+   297	    expect(hidden).toBeDefined();
+   298	    expect(hidden?.target_id).toBeUndefined();
+   299	    expect(hidden?.source_id).toBeUndefined();
+   300	  });
+   301	
+   302	  it('VOC detail returns active outbound related_to links on the Links tab payload', async () => {
+   303	    const { sourceVoc, targetVoc } = await seedVocPair();
+   304	    const create = await postEntityLink(adminCookie, sourceVoc.id, targetVoc.id);
+   305	    expect(create.statusCode).toBe(201);
+   306	    const linkId = create.json<{ id: string }>().id;
+   307	
+   308	    const res = await app.inject({
+   309	      method: 'GET',
+   310	      url: `/vocs/${sourceVoc.id}`,
+   311	      headers: { cookie: `${SESSION_COOKIE_NAME}=${adminCookie}` },
+   312	    });
+   313	    expect(res.statusCode).toBe(200);
+   314	    const body = res.json<{ links?: Array<{ id: string; visibility_state: string }> }>();
+   315	    expect(
+   316	      body.links?.some((link) => link.id === linkId && link.visibility_state === 'allowed'),
+   317	    ).toBe(true);
+   318	  });
+   319	
+   320	  it('PATCH detaches an active related_to link, preserves the row, and audits the detach', async () => {
+   321	    const { sourceVoc, targetVoc } = await seedVocPair();
+   322	    const create = await postEntityLink(adminCookie, sourceVoc.id, targetVoc.id);
+   323	    expect(create.statusCode).toBe(201);
+   324	    const linkId = create.json<{ id: string }>().id;
+   325	
+   326	    const res = await patchEntityLink(adminCookie, linkId, { reason: 'No longer relevant' });
+   327	    expect(res.statusCode).toBe(200);
+   328	    const body = res.json<{ id: string; status: string; detached_at: string | null }>();
+   329	    expect(body).toMatchObject({ id: linkId, status: 'detached' });
+   330	    expect(body.detached_at).toEqual(expect.any(String));
+   331	
+   332	    const linkRows = await dbHandle.pool.query<{
+   333	      status: string;
+   334	      detached_by: string | null;
+   335	      detach_reason: string | null;
+   336	      detached_at: Date | null;
+   337	    }>(
+   338	      `select status, detached_by, detach_reason, detached_at
+   339	        from core.entity_links
+   340	        where id = $1`,
+   341	      [linkId],
+   342	    );
+   343	    expect(linkRows.rowCount).toBe(1);
+   344	    expect(linkRows.rows[0]).toMatchObject({
+   345	      status: 'detached',
+   346	      detached_by: adminActorId,
+   347	      detach_reason: 'No longer relevant',
+   348	    });
+   349	    expect(linkRows.rows[0]?.detached_at).toBeInstanceOf(Date);
+   350	
+   351	    const auditRows = await dbHandle.pool.query<{ detail: Record<string, unknown> }>(
+   352	      `select detail from core.audit_log
+   353	        where event_type = 'entity_link.detached' and subject_id = $1`,
+   354	      [linkId],
+   355	    );
+   356	    expect(auditRows.rowCount).toBe(1);
+   357	    expect(auditRows.rows[0]?.detail).toMatchObject({
+   358	      link_id: linkId,
+   359	      source: { type: 'voc', id: sourceVoc.id },
+   360	      target: { type: 'voc', id: targetVoc.id },
+   361	      relation_type: 'related_to',
+   362	      reason: 'No longer relevant',
+   363	    });
+   364	  });
+   365	
+   366	  it('after detach, GET /entity-links and VOC detail Links tab omit the detached link', async () => {
+   367	    const { sourceVoc, targetVoc } = await seedVocPair();
+   368	    const create = await postEntityLink(adminCookie, sourceVoc.id, targetVoc.id);
+   369	    expect(create.statusCode).toBe(201);
+   370	    const linkId = create.json<{ id: string }>().id;
+   371	
+   372	    const detach = await patchEntityLink(adminCookie, linkId, { reason: 'Superseded' });
+   373	    expect(detach.statusCode).toBe(200);
+   374	
+   375	    const list = await app.inject({
+   376	      method: 'GET',
+   377	      url: `/entity-links?source_type=voc&source_id=${sourceVoc.id}`,
+   378	      headers: { cookie: `${SESSION_COOKIE_NAME}=${adminCookie}` },
+   379	    });
+   380	    expect(list.statusCode).toBe(200);
+   381	    expect(
+   382	      list.json<{ items: Array<{ id: string }> }>().items.some((item) => item.id === linkId),
+   383	    ).toBe(false);
+   384	
+   385	    const detail = await app.inject({
+   386	      method: 'GET',
+   387	      url: `/vocs/${sourceVoc.id}`,
+   388	      headers: { cookie: `${SESSION_COOKIE_NAME}=${adminCookie}` },
+   389	    });
+   390	    expect(detail.statusCode).toBe(200);
+   391	    const body = detail.json<{ links?: Array<{ id: string }> }>();
+   392	    expect(body.links?.some((link) => link.id === linkId)).toBe(false);
+   393	  });
+   394	
+   395	  it('PATCH on an already-detached link returns 409', async () => {
+   396	    const { sourceVoc, targetVoc } = await seedVocPair();
+   397	    const create = await postEntityLink(adminCookie, sourceVoc.id, targetVoc.id);
+   398	    expect(create.statusCode).toBe(201);
+   399	    const linkId = create.json<{ id: string }>().id;
+   400	
+   401	    const first = await patchEntityLink(adminCookie, linkId, { reason: 'Initial detach' });
+   402	    expect(first.statusCode).toBe(200);
+   403	
+   404	    const second = await patchEntityLink(adminCookie, linkId, { reason: 'Again' });
+   405	    expect(second.statusCode).toBe(409);
+   406	    expect(second.json<{ code: string }>().code).toBe('conflict.stale_write');
+   407	  });
+   408	
+   409	  it('PATCH returns 404 when actor lacks scope on the target endpoint', async () => {
+   410	    const { msA, sourceVoc, targetVoc } = await seedVocPair();
+   411	    const create = await postEntityLink(adminCookie, sourceVoc.id, targetVoc.id);
+   412	    expect(create.statusCode).toBe(201);
+   413	    const linkId = create.json<{ id: string }>().id;
+   414	
+   415	    const { id: devId, externalId } = await insertDevActor(
+   416	      dbHandle,
+   417	      WORKSPACE_ID,
+   418	      uid('detach404'),
+   419	    );
+   420	    await grantCapability(dbHandle, WORKSPACE_ID, devId, 'voc.read', msA, adminActorId);
+   421	    const devCookie = await loginAs(app, externalId);
+   422	
+   423	    const res = await patchEntityLink(devCookie, linkId, { reason: 'No scope' });
+   424	    expect(res.statusCode).toBe(404);
+   425	  });
+   426	
+   427	  it('PATCH rejects missing or empty detach reason', async () => {
+   428	    const { sourceVoc, targetVoc } = await seedVocPair();
+   429	    const create = await postEntityLink(adminCookie, sourceVoc.id, targetVoc.id);
+   430	    expect(create.statusCode).toBe(201);
+   431	    const linkId = create.json<{ id: string }>().id;
+   432	
+   433	    for (const payload of [{}, { reason: '' }, { reason: '   ' }]) {
+   434	      const res = await patchEntityLink(adminCookie, linkId, payload);
+   435	      expect(res.statusCode).toBe(422);
+   436	      expect(res.json<{ code: string }>().code).toBe('validation.failed');
+   437	    }
+   438	  });
+   439	
+   440	  it('detach frees the active unique slot so the same VOC pair can be linked again', async () => {
+   441	    const { sourceVoc, targetVoc } = await seedVocPair();
+   442	    const first = await postEntityLink(adminCookie, sourceVoc.id, targetVoc.id);
+   443	    expect(first.statusCode).toBe(201);
+   444	    const firstId = first.json<{ id: string }>().id;
+   445	
+   446	    const detach = await patchEntityLink(adminCookie, firstId, { reason: 'Relink needed' });
+   447	    expect(detach.statusCode).toBe(200);
+   448	
+   449	    const second = await postEntityLink(adminCookie, sourceVoc.id, targetVoc.id);
+   450	    expect(second.statusCode).toBe(201);
+   451	    expect(second.json<{ id: string }>().id).not.toBe(firstId);
+   452	
+   453	    const count = await dbHandle.pool.query<{ active: number; detached: number }>(
+   454	      `select
+   455	          count(*) filter (where status = 'active')::int as active,
+   456	          count(*) filter (where status = 'detached')::int as detached
+   457	        from core.entity_links
+   458	        where source_id = $1 and target_id = $2`,
+   459	      [sourceVoc.id, targetVoc.id],
+   460	    );
+   461	    expect(count.rows[0]).toMatchObject({ active: 1, detached: 1 });
+   462	  });
+   463	});
+
+hook: PostToolUse
+hook: PostToolUse Failed
+exec
+/bin/zsh -lc 'git diff --check && git diff --name-only | sort' in /Users/hyojung/Desktop/2026/wt-113-entity-link-detach
+ succeeded in 0ms:
+git: warning: confstr() failed with code 5: couldn't get path of DARWIN_USER_TEMP_DIR; using /tmp instead
+git: warning: confstr() failed with code 5: couldn't get path of DARWIN_USER_TEMP_DIR; using /tmp instead
+apps/backend/migrations/meta/_journal.json
+apps/backend/src/db/schema/core.ts
+apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts
+apps/backend/src/modules/entity-links/repo.ts
+apps/backend/src/modules/entity-links/routes.ts
+apps/backend/src/modules/entity-links/service.ts
+docs/design/11-entity-linking.md
+docs/implementation/06-entity-linking-contract.md
+packages/shared/src/entity-links.ts
+packages/shared/src/enums/audit-events.ts
+
+hook: PostToolUse
+hook: PostToolUse Failed
+hook: PostToolUse Failed
+hook: PostToolUse Failed
+codex
+{
+  "verdict": "request_changes",
+  "summary": "Detach mostly follows the contract, but the service checks active status before both-side VOC-read authorization, leaking detached-link existence/state to out-of-scope actors.",
+  "findings": [
+    {
+      "severity": "major",
+      "area": "authz",
+      "file": "apps/backend/src/modules/entity-links/service.ts:231",
+      "issue": "detachLink returns 409 for any non-active in-workspace link before resolving endpoint scope, so an actor lacking source or target VOC-read can distinguish an existing detached/revoked link from a missing link.",
+      "fix": "Resolve endpoints and run the reused both-side voc.read helper before the status check, and add a regression where an out-of-scope actor PATCHes an already-detached link and still gets 404."
+    }
+  ],
+  "deviations_acceptable_with_doc": [
+    "D1 is acceptable: using existing conflict.stale_write preserves the required HTTP 409 without touching out-of-scope errors/codes.ts."
+  ],
+  "must_fix_before_commit": [
+    "Move the active-status conflict check after both-side authorization so out-of-scope links always return 404, including already-detached rows.",
+    "Add/adjust test coverage for out-of-scope PATCH against an already-detached link returning 404."
+  ]
+}
+hook: Stop
+hook: Stop
+hook: Stop Failed
+hook: Stop Failed
+tokens used
+71,516
+{
+  "verdict": "request_changes",
+  "summary": "Detach mostly follows the contract, but the service checks active status before both-side VOC-read authorization, leaking detached-link existence/state to out-of-scope actors.",
+  "findings": [
+    {
+      "severity": "major",
+      "area": "authz",
+      "file": "apps/backend/src/modules/entity-links/service.ts:231",
+      "issue": "detachLink returns 409 for any non-active in-workspace link before resolving endpoint scope, so an actor lacking source or target VOC-read can distinguish an existing detached/revoked link from a missing link.",
+      "fix": "Resolve endpoints and run the reused both-side voc.read helper before the status check, and add a regression where an out-of-scope actor PATCHes an already-detached link and still gets 404."
+    }
+  ],
+  "deviations_acceptable_with_doc": [
+    "D1 is acceptable: using existing conflict.stale_write preserves the required HTTP 409 without touching out-of-scope errors/codes.ts."
+  ],
+  "must_fix_before_commit": [
+    "Move the active-status conflict check after both-side authorization so out-of-scope links always return 404, including already-detached rows.",
+    "Add/adjust test coverage for out-of-scope PATCH against an already-detached link returning 404."
+  ]
+}

--- a/apps/backend/migrations/0019_entity_link_detach.sql
+++ b/apps/backend/migrations/0019_entity_link_detach.sql
@@ -1,0 +1,12 @@
+-- Issue #113: Slice 4.2 entity link soft detach lifecycle.
+-- Adds detach metadata to core.entity_links and grants fops_app UPDATE only.
+-- Hard delete remains unavailable to the app role; canonical link history is
+-- preserved by transitioning active links to status='detached'.
+
+ALTER TABLE "core"."entity_links"
+  ADD COLUMN IF NOT EXISTS "detached_by" uuid REFERENCES "core"."actors"("id"),
+  ADD COLUMN IF NOT EXISTS "detach_reason" text,
+  ADD COLUMN IF NOT EXISTS "detached_at" timestamptz;
+--> statement-breakpoint
+
+GRANT UPDATE ON "core"."entity_links" TO fops_app;

--- a/apps/backend/migrations/meta/0019_snapshot.json
+++ b/apps/backend/migrations/meta/0019_snapshot.json
@@ -1,0 +1,1929 @@
+{
+  "id": "7b71f5e6-c6ec-48a5-9467-3f7079873719",
+  "prevId": "0ef5fa7e-15d6-4d24-8530-d1a620d6553b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "core.actors": {
+      "name": "actors",
+      "schema": "core",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_level": {
+          "name": "role_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'internal_member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "actors_workspace_idx": {
+          "name": "actors_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "actors_workspace_external_id_uq": {
+          "name": "actors_workspace_external_id_uq",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "actors_workspace_email_uq": {
+          "name": "actors_workspace_email_uq",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "actors_workspace_id_workspaces_id_fk": {
+          "name": "actors_workspace_id_workspaces_id_fk",
+          "tableFrom": "actors",
+          "tableTo": "workspaces",
+          "schemaTo": "core",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "actors_role_level_check": {
+          "name": "actors_role_level_check",
+          "value": "\"core\".\"actors\".\"role_level\" in ('admin','developer','user')"
+        },
+        "actors_actor_type_check": {
+          "name": "actors_actor_type_check",
+          "value": "\"core\".\"actors\".\"actor_type\" in ('internal_member','system')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "core.analytics_areas": {
+      "name": "analytics_areas",
+      "schema": "core",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "managed_system_id": {
+          "name": "managed_system_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_team_id": {
+          "name": "owner_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_by_actor_id": {
+          "name": "archived_by_actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "analytics_areas_workspace_idx": {
+          "name": "analytics_areas_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "analytics_areas_workspace_managed_system_idx": {
+          "name": "analytics_areas_workspace_managed_system_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "managed_system_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "analytics_areas_workspace_ms_slug_active_uq": {
+          "name": "analytics_areas_workspace_ms_slug_active_uq",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "managed_system_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"core\".\"analytics_areas\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "analytics_areas_workspace_id_workspaces_id_fk": {
+          "name": "analytics_areas_workspace_id_workspaces_id_fk",
+          "tableFrom": "analytics_areas",
+          "tableTo": "workspaces",
+          "schemaTo": "core",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "analytics_areas_managed_system_id_managed_systems_id_fk": {
+          "name": "analytics_areas_managed_system_id_managed_systems_id_fk",
+          "tableFrom": "analytics_areas",
+          "tableTo": "managed_systems",
+          "schemaTo": "core",
+          "columnsFrom": ["managed_system_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "analytics_areas_owner_team_id_teams_id_fk": {
+          "name": "analytics_areas_owner_team_id_teams_id_fk",
+          "tableFrom": "analytics_areas",
+          "tableTo": "teams",
+          "schemaTo": "core",
+          "columnsFrom": ["owner_team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "analytics_areas_archived_by_actor_id_actors_id_fk": {
+          "name": "analytics_areas_archived_by_actor_id_actors_id_fk",
+          "tableFrom": "analytics_areas",
+          "tableTo": "actors",
+          "schemaTo": "core",
+          "columnsFrom": ["archived_by_actor_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "core.audit_log": {
+      "name": "audit_log",
+      "schema": "core",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_log_workspace_created_at_idx": {
+          "name": "audit_log_workspace_created_at_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_workspace_subject_created_at_idx": {
+          "name": "audit_log_workspace_subject_created_at_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_workspace_actor_created_at_idx": {
+          "name": "audit_log_workspace_actor_created_at_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_workspace_event_created_at_idx": {
+          "name": "audit_log_workspace_event_created_at_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_workspace_id_workspaces_id_fk": {
+          "name": "audit_log_workspace_id_workspaces_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "workspaces",
+          "schemaTo": "core",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_log_actor_id_actors_id_fk": {
+          "name": "audit_log_actor_id_actors_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "actors",
+          "schemaTo": "core",
+          "columnsFrom": ["actor_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "core.entity_links": {
+      "name": "entity_links",
+      "schema": "core",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relation_type": {
+          "name": "relation_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'internal_only'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "managed_system_id": {
+          "name": "managed_system_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detached_by": {
+          "name": "detached_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detach_reason": {
+          "name": "detach_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detached_at": {
+          "name": "detached_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "entity_links_active_unique_idx": {
+          "name": "entity_links_active_unique_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "relation_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"core\".\"entity_links\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entity_links_active_source_idx": {
+          "name": "entity_links_active_source_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"core\".\"entity_links\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entity_links_active_target_idx": {
+          "name": "entity_links_active_target_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"core\".\"entity_links\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entity_links_workspace_ms_status_idx": {
+          "name": "entity_links_workspace_ms_status_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "managed_system_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entity_links_workspace_id_workspaces_id_fk": {
+          "name": "entity_links_workspace_id_workspaces_id_fk",
+          "tableFrom": "entity_links",
+          "tableTo": "workspaces",
+          "schemaTo": "core",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "entity_links_managed_system_id_managed_systems_id_fk": {
+          "name": "entity_links_managed_system_id_managed_systems_id_fk",
+          "tableFrom": "entity_links",
+          "tableTo": "managed_systems",
+          "schemaTo": "core",
+          "columnsFrom": ["managed_system_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "entity_links_created_by_actors_id_fk": {
+          "name": "entity_links_created_by_actors_id_fk",
+          "tableFrom": "entity_links",
+          "tableTo": "actors",
+          "schemaTo": "core",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "entity_links_detached_by_actors_id_fk": {
+          "name": "entity_links_detached_by_actors_id_fk",
+          "tableFrom": "entity_links",
+          "tableTo": "actors",
+          "schemaTo": "core",
+          "columnsFrom": ["detached_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "entity_links_relation_type_check": {
+          "name": "entity_links_relation_type_check",
+          "value": "\"core\".\"entity_links\".\"relation_type\" in ('related_to')"
+        },
+        "entity_links_visibility_check": {
+          "name": "entity_links_visibility_check",
+          "value": "\"core\".\"entity_links\".\"visibility\" in ('internal_only','summary_visible','visible_to_reporter','admin_only')"
+        },
+        "entity_links_status_check": {
+          "name": "entity_links_status_check",
+          "value": "\"core\".\"entity_links\".\"status\" in ('active','stale','detached','revoked')"
+        },
+        "entity_links_source_type_check": {
+          "name": "entity_links_source_type_check",
+          "value": "\"core\".\"entity_links\".\"source_type\" in ('voc')"
+        },
+        "entity_links_target_type_check": {
+          "name": "entity_links_target_type_check",
+          "value": "\"core\".\"entity_links\".\"target_type\" in ('voc')"
+        },
+        "entity_links_not_self_check": {
+          "name": "entity_links_not_self_check",
+          "value": "not (\"core\".\"entity_links\".\"source_type\" = \"core\".\"entity_links\".\"target_type\" and \"core\".\"entity_links\".\"source_id\" = \"core\".\"entity_links\".\"target_id\")"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "core.idempotency_keys": {
+      "name": "idempotency_keys",
+      "schema": "core",
+      "columns": {
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_hash": {
+          "name": "request_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idempotency_keys_created_at_idx": {
+          "name": "idempotency_keys_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "idempotency_keys_actor_id_actors_id_fk": {
+          "name": "idempotency_keys_actor_id_actors_id_fk",
+          "tableFrom": "idempotency_keys",
+          "tableTo": "actors",
+          "schemaTo": "core",
+          "columnsFrom": ["actor_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "idempotency_keys_actor_id_key_pk": {
+          "name": "idempotency_keys_actor_id_key_pk",
+          "columns": ["actor_id", "key"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "core.managed_systems": {
+      "name": "managed_systems",
+      "schema": "core",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_owner_actor_id": {
+          "name": "default_owner_actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_owner_team_id": {
+          "name": "default_owner_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_by_actor_id": {
+          "name": "archived_by_actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "managed_systems_workspace_idx": {
+          "name": "managed_systems_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managed_systems_workspace_slug_active_uq": {
+          "name": "managed_systems_workspace_slug_active_uq",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"core\".\"managed_systems\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "managed_systems_workspace_id_workspaces_id_fk": {
+          "name": "managed_systems_workspace_id_workspaces_id_fk",
+          "tableFrom": "managed_systems",
+          "tableTo": "workspaces",
+          "schemaTo": "core",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "managed_systems_default_owner_actor_id_actors_id_fk": {
+          "name": "managed_systems_default_owner_actor_id_actors_id_fk",
+          "tableFrom": "managed_systems",
+          "tableTo": "actors",
+          "schemaTo": "core",
+          "columnsFrom": ["default_owner_actor_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "managed_systems_default_owner_team_id_teams_id_fk": {
+          "name": "managed_systems_default_owner_team_id_teams_id_fk",
+          "tableFrom": "managed_systems",
+          "tableTo": "teams",
+          "schemaTo": "core",
+          "columnsFrom": ["default_owner_team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "managed_systems_archived_by_actor_id_actors_id_fk": {
+          "name": "managed_systems_archived_by_actor_id_actors_id_fk",
+          "tableFrom": "managed_systems",
+          "tableTo": "actors",
+          "schemaTo": "core",
+          "columnsFrom": ["archived_by_actor_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "managed_systems_default_owner_xor_check": {
+          "name": "managed_systems_default_owner_xor_check",
+          "value": "\"core\".\"managed_systems\".\"default_owner_actor_id\" is null or \"core\".\"managed_systems\".\"default_owner_team_id\" is null"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "core.rate_limits": {
+      "name": "rate_limits",
+      "schema": "core",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "route_group": {
+          "name": "route_group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "rate_limits_expires_at_idx": {
+          "name": "rate_limits_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "rate_limits_key_route_group_pk": {
+          "name": "rate_limits_key_route_group_pk",
+          "columns": ["key", "route_group"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "core.sessions": {
+      "name": "sessions",
+      "schema": "core",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_user_agent_summary": {
+          "name": "created_user_agent_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_ip_summary": {
+          "name": "created_ip_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sessions_workspace_idx": {
+          "name": "sessions_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_workspace_actor_idx": {
+          "name": "sessions_workspace_actor_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_actor_id_actors_id_fk": {
+          "name": "sessions_actor_id_actors_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "actors",
+          "schemaTo": "core",
+          "columnsFrom": ["actor_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sessions_workspace_id_workspaces_id_fk": {
+          "name": "sessions_workspace_id_workspaces_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "workspaces",
+          "schemaTo": "core",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "core.teams": {
+      "name": "teams",
+      "schema": "core",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_by_actor_id": {
+          "name": "archived_by_actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "teams_workspace_idx": {
+          "name": "teams_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "teams_workspace_name_active_uq": {
+          "name": "teams_workspace_name_active_uq",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"core\".\"teams\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "teams_workspace_id_workspaces_id_fk": {
+          "name": "teams_workspace_id_workspaces_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "workspaces",
+          "schemaTo": "core",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "teams_archived_by_actor_id_actors_id_fk": {
+          "name": "teams_archived_by_actor_id_actors_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "actors",
+          "schemaTo": "core",
+          "columnsFrom": ["archived_by_actor_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "core.workspaces": {
+      "name": "workspaces",
+      "schema": "core",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "permission.permission_denies": {
+      "name": "permission_denies",
+      "schema": "permission",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capability": {
+          "name": "capability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "managed_system_id": {
+          "name": "managed_system_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_actor_id": {
+          "name": "created_by_actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by_actor_id": {
+          "name": "revoked_by_actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "permission_denies_workspace_actor_idx": {
+          "name": "permission_denies_workspace_actor_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "permission_denies_active_uq": {
+          "name": "permission_denies_active_uq",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "capability",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"permission\".\"permission_denies\".\"revoked_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "permission.permission_grants": {
+      "name": "permission_grants",
+      "schema": "permission",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capability": {
+          "name": "capability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "managed_system_id": {
+          "name": "managed_system_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sensitive_reason": {
+          "name": "sensitive_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_by_actor_id": {
+          "name": "granted_by_actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by_actor_id": {
+          "name": "revoked_by_actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_reason": {
+          "name": "revoked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "permission_grants_workspace_actor_idx": {
+          "name": "permission_grants_workspace_actor_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "permission_grants_workspace_capability_idx": {
+          "name": "permission_grants_workspace_capability_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "capability",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "permission_grants_active_uq": {
+          "name": "permission_grants_active_uq",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "capability",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"permission\".\"permission_grants\".\"revoked_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "permission.permission_requests": {
+      "name": "permission_requests",
+      "schema": "permission",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requester_actor_id": {
+          "name": "requester_actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_capability": {
+          "name": "requested_capability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_managed_system_id": {
+          "name": "requested_managed_system_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_object_type": {
+          "name": "requested_object_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_object_id": {
+          "name": "requested_object_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_expiration": {
+          "name": "requested_expiration",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_object_type": {
+          "name": "source_object_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_object_id": {
+          "name": "source_object_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_action_id": {
+          "name": "source_action_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "return_route_intent": {
+          "name": "return_route_intent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "permission_requests_workspace_requester_idx": {
+          "name": "permission_requests_workspace_requester_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requester_actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "permission_requests_workspace_status_idx": {
+          "name": "permission_requests_workspace_status_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "permission_requests_active_uq": {
+          "name": "permission_requests_active_uq",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requester_actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requested_capability",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"permission\".\"permission_requests\".\"status\" in ('pending','needs_more_info')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "core": "core",
+    "permission": "permission"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/backend/migrations/meta/_journal.json
+++ b/apps/backend/migrations/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1781533641945,
       "tag": "0018_entity_links",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1781534641945,
+      "tag": "0019_entity_link_detach",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/db/schema/core.ts
+++ b/apps/backend/src/db/schema/core.ts
@@ -306,6 +306,9 @@ export const entityLinks = coreSchema.table(
       .references(() => actors.id),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp('updated_at', { withTimezone: true }),
+    detachedBy: uuid('detached_by').references(() => actors.id),
+    detachReason: text('detach_reason'),
+    detachedAt: timestamp('detached_at', { withTimezone: true }),
   },
   (t) => ({
     relationTypeCheck: check(

--- a/apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts
+++ b/apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts
@@ -1,4 +1,4 @@
-// POST/GET /entity-links integration tests — Slice 4.1 issue #112.
+// POST/GET/PATCH /entity-links integration tests — Slice 4.1 #112 + Slice 4.2 #113.
 //
 // Gate: DATABASE_URL + WORKSPACE_ID + DATABASE_URL_MIGRATE. The migrate role is
 // required because core.entity_links is append-only to fops_app.
@@ -82,7 +82,9 @@ describe.skipIf(!runIntegration)('POST/GET /entity-links (#112)', () => {
       [WORKSPACE_ID, `${SLUG_PREFIX}%`],
     );
     await migrateHandle.pool.query(
-      `delete from core.audit_log where workspace_id = $1 and event_type = 'entity_link.created'`,
+      `delete from core.audit_log
+        where workspace_id = $1
+          and event_type in ('entity_link.created', 'entity_link.detached')`,
       [WORKSPACE_ID],
     );
     await cleanupReadTestTables(dbHandle, WORKSPACE_ID, SLUG_PREFIX);
@@ -137,6 +139,18 @@ describe.skipIf(!runIntegration)('POST/GET /entity-links (#112)', () => {
         relation_type: 'related_to',
         ...extra,
       },
+    });
+  }
+
+  async function patchEntityLink(cookie: string, linkId: string, payload: Record<string, unknown>) {
+    return await app.inject({
+      method: 'PATCH',
+      url: `/entity-links/${linkId}`,
+      headers: {
+        cookie: `${SESSION_COOKIE_NAME}=${cookie}`,
+        'content-type': 'application/json',
+      },
+      payload,
     });
   }
 
@@ -301,5 +315,170 @@ describe.skipIf(!runIntegration)('POST/GET /entity-links (#112)', () => {
     expect(
       body.links?.some((link) => link.id === linkId && link.visibility_state === 'allowed'),
     ).toBe(true);
+  });
+
+  it('PATCH detaches an active related_to link, preserves the row, and audits the detach', async () => {
+    const { sourceVoc, targetVoc } = await seedVocPair();
+    const create = await postEntityLink(adminCookie, sourceVoc.id, targetVoc.id);
+    expect(create.statusCode).toBe(201);
+    const linkId = create.json<{ id: string }>().id;
+
+    const res = await patchEntityLink(adminCookie, linkId, { reason: 'No longer relevant' });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ id: string; status: string; detached_at: string | null }>();
+    expect(body).toMatchObject({ id: linkId, status: 'detached' });
+    expect(body.detached_at).toEqual(expect.any(String));
+
+    const linkRows = await dbHandle.pool.query<{
+      status: string;
+      detached_by: string | null;
+      detach_reason: string | null;
+      detached_at: Date | null;
+    }>(
+      `select status, detached_by, detach_reason, detached_at
+        from core.entity_links
+        where id = $1`,
+      [linkId],
+    );
+    expect(linkRows.rowCount).toBe(1);
+    expect(linkRows.rows[0]).toMatchObject({
+      status: 'detached',
+      detached_by: adminActorId,
+      detach_reason: 'No longer relevant',
+    });
+    expect(linkRows.rows[0]?.detached_at).toBeInstanceOf(Date);
+
+    const auditRows = await dbHandle.pool.query<{ detail: Record<string, unknown> }>(
+      `select detail from core.audit_log
+        where event_type = 'entity_link.detached' and subject_id = $1`,
+      [linkId],
+    );
+    expect(auditRows.rowCount).toBe(1);
+    expect(auditRows.rows[0]?.detail).toMatchObject({
+      link_id: linkId,
+      source: { type: 'voc', id: sourceVoc.id },
+      target: { type: 'voc', id: targetVoc.id },
+      relation_type: 'related_to',
+      reason: 'No longer relevant',
+    });
+  });
+
+  it('after detach, GET /entity-links and VOC detail Links tab omit the detached link', async () => {
+    const { sourceVoc, targetVoc } = await seedVocPair();
+    const create = await postEntityLink(adminCookie, sourceVoc.id, targetVoc.id);
+    expect(create.statusCode).toBe(201);
+    const linkId = create.json<{ id: string }>().id;
+
+    const detach = await patchEntityLink(adminCookie, linkId, { reason: 'Superseded' });
+    expect(detach.statusCode).toBe(200);
+
+    const list = await app.inject({
+      method: 'GET',
+      url: `/entity-links?source_type=voc&source_id=${sourceVoc.id}`,
+      headers: { cookie: `${SESSION_COOKIE_NAME}=${adminCookie}` },
+    });
+    expect(list.statusCode).toBe(200);
+    expect(
+      list.json<{ items: Array<{ id: string }> }>().items.some((item) => item.id === linkId),
+    ).toBe(false);
+
+    const detail = await app.inject({
+      method: 'GET',
+      url: `/vocs/${sourceVoc.id}`,
+      headers: { cookie: `${SESSION_COOKIE_NAME}=${adminCookie}` },
+    });
+    expect(detail.statusCode).toBe(200);
+    const body = detail.json<{ links?: Array<{ id: string }> }>();
+    expect(body.links?.some((link) => link.id === linkId)).toBe(false);
+  });
+
+  it('PATCH on an already-detached link returns 409', async () => {
+    const { sourceVoc, targetVoc } = await seedVocPair();
+    const create = await postEntityLink(adminCookie, sourceVoc.id, targetVoc.id);
+    expect(create.statusCode).toBe(201);
+    const linkId = create.json<{ id: string }>().id;
+
+    const first = await patchEntityLink(adminCookie, linkId, { reason: 'Initial detach' });
+    expect(first.statusCode).toBe(200);
+
+    const second = await patchEntityLink(adminCookie, linkId, { reason: 'Again' });
+    expect(second.statusCode).toBe(409);
+    expect(second.json<{ code: string }>().code).toBe('conflict.stale_write');
+  });
+
+  it('PATCH returns 404 when actor lacks scope on the target endpoint', async () => {
+    const { msA, sourceVoc, targetVoc } = await seedVocPair();
+    const create = await postEntityLink(adminCookie, sourceVoc.id, targetVoc.id);
+    expect(create.statusCode).toBe(201);
+    const linkId = create.json<{ id: string }>().id;
+
+    const { id: devId, externalId } = await insertDevActor(
+      dbHandle,
+      WORKSPACE_ID,
+      uid('detach404'),
+    );
+    await grantCapability(dbHandle, WORKSPACE_ID, devId, 'voc.read', msA, adminActorId);
+    const devCookie = await loginAs(app, externalId);
+
+    const res = await patchEntityLink(devCookie, linkId, { reason: 'No scope' });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('PATCH returns 404 for an already-detached link when actor lacks target scope', async () => {
+    const { msA, sourceVoc, targetVoc } = await seedVocPair();
+    const create = await postEntityLink(adminCookie, sourceVoc.id, targetVoc.id);
+    expect(create.statusCode).toBe(201);
+    const linkId = create.json<{ id: string }>().id;
+
+    const detach = await patchEntityLink(adminCookie, linkId, { reason: 'Authorized detach' });
+    expect(detach.statusCode).toBe(200);
+
+    const { id: devId, externalId } = await insertDevActor(
+      dbHandle,
+      WORKSPACE_ID,
+      uid('detached404'),
+    );
+    await grantCapability(dbHandle, WORKSPACE_ID, devId, 'voc.read', msA, adminActorId);
+    const devCookie = await loginAs(app, externalId);
+
+    const res = await patchEntityLink(devCookie, linkId, { reason: 'No target scope' });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('PATCH rejects missing or empty detach reason', async () => {
+    const { sourceVoc, targetVoc } = await seedVocPair();
+    const create = await postEntityLink(adminCookie, sourceVoc.id, targetVoc.id);
+    expect(create.statusCode).toBe(201);
+    const linkId = create.json<{ id: string }>().id;
+
+    for (const payload of [{}, { reason: '' }, { reason: '   ' }]) {
+      const res = await patchEntityLink(adminCookie, linkId, payload);
+      expect(res.statusCode).toBe(422);
+      expect(res.json<{ code: string }>().code).toBe('validation.failed');
+    }
+  });
+
+  it('detach frees the active unique slot so the same VOC pair can be linked again', async () => {
+    const { sourceVoc, targetVoc } = await seedVocPair();
+    const first = await postEntityLink(adminCookie, sourceVoc.id, targetVoc.id);
+    expect(first.statusCode).toBe(201);
+    const firstId = first.json<{ id: string }>().id;
+
+    const detach = await patchEntityLink(adminCookie, firstId, { reason: 'Relink needed' });
+    expect(detach.statusCode).toBe(200);
+
+    const second = await postEntityLink(adminCookie, sourceVoc.id, targetVoc.id);
+    expect(second.statusCode).toBe(201);
+    expect(second.json<{ id: string }>().id).not.toBe(firstId);
+
+    const count = await dbHandle.pool.query<{ active: number; detached: number }>(
+      `select
+          count(*) filter (where status = 'active')::int as active,
+          count(*) filter (where status = 'detached')::int as detached
+        from core.entity_links
+        where source_id = $1 and target_id = $2`,
+      [sourceVoc.id, targetVoc.id],
+    );
+    expect(count.rows[0]).toMatchObject({ active: 1, detached: 1 });
   });
 });

--- a/apps/backend/src/modules/entity-links/repo.ts
+++ b/apps/backend/src/modules/entity-links/repo.ts
@@ -23,6 +23,9 @@ export interface EntityLinkRow {
   created_by: string;
   created_at: Date;
   updated_at: Date | null;
+  detached_by: string | null;
+  detach_reason: string | null;
+  detached_at: Date | null;
 }
 
 function mapEntityLinkRow(row: Record<string, unknown>): EntityLinkRow {
@@ -46,6 +49,14 @@ function mapEntityLinkRow(row: Record<string, unknown>): EntityLinkRow {
         : row.updated_at instanceof Date
           ? row.updated_at
           : new Date(row.updated_at as string),
+    detached_by: (row.detached_by as string | null) ?? null,
+    detach_reason: (row.detach_reason as string | null) ?? null,
+    detached_at:
+      row.detached_at === null || row.detached_at === undefined
+        ? null
+        : row.detached_at instanceof Date
+          ? row.detached_at
+          : new Date(row.detached_at as string),
   };
 }
 
@@ -96,7 +107,7 @@ export async function insertActiveVocRelatedToLink(
     RETURNING
       id, workspace_id, source_type, source_id, target_type, target_id,
       relation_type, visibility, status, managed_system_id, created_by,
-      created_at, updated_at
+      created_at, updated_at, detached_by, detach_reason, detached_at
   `);
   const insertedRow = inserted.rows[0];
   if (insertedRow) return { row: mapEntityLinkRow(insertedRow), inserted: true };
@@ -120,7 +131,7 @@ export async function selectActiveVocRelatedToLink(
     SELECT
       id, workspace_id, source_type, source_id, target_type, target_id,
       relation_type, visibility, status, managed_system_id, created_by,
-      created_at, updated_at
+      created_at, updated_at, detached_by, detach_reason, detached_at
     FROM core.entity_links
     WHERE workspace_id = ${input.workspaceId}
       AND source_type = 'voc'
@@ -158,7 +169,7 @@ export async function selectActiveLinksForEndpoint(
     SELECT
       id, workspace_id, source_type, source_id, target_type, target_id,
       relation_type, visibility, status, managed_system_id, created_by,
-      created_at, updated_at
+      created_at, updated_at, detached_by, detach_reason, detached_at
     FROM core.entity_links
     WHERE workspace_id = ${input.workspaceId}
       AND status = 'active'
@@ -166,4 +177,51 @@ export async function selectActiveLinksForEndpoint(
     ORDER BY created_at DESC, id DESC
   `);
   return result.rows.map(mapEntityLinkRow);
+}
+
+export async function selectEntityLinkById(
+  db: Db | Tx,
+  input: { workspaceId: string; linkId: string },
+): Promise<EntityLinkRow | null> {
+  const result = await (db as Db).execute<Record<string, unknown>>(sql`
+    SELECT
+      id, workspace_id, source_type, source_id, target_type, target_id,
+      relation_type, visibility, status, managed_system_id, created_by,
+      created_at, updated_at, detached_by, detach_reason, detached_at
+    FROM core.entity_links
+    WHERE workspace_id = ${input.workspaceId}
+      AND id = ${input.linkId}
+    LIMIT 1
+  `);
+  const row = result.rows[0];
+  return row ? mapEntityLinkRow(row) : null;
+}
+
+export async function detachVocRelatedToLink(
+  tx: Tx,
+  input: {
+    workspaceId: string;
+    linkId: string;
+    actorId: string;
+    reason: string;
+  },
+): Promise<EntityLinkRow | null> {
+  const updated = await (tx as Db).execute<Record<string, unknown>>(sql`
+    UPDATE core.entity_links
+    SET
+      status = 'detached',
+      detached_by = ${input.actorId},
+      detach_reason = ${input.reason},
+      detached_at = now(),
+      updated_at = now()
+    WHERE workspace_id = ${input.workspaceId}
+      AND id = ${input.linkId}
+      AND status = 'active'
+    RETURNING
+      id, workspace_id, source_type, source_id, target_type, target_id,
+      relation_type, visibility, status, managed_system_id, created_by,
+      created_at, updated_at, detached_by, detach_reason, detached_at
+  `);
+  const row = updated.rows[0];
+  return row ? mapEntityLinkRow(row) : null;
 }

--- a/apps/backend/src/modules/entity-links/routes.ts
+++ b/apps/backend/src/modules/entity-links/routes.ts
@@ -1,6 +1,11 @@
 import type { FastifyPluginAsync } from 'fastify';
+import { z } from 'zod';
 
-import { createEntityLinkRequestSchema, listEntityLinksQuerySchema } from '@fops/shared';
+import {
+  createEntityLinkRequestSchema,
+  detachEntityLinkRequestSchema,
+  listEntityLinksQuerySchema,
+} from '@fops/shared';
 
 import { HttpError, fieldsFromZodIssues, sendError } from '../../lib/errors.js';
 import { requireSession } from '../../middleware/require-session.js';
@@ -23,6 +28,7 @@ export const entityLinksRoutes: FastifyPluginAsync<EntityLinksRoutesOptions> = a
   opts,
 ) => {
   const { sessionService, entityLinksService, workspaceId, rateLimitConfig } = opts;
+  const entityLinkParamsSchema = z.object({ id: z.string().uuid() }).strict();
 
   app.route({
     method: 'POST',
@@ -98,6 +104,42 @@ export const entityLinksRoutes: FastifyPluginAsync<EntityLinksRoutesOptions> = a
         side,
       });
       return reply.code(200).send({ items });
+    },
+  });
+
+  app.route({
+    method: 'PATCH',
+    url: '/entity-links/:id',
+    preHandler: [requireSession(sessionService), requireWorkspace(workspaceId)],
+    ...(rateLimitConfig ? { config: { rateLimit: rateLimitConfig.mutation as never } } : {}),
+    handler: async (req, reply) => {
+      const sess = req.session;
+      if (!sess) throw new HttpError('internal.unexpected', 'session missing after middleware');
+
+      const parsedParams = entityLinkParamsSchema.safeParse(req.params);
+      if (!parsedParams.success) {
+        return sendError(reply, 'validation.failed', 'invalid route parameters', {
+          fields: fieldsFromZodIssues(parsedParams.error.issues),
+        });
+      }
+
+      const parsed = detachEntityLinkRequestSchema.safeParse(req.body ?? {});
+      if (!parsed.success) {
+        return sendError(reply, 'validation.failed', 'invalid request body', {
+          fields: fieldsFromZodIssues(parsed.error.issues),
+        });
+      }
+
+      const link = await entityLinksService.detachLink({
+        actor: {
+          actor_id: sess.actor_id,
+          workspace_id: sess.workspace_id,
+          role_level: sess.role_level,
+        },
+        linkId: parsedParams.data.id,
+        reason: parsed.data.reason,
+      });
+      return reply.code(200).send(link);
     },
   });
 };

--- a/apps/backend/src/modules/entity-links/service.ts
+++ b/apps/backend/src/modules/entity-links/service.ts
@@ -1,4 +1,4 @@
-import type { EntityLinkDto, EntityLinkRef } from '@fops/shared';
+import type { DetachedEntityLinkResponse, EntityLinkDto, EntityLinkRef } from '@fops/shared';
 
 import type { Db } from '../../db/client.js';
 import { HttpError } from '../../lib/errors.js';
@@ -6,9 +6,11 @@ import type { AuditService } from '../core/audit/audit-service.js';
 import type { CheckService } from '../permissions/check-service.js';
 import {
   type EntityLinkRow,
+  detachVocRelatedToLink,
   insertActiveVocRelatedToLink,
   resolveVocEndpoint,
   selectActiveLinksForEndpoint,
+  selectEntityLinkById,
 } from './repo.js';
 
 export interface EntityLinksActor {
@@ -48,6 +50,17 @@ function toHiddenDto(row: EntityLinkRow): EntityLinkDto {
     target_type: row.target_type,
     relation_type: row.relation_type,
     visibility_state: 'hidden',
+  };
+}
+
+function toDetachedResponse(row: EntityLinkRow): DetachedEntityLinkResponse {
+  if (row.status !== 'detached' || row.detached_at === null) {
+    throw new HttpError('internal.unexpected', 'detached entity link row missing detach fields');
+  }
+  return {
+    id: row.id,
+    status: 'detached',
+    detached_at: row.detached_at.toISOString(),
   };
 }
 
@@ -192,7 +205,82 @@ export function createEntityLinksService(deps: EntityLinksServiceDeps) {
     return items;
   }
 
-  return { createLink, listLinks };
+  async function detachLink(args: {
+    actor: EntityLinksActor;
+    linkId: string;
+    reason: string;
+  }): Promise<DetachedEntityLinkResponse> {
+    const { actor, linkId, reason } = args;
+
+    const link = await selectEntityLinkById(deps.db, {
+      workspaceId: actor.workspace_id,
+      linkId,
+    });
+    if (!link) {
+      throw new HttpError('not_found.record', 'entity link not found');
+    }
+    if (
+      link.source_type !== 'voc' ||
+      link.target_type !== 'voc' ||
+      link.relation_type !== 'related_to'
+    ) {
+      throw new HttpError('validation.failed', 'unsupported entity link tuple', {
+        fields: [{ path: [], code: 'unsupported_tuple' }],
+      });
+    }
+    const [sourceRow, targetRow] = await Promise.all([
+      resolveVocEndpoint(deps.db, actor.workspace_id, link.source_id),
+      resolveVocEndpoint(deps.db, actor.workspace_id, link.target_id),
+    ]);
+    if (!sourceRow || !targetRow) {
+      throw new HttpError('not_found.record', 'entity link endpoint not found');
+    }
+
+    const [sourceAllowed, targetAllowed] = await Promise.all([
+      assertVocReadScope(deps, actor, sourceRow.managed_system_id),
+      assertVocReadScope(deps, actor, targetRow.managed_system_id),
+    ]);
+    if (!sourceAllowed || !targetAllowed) {
+      throw new HttpError('not_found.record', 'entity link not found');
+    }
+    if (link.status !== 'active') {
+      throw new HttpError('conflict.stale_write', 'entity link is no longer active');
+    }
+
+    const detached = await deps.db.transaction(async (tx) => {
+      const updated = await detachVocRelatedToLink(tx, {
+        workspaceId: actor.workspace_id,
+        linkId,
+        actorId: actor.actor_id,
+        reason,
+      });
+      if (!updated) {
+        throw new HttpError('conflict.stale_write', 'entity link is no longer active');
+      }
+
+      await deps.auditService.record(tx, {
+        workspace_id: actor.workspace_id,
+        actor_id: actor.actor_id,
+        event_type: 'entity_link.detached',
+        subject_type: 'entity_link',
+        subject_id: updated.id,
+        summary: 'Entity link detached',
+        detail: {
+          link_id: updated.id,
+          source: { type: updated.source_type, id: updated.source_id },
+          target: { type: updated.target_type, id: updated.target_id },
+          relation_type: updated.relation_type,
+          reason,
+        },
+      });
+
+      return updated;
+    });
+
+    return toDetachedResponse(detached);
+  }
+
+  return { createLink, listLinks, detachLink };
 }
 
 export type EntityLinksService = ReturnType<typeof createEntityLinksService>;

--- a/docs/design/11-entity-linking.md
+++ b/docs/design/11-entity-linking.md
@@ -86,6 +86,12 @@ links only. The tracer creates `core.entity_links` rows with `status='active'`,
 `visibility='internal_only'`, and backend-decided read visibility of `allowed`
 or `hidden`.
 
+Slice 4.2 detach lifecycle (#113): production support detaches only existing
+active VOC↔VOC `related_to` links via `PATCH /entity-links/:id` with a required
+non-empty reason. Detach transitions `status` to `detached`, records
+`detached_by`, `detach_reason`, and `detached_at`, and preserves the row; hard
+delete and `DELETE /entity-links/:id` are intentionally not used.
+
 ## Visibility
 
 ```text
@@ -136,6 +142,10 @@ Acceptance Criteria:
   and timestamp.
 - Sensitive detach actions are audited.
 ```
+
+Slice 4.2 (#113) implements this for VOC↔VOC `related_to` as `detached` only.
+`revoked` remains reserved for future admin/policy flows and `stale` remains
+deferred.
 
 ### FR-LINK-002: Enforce Visibility
 

--- a/docs/implementation/06-entity-linking-contract.md
+++ b/docs/implementation/06-entity-linking-contract.md
@@ -68,6 +68,26 @@ voc -> voc
   as visibility_state=allowed when readable and visibility_state=hidden when not
 ```
 
+## Link Detach Validation
+
+Slice 4.2 detach lifecycle (#113):
+
+```text
+PATCH /entity-links/:id
+- request body: { reason: string } where reason is required, trimmed, and non-empty
+- supported transition: active -> detached only
+- authz: actor must have the same voc.read capability used by link creation on
+  both source and target VOC Managed Systems
+- not found / cross-workspace / missing scope on either endpoint: 404
+- already detached, revoked, stale, or lost update race: 409
+- side effects in one transaction: update status/detach metadata and append
+  audit_log event_type entity_link.detached
+- hard delete is forbidden; fops_app has UPDATE but not DELETE on core.entity_links
+```
+
+Because the active uniqueness constraint is partial (`WHERE status='active'`),
+detaching a link intentionally frees the same VOC pair to be linked again later.
+
 ## Visibility Enforcement
 
 ```text

--- a/packages/shared/src/entity-links.ts
+++ b/packages/shared/src/entity-links.ts
@@ -38,6 +38,13 @@ export const createEntityLinkRequestSchema = z
   .strict();
 export type CreateEntityLinkRequest = z.infer<typeof createEntityLinkRequestSchema>;
 
+export const detachEntityLinkRequestSchema = z
+  .object({
+    reason: z.string().trim().min(1),
+  })
+  .strict();
+export type DetachEntityLinkRequest = z.infer<typeof detachEntityLinkRequestSchema>;
+
 export const listEntityLinksQuerySchema = z
   .object({
     source_type: entityLinkEntityTypeSchema.optional(),
@@ -107,3 +114,10 @@ export const listEntityLinksResponseSchema = z.object({
   items: z.array(entityLinkDtoSchema),
 });
 export type ListEntityLinksResponse = z.infer<typeof listEntityLinksResponseSchema>;
+
+export const detachedEntityLinkResponseSchema = z.object({
+  id: z.string().uuid(),
+  status: z.literal('detached'),
+  detached_at: z.string().datetime(),
+});
+export type DetachedEntityLinkResponse = z.infer<typeof detachedEntityLinkResponseSchema>;

--- a/packages/shared/src/enums/audit-events.ts
+++ b/packages/shared/src/enums/audit-events.ts
@@ -60,6 +60,8 @@ export const AUDIT_EVENT_TYPES = [
   'attachment_uploaded',
   // Slice 4.1 #112: canonical entity link creation tracer.
   'entity_link.created',
+  // Slice 4.2 #113: audited soft detach lifecycle.
+  'entity_link.detached',
 ] as const;
 export type AuditEventType = (typeof AUDIT_EVENT_TYPES)[number];
 
@@ -162,6 +164,21 @@ export const entityLinkCreatedDetailSchema = z.object({
 });
 export type EntityLinkCreatedDetail = z.infer<typeof entityLinkCreatedDetailSchema>;
 
+export const entityLinkDetachedDetailSchema = z.object({
+  link_id: z.string().uuid(),
+  source: z.object({
+    type: z.literal('voc'),
+    id: z.string().uuid(),
+  }),
+  target: z.object({
+    type: z.literal('voc'),
+    id: z.string().uuid(),
+  }),
+  relation_type: z.literal('related_to'),
+  reason: z.string().min(1),
+});
+export type EntityLinkDetachedDetail = z.infer<typeof entityLinkDetachedDetailSchema>;
+
 export const AUDIT_EVENT_DETAIL_SCHEMAS = {
   permission_requested: permissionRequestedDetailSchema,
   managed_system_registered: managedSystemRegisteredDetailSchema,
@@ -189,4 +206,6 @@ export const AUDIT_EVENT_DETAIL_SCHEMAS = {
   attachment_uploaded: attachmentUploadedDetailSchema,
   // Slice 4.1 #112.
   'entity_link.created': entityLinkCreatedDetailSchema,
+  // Slice 4.2 #113.
+  'entity_link.detached': entityLinkDetachedDetailSchema,
 } as const satisfies Record<AuditEventType, z.ZodTypeAny>;


### PR DESCRIPTION
Closes #113. Slice 4.2 — FR-LINK-001A detach lifecycle.

## What ships

- `PATCH /entity-links/:id` `{reason}` — soft detach: active→`detached` with `detached_by`/`detach_reason`/`detached_at` preserved. NO hard delete (DELETE would lie; the row persists as canonical history).
- Migration `0019_entity_link_detach.sql` — adds the 3 detach columns + grants `fops_app` UPDATE (still no DELETE). Journal/snapshot registered (same hand-technique as 0018 — `drizzle-kit generate` is blocked by a pre-existing 0003/0004 snapshot collision).
- Audit `entity_link.detached` emitted in the same transaction as the status flip.
- Detached links drop off `GET /entity-links` + the VOC detail Links tab (active-only filter); the `WHERE status='active'` partial unique index frees the slot so the same pair can be re-linked.

## Security

Both-side `voc.read` authorization runs **before** the active-status check — an out-of-scope actor gets 404 for an existing detached link (no existence leak). This was a REVIEWER-caught major finding (`.review/ISSUE-113-REVIEW.json`), fixed in `6b53b7d` with a regression test (out-of-scope PATCH on already-detached → 404).

## Scope deferred

`revoked`/`stale` statuses, visibility matrix (#115), `/integration/links` UI (#114), FR-LINK-003 (Slice 7).

## Evidence

- Tests: **14/14 pass** (7 from #112 + 7 detach) — `.review/ISSUE-113-VERIFY.json`, classifier PASS, head_sha matches HEAD `4fa5dcd`
- Typecheck: no new errors beyond baseline
- Review: adversarial read-only pass — request_changes (1 major, existence leak) → fixed → re-verified
- Migration: journal-driven `drizzle-kit migrate` on a fresh DB confirmed the 3 columns + INSERT/SELECT/UPDATE grant (no DELETE)
- Deviation D1: 409 reuses `conflict.stale_write` (errors/codes.ts out of scope) — `.review/ISSUE-113-DEVIATIONS.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)