### PR TITLE
fix: #147 entity-link 튜플 검증 드리프트 — 공유 레지스트리 단일화

### DIFF
--- a/apps/backend/src/db/schema/core.ts
+++ b/apps/backend/src/db/schema/core.ts
@@ -295,7 +295,7 @@ export const analyticsAreas = coreSchema.table(
 
 // ─────────────────────────────────────────────────────────────────────────
 // core.entity_links — Slice 4.1 tracer. Canonical polymorphic relationship
-// table; this slice permits only active VOC↔VOC related_to links.
+// table; registered tuples are enforced by entity_links_tuple_check.
 // ─────────────────────────────────────────────────────────────────────────
 export const entityLinks = coreSchema.table(
   'entity_links',
@@ -326,7 +326,7 @@ export const entityLinks = coreSchema.table(
   (t) => ({
     tupleCheck: check(
       'entity_links_tuple_check',
-      sql`(${t.sourceType}, ${t.targetType}, ${t.relationType}) in (('voc','voc','related_to'), ('voc','finding','created_finding'), ('voc','finding','evidence_of'))`,
+      sql`(${t.sourceType}, ${t.targetType}, ${t.relationType}) in (('voc','voc','related_to'), ('voc','finding','created_finding'), ('voc','finding','evidence_of'), ('voc_cluster','finding','created_finding'), ('finding','task_request','requested_task'), ('task_request','task','converted_to'), ('finding','task','requested_task'), ('voc','task','evidence_of'), ('voc','task_request','requested_task'), ('voc_cluster','task_request','requested_task'))`,
     ),
     visibilityCheck: check(
       'entity_links_visibility_check',

--- a/apps/backend/src/modules/entity-links/AGENTS.md
+++ b/apps/backend/src/modules/entity-links/AGENTS.md
@@ -11,7 +11,7 @@ Entity Links owns link behavior even when link tables live in the `core` databas
 - `summary_visible` exposes only the approved summary contract.
 - `internal_only` links are hidden from Reporter.
 - Cross-workspace links are rejected.
-- The `entity_links_tuple_check` CHECK constraint (`apps/backend/src/db/schema/core.ts`, `entityLinks` table) allows exactly these `(source_type, target_type, relation_type)` tuples: `('voc','voc','related_to')`, `('voc','finding','created_finding')`, `('voc','finding','evidence_of')`. Adding a new relation type requires a migration that extends this CHECK constraint — do not attempt to add a relation type in application code alone.
+- `registeredEntityLinkPairs` in `packages/shared/src/entity-links.ts` is the canonical tuple registry (currently 10 tuples). The DB `entity_links_tuple_check` CHECK constraint must be kept in sync via migration; adding a relation type requires both a shared-list entry and a migration extending the CHECK.
 
 ## Provider Contract
 

--- a/apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts
+++ b/apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts
@@ -6,9 +6,15 @@
 import type { FastifyInstance } from 'fastify';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
+import { type EntityLinkEntityType, registeredEntityLinkPairs } from '@fops/shared';
+
 import { loadConfig } from '../../../config.js';
 import { type DbHandle, createDb } from '../../../db/client.js';
 import { buildServer } from '../../../server.js';
+import { insertFindingRow } from '../../findings/__tests__/_seed-helpers.js';
+import { insertTaskRequestRow } from '../../task-requests/__tests__/_seed-helpers.js';
+import { insertTaskRow } from '../../tasks/__tests__/_seed-helpers.js';
+import { insertVocClusterRow } from '../../voc-clusters/__tests__/_seed-helpers.js';
 import {
   SESSION_COOKIE_NAME,
   cleanupReadTestTables,
@@ -19,7 +25,6 @@ import {
   loginAs,
   uid,
 } from '../../voc/__tests__/_seed-helpers.js';
-import { insertFindingRow } from '../../findings/__tests__/_seed-helpers.js';
 
 const APP_URL = process.env.DATABASE_URL ?? '';
 const MIGRATE_URL = process.env.DATABASE_URL_MIGRATE ?? '';
@@ -89,7 +94,31 @@ describe.skipIf(!runIntegration)('POST/GET /entity-links (#112)', () => {
       [WORKSPACE_ID],
     );
     await migrateHandle.pool.query(
+      `delete from task.tasks
+        where workspace_id = $1
+          and primary_managed_system_id in (
+            select id from core.managed_systems where workspace_id = $1 and slug like $2
+          )`,
+      [WORKSPACE_ID, `${SLUG_PREFIX}%`],
+    );
+    await migrateHandle.pool.query(
+      `delete from task_request.task_requests
+        where workspace_id = $1
+          and primary_managed_system_id in (
+            select id from core.managed_systems where workspace_id = $1 and slug like $2
+          )`,
+      [WORKSPACE_ID, `${SLUG_PREFIX}%`],
+    );
+    await migrateHandle.pool.query(
       `delete from finding.findings
+        where workspace_id = $1
+          and primary_managed_system_id in (
+            select id from core.managed_systems where workspace_id = $1 and slug like $2
+          )`,
+      [WORKSPACE_ID, `${SLUG_PREFIX}%`],
+    );
+    await migrateHandle.pool.query(
+      `delete from voc_cluster.voc_clusters
         where workspace_id = $1
           and primary_managed_system_id in (
             select id from core.managed_systems where workspace_id = $1 and slug like $2
@@ -143,11 +172,11 @@ describe.skipIf(!runIntegration)('POST/GET /entity-links (#112)', () => {
   }
 
   async function seedEntityLinkDirectly(input: {
-    sourceType?: 'voc';
+    sourceType?: EntityLinkEntityType;
     sourceId: string;
-    targetType?: 'voc' | 'finding';
+    targetType?: EntityLinkEntityType;
     targetId: string;
-    relationType?: 'related_to' | 'created_finding';
+    relationType?: string;
     managedSystemId: string;
     visibility: 'internal_only' | 'summary_visible' | 'visible_to_reporter' | 'admin_only';
   }): Promise<string> {
@@ -189,7 +218,57 @@ describe.skipIf(!runIntegration)('POST/GET /entity-links (#112)', () => {
     });
   }
 
-  async function postEntityLink(cookie: string, sourceId: string, targetId: string, extra = {}) {
+  async function seedRegisteredTupleEndpoints(): Promise<{
+    msA: string;
+    endpoints: Record<EntityLinkEntityType, { id: string }>;
+    vocTarget: { id: string };
+  }> {
+    const { msA, sourceVoc, targetVoc } = await seedVocPair();
+    const cluster = await insertVocClusterRow(migrateHandle, {
+      workspaceId: WORKSPACE_ID,
+      primaryManagedSystemId: msA,
+      title: 'Tuple Cluster',
+      status: 'confirmed',
+      createdBy: adminActorId,
+    });
+    const finding = await seedFindingDirectly({
+      managedSystemId: msA,
+      sourceVocId: sourceVoc.id,
+      title: 'Tuple Finding',
+    });
+    const taskRequest = await insertTaskRequestRow(migrateHandle, {
+      workspaceId: WORKSPACE_ID,
+      sourceType: 'finding',
+      sourceId: finding.id,
+      primaryManagedSystemId: msA,
+      requesterActorId: adminActorId,
+    });
+    const task = await insertTaskRow(migrateHandle, {
+      workspaceId: WORKSPACE_ID,
+      primaryManagedSystemId: msA,
+      title: 'Tuple Task',
+      createdBy: adminActorId,
+    });
+
+    return {
+      msA,
+      endpoints: {
+        voc: sourceVoc,
+        finding,
+        voc_cluster: cluster,
+        task_request: taskRequest,
+        task,
+      },
+      vocTarget: targetVoc,
+    };
+  }
+
+  async function postEntityLink(
+    cookie: string,
+    sourceId: string,
+    targetId: string,
+    extra: Record<string, unknown> = {},
+  ) {
     return app.inject({
       method: 'POST',
       url: '/entity-links',
@@ -301,6 +380,57 @@ describe.skipIf(!runIntegration)('POST/GET /entity-links (#112)', () => {
       const res = await postEntityLink(adminCookie, sourceVoc.id, targetVoc.id, extra);
       expect(res.statusCode).toBe(422);
       expect(res.json<{ code: string }>().code).toBe('validation.failed');
+    }
+  });
+
+  it('POST and GET honor every shared registered entity-link tuple', async () => {
+    const { endpoints, vocTarget } = await seedRegisteredTupleEndpoints();
+
+    for (const tuple of registeredEntityLinkPairs) {
+      const source = endpoints[tuple.source_type];
+      const target = tuple.target_type === 'voc' ? vocTarget : endpoints[tuple.target_type];
+
+      const created = await postEntityLink(adminCookie, source.id, target.id, {
+        source: { type: tuple.source_type, id: source.id },
+        target: { type: tuple.target_type, id: target.id },
+        relation_type: tuple.relation_type,
+      });
+      expect(created.statusCode, JSON.stringify(tuple)).toBeGreaterThanOrEqual(200);
+      expect(created.statusCode, JSON.stringify(tuple)).toBeLessThanOrEqual(201);
+      const createdBody = created.json<{
+        id: string;
+        visibility_state: string;
+        source_type: string;
+        target_type: string;
+        relation_type: string;
+      }>();
+      expect(createdBody, JSON.stringify(tuple)).toMatchObject({
+        visibility_state: 'allowed',
+        source_type: tuple.source_type,
+        target_type: tuple.target_type,
+        relation_type: tuple.relation_type,
+      });
+
+      const list = await getEntityLinks(
+        adminCookie,
+        `?source_type=${tuple.source_type}&source_id=${source.id}`,
+      );
+      expect(list.statusCode, JSON.stringify(tuple)).toBe(200);
+      const listed = list
+        .json<{
+          items: Array<{
+            id: string;
+            visibility_state: string;
+            target_type: string;
+            relation_type: string;
+          }>;
+        }>()
+        .items.find((item) => item.id === createdBody.id);
+      expect(listed, JSON.stringify(tuple)).toMatchObject({
+        visibility_state: 'allowed',
+        target_type: tuple.target_type,
+        relation_type: tuple.relation_type,
+      });
     }
   });
 
@@ -858,19 +988,24 @@ describe.skipIf(!runIntegration)('POST/GET /entity-links (#112)', () => {
   });
 
   it('DB tuple check allows only registered entity-link tuples', async () => {
-    const { msA, sourceVoc, targetVoc } = await seedVocPair();
-    const finding = await seedFindingDirectly({ managedSystemId: msA, sourceVocId: sourceVoc.id });
+    const { msA, endpoints, vocTarget } = await seedRegisteredTupleEndpoints();
 
-    await expect(
-      seedEntityLinkDirectly({
-        sourceId: sourceVoc.id,
-        targetType: 'finding',
-        targetId: finding.id,
-        relationType: 'created_finding',
-        managedSystemId: msA,
-        visibility: 'internal_only',
-      }),
-    ).resolves.toEqual(expect.any(String));
+    for (const tuple of registeredEntityLinkPairs) {
+      const source = endpoints[tuple.source_type];
+      const target = tuple.target_type === 'voc' ? vocTarget : endpoints[tuple.target_type];
+
+      await expect(
+        seedEntityLinkDirectly({
+          sourceType: tuple.source_type,
+          sourceId: source.id,
+          targetType: tuple.target_type,
+          targetId: target.id,
+          relationType: tuple.relation_type,
+          managedSystemId: msA,
+          visibility: 'internal_only',
+        }),
+      ).resolves.toEqual(expect.any(String));
+    }
 
     await expect(
       migrateHandle.pool.query(
@@ -879,7 +1014,7 @@ describe.skipIf(!runIntegration)('POST/GET /entity-links (#112)', () => {
             relation_type, visibility, status, managed_system_id, created_by
           )
          values ($1, 'voc', $2, 'finding', $3, 'related_to', 'internal_only', 'active', $4, $5)`,
-        [WORKSPACE_ID, sourceVoc.id, finding.id, msA, adminActorId],
+        [WORKSPACE_ID, endpoints.voc.id, endpoints.finding.id, msA, adminActorId],
       ),
     ).rejects.toThrow();
 
@@ -890,7 +1025,7 @@ describe.skipIf(!runIntegration)('POST/GET /entity-links (#112)', () => {
             relation_type, visibility, status, managed_system_id, created_by
           )
          values ($1, 'finding', $2, 'voc', $3, 'created_finding', 'internal_only', 'active', $4, $5)`,
-        [WORKSPACE_ID, finding.id, targetVoc.id, msA, adminActorId],
+        [WORKSPACE_ID, endpoints.finding.id, vocTarget.id, msA, adminActorId],
       ),
     ).rejects.toThrow();
   });

--- a/apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts
+++ b/apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts
@@ -390,6 +390,8 @@ describe.skipIf(!runIntegration)('POST/GET /entity-links (#112)', () => {
       const source = endpoints[tuple.source_type];
       const target = tuple.target_type === 'voc' ? vocTarget : endpoints[tuple.target_type];
 
+      // Rate-limit tiers currently share one global counter (#153); this test asserts tuple registration/visibility, not rate limits.
+      await migrateHandle.pool.query('delete from core.rate_limits');
       const created = await postEntityLink(adminCookie, source.id, target.id, {
         source: { type: tuple.source_type, id: source.id },
         target: { type: tuple.target_type, id: target.id },

--- a/apps/backend/src/modules/entity-links/service.ts
+++ b/apps/backend/src/modules/entity-links/service.ts
@@ -2,12 +2,14 @@ import type {
   DetachedEntityLinkResponse,
   EntityLinkDto,
   EntityLinkEntityType,
+  EntityLinkPair,
   EntityLinkRef,
   EntityLinkRelationType,
   EntityLinkTargetSummary,
   EntityLinkVisibilityState,
   TaskReporterSummary,
 } from '@fops/shared';
+import { isRegisteredEntityLinkPair, registeredEntityLinkPairs } from '@fops/shared';
 
 import type { Db } from '../../db/client.js';
 import type { Tx } from '../../db/tx.js';
@@ -387,36 +389,50 @@ function providerFor(type: EntityLinkEntityType): EntityLinkProvider {
   return entityLinkProviders[type];
 }
 
+const creatableEntityLinkPairs = registeredEntityLinkPairs;
+const listVisibleEntityLinkPairs = registeredEntityLinkPairs;
+
+function tupleListIncludes(
+  pairs: readonly EntityLinkPair[],
+  input: {
+    sourceType: EntityLinkEntityType;
+    targetType: EntityLinkEntityType;
+    relationType: EntityLinkRelationType;
+  },
+): boolean {
+  return pairs.some(
+    (pair) =>
+      pair.source_type === input.sourceType &&
+      pair.target_type === input.targetType &&
+      pair.relation_type === input.relationType,
+  );
+}
+
 function isCreatableTuple(input: {
   sourceType: EntityLinkEntityType;
   targetType: EntityLinkEntityType;
   relationType: EntityLinkRelationType;
 }): boolean {
   return (
-    (input.sourceType === 'voc' &&
-      input.targetType === 'voc' &&
-      input.relationType === 'related_to') ||
-    (input.sourceType === 'voc' &&
-      input.targetType === 'finding' &&
-      input.relationType === 'created_finding') ||
-    (input.sourceType === 'voc' &&
-      input.targetType === 'finding' &&
-      input.relationType === 'evidence_of') ||
-    (input.sourceType === 'voc_cluster' &&
-      input.targetType === 'finding' &&
-      input.relationType === 'created_finding') ||
-    (input.sourceType === 'finding' &&
-      input.targetType === 'task_request' &&
-      input.relationType === 'requested_task') ||
-    (input.sourceType === 'task_request' &&
-      input.targetType === 'task' &&
-      input.relationType === 'converted_to') ||
-    (input.sourceType === 'finding' &&
-      input.targetType === 'task' &&
-      input.relationType === 'requested_task') ||
-    (input.sourceType === 'voc' &&
-      input.targetType === 'task' &&
-      input.relationType === 'evidence_of')
+    isRegisteredEntityLinkPair({
+      source_type: input.sourceType,
+      target_type: input.targetType,
+      relation_type: input.relationType,
+    }) && tupleListIncludes(creatableEntityLinkPairs, input)
+  );
+}
+
+function isListVisibleTuple(input: {
+  sourceType: EntityLinkEntityType;
+  targetType: EntityLinkEntityType;
+  relationType: EntityLinkRelationType;
+}): boolean {
+  return (
+    isRegisteredEntityLinkPair({
+      source_type: input.sourceType,
+      target_type: input.targetType,
+      relation_type: input.relationType,
+    }) && tupleListIncludes(listVisibleEntityLinkPairs, input)
   );
 }
 
@@ -441,7 +457,7 @@ async function evaluateRowVisibility(
   resolvedByEndpoint: Map<string, LinkEndpointRow | null>,
 ): Promise<LinkVisibilityDecision> {
   if (
-    !isCreatableTuple({
+    !isListVisibleTuple({
       sourceType: row.source_type,
       targetType: row.target_type,
       relationType: row.relation_type,

--- a/packages/shared/src/entity-links.ts
+++ b/packages/shared/src/entity-links.ts
@@ -18,6 +18,12 @@ export const entityLinkRelationTypeSchema = z.enum([
 ]);
 export type EntityLinkRelationType = z.infer<typeof entityLinkRelationTypeSchema>;
 
+export type EntityLinkPair = {
+  source_type: EntityLinkEntityType;
+  target_type: EntityLinkEntityType;
+  relation_type: EntityLinkRelationType;
+};
+
 export const entityLinkVisibilitySchema = z.enum([
   'internal_only',
   'summary_visible',
@@ -101,59 +107,58 @@ export const entityLinkTargetSummarySchema = z.discriminatedUnion('type', [
 ]);
 export type EntityLinkTargetSummary = z.infer<typeof entityLinkTargetSummarySchema>;
 
-export const registeredEntityLinkPairSchema = z.union([
-  z.object({
-    source_type: z.literal('voc'),
-    target_type: z.literal('voc'),
-    relation_type: z.literal('related_to'),
-  }),
-  z.object({
-    source_type: z.literal('voc'),
-    target_type: z.literal('finding'),
-    relation_type: z.literal('created_finding'),
-  }),
-  z.object({
-    source_type: z.literal('voc'),
-    target_type: z.literal('finding'),
-    relation_type: z.literal('evidence_of'),
-  }),
-  z.object({
-    source_type: z.literal('voc_cluster'),
-    target_type: z.literal('finding'),
-    relation_type: z.literal('created_finding'),
-  }),
-  z.object({
-    source_type: z.literal('finding'),
-    target_type: z.literal('task_request'),
-    relation_type: z.literal('requested_task'),
-  }),
-  z.object({
-    source_type: z.literal('voc'),
-    target_type: z.literal('task_request'),
-    relation_type: z.literal('requested_task'),
-  }),
-  z.object({
-    source_type: z.literal('voc_cluster'),
-    target_type: z.literal('task_request'),
-    relation_type: z.literal('requested_task'),
-  }),
-  z.object({
-    source_type: z.literal('task_request'),
-    target_type: z.literal('task'),
-    relation_type: z.literal('converted_to'),
-  }),
-  z.object({
-    source_type: z.literal('finding'),
-    target_type: z.literal('task'),
-    relation_type: z.literal('requested_task'),
-  }),
-  z.object({
-    source_type: z.literal('voc'),
-    target_type: z.literal('task'),
-    relation_type: z.literal('evidence_of'),
-  }),
-]);
-export type RegisteredEntityLinkPair = z.infer<typeof registeredEntityLinkPairSchema>;
+export const registeredEntityLinkPairs = [
+  { source_type: 'voc', target_type: 'voc', relation_type: 'related_to' },
+  { source_type: 'voc', target_type: 'finding', relation_type: 'created_finding' },
+  { source_type: 'voc', target_type: 'finding', relation_type: 'evidence_of' },
+  { source_type: 'voc_cluster', target_type: 'finding', relation_type: 'created_finding' },
+  { source_type: 'finding', target_type: 'task_request', relation_type: 'requested_task' },
+  { source_type: 'task_request', target_type: 'task', relation_type: 'converted_to' },
+  { source_type: 'finding', target_type: 'task', relation_type: 'requested_task' },
+  { source_type: 'voc', target_type: 'task', relation_type: 'evidence_of' },
+  { source_type: 'voc', target_type: 'task_request', relation_type: 'requested_task' },
+  {
+    source_type: 'voc_cluster',
+    target_type: 'task_request',
+    relation_type: 'requested_task',
+  },
+] as const satisfies readonly EntityLinkPair[];
+
+export type RegisteredEntityLinkPair = (typeof registeredEntityLinkPairs)[number];
+
+const entityLinkPairKey = (pair: EntityLinkPair) =>
+  `${pair.source_type}:${pair.target_type}:${pair.relation_type}`;
+
+const registeredEntityLinkPairKeys = new Set(registeredEntityLinkPairs.map(entityLinkPairKey));
+
+export function isRegisteredEntityLinkPair(input: unknown): input is RegisteredEntityLinkPair {
+  if (input === null || typeof input !== 'object') return false;
+  const maybePair = input as Partial<EntityLinkPair>;
+  if (
+    maybePair.source_type === undefined ||
+    maybePair.target_type === undefined ||
+    maybePair.relation_type === undefined
+  ) {
+    return false;
+  }
+  return registeredEntityLinkPairKeys.has(entityLinkPairKey(maybePair as EntityLinkPair));
+}
+
+function registeredEntityLinkPairOption(pair: RegisteredEntityLinkPair) {
+  return z.object({
+    source_type: z.literal(pair.source_type),
+    target_type: z.literal(pair.target_type),
+    relation_type: z.literal(pair.relation_type),
+  });
+}
+
+export const registeredEntityLinkPairSchema = z.union(
+  registeredEntityLinkPairs.map(registeredEntityLinkPairOption) as [
+    ReturnType<typeof registeredEntityLinkPairOption>,
+    ReturnType<typeof registeredEntityLinkPairOption>,
+    ...ReturnType<typeof registeredEntityLinkPairOption>[],
+  ],
+) as unknown as z.ZodType<RegisteredEntityLinkPair>;
 
 export const createEntityLinkRequestSchema = z
   .object({


### PR DESCRIPTION
Closes #147

## 변경
- `packages/shared/src/entity-links.ts`: `registeredEntityLinkPairs` const(10 튜플, 마이그레이션 0026과 동일) 신설 — 단일 정본. 스키마·`isRegisteredEntityLinkPair` predicate 파생(외부 계약 불변).
- `entity-links/service.ts`: 수기 `isCreatableTuple` 제거, `creatable`/`listVisible` 별칭으로 공유 predicate 소비 → voc→task_request, voc_cluster→task_request 링크가 리스트에서 hidden 처리되던 정합성 버그 해소.
- `db/schema/core.ts`: CHECK 선언 3→10 튜플(적용된 0026과 동기화, drizzle-kit 역행 마이그레이션 위험 제거) + 스테일 주석 수정. 마이그레이션 파일 없음.
- 회귀 테스트: 등록 튜플 전수(create+list visibility) 순회 — 향후 드리프트 시 즉시 실패. DB CHECK 양성 케이스도 전수 순회.
- doc-sync: `entity-links/AGENTS.md` 튜플 계약을 공유 레지스트리 참조로 개정.

## 증거 (worktree .review/)
- `ISSUE-147-VERIFY.json`: **PASS 57/57, exit 0**, producer VERIFIER, head_sha=05fbac1, DB=verify_issue_147(스로어웨이).
- `ISSUE-147-REVIEW.json`: approve (클린 컨텍스트 리뷰어, low 3건).
- typecheck(baseline-aware): exit 0.

## 파생
- 검증 과정에서 기존 잠복 버그 발견 → #153 등록 (rate-limit 티어가 global 카운터 공유; server.ts 소관이라 본 PR 범위 밖).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LpLNFXAbcMDYg6biobr8Xk