### PR TITLE
fix(backend): voc-clusters create/update 감사 기록 추가 (#156)

### DIFF
--- a/apps/backend/src/modules/voc-clusters/__tests__/create-cluster-display-id.integration.test.ts
+++ b/apps/backend/src/modules/voc-clusters/__tests__/create-cluster-display-id.integration.test.ts
@@ -81,6 +81,9 @@ describe.skipIf(!runIntegration)('cluster display_id assignment (#142)', () => {
         `delete from core.managed_systems where workspace_id = $1`,
         [workspaceId],
       );
+      await migrateHandle.pool.query(`delete from core.audit_log where workspace_id = $1`, [
+        workspaceId,
+      ]);
       await migrateHandle.pool.query(`delete from core.actors where workspace_id = $1`, [
         workspaceId,
       ]);

--- a/apps/backend/src/modules/voc-clusters/__tests__/mutation-authz-audit.integration.test.ts
+++ b/apps/backend/src/modules/voc-clusters/__tests__/mutation-authz-audit.integration.test.ts
@@ -415,6 +415,69 @@ describe.skipIf(!runIntegration)('VOC cluster mutation authorization and audit r
     expect(await auditCount()).toBe(0);
   });
 
+  it('records voc_cluster_created audit row for an authorized createCluster', async () => {
+    const result = await vocClustersService.createCluster({
+      actor: manager(),
+      input: {
+        title: 'Audited created cluster',
+        summary: 'Created cluster summary',
+        primary_managed_system_id: managedSystemId,
+      },
+    });
+
+    expect(result.status).toBe(201);
+    const rows = await auditRows(['voc_cluster_created']);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      workspace_id: workspaceId,
+      actor_id: managerActorId,
+      event_type: 'voc_cluster_created',
+      subject_type: 'voc_cluster',
+      subject_id: result.body.id,
+    });
+    expect(rows[0]?.detail).toMatchObject({
+      voc_cluster_id: result.body.id,
+      primary_managed_system_id: managedSystemId,
+      title: 'Audited created cluster',
+      summary_present: true,
+      status: 'draft',
+    });
+  });
+
+  it('records voc_cluster_updated audit row for an authorized updateCluster', async () => {
+    const cluster = await seedCluster('Audited update cluster');
+
+    const result = await vocClustersService.updateCluster({
+      actor: manager(),
+      clusterId: cluster.id,
+      input: {
+        title: 'Audited updated cluster',
+        summary: 'Updated cluster summary',
+        status: 'confirmed',
+      },
+    });
+
+    expect(result.status).toBe(200);
+    const rows = await auditRows(['voc_cluster_updated']);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      workspace_id: workspaceId,
+      actor_id: managerActorId,
+      event_type: 'voc_cluster_updated',
+      subject_type: 'voc_cluster',
+      subject_id: cluster.id,
+    });
+    expect(rows[0]?.detail).toMatchObject({
+      voc_cluster_id: cluster.id,
+      primary_managed_system_id: managedSystemId,
+      changes: {
+        title: { from: 'Audited update cluster', to: 'Audited updated cluster' },
+        summary: { from: null, to: 'Updated cluster summary' },
+        status: { from: 'draft', to: 'confirmed' },
+      },
+    });
+  });
+
   it('records voc_cluster_member_added audit row for an authorized addMember', async () => {
     const cluster = await seedCluster('Audited add member cluster');
     const voc = await seedVoc('Audited add member VOC');

--- a/apps/backend/src/modules/voc-clusters/service.ts
+++ b/apps/backend/src/modules/voc-clusters/service.ts
@@ -188,6 +188,21 @@ export function createVocClustersService(deps: VocClustersServiceDeps) {
         primaryManagedSystemId: ms.id,
         createdBy: args.actor.actor_id,
       });
+      await deps.auditService.record(tx, {
+        workspace_id: args.actor.workspace_id,
+        actor_id: args.actor.actor_id,
+        event_type: 'voc_cluster_created',
+        subject_type: 'voc_cluster',
+        subject_id: row.id,
+        summary: 'VOC cluster created',
+        detail: {
+          voc_cluster_id: row.id,
+          primary_managed_system_id: row.primary_managed_system_id,
+          title: row.title,
+          summary_present: row.summary !== null,
+          status: row.status,
+        },
+      });
       return { status: 201, body: clusterToDto(row) };
     });
   }
@@ -274,6 +289,35 @@ export function createVocClustersService(deps: VocClustersServiceDeps) {
         ...(args.input.summary !== undefined ? { summary: args.input.summary } : {}),
         ...(args.input.status !== undefined ? { status: args.input.status } : {}),
       });
