### PR TITLE
refactor(backend): permissions check 라우트 DB 쿼리를 request-service로 이동 (#148)

### DIFF
--- a/apps/backend/src/modules/permissions/request-service.ts
+++ b/apps/backend/src/modules/permissions/request-service.ts
@@ -1,5 +1,6 @@
-// Permission-request application service. Owns the write-side of permission
-// asks per docs/implementation/02-domain-module-boundaries.md and
+// Permission-request application service. Owns permission request commands and
+// permission_requests read models per
+// docs/implementation/02-domain-module-boundaries.md and
 // docs/implementation/05-permission-policy.md.
 //
 // Single transaction contract (AGENTS.md, ADR-0008):
@@ -21,7 +22,7 @@
 // values inside the index so duplicate inserts with all-NULL scope/source
 // still collide as expected.
 
-import { and, desc, eq, inArray, sql } from 'drizzle-orm';
+import { and, desc, eq, inArray, isNull, sql } from 'drizzle-orm';
 import type { DatabaseError } from 'pg';
 
 import {
@@ -37,7 +38,8 @@ import { HttpError } from '../../lib/errors.js';
 import type { AuditService } from '../core/audit/audit-service.js';
 import { hashRequestBody } from '../core/idempotency/canonicalize.js';
 import type { IdempotencyService } from '../core/idempotency/idempotency-service.js';
-import type { ActorContext, CheckService } from './check-service.js';
+import type { ActorContext, CheckScope, CheckService } from './check-service.js';
+import type { OpenRequestSummary } from './state-mapper.js';
 
 export interface CreatePermissionRequestBody {
   requested_capability: string;
@@ -244,6 +246,38 @@ export function createRequestService(deps: RequestServiceDeps) {
     });
   }
 
+  async function findOpenRequestSummary(
+    actor: ActorContext,
+    capability: Capability,
+    scope: CheckScope,
+  ): Promise<OpenRequestSummary | null> {
+    const msFilter =
+      scope.managed_system_id !== undefined
+        ? eq(permissionRequests.requestedManagedSystemId, scope.managed_system_id)
+        : isNull(permissionRequests.requestedManagedSystemId);
+
+    const rows = await db
+      .select({ status: permissionRequests.status })
+      .from(permissionRequests)
+      .where(
+        and(
+          eq(permissionRequests.workspaceId, scope.workspace_id),
+          eq(permissionRequests.requesterActorId, actor.actor_id),
+          eq(permissionRequests.requestedCapability, capability),
+          msFilter,
+          inArray(permissionRequests.status, [...ACTIVE_STATUSES]),
+        ),
+      )
+      .limit(1);
+
+    const row = rows[0] ?? null;
+    if (!row) return null;
+    if (row.status === 'pending' || row.status === 'needs_more_info') {
+      return { status: row.status };
+    }
+    return null;
+  }
+
   // Admin-only workspace-wide list of open (pending|needs_more_info) requests.
   // Guarded by workspace.admin (issue #87). Mirrors the managed-system admin
   // gate: throws permission.denied (mapped to 403) for non-admins. The count
@@ -329,5 +363,5 @@ export function createRequestService(deps: RequestServiceDeps) {
     }));
   }
 
-  return { createRequest, listMine, listAllActive };
+  return { createRequest, findOpenRequestSummary, listMine, listAllActive };
 }

--- a/apps/backend/src/modules/permissions/routes.ts
+++ b/apps/backend/src/modules/permissions/routes.ts
@@ -1,14 +1,12 @@
 // Permission routes. Thin controllers per AGENTS.md:65-66 — every DB read of
-// permission_* tables happens inside `check-service.ts`. The route's only
+// permission_* tables happens inside permission services. The route's only
 // jobs are: parse + validate query params, look up the actor's role_level,
 // call the service, and shape the response envelope.
 
-import { and, eq, isNull, sql } from 'drizzle-orm';
 import type { FastifyPluginAsync } from 'fastify';
 import { z } from 'zod';
 
 import { type Capability, isCapability } from '@fops/shared';
-import { permissionRequests } from '../../db/schema/permission.js';
 import { HttpError, sendError } from '../../lib/errors.js';
 import { requireSession } from '../../middleware/require-session.js';
 import { requireWorkspace } from '../../middleware/require-workspace.js';
@@ -97,29 +95,10 @@ export const permissionsRoutes: FastifyPluginAsync<PermissionsRoutesOptions> = a
       // `permission_requests_active_uq` (workspace, requester, capability,
       // COALESCE(managed_system_id, sentinel)). A null query MS hits null
       // rows; a concrete MS UUID hits exactly its own rows.
-      const msFilter =
-        q.managed_system_id !== undefined
-          ? eq(permissionRequests.requestedManagedSystemId, q.managed_system_id)
-          : isNull(permissionRequests.requestedManagedSystemId);
-      const openReqRows = await app.db
-        .select({ status: permissionRequests.status })
-        .from(permissionRequests)
-        .where(
-          and(
-            eq(permissionRequests.workspaceId, sess.workspace_id),
-            eq(permissionRequests.requesterActorId, sess.actor_id),
-            eq(permissionRequests.requestedCapability, capability),
-            msFilter,
-            sql`${permissionRequests.status} in ('pending','needs_more_info')`,
-          ),
-        )
-        .limit(1);
-      const openReq = openReqRows[0] ?? null;
-      // We only feed pending/needs_more_info/rejected to the mapper; any
-      // other status (approved/expired/revoked) is irrelevant for the
-      // request flow.
-      const openRequestSummary =
-        openReq && isMapperStatus(openReq.status) ? { status: openReq.status } : null;
+      const openRequestSummary = await requestService.findOpenRequestSummary(actor, capability, {
+        workspace_id: sess.workspace_id,
+        ...(q.managed_system_id !== undefined ? { managed_system_id: q.managed_system_id } : {}),
+      });
 
       const state: FrontendState = toFrontendState(decision, openRequestSummary);
       return { state, decision };
@@ -225,7 +204,3 @@ export const permissionsRoutes: FastifyPluginAsync<PermissionsRoutesOptions> = a
     },
   });
 };
-
-function isMapperStatus(value: string): value is 'pending' | 'needs_more_info' | 'rejected' {
-  return value === 'pending' || value === 'needs_more_info' || value === 'rejected';
-}


### PR DESCRIPTION
Closes #148

## 변경
- GET /me/permissions/check의 permission_requests 직접 select를 `requestService.findOpenRequestSummary`로 이동 (AGENTS.md 레이어 규칙 준수, 동작 불변)
- routes.ts에서 DB import 제거, 매칭 조건(workspace/actor/capability, managed_system null-only/exact, pending|needs_more_info, limit 1) 동일 유지

## 증거
- VERIFY PASS 49/49, exit 0, head 4b6d5cd (.review/ISSUE-148-VERIFY.json, throwaway DB)
- typecheck: 베이스라인 대비 신규 에러 0
- REVIEW approve 무소견 (clean-context codex read-only)
- ARCHITECT 설계 패스 선행 (.review/ISSUE-148-DESIGN.txt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LpLNFXAbcMDYg6biobr8Xk