### PR TITLE
fix(backend): entity-links voc provider가 voc.triage 읽기 범위 인정 (#162)

### DIFF
--- a/apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts
+++ b/apps/backend/src/modules/entity-links/__tests__/entity-links.integration.test.ts
@@ -526,6 +526,47 @@ describe.skipIf(!runIntegration)('POST/GET /entity-links (#112)', () => {
     expect(hidden?.source_id).toBeUndefined();
   });
 
+  it('GET by VOC source accepts managed-system scoped voc.triage without voc.read', async () => {
+    const msA = await insertMsDirectly(
+      dbHandle,
+      WORKSPACE_ID,
+      `${uid(SLUG_PREFIX)}-triage`,
+      'Links Triage MS',
+    );
+    const sourceVoc = await insertVocDirectly(
+      dbHandle,
+      WORKSPACE_ID,
+      msA,
+      reporterId,
+      'GET Triage Source VOC',
+    );
+    const targetVoc = await insertVocDirectly(
+      dbHandle,
+      WORKSPACE_ID,
+      msA,
+      reporterId,
+      'GET Triage Target VOC',
+    );
+    const create = await postEntityLink(adminCookie, sourceVoc.id, targetVoc.id);
+    expect(create.statusCode).toBe(201);
+    const linkId = create.json<{ id: string }>().id;
+
+    const { id: devId, externalId } = await insertDevActor(dbHandle, WORKSPACE_ID, uid('triage'));
+    await grantCapability(dbHandle, WORKSPACE_ID, devId, 'voc.triage', msA, adminActorId);
+    const devCookie = await loginAs(app, externalId);
+
+    const res = await getEntityLinks(devCookie, `?source_type=voc&source_id=${sourceVoc.id}`);
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ items: Array<Record<string, unknown>> }>();
+    expect(body.items).toHaveLength(1);
+    expect(body.items[0]).toMatchObject({
+      id: linkId,
+      visibility_state: 'allowed',
+      source_id: sourceVoc.id,
+      target_id: targetVoc.id,
+    });
+  });
+
   it('VOC detail returns active outbound related_to links on the Links tab payload', async () => {
     const { sourceVoc, targetVoc } = await seedVocPair();
     const create = await postEntityLink(adminCookie, sourceVoc.id, targetVoc.id);

--- a/apps/backend/src/modules/entity-links/service.ts
+++ b/apps/backend/src/modules/entity-links/service.ts
@@ -212,11 +212,17 @@ async function assertVocReadScope(
   subject: LinkEndpointRow,
 ): Promise<boolean> {
   if (subject.reporter_id && actor.actor_id === subject.reporter_id) return true;
-  const decision = await deps.checkService.checkCapability(actor, 'voc.read', {
+  const readDecision = await deps.checkService.checkCapability(actor, 'voc.read', {
     workspace_id: actor.workspace_id,
     managed_system_id: subject.managed_system_id,
   });
-  return decision.allow;
+  if (readDecision.allow) return true;
+
+  const triageDecision = await deps.checkService.checkCapability(actor, 'voc.triage', {
+    workspace_id: actor.workspace_id,
+    managed_system_id: subject.managed_system_id,
+  });
+  return triageDecision.allow;
 }
 
 async function assertFindingReadScope(


### PR DESCRIPTION
Closes #162

## 변경
- `assertVocReadScope`: voc.read deny 시 voc.triage 추가 체크 (voc 모듈 계약 repo-read.ts의 read∪triage 합집합과 일치). 동일 workspace/MS scope, 다른 provider 불변
- entity-links 계약 회귀 테스트 1건 추가 (triage-only actor VOC focus 통과)

## 효과
triage-only dev의 POST internal-comment/public-update가 404 롤백되던 잠재 회귀(#112발) 해소 — 실패하던 voc 테스트 3건 무수정 자연 그린.

## 증거
- entity-links PASS 58/58, voc 전체 PASS 294/294 (head 0213156, .review/ISSUE-162-VERIFY-*.json)
- typecheck 신규 에러 0, REVIEW approve 무소견 (권한 정합성 중점)
- ARCHITECT 설계·노출범위 분석: .review/ISSUE-162-DESIGN.txt

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LpLNFXAbcMDYg6biobr8Xk