+      const changes: Partial<{
+        title: { from: string; to: string };
+        summary: { from: string | null; to: string | null };
+        status: { from: VocClusterRow['status']; to: VocClusterRow['status'] };
+      }> = {};
+      if (cluster.title !== updated.title) {
+        changes.title = { from: cluster.title, to: updated.title };
+      }
+      if (cluster.summary !== updated.summary) {
+        changes.summary = { from: cluster.summary, to: updated.summary };
+      }
+      if (cluster.status !== updated.status) {
+        changes.status = { from: cluster.status, to: updated.status };
+      }
+      if (Object.keys(changes).length > 0) {
+        await deps.auditService.record(tx, {
+          workspace_id: args.actor.workspace_id,
+          actor_id: args.actor.actor_id,
+          event_type: 'voc_cluster_updated',
+          subject_type: 'voc_cluster',
+          subject_id: cluster.id,
+          summary: 'VOC cluster updated',
+          detail: {
+            voc_cluster_id: cluster.id,
+            primary_managed_system_id: updated.primary_managed_system_id,
+            changes,
+          },
+        });
+      }
       return { status: 200, body: clusterToDto(updated) };
     });
   }

--- a/docs/implementation/03-api-contracts.md
+++ b/docs/implementation/03-api-contracts.md
@@ -605,7 +605,7 @@ records. Cluster merge and split endpoints are out of scope for MVP.
 | Authz | Read/list = Admin OR Developer with `finding.read` on the cluster MS. Create/edit/confirm/member-add/remove/create-finding = Admin OR Developer with `finding.manage` on the cluster MS. Reuses the Finding capabilities (no `voc_cluster.*` caps) — see ADR-0024 §H. |
 | Create-finding denial | Source-unreadable ⇒ `404 not_found.record` (hidden); readable-but-no-`finding.manage` ⇒ `403 permission.denied` (mirrors ADR-0024 §C). |
 | Idempotency | `Idempotency-Key`-scoped (same as `POST /vocs/:id/create-finding`): same key replays the same finding; distinct keys create distinct findings. |
-| Audit events | `voc_cluster_member_added`, `voc_cluster_member_removed`, `finding_created_from_voc_cluster`, `task_request_created_from_voc_cluster`. |
+| Audit events | `voc_cluster_created`, `voc_cluster_updated`, `voc_cluster_member_added`, `voc_cluster_member_removed`, `finding_created_from_voc_cluster`, `task_request_created_from_voc_cluster`. |
 
 ### Task Request Create From VOC / VOC Cluster Contract
 

--- a/packages/shared/src/audit/__tests__/voc-audit-schemas.test.ts
+++ b/packages/shared/src/audit/__tests__/voc-audit-schemas.test.ts
@@ -15,7 +15,12 @@ import {
   vocTriagePostponedDetailSchema,
   vocDescriptionEditedDetailSchema,
 } from '../voc.js';
-import { AUDIT_EVENT_TYPES, AUDIT_EVENT_DETAIL_SCHEMAS } from '../../enums/audit-events.js';
+import {
+  AUDIT_EVENT_TYPES,
+  AUDIT_EVENT_DETAIL_SCHEMAS,
+  vocClusterCreatedDetailSchema,
+  vocClusterUpdatedDetailSchema,
+} from '../../enums/audit-events.js';
 
 const U = '01919b8c-0000-7000-8000-000000000001';
 
@@ -481,5 +486,57 @@ describe('AUDIT_EVENT_TYPES registry', () => {
   it.each(VOC_EVENTS)('%s is in AUDIT_EVENT_TYPES and has a detail schema', (event) => {
     expect(AUDIT_EVENT_TYPES).toContain(event);
     expect(AUDIT_EVENT_DETAIL_SCHEMAS).toHaveProperty(event);
+  });
+});
+
+describe('VOC cluster audit event registry', () => {
+  const VOC_CLUSTER_EVENTS = ['voc_cluster_created', 'voc_cluster_updated'] as const;
+
+  it.each(VOC_CLUSTER_EVENTS)('%s is in AUDIT_EVENT_TYPES and has a detail schema', (event) => {
+    expect(AUDIT_EVENT_TYPES).toContain(event);
+    expect(AUDIT_EVENT_DETAIL_SCHEMAS).toHaveProperty(event);
+  });
+});
+
+describe('vocClusterCreatedDetailSchema', () => {
+  it('accepts required shape', () => {
+    expect(
+      vocClusterCreatedDetailSchema.parse({
+        voc_cluster_id: U,
+        primary_managed_system_id: U,
+        title: 'Cluster title',
+        summary_present: true,
+        status: 'draft',
+      }),
+    ).toMatchObject({ voc_cluster_id: U, status: 'draft' });
+  });
+});
+
+describe('vocClusterUpdatedDetailSchema', () => {
+  it('accepts changed title, summary, and status', () => {
+    expect(
+      vocClusterUpdatedDetailSchema.parse({
+        voc_cluster_id: U,
+        primary_managed_system_id: U,
+        changes: {
+          title: { from: 'Old title', to: 'New title' },
+          summary: { from: null, to: 'New summary' },
+          status: { from: 'draft', to: 'confirmed' },
+        },
+      }),
+    ).toMatchObject({
+      voc_cluster_id: U,
+      changes: { status: { from: 'draft', to: 'confirmed' } },
+    });
+  });
+
+  it('rejects an empty changes object', () => {
+    expect(() =>
+      vocClusterUpdatedDetailSchema.parse({
+        voc_cluster_id: U,
+        primary_managed_system_id: U,
+        changes: {},
+      }),
+    ).toThrow();
   });
 });

