### PR TITLE
test(backend): register the recommendation-decisions grant set as designed (#207)

### DIFF
--- a/apps/backend/src/db/__tests__/role-grants-product-tables.integration.test.ts
+++ b/apps/backend/src/db/__tests__/role-grants-product-tables.integration.test.ts
@@ -45,7 +45,13 @@ type DmlPrivilege = (typeof DML_PRIVILEGES)[number];
 const FULL_DML: readonly DmlPrivilege[] = DML_PRIVILEGES;
 
 // Tables intentionally narrower than full-DML for fops_app, keyed by the
-// fully-qualified `schema.table` name. Grants come from migrations 0010, 0037, and 0039.
+// fully-qualified `schema.table` name. Grants come from migrations 0010, 0037,
+// 0039, and 0044.
+//
+// A table absent from this map is asserted as full-DML. That default is why a
+// new narrower table shows up here as a missing-DELETE failure rather than as
+// silence: the entry is the design record, and adding one is a decision, not
+// paperwork (#207).
 const EXPECTED_GRANTS: Record<string, readonly DmlPrivilege[]> = {
   'survey.surveys': ['SELECT', 'INSERT', 'UPDATE'],
   'survey.survey_questions': ['SELECT', 'INSERT', 'UPDATE', 'DELETE'],
@@ -62,6 +68,11 @@ const EXPECTED_GRANTS: Record<string, readonly DmlPrivilege[]> = {
   // must remain without table-wide UPDATE.
   'voc.public_update_review_candidates': ['SELECT', 'INSERT'],
   'voc.reporter_facing_status_transitions': ['SELECT'],
+  // No DELETE by design (migration 0044): a dismissal the application can
+  // erase is not a dismissal that survives recomputation. UPDATE is granted
+  // for the one legal transition out of a terminal state — a dismissed pair
+  // promoted to `confirmed` in place (ADR-0034 D3).
+  'voc.voc_recommendation_decisions': ['SELECT', 'INSERT', 'UPDATE'],
 };
 
 describe.skipIf(!runIntegration)('ADR-0008 role grants — product tables (Slice 3 #22)', () => {
@@ -112,7 +123,7 @@ describe.skipIf(!runIntegration)('ADR-0008 role grants — product tables (Slice
         }
         if (!expected.has(priv) && got.has(priv)) {
           failures.push(
-            `fops_app has unexpected GRANT ${priv} ON ${fq}; ${fq} is append-only by design (migration 0010 or 0037) — REVOKE it or update EXPECTED_GRANTS if the design changed`,
+            `fops_app has unexpected GRANT ${priv} ON ${fq}; ${fq} is narrower than full-DML by design (see the migration that created it) — REVOKE it or update EXPECTED_GRANTS if the design changed`,
           );
         }
       }

--- a/apps/backend/src/modules/voc/AGENTS.md
+++ b/apps/backend/src/modules/voc/AGENTS.md
@@ -136,6 +136,18 @@ has a user to be honest with.
   single `not_found.record` shape. Do not introduce a permission-denied branch
   at the route boundary.
 
+**`voc.voc_recommendation_decisions` is not full-DML for `fops_app`: `SELECT,
+INSERT, UPDATE` and no DELETE** (migration 0044). A dismissal the application
+can erase is not a dismissal that survives recomputation — ADR-0034 D6 recomputes
+recommendations on read, so the suppression row is the only thing standing
+between a human judgement and its own undoing. UPDATE exists for exactly one
+transition, `dismissed` → `confirmed` in place; that is why the table is not
+plain insert-only. Test teardown must delete these rows through
+`DATABASE_URL_MIGRATE`, like `core.audit_log` (#205). The grant set is asserted
+by `db/__tests__/role-grants-product-tables.integration.test.ts`, whose
+`EXPECTED_GRANTS` map defaults an unlisted table to full-DML — a new narrower
+table must be registered there in the same chunk (#207).
+
 `recommendations/constants.ts` pins `VOC_RECOMMENDATION_SIMILARITY_THRESHOLD =
 0.75` in code. ADR-0034 D5 requires a committed evaluation fixture beside it,
 and requires that changing the default updates the fixture in the same change.


### PR DESCRIPTION
Closes #207.

## Which side was the bug

The issue offered two readings — a missing `GRANT DELETE`, or an unregistered append-only table. **Migration 0044 settles it in its own comment**, so no ADR interpretation was needed:

> No DELETE for fops_app: a dismissal that the application can erase is not a dismissal that survives recomputation. UPDATE is granted only so a previously dismissed pair can be promoted to `confirmed` in place — the one legal transition out of a terminal state, and the reason the unique key cannot simply be insert-only.

ADR-0034 D6 computes recommendations on read against current vectors, so the suppression row is the only thing standing between a human judgement and its own undoing. The migration is right; the guard was uninformed.

## Change

- `EXPECTED_GRANTS` gains `'voc.voc_recommendation_decisions': ['SELECT','INSERT','UPDATE']` with the rationale inline.
- `modules/voc/AGENTS.md` records the design, plus the teardown consequence: these rows delete through `DATABASE_URL_MIGRATE`, like `core.audit_log` (#205).
- The over-grant failure message named migrations 0010 and 0037 and would have misdirected anyone hitting it on a later table — now points at the creating migration generically.
- A note on the map's full-DML default, so the next narrower table gets an entry instead of a red guard.

## Verification

```
pnpm --filter backend test:integration  1 failed / 1135 passed   (was 2 failed / 1134)
                                        only #206 remains
pnpm typecheck                          3 errors, all pre-existing on develop
pnpm check:boundaries                   OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BfiR55zJ7n8uYpr1s3X6q