### PR TITLE
test: teach both route-drift guards the fastify shorthand form (#206)

### DIFF
--- a/apps/backend/src/__tests__/fe-call-endpoints-exist.test.ts
+++ b/apps/backend/src/__tests__/fe-call-endpoints-exist.test.ts
@@ -13,9 +13,10 @@
  *       - `apiClient('METHOD', '/foo'...)` / template literal `\`/foo/...\``
  *       - `fetch('/foo', ...)` / `fetch(\`/foo/...\`)`
  *   - Reduce each match to its root prefix (`/foo`).
- *   - Assert each root prefix is registered by some `app.route({ url: '/foo...' })`
- *     in BE (`server.ts` + `modules/*\/routes.ts` + `modules/* /*-routes.ts`),
- *     or listed in KNOWN_FE_ONLY.
+ *   - Assert each root prefix is registered in BE (`server.ts` +
+ *     `modules/*\/routes.ts` + `modules/* /*-routes.ts`) in either fastify
+ *     form — `app.route({ url: '/foo' })` or `app.get('/foo', ...)` — or
+ *     listed in KNOWN_FE_ONLY.
  *
  * Pure file-read assertion. No DB, no server boot. Always runs.
  */
@@ -41,15 +42,30 @@ const FE_SRC = path.join(REPO_ROOT, 'apps/frontend/src');
 const BE_SRC = path.join(REPO_ROOT, 'apps/backend/src');
 
 // ─── BE-side route discovery ───────────────────────────────────────────────
-// Reuse the same `url:` extractor as vite-proxy-completeness; quote-aware,
-// single-line. Walk server.ts + every `routes.ts` AND every `*-routes.ts`
-// (the latter so file naming variants — e.g. `list-actors-routes.ts` —
-// are not silently missed).
+// Walk server.ts + every `routes.ts` AND every `*-routes.ts` (the latter so
+// file naming variants — e.g. `list-actors-routes.ts` — are not silently
+// missed).
+//
+// Fastify accepts two registration forms and this repo uses both: the object
+// form `app.route({ url: '/x' })` (71 declarations) and the method shorthand
+// `app.get('/x', opts, handler)` (10, all in `modules/surveys/routes.ts`).
+// Matching only the object form made every shorthand route invisible, so the
+// check reported `/surveys` as an unregistered endpoint for months while the
+// routes were live — a false positive that trained readers to ignore the one
+// red line in the gate (#206). Missing a form here fails loud in this
+// direction, but the twin proxy check reads the same source and a miss there
+// fails silent, so both forms must stay covered.
+const ROUTE_URL_PATTERNS: readonly RegExp[] = [
+  /url:\s*['"`](\/[A-Za-z0-9/_\-:]*)['"`]/g,
+  /\b(?:app|fastify)\.(?:get|post|put|patch|delete|head|options|all)\(\s*['"`](\/[A-Za-z0-9/_\-:]*)['"`]/g,
+];
+
 function extractRouteUrls(source: string): string[] {
-  const re = /url:\s*['"](\/[A-Za-z0-9/_\-:]*)['"]/g;
   const out: string[] = [];
-  for (const m of source.matchAll(re)) {
-    if (m[1]) out.push(m[1]);
+  for (const re of ROUTE_URL_PATTERNS) {
+    for (const m of source.matchAll(re)) {
+      if (m[1]) out.push(m[1]);
+    }
   }
   return out;
 }
@@ -128,6 +144,29 @@ function rootPrefix(url: string): string {
 }
 
 describe('FE→BE reverse drift (post-#21)', () => {
+  // The check is only as good as its route discovery: a form it cannot see
+  // reads as "the backend never registered this" (#206).
+  it('discovers both fastify registration forms', () => {
+    const urls = extractRouteUrls(
+      [
+        "app.route({ method: 'GET', url: '/object-form' });",
+        "app.get('/shorthand', { preHandler: pre }, handler);",
+        'app.post(`/shorthand/:id/nested`, handler);',
+        "cache.get('not-a-route');",
+        "map.get('/looks-like-a-path-but-is-not-fastify');",
+      ].join('\n'),
+    );
+    expect(new Set(urls)).toEqual(
+      new Set(['/object-form', '/shorthand', '/shorthand/:id/nested']),
+    );
+  });
+
+  it('discovers the shorthand-registered routes in the real backend source', () => {
+    // `modules/surveys/routes.ts` is the repo's only shorthand user today, and
+    // the prefix this check falsely reported as missing.
+    expect(collectBackendRoutes().has('/surveys')).toBe(true);
+  });
+
   it('every FE URL prefix has a matching BE route (or is in KNOWN_FE_ONLY)', () => {
     const beRoots = collectBackendRoutes();
     expect(beRoots.size, 'should discover at least one BE route').toBeGreaterThan(0);

--- a/apps/frontend/src/__tests__/vite-proxy-completeness.test.ts
+++ b/apps/frontend/src/__tests__/vite-proxy-completeness.test.ts
@@ -11,8 +11,9 @@
  * any unit test. The latest occurrence was `/attachments` (PR #75 hotfix).
  *
  * Implementation:
- *   - Parse `apps/backend/src/server.ts` for top-level `app.route({ url: '/x' })`.
- *   - Parse every `apps/backend/src/modules/<name>/routes.ts` for the same.
+ *   - Parse `apps/backend/src/server.ts` for both fastify registration forms:
+ *     `app.route({ url: '/x' })` and `app.get('/x', …)`.
+ *   - Parse every `apps/backend/src/modules/<name>/*routes.ts` for the same.
  *   - Reduce to unique root prefixes (`/foo/bar` → `/foo`).
  *   - Assert each is a proxy key in `vite.config.ts` (or in KNOWN_FE_ONLY).
  *
@@ -35,13 +36,23 @@ const SERVER_TS = path.join(REPO_ROOT, 'apps/backend/src/server.ts');
 const VITE_CONFIG = path.join(REPO_ROOT, 'apps/frontend/vite.config.ts');
 const MODULES_DIR = path.join(REPO_ROOT, 'apps/backend/src/modules');
 
+// Fastify accepts two registration forms and this repo uses both: the object
+// form `app.route({ url: '/x' })` and the method shorthand `app.get('/x', …)`
+// (the latter only in `modules/surveys/routes.ts` today). A form this check
+// cannot see is a backend prefix it never demands a proxy entry for — and
+// unlike the twin check in `apps/backend/src/__tests__/fe-call-endpoints-exist.test.ts`,
+// which goes red, a miss here is silently green (#206). Keep both forms.
+const ROUTE_URL_PATTERNS: readonly RegExp[] = [
+  /url:\s*['"`](\/[A-Za-z0-9/_\-:]*)['"`]/g,
+  /\b(?:app|fastify)\.(?:get|post|put|patch|delete|head|options|all)\(\s*['"`](\/[A-Za-z0-9/_\-:]*)['"`]/g,
+];
+
 function extractRouteUrls(source: string): string[] {
-  // Match `url: '/...'` or `url: "/..."` inside `app.route({ ... })` /
-  // `fastify.route({ ... })`. Quote-aware, single-line.
-  const re = /url:\s*['"](\/[A-Za-z0-9/_\-:]*)['"]/g;
   const out: string[] = [];
-  for (const m of source.matchAll(re)) {
-    if (m[1]) out.push(m[1]);
+  for (const re of ROUTE_URL_PATTERNS) {
+    for (const m of source.matchAll(re)) {
+      if (m[1]) out.push(m[1]);
+    }
   }
   return out;
 }
@@ -49,12 +60,14 @@ function extractRouteUrls(source: string): string[] {
 function collectBackendRoutes(): string[] {
   const urls: string[] = [];
   urls.push(...extractRouteUrls(fs.readFileSync(SERVER_TS, 'utf8')));
-  // Walk apps/backend/src/modules/*/routes.ts
+  // Walk apps/backend/src/modules/*/routes.ts AND *-routes.ts naming variants
+  // (e.g. `auth/list-actors-routes.ts`), matching the twin check's discovery.
   for (const entry of fs.readdirSync(MODULES_DIR, { withFileTypes: true })) {
     if (!entry.isDirectory()) continue;
-    const candidate = path.join(MODULES_DIR, entry.name, 'routes.ts');
-    if (fs.existsSync(candidate)) {
-      urls.push(...extractRouteUrls(fs.readFileSync(candidate, 'utf8')));
+    const moduleDir = path.join(MODULES_DIR, entry.name);
+    for (const fileEntry of fs.readdirSync(moduleDir, { withFileTypes: true })) {
+      if (!fileEntry.isFile() || !fileEntry.name.endsWith('routes.ts')) continue;
+      urls.push(...extractRouteUrls(fs.readFileSync(path.join(moduleDir, fileEntry.name), 'utf8')));
     }
   }
   return urls;
@@ -82,6 +95,26 @@ function parseProxyKeys(viteConfig: string): Set<string> {
 }
 
 describe('Vite dev proxy completeness (Slice 3 #22)', () => {
+  // A registration form this check cannot parse is a prefix it never demands a
+  // proxy entry for, and the omission looks like a pass (#206).
+  it('discovers both fastify registration forms', () => {
+    const urls = extractRouteUrls(
+      [
+        "app.route({ method: 'GET', url: '/object-form' });",
+        "app.get('/shorthand', { preHandler: pre }, handler);",
+        'app.post(`/shorthand/:id/nested`, handler);',
+        "cache.get('not-a-route');",
+        "map.get('/looks-like-a-path-but-is-not-fastify');",
+      ].join('\n'),
+    );
+    expect(new Set(urls)).toEqual(new Set(['/object-form', '/shorthand', '/shorthand/:id/nested']));
+  });
+
+  it('discovers the shorthand-registered routes in the real backend source', () => {
+    // `modules/surveys/routes.ts` is the repo's only shorthand user today.
+    expect(new Set(collectBackendRoutes().map(rootPrefix)).has('/surveys')).toBe(true);
+  });
+
   it('every BE root prefix has a matching vite proxy entry (or is in KNOWN_FE_ONLY)', () => {
     const backendUrls = collectBackendRoutes();
     expect(backendUrls.length, 'should discover at least one BE route').toBeGreaterThan(0);

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -65,6 +65,12 @@ export default defineConfig({
         target: 'http://127.0.0.1:3011',
         bypass: (req) => (req.headers.accept?.includes('text/html') ? req.url : undefined),
       },
+      // #187: POST /survey-responses/:id/{create-finding,
+      // evidence-excerpt-candidates,approved-excerpts}. A backend-only root
+      // prefix — no FE route of this name — so forward it unconditionally.
+      // Missing until #206: the proxy check could not see the shorthand
+      // `app.post('/survey-responses/...')` form these routes use.
+      '/survey-responses': 'http://127.0.0.1:3011',
       // Slice 3 #22: POST /attachments (multipart upload) + GET
       // /attachments/:id/download (streaming). No FE-route collision; forward
       // root path unconditionally.

--- a/docs/frontend/specs/actors.md
+++ b/docs/frontend/specs/actors.md
@@ -39,3 +39,10 @@ FE-only mapping inside `useWorkspaceActors`; today every BE row maps to
 
 - Forward drift (BE→proxy): `apps/frontend/src/__tests__/vite-proxy-completeness.test.ts`.
 - Reverse drift (FE→BE): `apps/backend/src/__tests__/fe-call-endpoints-exist.test.ts`.
+
+Both discover backend routes by reading source, and both must parse **either**
+fastify registration form — `app.route({ url: '/x' })` or the method shorthand
+`app.get('/x', …)`. A form neither can see disappears from the check: the
+reverse guard then reports a live route as missing (a false red the reader
+learns to ignore), and the forward guard stops demanding a proxy entry for it
+at all (a silent green). Both failure modes were live until #206.


### PR DESCRIPTION
Closes #206.

## The issue's premise was wrong

> FE가 `/surveys`를 호출하는데 BE 라우트 없음

`modules/surveys/routes.ts:103` has served `GET /surveys` all along. Neither side of the drift pair was wrong — **the detector was**.

Fastify takes two registration forms and this repo uses both: the object form `app.route({ url: '/x' })` (71 declarations) and the method shorthand `app.get('/x', …)` (10, all in surveys). Both guards matched only `url:`, so every shorthand route was invisible.

## The two guards fail in opposite directions

That asymmetry is why this sat for months:

| Guard | Direction | Failure mode |
|---|---|---|
| `fe-call-endpoints-exist` (BE) | FE→BE | **Red, and stayed red.** Became "the one allowed failure" a human had to remember on every gate reading — the exact state that hides a real second failure. |
| `vite-proxy-completeness` (FE) | BE→proxy | **Silent green.** It simply stopped demanding a dev-proxy entry for prefixes it could not see. |

The silent one was hiding a real bug: **`/survey-responses` (#187's three POST routes) had no entry in `vite.config.ts`.** An FE call to them would have been served SPA HTML in dev — precisely the bug class that check exists to catch. Fixing the extractor surfaced it immediately.

## Change

- Both extractors gain the shorthand pattern, scoped to `app.`/`fastify.` receivers so `map.get('/x')` cannot forge a route.
- The forward guard gains the `*-routes.ts` file-naming coverage the reverse one already had — it was missing `auth/list-actors-routes.ts` entirely.
- `'/survey-responses'` added to the dev proxy (backend-only prefix, no FE route collision → unconditional forward, mirrors `/attachments`).
- A discovery test in each file, so a future form change fails on the detector rather than on its victims.
- `docs/frontend/specs/actors.md` records both failure modes.

## Verification

```
pnpm --filter backend test:integration  126 files / 1138 passed, 0 failed
                                        ← first fully green integration gate (was 1 failed / 1135)
pnpm --filter frontend test             131 files / 652 passed
pnpm typecheck                          3 errors, all pre-existing on develop
pnpm check:boundaries                   OK
```

Non-vacuity: reverting the vite entry re-fails the forward guard; reverting the extractor re-produces the original `/surveys` red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BfiR55zJ7n8uYpr1s3X6q