--- a/packages/shared/src/enums/audit-events.ts
+++ b/packages/shared/src/enums/audit-events.ts
@@ -65,6 +65,8 @@ export const AUDIT_EVENT_TYPES = [
   // Slice 5 #121: Finding created from a source VOC.
   'finding_created_from_voc',
   // Slice 5 #126: VOC Cluster membership and cluster-created Finding.
+  'voc_cluster_created',
+  'voc_cluster_updated',
   'voc_cluster_member_added',
   'voc_cluster_member_removed',
   'finding_created_from_voc_cluster',
@@ -330,6 +332,42 @@ export type FindingCreatedFromVocClusterDetail = z.infer<
   typeof findingCreatedFromVocClusterDetailSchema
 >;
 
+const vocClusterStatusDetailSchema = z.enum(['draft', 'confirmed']);
+
+export const vocClusterCreatedDetailSchema = z.object({
+  voc_cluster_id: z.string().uuid(),
+  primary_managed_system_id: z.string().uuid(),
+  title: z.string().min(1),
+  summary_present: z.boolean(),
+  status: vocClusterStatusDetailSchema,
+});
+export type VocClusterCreatedDetail = z.infer<typeof vocClusterCreatedDetailSchema>;
+
+export const vocClusterUpdatedDetailSchema = z.object({
+  voc_cluster_id: z.string().uuid(),
+  primary_managed_system_id: z.string().uuid(),
+  changes: z
+    .object({
+      title: z.object({ from: z.string().min(1), to: z.string().min(1) }).optional(),
+      summary: z
+        .object({
+          from: z.string().nullable(),
+          to: z.string().nullable(),
+        })
+        .optional(),
+      status: z
+        .object({
+          from: vocClusterStatusDetailSchema,
+          to: vocClusterStatusDetailSchema,
+        })
+        .optional(),
+    })
+    .refine((changes) => Object.keys(changes).length > 0, {
+      message: 'at least one cluster field change is required',
+    }),
+});
+export type VocClusterUpdatedDetail = z.infer<typeof vocClusterUpdatedDetailSchema>;
+
 export const vocClusterMemberAddedDetailSchema = z.object({
   voc_cluster_id: z.string().uuid(),
   voc_id: z.string().uuid(),
@@ -475,6 +513,8 @@ export const AUDIT_EVENT_DETAIL_SCHEMAS = {
   // Slice 5 #121.
   finding_created_from_voc: findingCreatedFromVocDetailSchema,
   // Slice 5 #126.
+  voc_cluster_created: vocClusterCreatedDetailSchema,
+  voc_cluster_updated: vocClusterUpdatedDetailSchema,
   voc_cluster_member_added: vocClusterMemberAddedDetailSchema,
   voc_cluster_member_removed: vocClusterMemberRemovedDetailSchema,
   finding_created_from_voc_cluster: findingCreatedFromVocClusterDetailSchema,


### PR DESCRIPTION
Closes #156

## 변경
- `voc_cluster_created` / `voc_cluster_updated` 감사 이벤트 추가: shared enum + detail schema + 매핑, createCluster/updateCluster 트랜잭션 내 `auditService.record` (addMember 패턴)
- 감사 회귀 테스트 2건 확장 (#149 테스트 파일), shared registry 테스트 추가
- doc-sync: 03-api-contracts.md 감사 이벤트 목록 갱신
- follow-up: #142 display-id 테스트 teardown에 audit_log 정리 (신규 감사 기록으로 인한 FK 위반 수정)

## 증거
- VERIFY PASS 17/17, exit 0, head 468c482 (.review/ISSUE-156-VERIFY.json, throwaway DB)
- typecheck: 베이스라인 대비 신규 에러 0
- REVIEW approve 무소견 2회 (attempt2 전체 diff + follow-up)
- attempt1 블로커(shared enum 스코프) → ARCHITECT 설계 패스 후 스코프 확장 재디스패치

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LpLNFXAbcMDYg6biobr8Xk