### PR TITLE
fix: #153 rate-limit 티어별 routeGroup 격리 — 단일 'global' PG 카운터 공유 해소

### DIFF
--- a/apps/backend/src/__tests__/server-rate-limit.test.ts
+++ b/apps/backend/src/__tests__/server-rate-limit.test.ts
@@ -13,6 +13,20 @@ type FakeSession = {
   workspace_id: string;
 };
 
+type RateLimitRow = {
+  key: string;
+  routeGroup: string;
+  counter: number;
+};
+
+const RATE_LIMIT_TIER_PROBES = [
+  ['mutation', '/issue-153-mutation-probe'],
+  ['sensitive', '/issue-153-sensitive-probe'],
+  ['read', '/issue-153-read-probe'],
+  ['reporterEdit', '/issue-153-reporter-edit-probe'],
+  ['attachmentMutation', '/issue-153-attachment-mutation-probe'],
+] as const;
+
 function config(): AppConfig {
   return {
     NODE_ENV: 'test',
@@ -42,9 +56,13 @@ function extractSqlParams(query: unknown): unknown[] {
 function createDbHandle(opts: {
   sessions?: Record<string, FakeSession>;
   failSessionLookup?: boolean;
-}): DbHandle & { sessionLookupCount: () => number } {
+}): DbHandle & {
+  sessionLookupCount: () => number;
+  rateLimitRows: () => RateLimitRow[];
+} {
   const sessions = opts.sessions ?? {};
   const counters = new Map<string, number>();
+  const rateLimitRows = new Map<string, RateLimitRow>();
   let sessionLookupCount = 0;
 
   const db = {
@@ -66,6 +84,7 @@ function createDbHandle(opts: {
       const counterKey = `${routeGroup}:${key}`;
       const counter = (counters.get(counterKey) ?? 0) + 1;
       counters.set(counterKey, counter);
+      rateLimitRows.set(counterKey, { key, routeGroup, counter });
       return { rows: [{ counter, ttl_ms: '60000' } as T] };
     },
   };
@@ -75,12 +94,23 @@ function createDbHandle(opts: {
     pool: pool as unknown as DbHandle['pool'],
     close: async () => undefined,
     sessionLookupCount: () => sessionLookupCount,
+    rateLimitRows: () =>
+      Array.from(rateLimitRows.values()).sort((a, b) =>
+        `${a.routeGroup}:${a.key}`.localeCompare(`${b.routeGroup}:${b.key}`),
+      ),
   };
 }
 
 async function buildFakeServer(dbHandle: DbHandle): Promise<FastifyInstance> {
   const app = await buildServer({ config: config(), dbHandle });
   app.get('/issue-25-global-probe', async () => ({ ok: true }));
+  for (const [tier, url] of RATE_LIMIT_TIER_PROBES) {
+    app.get(
+      url,
+      { config: { rateLimit: app.rateLimitConfig[tier] as never } },
+      async () => ({ ok: true, tier }),
+    );
+  }
   await app.ready();
   return app;
 }
@@ -89,12 +119,13 @@ async function statusesFor(
   app: FastifyInstance,
   count: number,
   headers?: Record<string, string>,
+  url = '/issue-25-global-probe',
 ): Promise<number[]> {
   const statuses: number[] = [];
   for (let i = 0; i < count; i += 1) {
     const res = await app.inject({
       method: 'GET',
-      url: '/issue-25-global-probe',
+      url,
       ...(headers ? { headers } : {}),
     });
     statuses.push(res.statusCode);
@@ -137,6 +168,42 @@ describe('global rate limit actor resolution', () => {
     const actorBOverLimit = await statusesFor(app, 1, { cookie: sessionCookie('session-b') });
     expect(actorAOverLimit).toEqual([429]);
     expect(actorBOverLimit).toEqual([429]);
+  });
+
+  it('keeps route-level tiers in distinct Postgres route_group buckets', async () => {
+    const dbHandle = createDbHandle({
+      sessions: {
+        'session-a': {
+          workspace_id: WORKSPACE_ID,
+          actor_id: '10000000-0000-4000-8000-000000000001',
+        },
+      },
+    });
+    app = await buildFakeServer(dbHandle);
+    const headers = { cookie: sessionCookie('session-a') };
+
+    expect(await statusesFor(app, 10, headers, '/issue-153-mutation-probe')).toEqual(
+      Array(10).fill(200),
+    );
+    expect(await statusesFor(app, 1, headers, '/issue-153-mutation-probe')).toEqual([429]);
+    expect(await statusesFor(app, 1, headers, '/issue-153-read-probe')).toEqual([200]);
+    expect(await statusesFor(app, 1, headers, '/issue-153-sensitive-probe')).toEqual([200]);
+    expect(await statusesFor(app, 1, headers, '/issue-153-reporter-edit-probe')).toEqual([200]);
+    expect(await statusesFor(app, 1, headers, '/issue-153-attachment-mutation-probe')).toEqual([
+      200,
+    ]);
+
+    const rows = dbHandle.rateLimitRows();
+    expect(rows.map((row) => row.routeGroup).sort()).toEqual([
+      'attachment_mutation',
+      'mutation',
+      'read',
+      'reporter_edit',
+      'sensitive',
+    ]);
+    expect(rows.find((row) => row.routeGroup === 'mutation')?.counter).toBe(11);
+    expect(rows.find((row) => row.routeGroup === 'read')?.counter).toBe(1);
+    expect(rows.some((row) => row.routeGroup === 'global')).toBe(false);
   });
 
   it('caches actor session resolution for repeated requests with the same cookie', async () => {

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -237,13 +237,13 @@ export async function buildServer(opts: BuildServerOptions): Promise<FastifyInst
       max: 10,
       timeWindow: '1 minute',
       keyGenerator: actorAwareKeyGenerator,
-      store: createPgRateLimitStore(dbHandle.pool, 'mutation') as never,
+      routeGroup: 'mutation',
     },
     sensitive: {
       max: 5,
       timeWindow: '1 minute',
       keyGenerator: actorAwareKeyGenerator,
-      store: createPgRateLimitStore(dbHandle.pool, 'sensitive') as never,
+      routeGroup: 'sensitive',
     },
     // TODO(F18 follow-up): add admin bypass for the read tier once the
     // admin-role detection helper lands (see plan §C3 follow-up F18).
@@ -251,7 +251,7 @@ export async function buildServer(opts: BuildServerOptions): Promise<FastifyInst
       max: 300,
       timeWindow: '1 minute',
       keyGenerator: actorAwareKeyGenerator,
-      store: createPgRateLimitStore(dbHandle.pool, 'read') as never,
+      routeGroup: 'read',
     },
     // Slice 3 #17 — Reporter pre-triage edit (PATCH /vocs/:id/description).
     // 30/min per actor (more permissive than generic `mutation: 10/min` because
@@ -261,7 +261,7 @@ export async function buildServer(opts: BuildServerOptions): Promise<FastifyInst
       max: 30,
       timeWindow: '1 minute',
       keyGenerator: actorAwareKeyGenerator,
-      store: createPgRateLimitStore(dbHandle.pool, 'reporter_edit') as never,
+      routeGroup: 'reporter_edit',
     },
     // PLAN-22 C3a — POST /attachments. 20/min per actor. Admin bypass is a
     // documented follow-up: it depends on the same admin-role helper called
@@ -270,7 +270,7 @@ export async function buildServer(opts: BuildServerOptions): Promise<FastifyInst
       max: 20,
       timeWindow: '1 minute',
       keyGenerator: actorAwareKeyGenerator,
-      store: createPgRateLimitStore(dbHandle.pool, 'attachment_mutation') as never,
+      routeGroup: 'attachment_mutation',
     },
   });
 


### PR DESCRIPTION
Closes #153

## 문제
`@fastify/rate-limit` v10은 라우트 레벨 `config.rateLimit`의 `store` 클래스를 인스턴스화하지 않고 전역 store의 `.child(mergedParams)`만 호출한다. 티어 config에 plain `routeGroup` 필드가 없어 모든 티어(mutation/sensitive/read/reporterEdit/attachmentMutation)가 actor당 `route_group='global'` PG 카운터 한 줄을 공유 — read 트래픽(300/min)이 mutation 예산(10/min)을 잠식해 조기 429.

## 수정
- `server.ts` `rateLimitConfig` 5개 티어 전부에 plain `routeGroup` 필드 추가 (mutation / sensitive / read / reporter_edit / attachment_mutation — 기존 `createPgRateLimitStore` 인자와 동일 문자열, purge job 의미 보존)
- 플러그인이 사용하지 않는 dead `store:` 필드 제거 (`createPgRateLimitStore`는 전역 등록 store에서 계속 사용 — 존치)
- 티어 격리 회귀 테스트 추가: 구 shared-'global' 동작에서는 실패하는 테스트 (distinct `route_group` 행 + 타 티어 예산 비잠식 검증)

## 증거 (multi-agent workflow, Standard 티어)
- REVIEW (클린 컨텍스트 codex read-only): **approve**, 소견 0건 — `.review/ISSUE-153-REVIEW.json`
- VERIFY (스로어웨이 DB `verify_issue_153`, scrubbed env): **PASS 5/5, failed 0, exit 0**, head_sha `ebdc4df` 일치 — `.review/ISSUE-153-VERIFY.json`
- typecheck: 베이스라인 대비 신규 에러 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LpLNFXAbcMDYg6biobr8Xk