### PR TITLE
chore(db): 0029 display_counters 소유권/GRANT 하드닝 (#158)

### DIFF
--- a/apps/backend/migrations/0029_display_counters_owner.sql
+++ b/apps/backend/migrations/0029_display_counters_owner.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "core"."display_counters" OWNER TO fops_migrate;
+--> statement-breakpoint
+GRANT ALL ON "core"."display_counters" TO fops_migrate;
+--> statement-breakpoint

--- a/apps/backend/migrations/meta/_journal.json
+++ b/apps/backend/migrations/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1781700000000,
       "tag": "0028_display_id_not_null",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1781800000000,
+      "tag": "0029_display_counters_owner",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
Closes #158

## 변경
- 신규 마이그레이션 `0029_display_counters_owner.sql`: `ALTER TABLE core.display_counters OWNER TO fops_migrate` + `GRANT ALL TO fops_migrate` (0027 함수 OWNER 원칙과 일관, 적용 role 무관 견고)
- journal idx 29 등록. 0027 in-place 무수정, fops_app 권한 확대 없음(SECURITY DEFINER 캡슐화 유지)

## 증거 (모두 GRANT 워크어라운드 **없이**, superuser로 fresh DB 마이그레이션)
- display-id 스위트 PASS 8/8, voc-clusters 스위트 PASS 17/17 (head 9c9601f, .review/ISSUE-158-VERIFY-*.json)
- typecheck 베이스라인 대비 신규 에러 0, REVIEW approve 무소견
- ARCHITECT 설계 패스: in-place vs 신규 판단 근거 .review/ISSUE-158-DESIGN.txt

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LpLNFXAbcMDYg6biobr8Xk