### PR TITLE
feat(slice7): Tasks 칸반 보드 — PATCH /tasks/:id + dnd-kit 드래그 상태전환 (#138)

### DIFF
--- a/apps/backend/src/modules/tasks/__tests__/patch-task-status.integration.test.ts
+++ b/apps/backend/src/modules/tasks/__tests__/patch-task-status.integration.test.ts
@@ -63,8 +63,19 @@ describe.skipIf(!runIntegration)(
     async function cleanupFixtures(): Promise<void> {
       if (!migrateHandle) return;
       await migrateHandle.pool.query(
-        `delete from core.audit_log where workspace_id = $1 and event_type = 'task_status_changed'`,
-        [WORKSPACE_ID],
+        `delete from core.audit_log
+          where workspace_id = $1
+            and event_type = 'task_status_changed'
+            and subject_id in (
+              select task.id
+              from task.tasks task
+              join core.managed_systems managed_system
+                on managed_system.id = task.primary_managed_system_id
+              where task.workspace_id = $1
+                and managed_system.workspace_id = $1
+                and managed_system.slug like $2
+            )`,
+        [WORKSPACE_ID, `${SLUG_PREFIX}%`],
       );
       await migrateHandle.pool.query(
         `delete from core.idempotency_keys
@@ -187,6 +198,25 @@ describe.skipIf(!runIntegration)(
         expect(res.statusCode).toBe(422);
         expect(res.json<{ code: string }>().code).toBe("validation.failed");
       }
+    });
+
+    it("rejects a malformed If-Match header with the required-header validation shape", async () => {
+      const task = await seedTask();
+      const res = await patchTask(
+        adminCookie,
+        task.id,
+        { status: "doing" },
+        {
+          idempotencyKey: randomUUID(),
+          ifMatch: "not-an-iso-timestamp",
+        },
+      );
+
+      expect(res.statusCode).toBe(422);
+      expect(res.json()).toMatchObject({
+        code: "validation.failed",
+        detail: { fields: [{ path: ["headers", "if-match"], code: "required" }] },
+      });
     });
 
     it("denies a Developer without finding.manage on the task Managed System", async () => {

--- a/apps/backend/src/modules/tasks/__tests__/patch-task-status.integration.test.ts
+++ b/apps/backend/src/modules/tasks/__tests__/patch-task-status.integration.test.ts
@@ -1,0 +1,293 @@
+// Task status transition endpoint (#138).
+//
+// Gate: DATABASE_URL + DATABASE_URL_MIGRATE + WORKSPACE_ID. The verifier runs
+// this suite against live Postgres outside the sandbox.
+
+import { randomUUID } from "node:crypto";
+
+import type { FastifyInstance } from "fastify";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import { loadConfig } from "../../../config.js";
+import { type DbHandle, createDb } from "../../../db/client.js";
+import { buildServer } from "../../../server.js";
+import {
+  SESSION_COOKIE_NAME,
+  cleanupReadTestTables,
+  insertDevActor,
+  insertMsDirectly,
+  loginAs,
+  uid,
+} from "../../voc/__tests__/_seed-helpers.js";
+import { insertTaskRow } from "./_seed-helpers.js";
+
+const APP_URL = process.env.DATABASE_URL ?? "";
+const MIGRATE_URL = process.env.DATABASE_URL_MIGRATE ?? "";
+const WORKSPACE_ID = process.env.WORKSPACE_ID ?? "";
+const runIntegration = Boolean(APP_URL && MIGRATE_URL && WORKSPACE_ID);
+const SLUG_PREFIX = "it-task-status";
+
+describe.skipIf(!runIntegration)(
+  "PATCH /tasks/:id status transition (#138)",
+  () => {
+    let dbHandle: DbHandle;
+    let migrateHandle: DbHandle;
+    let app: FastifyInstance;
+    let adminCookie: string;
+    let adminActorId: string;
+
+    beforeAll(async () => {
+      process.env.NODE_ENV = "test";
+      dbHandle = createDb(APP_URL);
+      migrateHandle = createDb(MIGRATE_URL);
+      app = await buildServer({ config: loadConfig(), dbHandle });
+      await app.ready();
+      adminCookie = await loginAs(app, "mock-admin-1");
+      const actors = await dbHandle.pool.query<{ id: string }>(
+        `select id from core.actors where workspace_id = $1 and external_id = 'mock-admin-1'`,
+        [WORKSPACE_ID],
+      );
+      adminActorId = actors.rows[0]?.id ?? "";
+      if (!adminActorId) throw new Error("seed admin actor not found");
+    });
+
+    beforeEach(async () => cleanupFixtures());
+
+    afterAll(async () => {
+      await cleanupFixtures();
+      await app?.close();
+      await dbHandle?.close();
+      await migrateHandle?.close();
+    });
+
+    async function cleanupFixtures(): Promise<void> {
+      if (!migrateHandle) return;
+      await migrateHandle.pool.query(
+        `delete from core.audit_log where workspace_id = $1 and event_type = 'task_status_changed'`,
+        [WORKSPACE_ID],
+      );
+      await migrateHandle.pool.query(
+        `delete from core.idempotency_keys
+        where actor_id in (select id from core.actors where workspace_id = $1 and external_id like 'mock-dev-task-status-%')
+           or actor_id = (select id from core.actors where workspace_id = $1 and external_id = 'mock-admin-1')`,
+        [WORKSPACE_ID],
+      );
+      await migrateHandle.pool.query(
+        `delete from task.tasks where workspace_id = $1 and primary_managed_system_id in (
+         select id from core.managed_systems where workspace_id = $1 and slug like $2
+       )`,
+        [WORKSPACE_ID, `${SLUG_PREFIX}%`],
+      );
+      await migrateHandle.pool.query(
+        `delete from permission.permission_grants where workspace_id = $1 and actor_id in (
+         select id from core.actors where workspace_id = $1 and external_id like 'mock-dev-task-status-%'
+       )`,
+        [WORKSPACE_ID],
+      );
+      await migrateHandle.pool.query(
+        `delete from core.rate_limits where key like $1 || ':%' or key like '127.0.0.%'`,
+        [WORKSPACE_ID],
+      );
+      await cleanupReadTestTables(dbHandle, WORKSPACE_ID, SLUG_PREFIX);
+    }
+
+    async function seedTask(status: "backlog" | "todo" | "doing" = "backlog") {
+      const msId = await insertMsDirectly(
+        dbHandle,
+        WORKSPACE_ID,
+        uid(SLUG_PREFIX),
+        "Task Status MS",
+      );
+      const task = await insertTaskRow(migrateHandle, {
+        workspaceId: WORKSPACE_ID,
+        primaryManagedSystemId: msId,
+        status,
+        createdBy: adminActorId,
+      });
+      const row = await dbHandle.pool.query<{ updated_at: Date }>(
+        `select updated_at from task.tasks where id = $1`,
+        [task.id],
+      );
+      const updatedAt = row.rows[0]?.updated_at?.toISOString();
+      if (!updatedAt) throw new Error("seed task updated_at missing");
+      return { ...task, msId, updatedAt };
+    }
+
+    function patchTask(
+      cookie: string,
+      taskId: string,
+      body: Record<string, unknown>,
+      headers: { idempotencyKey?: string; ifMatch?: string } = {},
+    ) {
+      const requestHeaders: Record<string, string> = {
+        cookie: `${SESSION_COOKIE_NAME}=${cookie}`,
+        "content-type": "application/json",
+      };
+      if (headers.idempotencyKey !== undefined)
+        requestHeaders["idempotency-key"] = headers.idempotencyKey;
+      if (headers.ifMatch !== undefined)
+        requestHeaders["if-match"] = headers.ifMatch;
+      return app.inject({
+        method: "PATCH",
+        url: `/tasks/${taskId}`,
+        headers: requestHeaders,
+        payload: body,
+      });
+    }
+
+    it("changes status, returns Task Detail, and writes task_status_changed audit detail", async () => {
+      const task = await seedTask();
+      const res = await patchTask(
+        adminCookie,
+        task.id,
+        { status: "doing" },
+        {
+          idempotencyKey: randomUUID(),
+          ifMatch: task.updatedAt,
+        },
+      );
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toMatchObject({
+        id: task.id,
+        status: "doing",
+        source: null,
+      });
+      const audit = await dbHandle.pool.query<{ detail: unknown }>(
+        `select detail from core.audit_log where workspace_id = $1 and event_type = 'task_status_changed' and subject_id = $2`,
+        [WORKSPACE_ID, task.id],
+      );
+      expect(audit.rowCount).toBe(1);
+      expect(audit.rows[0]?.detail).toEqual({ from: "backlog", to: "doing" });
+    });
+
+    it("returns 404 for a missing task", async () => {
+      const res = await patchTask(
+        adminCookie,
+        randomUUID(),
+        { status: "doing" },
+        {
+          idempotencyKey: randomUUID(),
+          ifMatch: new Date().toISOString(),
+        },
+      );
+      expect(res.statusCode).toBe(404);
+    });
+
+    it("rejects an invalid or non-strict status body", async () => {
+      const task = await seedTask();
+      for (const body of [
+        { status: "invalid" },
+        { status: "doing", extra: true },
+      ]) {
+        const res = await patchTask(adminCookie, task.id, body, {
+          idempotencyKey: randomUUID(),
+          ifMatch: task.updatedAt,
+        });
+        expect(res.statusCode).toBe(422);
+        expect(res.json<{ code: string }>().code).toBe("validation.failed");
+      }
+    });
+
+    it("denies a Developer without finding.manage on the task Managed System", async () => {
+      const task = await seedTask();
+      const dev = await insertDevActor(
+        dbHandle,
+        WORKSPACE_ID,
+        uid("mock-dev-task-status"),
+      );
+      const devCookie = await loginAs(app, dev.externalId);
+      const res = await patchTask(
+        devCookie,
+        task.id,
+        { status: "doing" },
+        {
+          idempotencyKey: randomUUID(),
+          ifMatch: task.updatedAt,
+        },
+      );
+      expect(res.statusCode).toBe(403);
+      expect(res.json<{ code: string }>().code).toBe("permission.denied");
+    });
+
+    it("returns stale_write with current_updated_at for an authorised stale request", async () => {
+      const task = await seedTask();
+      const res = await patchTask(
+        adminCookie,
+        task.id,
+        { status: "doing" },
+        {
+          idempotencyKey: randomUUID(),
+          ifMatch: "2000-01-01T00:00:00.000Z",
+        },
+      );
+      expect(res.statusCode).toBe(409);
+      expect(res.json()).toMatchObject({
+        code: "conflict.stale_write",
+        detail: { current_updated_at: task.updatedAt },
+      });
+    });
+
+    it("treats a same-status request as a no-op without an audit row", async () => {
+      const task = await seedTask("todo");
+      const res = await patchTask(
+        adminCookie,
+        task.id,
+        { status: "todo" },
+        {
+          idempotencyKey: randomUUID(),
+          ifMatch: task.updatedAt,
+        },
+      );
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toMatchObject({
+        id: task.id,
+        status: "todo",
+        updated_at: task.updatedAt,
+      });
+      const audits = await dbHandle.pool.query<{ n: number }>(
+        `select count(*)::int as n from core.audit_log where workspace_id = $1 and event_type = 'task_status_changed' and subject_id = $2`,
+        [WORKSPACE_ID, task.id],
+      );
+      expect(audits.rows[0]?.n).toBe(0);
+    });
+
+    it("replays the cached response for the same key, body, and If-Match", async () => {
+      const task = await seedTask();
+      const key = randomUUID();
+      const first = await patchTask(
+        adminCookie,
+        task.id,
+        { status: "doing" },
+        { idempotencyKey: key, ifMatch: task.updatedAt },
+      );
+      const second = await patchTask(
+        adminCookie,
+        task.id,
+        { status: "doing" },
+        { idempotencyKey: key, ifMatch: task.updatedAt },
+      );
+      expect(first.statusCode).toBe(200);
+      expect(second.statusCode).toBe(200);
+      expect(second.json()).toEqual(first.json());
+    });
+
+    it("requires both Idempotency-Key and If-Match headers", async () => {
+      const task = await seedTask();
+      const missingKey = await patchTask(
+        adminCookie,
+        task.id,
+        { status: "doing" },
+        { ifMatch: task.updatedAt },
+      );
+      const missingMatch = await patchTask(
+        adminCookie,
+        task.id,
+        { status: "doing" },
+        { idempotencyKey: randomUUID() },
+      );
+      expect(missingKey.statusCode).toBe(422);
+      expect(missingMatch.statusCode).toBe(422);
+    });
+  },
+);

--- a/apps/backend/src/modules/tasks/repo.ts
+++ b/apps/backend/src/modules/tasks/repo.ts
@@ -111,6 +111,23 @@ export async function lockTaskById(
   return row ? mapTaskRow(row) : null;
 }
 
+export async function updateTaskStatus(
+  tx: Tx,
+  input: { workspaceId: string; taskId: string; status: TaskStatus },
+): Promise<TaskRow> {
+  const result = await tx.execute<Record<string, unknown>>(sql`
+    UPDATE task.tasks
+       SET status = ${input.status},
+           updated_at = now()
+     WHERE id = ${input.taskId}
+       AND workspace_id = ${input.workspaceId}
+     RETURNING ${TASK_SELECT}
+  `);
+  const row = result.rows[0];
+  if (!row) throw new Error('updateTaskStatus returned no row');
+  return mapTaskRow(row);
+}
+
 export async function findTaskById(
   db: Db | Tx,
   input: { workspaceId: string; taskId: string },

--- a/apps/backend/src/modules/tasks/routes.ts
+++ b/apps/backend/src/modules/tasks/routes.ts
@@ -17,6 +17,7 @@ import type { TasksService } from './service.js';
 const UUID_REGEX = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
 const IDEMPOTENCY_KEY_REGEX =
   /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const ISO_TIMESTAMP_REGEX = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
 
 export interface TasksRoutesOptions {
   sessionService: SessionService;
@@ -42,7 +43,7 @@ function requireIdempotencyKey(headers: Record<string, unknown>): string {
 function requireIfMatch(headers: Record<string, unknown>): string {
   const raw = headers['if-match'];
   const value = Array.isArray(raw) ? raw[0] : raw;
-  if (typeof value !== 'string' || value.length === 0) {
+  if (typeof value !== 'string' || !ISO_TIMESTAMP_REGEX.test(value)) {
     throw new HttpError('validation.failed', 'If-Match header required', {
       fields: [{ path: ['headers', 'if-match'], code: 'required' }],
     });

--- a/apps/backend/src/modules/tasks/routes.ts
+++ b/apps/backend/src/modules/tasks/routes.ts
@@ -4,6 +4,7 @@ import {
   convertTaskRequestRequestSchema,
   linkExistingTaskRequestSchema,
   listTasksQuerySchema,
+  patchTaskStatusRequestSchema,
 } from '@fops/shared';
 
 import { HttpError, fieldsFromZodIssues, sendError } from '../../lib/errors.js';
@@ -38,6 +39,17 @@ function requireIdempotencyKey(headers: Record<string, unknown>): string {
   return headerKey;
 }
 
+function requireIfMatch(headers: Record<string, unknown>): string {
+  const raw = headers['if-match'];
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new HttpError('validation.failed', 'If-Match header required', {
+      fields: [{ path: ['headers', 'if-match'], code: 'required' }],
+    });
+  }
+  return value;
+}
+
 export const tasksRoutes: FastifyPluginAsync<TasksRoutesOptions> = async (app, opts) => {
   const { sessionService, tasksService, workspaceId, rateLimitConfig } = opts;
 
@@ -64,6 +76,47 @@ export const tasksRoutes: FastifyPluginAsync<TasksRoutesOptions> = async (app, o
         query: parsed.data,
       });
       return reply.header('cache-control', 'private, no-cache').code(200).send(result);
+    },
+  });
+
+  app.route({
+    method: 'PATCH',
+    url: '/tasks/:id',
+    preHandler: [requireSession(sessionService), requireWorkspace(workspaceId)],
+    ...(rateLimitConfig?.mutation
+      ? { config: { rateLimit: rateLimitConfig.mutation as never } }
+      : {}),
+    handler: async (req, reply) => {
+      const sess = req.session;
+      if (!sess) throw new Error('session missing after middleware');
+      const { id } = req.params as { id: string };
+      if (!UUID_REGEX.test(id)) {
+        return sendError(reply, 'validation.failed', 'id must be a valid UUID', {
+          fields: [{ path: ['id'], code: 'invalid' }],
+        });
+      }
+      const idempotencyKey = requireIdempotencyKey(req.headers as Record<string, unknown>);
+      const ifMatch = requireIfMatch(req.headers as Record<string, unknown>);
+      const rawBody = (req.body ?? {}) as Record<string, unknown>;
+      const parsed = patchTaskStatusRequestSchema.safeParse(rawBody);
+      if (!parsed.success) {
+        return sendError(reply, 'validation.failed', 'invalid request body', {
+          fields: fieldsFromZodIssues(parsed.error.issues),
+        });
+      }
+      const result = await tasksService.patchTaskStatus({
+        actor: {
+          actor_id: sess.actor_id,
+          workspace_id: sess.workspace_id,
+          role_level: sess.role_level,
+        },
+        taskId: id,
+        ifMatch,
+        input: parsed.data,
+        idempotencyKey,
+        requestHash: hashRequestBody({ taskId: id, ifMatch, route: 'task.status_update', ...rawBody }),
+      });
+      return reply.code(result.status).send(result.body);
     },
   });
 

--- a/apps/backend/src/modules/tasks/service.ts
+++ b/apps/backend/src/modules/tasks/service.ts
@@ -2,6 +2,7 @@ import {
   type ConvertTaskRequestRequest,
   type LinkExistingTaskRequest,
   type ListTasksQuery,
+  type PatchTaskStatusRequest,
   type TaskDetailDto,
   type TaskDto,
   registeredEntityLinkPairSchema,
@@ -26,6 +27,7 @@ import {
   lockTaskById,
   markTaskRequestConverted,
   resolveTaskSource,
+  updateTaskStatus,
 } from './repo.js';
 
 export interface TasksActor {
@@ -360,6 +362,79 @@ export function createTasksService(deps: TasksServiceDeps) {
     });
   }
 
+  async function patchTaskStatus(args: {
+    actor: TasksActor;
+    taskId: string;
+    ifMatch: string;
+    input: PatchTaskStatusRequest;
+    idempotencyKey: string;
+    requestHash: string;
+  }): Promise<{ status: number; body: TaskDetailDto }> {
+    return deps.db.transaction(async (tx) => {
+      return deps.idempotencyService.runIdempotent(
+        tx,
+        args.actor.actor_id,
+        args.idempotencyKey,
+        args.requestHash,
+        async () => {
+          const task = await lockTaskById(tx, {
+            workspaceId: args.actor.workspace_id,
+            taskId: args.taskId,
+          });
+          if (!task) throw new HttpError('not_found.record', 'task not found');
+
+          const canManage = await canManageFinding(
+            deps,
+            args.actor,
+            task.primary_managed_system_id,
+            { tx },
+          );
+          if (!canManage) {
+            throw new HttpError('permission.denied', 'finding.manage capability required');
+          }
+
+          if (task.updated_at.toISOString() !== args.ifMatch) {
+            throw new HttpError('conflict.stale_write', 'task updated_at does not match If-Match', {
+              current_updated_at: task.updated_at.toISOString(),
+            });
+          }
+
+          if (task.status === args.input.status) {
+            const source = task.source_task_request_id
+              ? await resolveTaskSource(tx, {
+                  workspaceId: args.actor.workspace_id,
+                  sourceTaskRequestId: task.source_task_request_id,
+                })
+              : null;
+            return { status: 200, body: { ...taskToDto(task), source } };
+          }
+
+          const updatedTask = await updateTaskStatus(tx, {
+            workspaceId: args.actor.workspace_id,
+            taskId: task.id,
+            status: args.input.status,
+          });
+          await deps.auditService.record(tx, {
+            workspace_id: args.actor.workspace_id,
+            actor_id: args.actor.actor_id,
+            event_type: 'task_status_changed',
+            subject_type: 'task',
+            subject_id: task.id,
+            summary: 'Task status changed',
+            detail: { from: task.status, to: updatedTask.status },
+          });
+          const source = updatedTask.source_task_request_id
+            ? await resolveTaskSource(tx, {
+                workspaceId: args.actor.workspace_id,
+                sourceTaskRequestId: updatedTask.source_task_request_id,
+              })
+            : null;
+          return { status: 200, body: { ...taskToDto(updatedTask), source } };
+        },
+      );
+    });
+  }
+
   async function listTasks(args: {
     actor: TasksActor;
     query: ListTasksQuery;
@@ -387,6 +462,7 @@ export function createTasksService(deps: TasksServiceDeps) {
     getTask,
     convertTaskRequest,
     linkExistingTask,
+    patchTaskStatus,
     listTasks,
   };
 }

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -12,6 +12,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
     "@fops/shared": "workspace:*",
     "@fops/ui": "workspace:*",
     "@hookform/resolvers": "3.9.1",

--- a/apps/frontend/src/features/tasks/routes/TaskBoardRoute.test.tsx
+++ b/apps/frontend/src/features/tasks/routes/TaskBoardRoute.test.tsx
@@ -16,9 +16,11 @@ const task = {
 
 const api = vi.hoisted(() => ({ listTasks: vi.fn(), updateTaskStatus: vi.fn() }));
 const draggableOptions = vi.hoisted(() => [] as Array<{ id?: string; disabled?: boolean }>);
+const sensorOptions = vi.hoisted(() => [] as Array<{ Sensor: unknown; options?: unknown }>);
+const navigate = vi.hoisted(() => vi.fn());
 
 vi.mock('@tanstack/react-router', () => ({
-  useNavigate: () => vi.fn(),
+  useNavigate: () => navigate,
   createFileRoute: () => () => ({ useSearch: () => ({}) }),
 }));
 vi.mock('@dnd-kit/core', () => ({
@@ -30,7 +32,10 @@ vi.mock('@dnd-kit/core', () => ({
     return { setNodeRef: vi.fn(), listeners: {}, attributes: {}, isDragging: false };
   },
   useDroppable: () => ({ setNodeRef: vi.fn(), isOver: false }),
-  useSensor: () => ({}),
+  useSensor: (Sensor: unknown, options?: unknown) => {
+    sensorOptions.push({ Sensor, options });
+    return {};
+  },
   useSensors: () => [],
 }));
 vi.mock('@fops/ui', async () => {
@@ -38,7 +43,6 @@ vi.mock('@fops/ui', async () => {
   return {
     ...actual,
     WorkbenchShell: ({ toolbar, children, detailPanel }: { toolbar: { title: React.ReactNode; actions: React.ReactNode }; children: React.ReactNode; detailPanel?: React.ReactNode }) => <div><header>{toolbar.title}{toolbar.actions}</header>{children}<aside>{detailPanel}</aside></div>,
-    ListSortButton: ({ value, onChange }: { value: string; onChange: (next: string) => void }) => <select aria-label="Group by" value={value} onChange={(event) => onChange(event.target.value)}><option value="status">Status</option><option value="priority">Priority</option><option value="managedSystem">Managed System</option><option value="assignee">Assignee</option></select>,
   };
 });
 vi.mock('@/features/voc/hooks/useWorkspaceActors', () => ({ useWorkspaceActors: () => ({ actors: [] }) }));
@@ -69,6 +73,8 @@ describe('TaskBoardRoute', () => {
     api.listTasks.mockReset();
     api.updateTaskStatus.mockReset();
     draggableOptions.length = 0;
+    sensorOptions.length = 0;
+    navigate.mockReset();
     vi.mocked(toast.error).mockReset();
     vi.mocked(toast.warning).mockReset();
   });
@@ -81,6 +87,23 @@ describe('TaskBoardRoute', () => {
       expect(screen.getByLabelText(`${status[0]!.toUpperCase()}${status.slice(1)} column`)).toBeInTheDocument();
     }
     expect(screen.getAllByText('비어있음').length).toBe(6);
+  });
+
+  it('keeps a pointer click on a status-board card available for selection', async () => {
+    api.listTasks.mockResolvedValue({ items: [task] });
+    renderBoard();
+    const card = await screen.findByRole('button', { name: `${task.display_id}: ${task.title}` });
+
+    fireEvent.pointerDown(card, { pointerId: 1, clientX: 10, clientY: 10 });
+    fireEvent.pointerUp(card, { pointerId: 1, clientX: 10, clientY: 10 });
+    fireEvent.click(card);
+
+    expect(sensorOptions).toContainEqual({
+      Sensor: expect.anything(),
+      options: { activationConstraint: { distance: 5 } },
+    });
+    expect(screen.getByText(`detail ${task.id}`)).toBeInTheDocument();
+    expect(navigate).toHaveBeenCalledWith({ to: '/tasks', search: { view: 'board', param: task.id } });
   });
 
   it('moves a card optimistically and sends concurrency and idempotency arguments', async () => {
@@ -140,8 +163,9 @@ describe('TaskBoardRoute', () => {
     await screen.findByText('TASK-1000');
     expect(draggableOptions).toContainEqual(expect.objectContaining({ id: task.id, disabled: false }));
     draggableOptions.length = 0;
-    fireEvent.change(screen.getByLabelText('Group by'), { target: { value: 'priority' } });
-    await waitFor(() => expect(screen.getByLabelText('high column')).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: 'Group by' }));
+    fireEvent.click(screen.getByRole('radio', { name: 'Priority' }));
+    await waitFor(() => expect(screen.getByLabelText('High column')).toBeInTheDocument());
     await waitFor(() => expect(draggableOptions).toContainEqual(expect.objectContaining({ id: task.id, disabled: true })));
     fireEvent.click(screen.getByRole('button', { name: 'simulate drag to doing' }));
     expect(api.updateTaskStatus).not.toHaveBeenCalled();

--- a/apps/frontend/src/features/tasks/routes/TaskBoardRoute.test.tsx
+++ b/apps/frontend/src/features/tasks/routes/TaskBoardRoute.test.tsx
@@ -1,0 +1,42 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import type * as React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { TaskBoardRoute } from './TaskBoardRoute';
+
+const task = {
+  id: '10000000-0000-0000-0000-000000000001', workspace_id: '90000000-0000-0000-0000-000000000009', display_id: 'TASK-1000',
+  primary_managed_system_id: '30000000-0000-0000-0000-000000000003', title: '매출 리포트 쿼리 플랜 개선', status: 'backlog' as const,
+  priority: 'high' as const, assignee_actor_id: null, due_date: null, milestone_id: null, analytics_area_id: null, source_task_request_id: null,
+  created_by: '20000000-0000-0000-0000-000000000002', created_at: '2026-07-10T00:00:00.000Z', updated_at: '2026-07-10T00:00:00.000Z',
+};
+vi.mock('@tanstack/react-router', () => ({ useNavigate: () => vi.fn() }));
+vi.mock('@fops/ui', async () => {
+  const actual = await vi.importActual<typeof import('@fops/ui')>('@fops/ui');
+  return { ...actual, WorkbenchShell: ({ children, detailPanel }: { children: React.ReactNode; detailPanel?: React.ReactNode }) => <div>{children}<aside>{detailPanel}</aside></div> };
+});
+vi.mock('@/features/voc/hooks/useWorkspaceActors', () => ({ useWorkspaceActors: () => ({ actors: [] }) }));
+vi.mock('@/lib/api/managed-systems', () => ({ fetchManagedSystems: vi.fn(async () => ({ items: [{ id: task.primary_managed_system_id, name: 'Billing Ops', archived_at: null }] })) }));
+vi.mock('@/lib/api/tasks', () => ({ listTasks: vi.fn(async () => ({ items: [task] })), updateTaskStatus: vi.fn() }));
+vi.mock('./TaskListRoute', () => ({ TaskDetailPanel: ({ taskId }: { taskId: string }) => <div>detail {taskId}</div> }));
+
+function renderBoard(selectedParam?: string) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={client}><TaskBoardRoute selectedParam={selectedParam} /></QueryClientProvider>);
+}
+
+describe('TaskBoardRoute', () => {
+  it('renders all seven status columns and an empty placeholder', async () => {
+    renderBoard();
+    await screen.findByText('TASK-1000');
+    for (const status of ['backlog', 'todo', 'doing', 'review', 'done', 'released', 'reopened']) {
+      expect(screen.getByLabelText(`${status[0]!.toUpperCase()}${status.slice(1)} column`)).toBeInTheDocument();
+    }
+    expect(screen.getAllByText('비어있음').length).toBe(6);
+  });
+
+  it('restores the board selected detail from the URL parameter', async () => {
+    renderBoard(task.id);
+    await waitFor(() => expect(screen.getByText(`detail ${task.id}`)).toBeInTheDocument());
+  });
+});

--- a/apps/frontend/src/features/tasks/routes/TaskBoardRoute.test.tsx
+++ b/apps/frontend/src/features/tasks/routes/TaskBoardRoute.test.tsx
@@ -1,8 +1,11 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, screen, waitFor } from '@testing-library/react';
-import type * as React from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { TaskBoardRoute } from './TaskBoardRoute';
+import { TasksRouteView } from '@/routes/_authed/tasks';
+import { ApiError } from '@/lib/api/types';
+import { toast } from 'sonner';
 
 const task = {
   id: '10000000-0000-0000-0000-000000000001', workspace_id: '90000000-0000-0000-0000-000000000009', display_id: 'TASK-1000',
@@ -10,23 +13,63 @@ const task = {
   priority: 'high' as const, assignee_actor_id: null, due_date: null, milestone_id: null, analytics_area_id: null, source_task_request_id: null,
   created_by: '20000000-0000-0000-0000-000000000002', created_at: '2026-07-10T00:00:00.000Z', updated_at: '2026-07-10T00:00:00.000Z',
 };
-vi.mock('@tanstack/react-router', () => ({ useNavigate: () => vi.fn() }));
+
+const api = vi.hoisted(() => ({ listTasks: vi.fn(), updateTaskStatus: vi.fn() }));
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => vi.fn(),
+  createFileRoute: () => () => ({ useSearch: () => ({}) }),
+}));
+vi.mock('@dnd-kit/core', () => ({
+  DndContext: ({ children, onDragEnd }: { children: React.ReactNode; onDragEnd: (event: unknown) => void }) => <><button type="button" onClick={() => onDragEnd({ active: { data: { current: { task } } }, over: { id: 'doing' } })}>simulate drag to doing</button>{children}</>,
+  KeyboardSensor: class {},
+  PointerSensor: class {},
+  useDraggable: () => ({ setNodeRef: vi.fn(), listeners: {}, attributes: {}, isDragging: false }),
+  useDroppable: () => ({ setNodeRef: vi.fn(), isOver: false }),
+  useSensor: () => ({}),
+  useSensors: () => [],
+}));
 vi.mock('@fops/ui', async () => {
   const actual = await vi.importActual<typeof import('@fops/ui')>('@fops/ui');
-  return { ...actual, WorkbenchShell: ({ children, detailPanel }: { children: React.ReactNode; detailPanel?: React.ReactNode }) => <div>{children}<aside>{detailPanel}</aside></div> };
+  return {
+    ...actual,
+    WorkbenchShell: ({ toolbar, children, detailPanel }: { toolbar: { title: React.ReactNode; actions: React.ReactNode }; children: React.ReactNode; detailPanel?: React.ReactNode }) => <div><header>{toolbar.title}{toolbar.actions}</header>{children}<aside>{detailPanel}</aside></div>,
+    ListSortButton: ({ value, onChange }: { value: string; onChange: (next: string) => void }) => <select aria-label="Group by" value={value} onChange={(event) => onChange(event.target.value)}><option value="status">Status</option><option value="priority">Priority</option><option value="managedSystem">Managed System</option><option value="assignee">Assignee</option></select>,
+  };
 });
 vi.mock('@/features/voc/hooks/useWorkspaceActors', () => ({ useWorkspaceActors: () => ({ actors: [] }) }));
 vi.mock('@/lib/api/managed-systems', () => ({ fetchManagedSystems: vi.fn(async () => ({ items: [{ id: task.primary_managed_system_id, name: 'Billing Ops', archived_at: null }] })) }));
-vi.mock('@/lib/api/tasks', () => ({ listTasks: vi.fn(async () => ({ items: [task] })), updateTaskStatus: vi.fn() }));
-vi.mock('./TaskListRoute', () => ({ TaskDetailPanel: ({ taskId }: { taskId: string }) => <div>detail {taskId}</div> }));
+vi.mock('@/lib/api/tasks', () => api);
+vi.mock('./TaskListRoute', () => ({
+  TaskDetailPanel: ({ taskId }: { taskId: string }) => <div>detail {taskId}</div>,
+  TaskListRoute: () => <div>task list unchanged</div>,
+}));
+vi.mock('./TaskRequestsRoute', () => ({ TaskRequestsRoute: () => <div>task requests unchanged</div> }));
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), warning: vi.fn() } }));
 
 function renderBoard(selectedParam?: string) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return render(<QueryClientProvider client={client}><TaskBoardRoute selectedParam={selectedParam} /></QueryClientProvider>);
+  const route = <TaskBoardRoute {...(selectedParam !== undefined ? { selectedParam } : {})} />;
+  return { client, ...render(<QueryClientProvider client={client}>{route}</QueryClientProvider>) };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => { resolve = resolvePromise; reject = rejectPromise; });
+  return { promise, resolve, reject };
 }
 
 describe('TaskBoardRoute', () => {
+  beforeEach(() => {
+    api.listTasks.mockReset();
+    api.updateTaskStatus.mockReset();
+    vi.mocked(toast.error).mockReset();
+    vi.mocked(toast.warning).mockReset();
+  });
+
   it('renders all seven status columns and an empty placeholder', async () => {
+    api.listTasks.mockResolvedValue({ items: [task] });
     renderBoard();
     await screen.findByText('TASK-1000');
     for (const status of ['backlog', 'todo', 'doing', 'review', 'done', 'released', 'reopened']) {
@@ -35,8 +78,78 @@ describe('TaskBoardRoute', () => {
     expect(screen.getAllByText('비어있음').length).toBe(6);
   });
 
+  it('moves a card optimistically and sends concurrency and idempotency arguments', async () => {
+    const update = deferred<never>();
+    api.listTasks.mockResolvedValue({ items: [task] });
+    api.updateTaskStatus.mockReturnValue(update.promise);
+    renderBoard();
+    await screen.findByText('TASK-1000');
+    fireEvent.click(screen.getByRole('button', { name: 'simulate drag to doing' }));
+    await waitFor(() => expect(api.updateTaskStatus).toHaveBeenCalledWith(task.id, 'doing', expect.objectContaining({ ifMatch: task.updated_at, idempotencyKey: expect.any(String) })));
+    expect(screen.getByLabelText('Doing column')).toHaveTextContent('TASK-1000');
+  });
+
+  it('rolls back a failed mutation', async () => {
+    const update = deferred<never>();
+    api.listTasks.mockResolvedValue({ items: [task] });
+    api.updateTaskStatus.mockReturnValue(update.promise);
+    renderBoard();
+    await screen.findByText('TASK-1000');
+    fireEvent.click(screen.getByRole('button', { name: 'simulate drag to doing' }));
+    await waitFor(() => expect(screen.getByLabelText('Doing column')).toHaveTextContent('TASK-1000'));
+    update.reject(new Error('update failed'));
+    await waitFor(() => expect(screen.getByLabelText('Backlog column')).toHaveTextContent('TASK-1000'));
+  });
+
+  it('does not allow an older failed mutation to clobber a newer optimistic move', async () => {
+    const first = deferred<never>();
+    const second = deferred<never>();
+    api.listTasks.mockResolvedValue({ items: [task] });
+    api.updateTaskStatus.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+    renderBoard();
+    await screen.findByText('TASK-1000');
+    fireEvent.click(screen.getByRole('button', { name: 'simulate drag to doing' }));
+    await waitFor(() => expect(screen.getByLabelText('Doing column')).toHaveTextContent('TASK-1000'));
+    fireEvent.click(screen.getByRole('button', { name: 'simulate drag to doing' }));
+    first.reject(new Error('first failed'));
+    await waitFor(() => expect(screen.getByLabelText('Doing column')).toHaveTextContent('TASK-1000'));
+  });
+
+  it('rolls back and refetches after a stale-write conflict', async () => {
+    api.listTasks.mockResolvedValue({ items: [task] });
+    api.updateTaskStatus.mockRejectedValue(new ApiError(409, { code: 'conflict.stale_write', message: 'stale' }));
+    renderBoard();
+    await screen.findByText('TASK-1000');
+    fireEvent.click(screen.getByRole('button', { name: 'simulate drag to doing' }));
+    await waitFor(() => expect(screen.getByLabelText('Backlog column')).toHaveTextContent('TASK-1000'));
+    await waitFor(() => expect(api.listTasks.mock.calls.length).toBeGreaterThan(1));
+    expect(toast.error).toHaveBeenCalledWith('Task changed elsewhere. Board refreshed.');
+  });
+
+  it('disables status drag outside status grouping and uses the toast backstop', async () => {
+    api.listTasks.mockResolvedValue({ items: [task] });
+    renderBoard();
+    await screen.findByText('TASK-1000');
+    fireEvent.change(screen.getByLabelText('Group by'), { target: { value: 'priority' } });
+    await waitFor(() => expect(screen.getByLabelText('high column')).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: 'simulate drag to doing' }));
+    expect(api.updateTaskStatus).not.toHaveBeenCalled();
+    expect(toast.warning).toHaveBeenCalledWith('Group by Status 일 때만 드래그로 상태를 변경할 수 있습니다.');
+  });
+
   it('restores the board selected detail from the URL parameter', async () => {
+    api.listTasks.mockResolvedValue({ items: [task] });
     renderBoard(task.id);
     await waitFor(() => expect(screen.getByText(`detail ${task.id}`)).toBeInTheDocument());
+  });
+
+  it.each(['backlog', 'my', 'inbox'] as const)('keeps the %s view on TaskListRoute', (view) => {
+    render(<TasksRouteView search={{ view }} />);
+    expect(screen.getByText('task list unchanged')).toBeInTheDocument();
+  });
+
+  it('keeps the requests view on TaskRequestsRoute', () => {
+    render(<TasksRouteView search={{ view: 'requests' }} />);
+    expect(screen.getByText('task requests unchanged')).toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/features/tasks/routes/TaskBoardRoute.test.tsx
+++ b/apps/frontend/src/features/tasks/routes/TaskBoardRoute.test.tsx
@@ -14,7 +14,7 @@ const task = {
   created_by: '20000000-0000-0000-0000-000000000002', created_at: '2026-07-10T00:00:00.000Z', updated_at: '2026-07-10T00:00:00.000Z',
 };
 
-const api = vi.hoisted(() => ({ listTasks: vi.fn(), updateTaskStatus: vi.fn() }));
+const api = vi.hoisted(() => ({ getTask: vi.fn(), listTasks: vi.fn(), updateTaskStatus: vi.fn() }));
 const draggableOptions = vi.hoisted(() => [] as Array<{ id?: string; disabled?: boolean }>);
 const sensorOptions = vi.hoisted(() => [] as Array<{ Sensor: unknown; options?: unknown }>);
 const navigate = vi.hoisted(() => vi.fn());
@@ -48,10 +48,10 @@ vi.mock('@fops/ui', async () => {
 vi.mock('@/features/voc/hooks/useWorkspaceActors', () => ({ useWorkspaceActors: () => ({ actors: [] }) }));
 vi.mock('@/lib/api/managed-systems', () => ({ fetchManagedSystems: vi.fn(async () => ({ items: [{ id: task.primary_managed_system_id, name: 'Billing Ops', archived_at: null }] })) }));
 vi.mock('@/lib/api/tasks', () => api);
-vi.mock('./TaskListRoute', () => ({
-  TaskDetailPanel: ({ taskId }: { taskId: string }) => <div>detail {taskId}</div>,
-  TaskListRoute: () => <div>task list unchanged</div>,
-}));
+vi.mock('./TaskListRoute', async () => {
+  const actual = await vi.importActual<typeof import('./TaskListRoute')>('./TaskListRoute');
+  return { ...actual, TaskListRoute: () => <div>task list unchanged</div> };
+});
 vi.mock('./TaskRequestsRoute', () => ({ TaskRequestsRoute: () => <div>task requests unchanged</div> }));
 vi.mock('sonner', () => ({ toast: { error: vi.fn(), warning: vi.fn() } }));
 
@@ -70,6 +70,7 @@ function deferred<T>() {
 
 describe('TaskBoardRoute', () => {
   beforeEach(() => {
+    api.getTask.mockReset();
     api.listTasks.mockReset();
     api.updateTaskStatus.mockReset();
     draggableOptions.length = 0;
@@ -91,6 +92,7 @@ describe('TaskBoardRoute', () => {
 
   it('keeps a pointer click on a status-board card available for selection', async () => {
     api.listTasks.mockResolvedValue({ items: [task] });
+    api.getTask.mockResolvedValue({ ...task, source: null });
     renderBoard();
     const card = await screen.findByRole('button', { name: `${task.display_id}: ${task.title}` });
 
@@ -102,7 +104,7 @@ describe('TaskBoardRoute', () => {
       Sensor: expect.anything(),
       options: { activationConstraint: { distance: 5 } },
     });
-    expect(screen.getByText(`detail ${task.id}`)).toBeInTheDocument();
+    await screen.findByText('Standalone task');
     expect(navigate).toHaveBeenCalledWith({ to: '/tasks', search: { view: 'board', param: task.id } });
   });
 
@@ -174,8 +176,27 @@ describe('TaskBoardRoute', () => {
 
   it('restores the board selected detail from the URL parameter', async () => {
     api.listTasks.mockResolvedValue({ items: [task] });
+    api.getTask.mockResolvedValue({ ...task, source: null });
     renderBoard(task.id);
-    await waitFor(() => expect(screen.getByText(`detail ${task.id}`)).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText(task.title)).toBeInTheDocument());
+  });
+
+  it('refreshes the selected detail after moving a task from done to released', async () => {
+    const doneTask = { ...task, status: 'done' as const };
+    const releasedTask = { ...doneTask, status: 'released' as const };
+    api.listTasks.mockResolvedValue({ items: [doneTask] });
+    api.getTask.mockResolvedValueOnce({ ...doneTask, source: null }).mockResolvedValueOnce({ ...releasedTask, source: null });
+    api.updateTaskStatus.mockResolvedValue(releasedTask);
+
+    renderBoard(doneTask.id);
+    const footerAction = await screen.findByRole('button', { name: 'Move to next status' });
+    expect(screen.getAllByText('Done').length).toBeGreaterThan(0);
+
+    fireEvent.click(footerAction);
+
+    await waitFor(() => expect(api.getTask).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(screen.queryByRole('button', { name: 'Move to next status' })).not.toBeInTheDocument());
+    expect(screen.getAllByText('Released').length).toBeGreaterThan(0);
   });
 
   it.each(['backlog', 'my', 'inbox'] as const)('keeps the %s view on TaskListRoute', (view) => {

--- a/apps/frontend/src/features/tasks/routes/TaskBoardRoute.test.tsx
+++ b/apps/frontend/src/features/tasks/routes/TaskBoardRoute.test.tsx
@@ -15,6 +15,7 @@ const task = {
 };
 
 const api = vi.hoisted(() => ({ listTasks: vi.fn(), updateTaskStatus: vi.fn() }));
+const draggableOptions = vi.hoisted(() => [] as Array<{ id?: string; disabled?: boolean }>);
 
 vi.mock('@tanstack/react-router', () => ({
   useNavigate: () => vi.fn(),
@@ -24,7 +25,10 @@ vi.mock('@dnd-kit/core', () => ({
   DndContext: ({ children, onDragEnd }: { children: React.ReactNode; onDragEnd: (event: unknown) => void }) => <><button type="button" onClick={() => onDragEnd({ active: { data: { current: { task } } }, over: { id: 'doing' } })}>simulate drag to doing</button>{children}</>,
   KeyboardSensor: class {},
   PointerSensor: class {},
-  useDraggable: () => ({ setNodeRef: vi.fn(), listeners: {}, attributes: {}, isDragging: false }),
+  useDraggable: (options: { id?: string; disabled?: boolean }) => {
+    draggableOptions.push(options);
+    return { setNodeRef: vi.fn(), listeners: {}, attributes: {}, isDragging: false };
+  },
   useDroppable: () => ({ setNodeRef: vi.fn(), isOver: false }),
   useSensor: () => ({}),
   useSensors: () => [],
@@ -64,6 +68,7 @@ describe('TaskBoardRoute', () => {
   beforeEach(() => {
     api.listTasks.mockReset();
     api.updateTaskStatus.mockReset();
+    draggableOptions.length = 0;
     vi.mocked(toast.error).mockReset();
     vi.mocked(toast.warning).mockReset();
   });
@@ -116,11 +121,14 @@ describe('TaskBoardRoute', () => {
   });
 
   it('rolls back and refetches after a stale-write conflict', async () => {
+    const update = deferred<never>();
     api.listTasks.mockResolvedValue({ items: [task] });
-    api.updateTaskStatus.mockRejectedValue(new ApiError(409, { code: 'conflict.stale_write', message: 'stale' }));
+    api.updateTaskStatus.mockReturnValue(update.promise);
     renderBoard();
     await screen.findByText('TASK-1000');
     fireEvent.click(screen.getByRole('button', { name: 'simulate drag to doing' }));
+    await waitFor(() => expect(screen.getByLabelText('Doing column')).toHaveTextContent('TASK-1000'));
+    update.reject(new ApiError(409, { code: 'conflict.stale_write', message: 'stale' }));
     await waitFor(() => expect(screen.getByLabelText('Backlog column')).toHaveTextContent('TASK-1000'));
     await waitFor(() => expect(api.listTasks.mock.calls.length).toBeGreaterThan(1));
     expect(toast.error).toHaveBeenCalledWith('Task changed elsewhere. Board refreshed.');
@@ -130,8 +138,11 @@ describe('TaskBoardRoute', () => {
     api.listTasks.mockResolvedValue({ items: [task] });
     renderBoard();
     await screen.findByText('TASK-1000');
+    expect(draggableOptions).toContainEqual(expect.objectContaining({ id: task.id, disabled: false }));
+    draggableOptions.length = 0;
     fireEvent.change(screen.getByLabelText('Group by'), { target: { value: 'priority' } });
     await waitFor(() => expect(screen.getByLabelText('high column')).toBeInTheDocument());
+    await waitFor(() => expect(draggableOptions).toContainEqual(expect.objectContaining({ id: task.id, disabled: true })));
     fireEvent.click(screen.getByRole('button', { name: 'simulate drag to doing' }));
     expect(api.updateTaskStatus).not.toHaveBeenCalled();
     expect(toast.warning).toHaveBeenCalledWith('Group by Status 일 때만 드래그로 상태를 변경할 수 있습니다.');

--- a/apps/frontend/src/features/tasks/routes/TaskBoardRoute.tsx
+++ b/apps/frontend/src/features/tasks/routes/TaskBoardRoute.tsx
@@ -141,7 +141,10 @@ export function TaskBoardRoute({ selectedParam }: { selectedParam?: string }) {
       toast.error('Task status could not be updated.');
     },
     onSettled: (_data, _error, _variables, context) => {
-      if (!context || mutationTokens.current.get(context.taskId) === context.token) void client.invalidateQueries({ queryKey: ['tasks'] });
+      if (!context || mutationTokens.current.get(context.taskId) === context.token) {
+        void client.invalidateQueries({ queryKey: ['tasks'] });
+        if (context) void client.invalidateQueries({ queryKey: ['task', context.taskId] });
+      }
     },
   });
   function selectTask(id: string) { setSelectedId(id); void navigate({ to: '/tasks', search: { view: 'board', param: id } }); }

--- a/apps/frontend/src/features/tasks/routes/TaskBoardRoute.tsx
+++ b/apps/frontend/src/features/tasks/routes/TaskBoardRoute.tsx
@@ -1,0 +1,128 @@
+import { TaskDetailPanel } from './TaskListRoute';
+import { useWorkspaceActors } from '@/features/voc/hooks/useWorkspaceActors';
+import { updateTaskStatus, listTasks } from '@/lib/api/tasks';
+import { fetchManagedSystems } from '@/lib/api/managed-systems';
+import { ApiError } from '@/lib/api/types';
+import type { TaskDto, TaskStatus } from '@fops/shared';
+import {
+  Button,
+  InternalTaskBadge,
+  ListFilterButton,
+  ListSortButton,
+  OutlineBadge,
+  SeverityBadge,
+  UserAvatar,
+  WorkbenchShell,
+} from '@fops/ui';
+import { DndContext, KeyboardSensor, PointerSensor, useDraggable, useDroppable, useSensor, useSensors, type DragEndEvent } from '@dnd-kit/core';
+import { useNavigate } from '@tanstack/react-router';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Plus } from 'lucide-react';
+import * as React from 'react';
+import { toast } from 'sonner';
+
+const STATUS_COLUMNS: Array<{ key: TaskStatus; label: string }> = [
+  { key: 'backlog', label: 'Backlog' }, { key: 'todo', label: 'Todo' },
+  { key: 'doing', label: 'Doing' }, { key: 'review', label: 'Review' },
+  { key: 'done', label: 'Done' }, { key: 'released', label: 'Released' },
+  { key: 'reopened', label: 'Reopened' },
+];
+const GROUP_OPTIONS = [
+  { value: 'status', label: 'Status (default)' }, { value: 'priority', label: 'Priority' },
+  { value: 'managedSystem', label: 'Managed System' }, { value: 'assignee', label: 'Assignee' },
+];
+type GroupBy = (typeof GROUP_OPTIONS)[number]['value'];
+type Filters = Record<string, string[]>;
+
+function severity(priority: TaskDto['priority']): 'low' | 'medium' | 'high' | 'critical' {
+  return priority === 'urgent' ? 'critical' : priority;
+}
+function groupValue(task: TaskDto, groupBy: GroupBy): string {
+  if (groupBy === 'priority') return task.priority;
+  if (groupBy === 'managedSystem') return task.primary_managed_system_id;
+  if (groupBy === 'assignee') return task.assignee_actor_id ?? '__unassigned';
+  return task.status;
+}
+function uuid(): string {
+  return typeof crypto !== 'undefined' && crypto.randomUUID ? crypto.randomUUID() : `${Date.now()}-${Math.random()}`;
+}
+
+function DraggableTaskCard({ task, selected, onSelect, managedSystemName, assigneeName, enabled }: {
+  task: TaskDto; selected: boolean; onSelect: () => void; managedSystemName: string; assigneeName?: string | undefined; enabled: boolean;
+}) {
+  const draggable = useDraggable({ id: task.id, data: { task }, disabled: false });
+  return (
+    <button
+      ref={draggable.setNodeRef}
+      type="button"
+      {...draggable.listeners}
+      {...draggable.attributes}
+      onClick={onSelect}
+      aria-label={`${task.display_id}: ${task.title}`}
+      className={`w-full cursor-grab rounded-sm border border-border-subtle bg-surface-card p-3 text-left shadow-sm transition ${selected ? 'ring-1 ring-border-selected' : ''} ${draggable.isDragging ? 'opacity-35' : ''}`}
+    >
+      <div className="flex items-center gap-1.5"><span className="font-mono text-xs text-text-muted">{task.display_id}</span><SeverityBadge severity={severity(task.priority)} /></div>
+      {task.source_task_request_id && <span className="mt-2 inline-flex rounded border border-accent-info/30 px-1.5 py-0.5 text-xs text-accent-info">Linked finding</span>}
+      <div className="mt-2 text-sm font-medium text-text-primary">{task.title}</div>
+      <div className="mt-3 flex items-center justify-between gap-2 text-xs text-text-muted"><span className="flex min-w-0 items-center gap-1.5 truncate"><span className="h-1.5 w-1.5 rounded-full bg-accent-info" />{managedSystemName}</span>{assigneeName ? <UserAvatar user={{ display_name: assigneeName }} size="sm" /> : <span className="rounded border border-border-subtle px-1.5 py-0.5">Unassigned</span>}</div>
+      {!enabled && <span className="sr-only">Drag changes status only when grouped by status.</span>}
+    </button>
+  );
+}
+
+function BoardColumn({ id, label, tasks, groupBy, selectedId, selectTask, names, enabled }: {
+  id: string; label: string; tasks: TaskDto[]; groupBy: GroupBy; selectedId: string | null; selectTask: (id: string) => void;
+  names: { systems: ReadonlyMap<string, string>; actors: ReadonlyMap<string, string> }; enabled: boolean;
+}) {
+  const droppable = useDroppable({ id, disabled: groupBy !== 'status' });
+  return <section ref={droppable.setNodeRef} className={`flex min-h-0 w-72 shrink-0 flex-col rounded-sm border border-border-subtle bg-surface-raised ${droppable.isOver ? 'ring-1 ring-accent-primary' : ''}`} aria-label={`${label} column`}>
+    <header className="flex items-center gap-2 border-b border-border-subtle px-3 py-2"><>{groupBy === 'status' ? <InternalTaskBadge status={id as TaskStatus} /> : <span className="text-xs font-semibold uppercase tracking-wide text-text-muted">{label}</span>}</><span className="text-xs tabular-nums text-text-muted">{tasks.length}</span></header>
+    <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto p-2">
+      {tasks.map((task) => <DraggableTaskCard key={task.id} task={task} selected={task.id === selectedId} onSelect={() => selectTask(task.id)} enabled={enabled} managedSystemName={names.systems.get(task.primary_managed_system_id) ?? 'Managed System'} assigneeName={task.assignee_actor_id ? names.actors.get(task.assignee_actor_id) : undefined} />)}
+      {tasks.length === 0 && <div className="p-3 text-center text-xs text-text-muted">비어있음</div>}
+    </div>
+  </section>;
+}
+
+export function TaskBoardRoute({ selectedParam }: { selectedParam?: string }) {
+  const navigate = useNavigate();
+  const client = useQueryClient();
+  const [groupBy, setGroupBy] = React.useState<GroupBy>('status');
+  const [filters, setFilters] = React.useState<Filters>({});
+  const [selectedId, setSelectedId] = React.useState<string | null>(selectedParam ?? null);
+  const tasksQuery = useQuery({ queryKey: ['tasks'] as const, queryFn: ({ signal }) => listTasks({ signal }), staleTime: 30_000 });
+  const { actors } = useWorkspaceActors();
+  const systemsQuery = useQuery({ queryKey: ['managed-systems', 'all'] as const, queryFn: ({ signal }) => fetchManagedSystems({ includeArchived: true, signal }), staleTime: 600_000 });
+  const sensors = useSensors(useSensor(PointerSensor), useSensor(KeyboardSensor));
+  const actorNames = React.useMemo(() => new Map((actors ?? []).map((a) => [a.id, a.display_name])), [actors]);
+  const systemNames = React.useMemo(() => new Map((systemsQuery.data?.items ?? []).map((s) => [s.id, s.name])), [systemsQuery.data?.items]);
+  const items = tasksQuery.data?.items ?? [];
+  React.useEffect(() => { if (selectedParam !== undefined) setSelectedId(selectedParam); }, [selectedParam]);
+  const filtered = React.useMemo(() => items.filter((task) => {
+    const priority = filters.priority; const milestone = filters.milestone; const assignee = filters.assignee;
+    return (!priority?.length || priority.includes(task.priority)) && (!milestone?.length || (milestone.includes('__any') && task.milestone_id !== null) || (milestone.includes('__none') && task.milestone_id === null)) && (!assignee?.length || (task.assignee_actor_id === null ? assignee.includes('__unassigned') : assignee.includes(task.assignee_actor_id)));
+  }), [items, filters]);
+  const columns = React.useMemo(() => {
+    if (groupBy === 'status') return STATUS_COLUMNS;
+    if (groupBy === 'priority') return ['urgent', 'high', 'medium', 'low'].map((key) => ({ key, label: key }));
+    if (groupBy === 'managedSystem') return [...systemNames].map(([key, label]) => ({ key, label }));
+    return [...new Set(filtered.map((t) => t.assignee_actor_id).filter((id): id is string => id !== null))].map((key) => ({ key, label: actorNames.get(key) ?? key })).concat({ key: '__unassigned', label: '미배정' });
+  }, [actorNames, filtered, groupBy, systemNames]);
+  const filterCategories = React.useMemo(() => [{ key: 'priority', label: 'Priority', options: ['urgent', 'high', 'medium', 'low'].map((value) => ({ value, label: value[0]!.toUpperCase() + value.slice(1) })) }, { key: 'milestone', label: 'Milestone', options: [{ value: '__any', label: 'Milestone 있음' }, { value: '__none', label: 'Milestone 없음' }] }, { key: 'assignee', label: 'Assignee', options: [{ value: '__unassigned', label: '미배정' }, ...[...actorNames].map(([value, label]) => ({ value, label }))] }], [actorNames]);
+  const mutation = useMutation({
+    mutationKey: ['task-status-transition'],
+    mutationFn: ({ task, status }: { task: TaskDto; status: TaskStatus }) => updateTaskStatus(task.id, status, { ifMatch: task.updated_at, idempotencyKey: uuid() }),
+    onMutate: async ({ task, status }) => { const previousStatus = task.status; client.setQueryData<{ items: TaskDto[] }>(['tasks'], (old) => old ? { ...old, items: old.items.map((item) => item.id === task.id ? { ...item, status } : item) } : old); return { taskId: task.id, previousStatus }; },
+    onError: (error, _variables, context) => { if (context) client.setQueryData<{ items: TaskDto[] }>(['tasks'], (old) => old ? { ...old, items: old.items.map((item) => item.id === context.taskId ? { ...item, status: context.previousStatus } : item) } : old); if (error instanceof ApiError && error.code === 'conflict.stale_write') { void client.invalidateQueries({ queryKey: ['tasks'] }); toast.error('Task changed elsewhere. Board refreshed.'); return; } toast.error('Task status could not be updated.'); },
+    onSettled: () => void client.invalidateQueries({ queryKey: ['tasks'] }),
+  });
+  function selectTask(id: string) { setSelectedId(id); void navigate({ to: '/tasks', search: { view: 'board', param: id } }); }
+  function onDragEnd(event: DragEndEvent) { const task = event.active.data.current?.task as TaskDto | undefined; const target = event.over?.id; if (groupBy !== 'status') { toast.warning('Group by Status 일 때만 드래그로 상태를 변경할 수 있습니다.'); return; } if (!task || typeof target !== 'string') return; if (task.status !== target) mutation.mutate({ task, status: target as TaskStatus }); }
+  if (tasksQuery.isLoading) return <div className="p-4 text-sm text-text-muted">Loading Tasks...</div>;
+  if (tasksQuery.error) return <div className="p-4 text-sm text-accent-danger">Task board unavailable.</div>;
+  const selected = selectedId ? items.find((item) => item.id === selectedId) ?? null : null;
+  return <WorkbenchShell toolbar={{ title: <span className="flex items-center gap-2">Board <OutlineBadge>{filtered.length} tasks</OutlineBadge></span>, actions: <><ListFilterButton categories={filterCategories} values={filters} onChange={setFilters} /><ListSortButton options={GROUP_OPTIONS} value={groupBy} defaultValue="status" onChange={(value) => setGroupBy(value as GroupBy)} /><Button variant="primary" size="sm" disabled title="Task creation API is not available yet"><Plus className="h-4 w-4" />New task</Button></> }} detailPanel={selected ? <TaskDetailPanel taskId={selected.id} actorNamesById={actorNames} managedSystemNamesById={systemNames} onClose={() => { setSelectedId(null); void navigate({ to: '/tasks', search: { view: 'board' } }); }} /> : null}>
+    <div className="border-b border-border-subtle bg-surface-canvas px-4 py-2"><div className="flex items-center gap-5 text-xs"><span><strong>{items.length}</strong> Total tasks</span><span><strong>{items.filter((t) => t.assignee_actor_id === null).length}</strong> Unassigned</span><span><strong>{items.filter((t) => t.status === 'doing').length}</strong> In progress</span></div></div>
+    <DndContext sensors={sensors} onDragEnd={onDragEnd}><div className="flex h-full gap-3 overflow-x-auto p-4">{columns.map((column) => <BoardColumn key={column.key} id={column.key} label={column.label} tasks={filtered.filter((task) => groupValue(task, groupBy) === column.key)} groupBy={groupBy} selectedId={selectedId} selectTask={selectTask} names={{ systems: systemNames, actors: actorNames }} enabled={groupBy === 'status'} />)}</div></DndContext>
+  </WorkbenchShell>;
+}

--- a/apps/frontend/src/features/tasks/routes/TaskBoardRoute.tsx
+++ b/apps/frontend/src/features/tasks/routes/TaskBoardRoute.tsx
@@ -8,7 +8,6 @@ import {
   Button,
   InternalTaskBadge,
   ListFilterButton,
-  ListSortButton,
   OutlineBadge,
   SeverityBadge,
   UserAvatar,
@@ -17,7 +16,7 @@ import {
 import { DndContext, KeyboardSensor, PointerSensor, useDraggable, useDroppable, useSensor, useSensors, type DragEndEvent } from '@dnd-kit/core';
 import { useNavigate } from '@tanstack/react-router';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { Plus } from 'lucide-react';
+import { Layers, Plus } from 'lucide-react';
 import * as React from 'react';
 import { toast } from 'sonner';
 
@@ -76,12 +75,22 @@ function BoardColumn({ id, label, tasks, groupBy, selectedId, selectTask, names,
 }) {
   const droppable = useDroppable({ id, disabled: groupBy !== 'status' });
   return <section ref={droppable.setNodeRef} className={`flex min-h-0 w-72 shrink-0 flex-col rounded-sm border border-border-subtle bg-surface-raised ${droppable.isOver ? 'ring-1 ring-accent-primary' : ''}`} aria-label={`${label} column`}>
-    <header className="flex items-center gap-2 border-b border-border-subtle px-3 py-2"><>{groupBy === 'status' ? <InternalTaskBadge status={id as TaskStatus} /> : <span className="text-xs font-semibold uppercase tracking-wide text-text-muted">{label}</span>}</><span className="text-xs tabular-nums text-text-muted">{tasks.length}</span></header>
+    <header className="flex items-center gap-2 border-b border-border-subtle px-3 py-2"><>{groupBy === 'status' ? <InternalTaskBadge status={id as TaskStatus} /> : <span className="text-xs font-semibold uppercase tracking-wide text-text-muted">{label}</span>}</><span className="text-xs tabular-nums text-text-muted">{tasks.length}</span><span className="flex-1" /><Button type="button" variant="ghost" size="sm" className="h-[22px] w-[22px] p-0" disabled title="Task creation API is not available yet" aria-label={`Add task to ${label}`}><Plus className="h-3 w-3" /></Button></header>
     <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto p-2">
       {tasks.map((task) => <DraggableTaskCard key={task.id} task={task} selected={task.id === selectedId} onSelect={() => selectTask(task.id)} enabled={enabled} managedSystemName={names.systems.get(task.primary_managed_system_id) ?? 'Managed System'} assigneeName={task.assignee_actor_id ? names.actors.get(task.assignee_actor_id) : undefined} />)}
       {tasks.length === 0 && <div className="p-3 text-center text-xs text-text-muted">비어있음</div>}
     </div>
   </section>;
+}
+
+function GroupByButton({ value, onChange }: { value: GroupBy; onChange: (value: GroupBy) => void }) {
+  const [open, setOpen] = React.useState(false);
+  return <div className="relative">
+    <Button type="button" variant="outline" size="sm" onClick={() => setOpen((current) => !current)} aria-expanded={open} aria-haspopup="dialog"><Layers className="h-4 w-4" />Group by</Button>
+    {open && <div role="dialog" aria-label="Group by options" className="absolute right-0 z-10 mt-1 w-52 rounded-md border border-border-subtle bg-surface-raised p-1 shadow-md">
+      <div role="radiogroup" aria-label="Group by">{GROUP_OPTIONS.map((option) => <button key={option.value} type="button" role="radio" aria-checked={option.value === value} className="flex w-full items-center rounded-sm px-2 py-1.5 text-left text-sm text-text-primary hover:bg-surface-card" onClick={() => { onChange(option.value); setOpen(false); }}>{option.label}</button>)}</div>
+    </div>}
+  </div>;
 }
 
 export function TaskBoardRoute({ selectedParam }: { selectedParam?: string }) {
@@ -94,7 +103,7 @@ export function TaskBoardRoute({ selectedParam }: { selectedParam?: string }) {
   const tasksQuery = useQuery({ queryKey: ['tasks'] as const, queryFn: ({ signal }) => listTasks({ signal }), staleTime: 30_000 });
   const { actors } = useWorkspaceActors();
   const systemsQuery = useQuery({ queryKey: ['managed-systems', 'all'] as const, queryFn: ({ signal }) => fetchManagedSystems({ includeArchived: true, signal }), staleTime: 600_000 });
-  const sensors = useSensors(useSensor(PointerSensor), useSensor(KeyboardSensor));
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }), useSensor(KeyboardSensor));
   const actorNames = React.useMemo(() => new Map((actors ?? []).map((a) => [a.id, a.display_name])), [actors]);
   const systemNames = React.useMemo(() => new Map((systemsQuery.data?.items ?? []).map((s) => [s.id, s.name])), [systemsQuery.data?.items]);
   const items = tasksQuery.data?.items ?? [];
@@ -105,7 +114,7 @@ export function TaskBoardRoute({ selectedParam }: { selectedParam?: string }) {
   }), [items, filters]);
   const columns = React.useMemo(() => {
     if (groupBy === 'status') return STATUS_COLUMNS;
-    if (groupBy === 'priority') return ['urgent', 'high', 'medium', 'low'].map((key) => ({ key, label: key }));
+    if (groupBy === 'priority') return ['urgent', 'high', 'medium', 'low'].map((key) => ({ key, label: key[0]!.toUpperCase() + key.slice(1) }));
     if (groupBy === 'managedSystem') return [...systemNames].map(([key, label]) => ({ key, label }));
     return [...new Set(filtered.map((t) => t.assignee_actor_id).filter((id): id is string => id !== null))].map((key) => ({ key, label: actorNames.get(key) ?? key })).concat({ key: '__unassigned', label: '미배정' });
   }, [actorNames, filtered, groupBy, systemNames]);
@@ -137,10 +146,16 @@ export function TaskBoardRoute({ selectedParam }: { selectedParam?: string }) {
   });
   function selectTask(id: string) { setSelectedId(id); void navigate({ to: '/tasks', search: { view: 'board', param: id } }); }
   function onDragEnd(event: DragEndEvent) { const task = event.active.data.current?.task as TaskDto | undefined; const target = event.over?.id; if (groupBy !== 'status') { toast.warning('Group by Status 일 때만 드래그로 상태를 변경할 수 있습니다.'); return; } if (!task || typeof target !== 'string') return; if (task.status !== target) mutation.mutate({ task, status: target as TaskStatus }); }
+  function moveToNextStatus(taskId: string) {
+    const task = items.find((item) => item.id === taskId);
+    const nextStatus: Partial<Record<TaskStatus, TaskStatus>> = { todo: 'doing', doing: 'review', review: 'done', done: 'released', reopened: 'todo' };
+    const next = task && nextStatus[task.status];
+    if (task && next) mutation.mutate({ task, status: next });
+  }
   if (tasksQuery.isLoading) return <div className="p-4 text-sm text-text-muted">Loading Tasks...</div>;
   if (tasksQuery.error) return <div className="p-4 text-sm text-accent-danger">Task board unavailable.</div>;
   const selected = selectedId ? items.find((item) => item.id === selectedId) ?? null : null;
-  return <WorkbenchShell toolbar={{ title: <span className="flex items-center gap-2">Board <OutlineBadge>{filtered.length} tasks</OutlineBadge></span>, actions: <><ListFilterButton categories={filterCategories} values={filters} onChange={setFilters} /><span className="text-xs text-text-muted">Group by</span><ListSortButton options={GROUP_OPTIONS} value={groupBy} defaultValue="status" onChange={(value) => setGroupBy(value as GroupBy)} /><Button variant="primary" size="sm" disabled title="Task creation API is not available yet"><Plus className="h-4 w-4" />New task</Button></> }} detailPanel={selected ? <TaskDetailPanel taskId={selected.id} actorNamesById={actorNames} managedSystemNamesById={systemNames} view="board" onClose={() => { setSelectedId(null); void navigate({ to: '/tasks', search: { view: 'board' } }); }} /> : null}>
+  return <WorkbenchShell toolbar={{ title: <span className="flex items-center gap-2">Board <OutlineBadge>{filtered.length} tasks</OutlineBadge></span>, actions: <><ListFilterButton categories={filterCategories} values={filters} onChange={setFilters} /><GroupByButton value={groupBy} onChange={setGroupBy} /><Button variant="primary" size="sm" disabled title="Task creation API is not available yet"><Plus className="h-4 w-4" />New task</Button></> }} detailPanel={selected ? <TaskDetailPanel taskId={selected.id} actorNamesById={actorNames} managedSystemNamesById={systemNames} view="board" onMoveToNextStatus={moveToNextStatus} onClose={() => { setSelectedId(null); void navigate({ to: '/tasks', search: { view: 'board' } }); }} /> : null}>
     <div className="flex items-stretch gap-4 border-b border-border-subtle bg-surface-canvas px-5 py-2.5">
       <StatBlock label="Total tasks" value={items.length} />
       <StatDivider />

--- a/apps/frontend/src/features/tasks/routes/TaskBoardRoute.tsx
+++ b/apps/frontend/src/features/tasks/routes/TaskBoardRoute.tsx
@@ -50,7 +50,7 @@ function uuid(): string {
 function DraggableTaskCard({ task, selected, onSelect, managedSystemName, assigneeName, enabled }: {
   task: TaskDto; selected: boolean; onSelect: () => void; managedSystemName: string; assigneeName?: string | undefined; enabled: boolean;
 }) {
-  const draggable = useDraggable({ id: task.id, data: { task }, disabled: false });
+  const draggable = useDraggable({ id: task.id, data: { task }, disabled: !enabled });
   return (
     <button
       ref={draggable.setNodeRef}
@@ -62,7 +62,7 @@ function DraggableTaskCard({ task, selected, onSelect, managedSystemName, assign
       className={`w-full cursor-grab rounded-sm border border-border-subtle bg-surface-card p-3 text-left shadow-sm transition ${selected ? 'ring-1 ring-border-selected' : ''} ${draggable.isDragging ? 'opacity-35' : ''}`}
     >
       <div className="flex items-center gap-1.5"><span className="font-mono text-xs text-text-muted">{task.display_id}</span><SeverityBadge severity={severity(task.priority)} /></div>
-      {task.source_task_request_id && <span className="mt-2 inline-flex rounded border border-accent-info/30 px-1.5 py-0.5 text-xs text-accent-info">Linked finding</span>}
+      {/* TaskDto does not project finding linkage or linked VOC counts; only TaskDetailDto.source does. */}
       <div className="mt-2 text-sm font-medium text-text-primary">{task.title}</div>
       <div className="mt-3 flex items-center justify-between gap-2 text-xs text-text-muted"><span className="flex min-w-0 items-center gap-1.5 truncate"><span className="h-1.5 w-1.5 rounded-full bg-accent-info" />{managedSystemName}</span>{assigneeName ? <UserAvatar user={{ display_name: assigneeName }} size="sm" /> : <span className="rounded border border-border-subtle px-1.5 py-0.5">Unassigned</span>}</div>
       {!enabled && <span className="sr-only">Drag changes status only when grouped by status.</span>}
@@ -90,6 +90,7 @@ export function TaskBoardRoute({ selectedParam }: { selectedParam?: string }) {
   const [groupBy, setGroupBy] = React.useState<GroupBy>('status');
   const [filters, setFilters] = React.useState<Filters>({});
   const [selectedId, setSelectedId] = React.useState<string | null>(selectedParam ?? null);
+  const mutationTokens = React.useRef(new Map<string, number>());
   const tasksQuery = useQuery({ queryKey: ['tasks'] as const, queryFn: ({ signal }) => listTasks({ signal }), staleTime: 30_000 });
   const { actors } = useWorkspaceActors();
   const systemsQuery = useQuery({ queryKey: ['managed-systems', 'all'] as const, queryFn: ({ signal }) => fetchManagedSystems({ includeArchived: true, signal }), staleTime: 600_000 });
@@ -108,21 +109,53 @@ export function TaskBoardRoute({ selectedParam }: { selectedParam?: string }) {
     if (groupBy === 'managedSystem') return [...systemNames].map(([key, label]) => ({ key, label }));
     return [...new Set(filtered.map((t) => t.assignee_actor_id).filter((id): id is string => id !== null))].map((key) => ({ key, label: actorNames.get(key) ?? key })).concat({ key: '__unassigned', label: '미배정' });
   }, [actorNames, filtered, groupBy, systemNames]);
-  const filterCategories = React.useMemo(() => [{ key: 'priority', label: 'Priority', options: ['urgent', 'high', 'medium', 'low'].map((value) => ({ value, label: value[0]!.toUpperCase() + value.slice(1) })) }, { key: 'milestone', label: 'Milestone', options: [{ value: '__any', label: 'Milestone 있음' }, { value: '__none', label: 'Milestone 없음' }] }, { key: 'assignee', label: 'Assignee', options: [{ value: '__unassigned', label: '미배정' }, ...[...actorNames].map(([value, label]) => ({ value, label }))] }], [actorNames]);
+  const filterCategories = React.useMemo(() => {
+    const assigneeIds = [...new Set(items.map((task) => task.assignee_actor_id).filter((id): id is string => id !== null))];
+    return [{ key: 'priority', label: 'Priority', options: ['urgent', 'high', 'medium', 'low'].map((value) => ({ value, label: value[0]!.toUpperCase() + value.slice(1) })) }, { key: 'milestone', label: 'Milestone', options: [{ value: '__any', label: 'Milestone 있음' }, { value: '__none', label: 'Milestone 없음' }] }, { key: 'assignee', label: 'Assignee', options: [{ value: '__unassigned', label: '미배정' }, ...assigneeIds.map((value) => ({ value, label: actorNames.get(value) ?? value }))] }];
+  }, [actorNames, items]);
   const mutation = useMutation({
     mutationKey: ['task-status-transition'],
     mutationFn: ({ task, status }: { task: TaskDto; status: TaskStatus }) => updateTaskStatus(task.id, status, { ifMatch: task.updated_at, idempotencyKey: uuid() }),
-    onMutate: async ({ task, status }) => { const previousStatus = task.status; client.setQueryData<{ items: TaskDto[] }>(['tasks'], (old) => old ? { ...old, items: old.items.map((item) => item.id === task.id ? { ...item, status } : item) } : old); return { taskId: task.id, previousStatus }; },
-    onError: (error, _variables, context) => { if (context) client.setQueryData<{ items: TaskDto[] }>(['tasks'], (old) => old ? { ...old, items: old.items.map((item) => item.id === context.taskId ? { ...item, status: context.previousStatus } : item) } : old); if (error instanceof ApiError && error.code === 'conflict.stale_write') { void client.invalidateQueries({ queryKey: ['tasks'] }); toast.error('Task changed elsewhere. Board refreshed.'); return; } toast.error('Task status could not be updated.'); },
-    onSettled: () => void client.invalidateQueries({ queryKey: ['tasks'] }),
+    onMutate: async ({ task, status }) => {
+      const token = (mutationTokens.current.get(task.id) ?? 0) + 1;
+      mutationTokens.current.set(task.id, token);
+      await client.cancelQueries({ queryKey: ['tasks'] });
+      const previousStatus = client.getQueryData<{ items: TaskDto[] }>(['tasks'])?.items.find((item) => item.id === task.id)?.status ?? task.status;
+      client.setQueryData<{ items: TaskDto[] }>(['tasks'], (old) => old ? { ...old, items: old.items.map((item) => item.id === task.id ? { ...item, status } : item) } : old);
+      return { taskId: task.id, previousStatus, token };
+    },
+    onError: (error, _variables, context) => {
+      if (context && mutationTokens.current.get(context.taskId) === context.token) {
+        client.setQueryData<{ items: TaskDto[] }>(['tasks'], (old) => old ? { ...old, items: old.items.map((item) => item.id === context.taskId ? { ...item, status: context.previousStatus } : item) } : old);
+      }
+      if (error instanceof ApiError && error.code === 'conflict.stale_write' && context && mutationTokens.current.get(context.taskId) === context.token) { void client.invalidateQueries({ queryKey: ['tasks'] }); toast.error('Task changed elsewhere. Board refreshed.'); return; }
+      toast.error('Task status could not be updated.');
+    },
+    onSettled: (_data, _error, _variables, context) => {
+      if (!context || mutationTokens.current.get(context.taskId) === context.token) void client.invalidateQueries({ queryKey: ['tasks'] });
+    },
   });
   function selectTask(id: string) { setSelectedId(id); void navigate({ to: '/tasks', search: { view: 'board', param: id } }); }
   function onDragEnd(event: DragEndEvent) { const task = event.active.data.current?.task as TaskDto | undefined; const target = event.over?.id; if (groupBy !== 'status') { toast.warning('Group by Status 일 때만 드래그로 상태를 변경할 수 있습니다.'); return; } if (!task || typeof target !== 'string') return; if (task.status !== target) mutation.mutate({ task, status: target as TaskStatus }); }
   if (tasksQuery.isLoading) return <div className="p-4 text-sm text-text-muted">Loading Tasks...</div>;
   if (tasksQuery.error) return <div className="p-4 text-sm text-accent-danger">Task board unavailable.</div>;
   const selected = selectedId ? items.find((item) => item.id === selectedId) ?? null : null;
-  return <WorkbenchShell toolbar={{ title: <span className="flex items-center gap-2">Board <OutlineBadge>{filtered.length} tasks</OutlineBadge></span>, actions: <><ListFilterButton categories={filterCategories} values={filters} onChange={setFilters} /><ListSortButton options={GROUP_OPTIONS} value={groupBy} defaultValue="status" onChange={(value) => setGroupBy(value as GroupBy)} /><Button variant="primary" size="sm" disabled title="Task creation API is not available yet"><Plus className="h-4 w-4" />New task</Button></> }} detailPanel={selected ? <TaskDetailPanel taskId={selected.id} actorNamesById={actorNames} managedSystemNamesById={systemNames} onClose={() => { setSelectedId(null); void navigate({ to: '/tasks', search: { view: 'board' } }); }} /> : null}>
-    <div className="border-b border-border-subtle bg-surface-canvas px-4 py-2"><div className="flex items-center gap-5 text-xs"><span><strong>{items.length}</strong> Total tasks</span><span><strong>{items.filter((t) => t.assignee_actor_id === null).length}</strong> Unassigned</span><span><strong>{items.filter((t) => t.status === 'doing').length}</strong> In progress</span></div></div>
+  return <WorkbenchShell toolbar={{ title: <span className="flex items-center gap-2">Board <OutlineBadge>{filtered.length} tasks</OutlineBadge></span>, actions: <><ListFilterButton categories={filterCategories} values={filters} onChange={setFilters} /><span className="text-xs text-text-muted">Group by</span><ListSortButton options={GROUP_OPTIONS} value={groupBy} defaultValue="status" onChange={(value) => setGroupBy(value as GroupBy)} /><Button variant="primary" size="sm" disabled title="Task creation API is not available yet"><Plus className="h-4 w-4" />New task</Button></> }} detailPanel={selected ? <TaskDetailPanel taskId={selected.id} actorNamesById={actorNames} managedSystemNamesById={systemNames} view="board" onClose={() => { setSelectedId(null); void navigate({ to: '/tasks', search: { view: 'board' } }); }} /> : null}>
+    <div className="flex items-stretch gap-4 border-b border-border-subtle bg-surface-canvas px-5 py-2.5">
+      <StatBlock label="Total tasks" value={items.length} />
+      <StatDivider />
+      <StatBlock label="Unassigned" value={items.filter((task) => task.assignee_actor_id === null).length} valueClassName="text-accent-warning" />
+      <StatDivider />
+      <StatBlock label="In progress" value={items.filter((task) => task.status === 'doing').length} valueClassName="text-accent-success" />
+    </div>
     <DndContext sensors={sensors} onDragEnd={onDragEnd}><div className="flex h-full gap-3 overflow-x-auto p-4">{columns.map((column) => <BoardColumn key={column.key} id={column.key} label={column.label} tasks={filtered.filter((task) => groupValue(task, groupBy) === column.key)} groupBy={groupBy} selectedId={selectedId} selectTask={selectTask} names={{ systems: systemNames, actors: actorNames }} enabled={groupBy === 'status'} />)}</div></DndContext>
   </WorkbenchShell>;
+}
+
+function StatBlock({ label, value, valueClassName = '' }: { label: string; value: number; valueClassName?: string }) {
+  return <div className="flex flex-col gap-0.5"><span className="text-xs uppercase tracking-wide text-text-muted">{label}</span><span className={`text-base font-semibold tabular-nums ${valueClassName}`}>{value}</span></div>;
+}
+
+function StatDivider() {
+  return <div className="w-px self-stretch bg-border-subtle" aria-hidden="true" />;
 }

--- a/apps/frontend/src/features/tasks/routes/TaskListRoute.tsx
+++ b/apps/frontend/src/features/tasks/routes/TaskListRoute.tsx
@@ -3,6 +3,7 @@ import { fetchManagedSystems } from '@/lib/api/managed-systems';
 import { useWorkspaceActors } from '@/features/voc/hooks/useWorkspaceActors';
 import type { TaskDetailDto, TaskDto } from '@fops/shared';
 import {
+  Button,
   DetailPanelHeader,
   DetailPanelHeaderActions,
   DetailPanelSectionNav,
@@ -21,6 +22,7 @@ import {
 } from '@fops/ui';
 import { useNavigate } from '@tanstack/react-router';
 import { useQuery } from '@tanstack/react-query';
+import { ArrowRight } from 'lucide-react';
 import * as React from 'react';
 
 const PRIORITY_SEVERITY: Record<TaskDto['priority'], ObjectRowSeverity> = {
@@ -64,12 +66,14 @@ export function TaskDetailPanel({
   actorNamesById,
   managedSystemNamesById,
   view = 'backlog',
+  onMoveToNextStatus,
 }: {
   taskId: string;
   onClose: () => void;
   actorNamesById: ReadonlyMap<string, string>;
   managedSystemNamesById: ReadonlyMap<string, string>;
   view?: 'backlog' | 'board';
+  onMoveToNextStatus?: (taskId: string) => void;
 }) {
   const scrollRef = React.useRef<HTMLDivElement>(null);
   const taskQuery = useQuery({
@@ -188,6 +192,13 @@ export function TaskDetailPanel({
           </div>
         </div>
       </div>
+      {view === 'board' && task.status !== 'backlog' && task.status !== 'released' && onMoveToNextStatus && (
+        <div className="border-t border-border-subtle p-3">
+          <Button type="button" variant="primary" className="w-full" onClick={() => onMoveToNextStatus(task.id)}>
+            <ArrowRight className="h-4 w-4" />Move to next status
+          </Button>
+        </div>
+      )}
     </aside>
   );
 }

--- a/apps/frontend/src/features/tasks/routes/TaskListRoute.tsx
+++ b/apps/frontend/src/features/tasks/routes/TaskListRoute.tsx
@@ -58,7 +58,7 @@ function formatDate(raw: string): string {
   }).format(new Date(raw));
 }
 
-function TaskDetailPanel({
+export function TaskDetailPanel({
   taskId,
   onClose,
   actorNamesById,

--- a/apps/frontend/src/features/tasks/routes/TaskListRoute.tsx
+++ b/apps/frontend/src/features/tasks/routes/TaskListRoute.tsx
@@ -63,11 +63,13 @@ export function TaskDetailPanel({
   onClose,
   actorNamesById,
   managedSystemNamesById,
+  view = 'backlog',
 }: {
   taskId: string;
   onClose: () => void;
   actorNamesById: ReadonlyMap<string, string>;
   managedSystemNamesById: ReadonlyMap<string, string>;
+  view?: 'backlog' | 'board';
 }) {
   const scrollRef = React.useRef<HTMLDivElement>(null);
   const taskQuery = useQuery({
@@ -98,7 +100,7 @@ export function TaskDetailPanel({
           <DetailPanelHeaderActions
             entityKind="task"
             entityId={task.id}
-            copyUrl={`/tasks?view=backlog&param=${task.id}`}
+            copyUrl={`/tasks?view=${view}&param=${task.id}`}
           />
         }
       />
@@ -279,6 +281,7 @@ export function TaskListRoute({ selectedParam }: { selectedParam?: string | unde
             taskId={selected.id}
             actorNamesById={actorNamesById}
             managedSystemNamesById={managedSystemNamesById}
+            view="backlog"
             onClose={() => {
               setSelectedId(null);
               void navigate({ to: '/tasks', search: { view: 'backlog' } });

--- a/apps/frontend/src/lib/api/tasks.ts
+++ b/apps/frontend/src/lib/api/tasks.ts
@@ -34,6 +34,19 @@ export async function getTask(id: string, signal?: AbortSignal): Promise<TaskDet
   return res.data;
 }
 
+export async function updateTaskStatus(
+  id: string,
+  status: TaskStatus,
+  options: { ifMatch: string; idempotencyKey: string },
+): Promise<TaskDetailDto> {
+  const res = await apiClient<TaskDetailDto>('PATCH', `/tasks/${id}`, {
+    body: { status },
+    ifMatch: options.ifMatch,
+    idempotencyKey: options.idempotencyKey,
+  });
+  return res.data;
+}
+
 export async function convertTaskRequest(
   id: string,
   body: ConvertTaskRequestRequest,

--- a/apps/frontend/src/routes/_authed/tasks.tsx
+++ b/apps/frontend/src/routes/_authed/tasks.tsx
@@ -1,4 +1,5 @@
 import { TaskListRoute } from '@/features/tasks/routes/TaskListRoute';
+import { TaskBoardRoute } from '@/features/tasks/routes/TaskBoardRoute';
 import { TaskRequestsRoute } from '@/features/tasks/routes/TaskRequestsRoute';
 import { createFileRoute } from '@tanstack/react-router';
 import { z } from 'zod';
@@ -19,6 +20,9 @@ function TasksRouteShell() {
   const search = Route.useSearch();
   if (search.view === 'requests') {
     return <TaskRequestsRoute selectedParam={search.param} />;
+  }
+  if (search.view === 'board') {
+    return <TaskBoardRoute selectedParam={search.param} />;
   }
   return <TaskListRoute selectedParam={search.param} />;
 }

--- a/apps/frontend/src/routes/_authed/tasks.tsx
+++ b/apps/frontend/src/routes/_authed/tasks.tsx
@@ -16,13 +16,16 @@ export const Route = createFileRoute('/_authed/tasks')({
   component: TasksRouteShell,
 });
 
-function TasksRouteShell() {
-  const search = Route.useSearch();
+export function TasksRouteView({ search }: { search: { view?: 'requests' | 'backlog' | 'board' | 'my' | 'inbox'; param?: string } }) {
   if (search.view === 'requests') {
-    return <TaskRequestsRoute selectedParam={search.param} />;
+    return <TaskRequestsRoute {...(search.param !== undefined ? { selectedParam: search.param } : {})} />;
   }
   if (search.view === 'board') {
-    return <TaskBoardRoute selectedParam={search.param} />;
+    return <TaskBoardRoute {...(search.param !== undefined ? { selectedParam: search.param } : {})} />;
   }
-  return <TaskListRoute selectedParam={search.param} />;
+  return <TaskListRoute {...(search.param !== undefined ? { selectedParam: search.param } : {})} />;
+}
+
+function TasksRouteShell() {
+  return <TasksRouteView search={Route.useSearch()} />;
 }

--- a/docs/adr/0030-task-status-transition-and-kanban-board.md
+++ b/docs/adr/0030-task-status-transition-and-kanban-board.md
@@ -1,0 +1,65 @@
+# ADR-0030: Task Status Transition And Kanban Board
+
+Date: 2026-07-14
+
+## Status
+
+Accepted
+
+## Context
+
+ADR-0027 defined the seven Task status values but intentionally did not define
+transition edges. Issue #138 introduces the status mutation needed by the Task
+kanban board. The mutation must retain the existing Task authority boundary,
+optimistic concurrency, idempotency, and audit guarantees. ADR-0005 and
+ADR-0009 also reserve a released-Task Public-Update review candidate, but its
+background job has not yet been implemented.
+
+## Decision
+
+`PATCH /tasks/:id` is the Task status mutation. Its body is strictly:
+
+```text
+{ status: TaskStatus }
+```
+
+Transitions are free: every Task status may move to every other Task status.
+No transition matrix is introduced. The kanban interaction needs direct moves,
+and the audit trail supplies the traceability that a matrix would otherwise try
+to encode. Same-status requests are 200 no-ops and write neither an UPDATE nor
+an audit row.
+
+Every changed status writes `task_status_changed` in the same transaction as
+the Task update. Its strict detail is:
+
+```text
+{ from: TaskStatus, to: TaskStatus }
+```
+
+The endpoint requires `If-Match` optimistic concurrency and an
+`Idempotency-Key`, following the audit-sensitive mutation rule in
+`03-api-contracts.md`. Its idempotency hash includes the supplied `If-Match`.
+
+The Task-to-`released` Public-Update review-candidate job described by
+ADR-0005 and ADR-0009 is deferred to a follow-up issue. The status write does
+not enqueue that job or create a candidate yet.
+
+For the Issue #138 board UI, drag and drop uses `@dnd-kit/core`, resolving the
+deferral in ADR-0016. Its keyboard and touch support meet the board's
+accessibility needs. The board renders a seventh `reopened` column, a
+documented deviation from the six-column prototype, and includes a Task stats
+strip because Issue #138 acceptance criteria require it even though the
+prototype shows that strip only on the backlog view.
+
+## Consequences
+
+- The board can move any Task directly between all seven columns without a
+  client-side transition matrix.
+- Task-status history is queryable from the canonical audit log.
+- Stale board cards fail safely with `conflict.stale_write` and the current
+  `updated_at` value.
+- Releasing a Task still does not alter reporter-facing VOC status or create a
+  Public-Update candidate until the deferred background-job issue lands.
+- The frontend board contract is intentionally broader than the six-column
+  prototype where the accepted Issue #138 requirements require seven columns
+  and a stats strip.

--- a/docs/implementation/03-api-contracts.md
+++ b/docs/implementation/03-api-contracts.md
@@ -695,7 +695,24 @@ POST /task-requests/:id/link-task
 GET /tasks
 GET /tasks/:id
 POST /tasks    # deferred in issue #134
-PATCH /tasks/:id   # 미구현 as of Slice 6 — Slice 7 Task status transition (#138) 예정
+
+### PATCH /tasks/:id — Task status transition (Slice 7 #138)
+
+| Aspect | Contract |
+|---|---|
+| Purpose | Mutate the internal Task status for the Task board. Transitions are free: any of `backlog`, `todo`, `doing`, `review`, `done`, `released`, or `reopened` may move to any other status. ADR-0027 defined the status vocabulary but no transition edges; the audit trail provides the required traceability. |
+| Headers | `Idempotency-Key: <uuidv4>` (required) · `If-Match: <updated_at ISO>` (required) · `Authorization: Bearer <session>` |
+| Body | `{ status: TaskStatus }` only; `.strict()` (zod) rejects unknown fields. |
+| Permission | Admin or Developer with `finding.manage` on the Task `primary_managed_system_id`, matching `GET /tasks/:id`, convert, and link-existing authority. |
+| Optimistic concurrency | `If-Match` compared against `task.updated_at`; mismatch → 409 `conflict.stale_write` with `detail.current_updated_at`. |
+| Service ordering | `SELECT FOR UPDATE task → permission check → If-Match compare → same-status no-op check → UPDATE status + updated_at → audit emit → refresh Task Detail DTO`. |
+| Empty-diff semantics | A request whose `status` already equals the stored status returns 200 with the current Task Detail DTO. It performs no UPDATE and emits no audit row; the idempotency cache still records the 200 response. |
+| Response | 200 `TaskDetailDto`, with the same `source` projection as `GET /tasks/:id`. Missing task → 404 `not_found.record`. |
+| Audit event | `task_status_changed` with strict detail `{ from: TaskStatus, to: TaskStatus }`, written in the same transaction as the UPDATE. |
+| Idempotency hash | Includes `taskId`, `ifMatch`, route, and request body. A retry after refetching a stale Task has a distinct hash; clients must mint a fresh `Idempotency-Key` for each distinct `If-Match` value. |
+| Released side effect | ADR-0005/0009's Public-Update review-candidate background job remains deferred. Moving a Task to `released` in this endpoint does not yet enqueue or emit that candidate. |
+| Error codes | `validation.failed` · `validation.malformed_idempotency_key` · `permission.denied` · `not_found.record` · `conflict.stale_write` · `conflict.idempotency_key_reuse` · `rate_limited.actor` |
+
 ```
 
 Task Request is not independently created through `POST /task-requests` as of

--- a/docs/implementation/03-api-contracts.md
+++ b/docs/implementation/03-api-contracts.md
@@ -695,6 +695,7 @@ POST /task-requests/:id/link-task
 GET /tasks
 GET /tasks/:id
 POST /tasks    # deferred in issue #134
+```
 
 ### PATCH /tasks/:id — Task status transition (Slice 7 #138)
 
@@ -712,8 +713,6 @@ POST /tasks    # deferred in issue #134
 | Idempotency hash | Includes `taskId`, `ifMatch`, route, and request body. A retry after refetching a stale Task has a distinct hash; clients must mint a fresh `Idempotency-Key` for each distinct `If-Match` value. |
 | Released side effect | ADR-0005/0009's Public-Update review-candidate background job remains deferred. Moving a Task to `released` in this endpoint does not yet enqueue or emit that candidate. |
 | Error codes | `validation.failed` · `validation.malformed_idempotency_key` · `permission.denied` · `not_found.record` · `conflict.stale_write` · `conflict.idempotency_key_reuse` · `rate_limited.actor` |
-
-```
 
 Task Request is not independently created through `POST /task-requests` as of
 Slice 6. It is created only through source transition routes:

--- a/packages/shared/src/enums/audit-events.ts
+++ b/packages/shared/src/enums/audit-events.ts
@@ -89,6 +89,8 @@ export const AUDIT_EVENT_TYPES = [
   'task_linked_to_request',
   // Slice 6 #135: Finding links an existing Task directly.
   'finding_task_linked',
+  // Slice 7 #138: Task board status transition.
+  'task_status_changed',
 ] as const;
 export type AuditEventType = (typeof AUDIT_EVENT_TYPES)[number];
 
@@ -481,6 +483,14 @@ export const findingTaskLinkedDetailSchema = z
   .strict();
 export type FindingTaskLinkedDetail = z.infer<typeof findingTaskLinkedDetailSchema>;
 
+export const taskStatusChangedDetailSchema = z
+  .object({
+    from: z.enum(['backlog', 'todo', 'doing', 'review', 'done', 'released', 'reopened']),
+    to: z.enum(['backlog', 'todo', 'doing', 'review', 'done', 'released', 'reopened']),
+  })
+  .strict();
+export type TaskStatusChangedDetail = z.infer<typeof taskStatusChangedDetailSchema>;
+
 export const AUDIT_EVENT_DETAIL_SCHEMAS = {
   permission_requested: permissionRequestedDetailSchema,
   managed_system_registered: managedSystemRegisteredDetailSchema,
@@ -537,4 +547,6 @@ export const AUDIT_EVENT_DETAIL_SCHEMAS = {
   task_linked_to_request: taskLinkedToRequestDetailSchema,
   // Slice 6 #135.
   finding_task_linked: findingTaskLinkedDetailSchema,
+  // Slice 7 #138.
+  task_status_changed: taskStatusChangedDetailSchema,
 } as const satisfies Record<AuditEventType, z.ZodTypeAny>;

--- a/packages/shared/src/tasks/index.ts
+++ b/packages/shared/src/tasks/index.ts
@@ -72,6 +72,13 @@ export const taskDetailDtoSchema = taskDtoSchema
   .strict();
 export type TaskDetailDto = z.infer<typeof taskDetailDtoSchema>;
 
+export const patchTaskStatusRequestSchema = z
+  .object({
+    status: taskStatusSchema,
+  })
+  .strict();
+export type PatchTaskStatusRequest = z.infer<typeof patchTaskStatusRequestSchema>;
+
 export const convertTaskRequestRequestSchema = z
   .object({
     title: z.string().trim().min(1).max(200),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
 
   apps/frontend:
     dependencies:
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@fops/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -632,6 +635,22 @@ packages:
   '@csstools/css-tokenizer@3.0.4':
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
@@ -4335,6 +4354,24 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
 
   '@csstools/css-tokenizer@3.0.4': {}
+
+  '@dnd-kit/accessibility@3.1.1(react@19.0.0)':
+    dependencies:
+      react: 19.0.0
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.0.0)
+      '@dnd-kit/utilities': 3.2.2(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.0.0)':
+    dependencies:
+      react: 19.0.0
+      tslib: 2.8.1
 
   '@drizzle-team/brocli@0.10.2': {}
 


### PR DESCRIPTION
Closes #138

## What
- **Backend**: `PATCH /tasks/:id` status transition (자유 전환, ADR-0030) — If-Match 낙관 동시성 + Idempotency-Key, `task_status_changed` audit ({from,to}), same-status no-op. 계약 문서 03-api-contracts.md 갱신.
- **Frontend**: `/tasks?view=board` 실제 칸반 — 7컬럼(reopened 포함, 문서화된 deviation), @dnd-kit/core 드래그(PointerSensor activationConstraint), 낙관 업데이트+롤백+409 refetch(레이스 가드), group-by 4종, 필터 칩, stats strip(문서화된 deviation), 디테일 패널 + board 딥링크 복원, Move-to-next-status footer.
- **ADR-0030** 신규: 전환 정책·audit·동시성·released 부작용 defer(#165)·DnD 선정·프로토타입 deviation 2건.

## Evidence (wt .review/, merge 후 아카이브)
- BE VERIFY: PASS 9/9, head f38cd9d, typecheck 베이스라인 외 0 (`ISSUE-138-VERIFY.json`)
- FE vitest: 22/22 (board 12 + 기존)
- 리뷰: BE 2라운드 approve(P1 1건 근거기각 disposition 기록), FE 5라운드 approve (`ISSUE-138-*REVIEW*.json`)
- VISUAL (playwright 라이브, 프로토타입 대비): **approve 94/100** — 드래그→PATCH 200 persist, 그룹바이, 필터, 딥링크 복원, 회귀 뷰 전부 PASS (`ISSUE-138-VISUAL.json` + 스크린샷)

## Notes
- dnd activationConstraint 때문에 향후 Playwright drag 스펙은 `dragTo()` 금지, stepped drag(mouse.down→move→up) 필수 (VISUAL 헤드업).
- released 전환 부작용(Public-Update 리뷰 후보 잡)은 #165로 defer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vf7FtdzPZ3TSUfJRyWTbGx