### PR TITLE
feat(surveys): unbranch with one PATCH instead of delete + recreate (#194)

### DIFF
--- a/apps/frontend/src/features/surveys/components/builder/SurveyBuilder.tsx
+++ b/apps/frontend/src/features/surveys/components/builder/SurveyBuilder.tsx
@@ -76,7 +76,6 @@ export function SurveyBuilder({
   const questionsRef = React.useRef(questions);
   const [selectedId, setSelectedId] = React.useState<string | null>(questions[0]?.id ?? null);
   const [preview, setPreview] = React.useState(false);
-  const [busyQuestionIds, setBusyQuestionIds] = React.useState<Set<string>>(() => new Set());
   const mutations = useSurveyQuestionMutations(survey.id);
   const editable = canManage && survey.status === 'draft' && !gateState;
   const selected = questions.find((question) => question.id === selectedId) ?? null;
@@ -91,35 +90,15 @@ export function SurveyBuilder({
   const patch = (next: SurveyQuestion) => {
     const current = questionsRef.current.find((question) => question.id === next.id);
     updateQuestions((all) => all.map((question) => (question.id === next.id ? next : question)));
-    if (
-      Boolean(current?.branch_parent_question_id) &&
-      !next.branch_parent_question_id &&
-      !next.id.startsWith('local-')
-    ) {
-      setBusyQuestionIds((current) => new Set(current).add(next.id));
-      void (async () => {
-        try {
-          await mutations.remove.mutateAsync(next.id);
-          const recreated = await mutations.create.mutateAsync(toInput(next));
-          updateQuestions((all) =>
-            all.map((question) =>
-              question.id === next.id ? { ...next, id: recreated.id } : question,
-            ),
-          );
-          setSelectedId((id) => (id === next.id ? recreated.id : id));
-        } finally {
-          setBusyQuestionIds((current) => {
-            const pending = new Set(current);
-            pending.delete(next.id);
-            return pending;
-          });
-        }
-      })();
-      return;
-    }
-    if (!next.id.startsWith('local-')) {
-      mutations.update.mutate({ id: next.id, body: toInput(next) });
-    }
+    if (next.id.startsWith('local-')) return;
+    const body = toInput(next);
+    // `toInput` omits falsy branch fields, which cannot express "clear it" —
+    // an omitted field means "leave as is" to the route. Unbranching is the
+    // one edit that must send an explicit null (#192/#194). The backend then
+    // clears trigger and depth in the same statement, so neither is sent here.
+    if (current?.branch_parent_question_id && !next.branch_parent_question_id)
+      body.branch_parent_question_id = null;
+    mutations.update.mutate({ id: next.id, body });
   };
 
   const add = () => {
@@ -187,7 +166,7 @@ export function SurveyBuilder({
             <QuestionEditor
               question={selected}
               questions={questions}
-              editable={editable && !busyQuestionIds.has(selected.id)}
+              editable={editable}
               onChange={patch}
             />
           ) : (

--- a/apps/frontend/src/features/surveys/routes/__tests__/SurveyScreens.test.tsx
+++ b/apps/frontend/src/features/surveys/routes/__tests__/SurveyScreens.test.tsx
@@ -206,7 +206,7 @@ describe('Survey screens', () => {
     );
   });
 
-  it('recreates a persisted branched question when its branch is removed', async () => {
+  it('clears a persisted branch with one PATCH and keeps the question id', async () => {
     const parentQuestion = survey.questions?.[0] as SurveyQuestion;
     const child: SurveyQuestion = {
       ...parentQuestion,
@@ -227,46 +227,39 @@ describe('Survey screens', () => {
     fireEvent.click(screen.getByText('Q2'));
     fireEvent.change(screen.getByLabelText('분기 부모 질문'), { target: { value: '' } });
     await waitFor(() =>
-      expect(apiClient).toHaveBeenCalledWith('DELETE', '/surveys/survey-1/questions/question-2'),
-    );
-    await waitFor(() =>
       expect(apiClient).toHaveBeenCalledWith(
-        'POST',
-        '/surveys/survey-1/questions',
+        'PATCH',
+        '/surveys/survey-1/questions/question-2',
         expect.objectContaining({
-          body: expect.objectContaining({ prompt: '추가 질문', sort_order: 1 }),
+          body: expect.objectContaining({ branch_parent_question_id: null }),
         }),
       ),
     );
-    const deleteIndex = apiClient.mock.calls.findIndex(
-      (call) => call[0] === 'DELETE' && call[1] === '/surveys/survey-1/questions/question-2',
+    // The #188 workaround deleted and re-created the row, which minted a new
+    // id. A PATCH must not touch either endpoint (#194).
+    expect(apiClient).not.toHaveBeenCalledWith('DELETE', '/surveys/survey-1/questions/question-2');
+    expect(apiClient).not.toHaveBeenCalledWith(
+      'POST',
+      '/surveys/survey-1/questions',
+      expect.anything(),
     );
-    const recreateIndex = apiClient.mock.calls.findIndex(
-      (call) =>
-        call[0] === 'POST' &&
-        call[1] === '/surveys/survey-1/questions' &&
-        call[2].body.prompt === '추가 질문',
-    );
-    expect(deleteIndex).toBeLessThan(recreateIndex);
-    const recreateBody = apiClient.mock.calls.find(
-      (call) =>
-        call[0] === 'POST' &&
-        call[1] === '/surveys/survey-1/questions' &&
-        call[2].body.prompt === '추가 질문',
+    // The backend clears trigger and depth alongside the parent, so sending
+    // them would be redundant — and sending a stale trigger would fight it.
+    const body = apiClient.mock.calls.find(
+      (call) => call[0] === 'PATCH' && call[1] === '/surveys/survey-1/questions/question-2',
     )?.[2].body;
-    expect(recreateBody).not.toHaveProperty('branch_parent_question_id');
-    expect(recreateBody).not.toHaveProperty('branch_trigger_option_key');
+    expect(body).not.toHaveProperty('branch_trigger_option_key');
   });
 
-  it('disables a question editor while removing its branch', async () => {
-    let resolveDelete: (() => void) | undefined;
+  it('stays editable through an unbranch, since the id no longer changes', async () => {
+    let resolvePatch: (() => void) | undefined;
     apiClient.mockImplementation((method: string, path: string) => {
-      if (method === 'DELETE' && path.endsWith('/question-2')) {
+      if (method === 'PATCH' && path.endsWith('/question-2')) {
         return new Promise((resolve) => {
-          resolveDelete = () => resolve({ data: {} });
+          resolvePatch = () => resolve({ data: { id: 'question-2' } });
         });
       }
-      return Promise.resolve({ data: { id: 'question-recreated' } });
+      return Promise.resolve({ data: { id: 'question-2' } });
     });
     const parentQuestion = survey.questions?.[0] as SurveyQuestion;
     const child: SurveyQuestion = {
@@ -287,74 +280,23 @@ describe('Survey screens', () => {
     );
     fireEvent.click(screen.getByText('Q2'));
     fireEvent.change(screen.getByLabelText('분기 부모 질문'), { target: { value: '' } });
-    await waitFor(() => expect(resolveDelete).toBeDefined());
+    await waitFor(() => expect(resolvePatch).toBeDefined());
+    // The busyQuestionIds lock existed only because the in-flight recreate
+    // invalidated the id an edit would target. With a stable id, edits during
+    // the request are ordinary follow-up PATCHes to the same row (#194).
     const title = screen.getByDisplayValue('추가 질문');
-    expect(title).toBeDisabled();
-    fireEvent.change(title, { target: { value: '삭제 중 수정' } });
-    expect(apiClient).not.toHaveBeenCalledWith(
-      'PATCH',
-      '/surveys/survey-1/questions/question-2',
-      expect.anything(),
-    );
-    await act(async () => resolveDelete?.());
-    await waitFor(() => expect(screen.getByDisplayValue('추가 질문')).not.toBeDisabled());
-  });
-
-  it('keeps the second question editor disabled while overlapping unbranch work is pending', async () => {
-    const resolveDelete = new Map<string, () => void>();
-    apiClient.mockImplementation((method: string, path: string) => {
-      if (method === 'DELETE') {
-        return new Promise((resolve) => {
-          resolveDelete.set(path, () => resolve({ data: {} }));
-        });
-      }
-      return Promise.resolve({ data: { id: 'question-recreated' } });
-    });
-    const parentQuestion = survey.questions?.[0] as SurveyQuestion;
-    const secondQuestion: SurveyQuestion = {
-      ...parentQuestion,
-      id: 'question-2',
-      prompt: '두 번째 질문',
-      branch_depth: 1,
-      branch_parent_question_id: 'question-1',
-      branch_trigger_option_key: 'no',
-      sort_order: 1,
-    };
-    const thirdQuestion: SurveyQuestion = {
-      ...secondQuestion,
-      id: 'question-3',
-      prompt: '세 번째 질문',
-      sort_order: 2,
-    };
-    renderWithQuery(
-      <SurveyBuilder
-        survey={{
-          ...survey,
-          questions: [...(survey.questions ?? []), secondQuestion, thirdQuestion],
-        }}
-        canManage
-        onBack={vi.fn()}
-      />,
-    );
-
-    fireEvent.click(screen.getByText('Q2'));
-    fireEvent.change(screen.getByLabelText('분기 부모 질문'), {
-      target: { value: '' },
-    });
+    expect(title).not.toBeDisabled();
+    fireEvent.change(title, { target: { value: '언브랜치 중 수정' } });
     await waitFor(() =>
-      expect(resolveDelete.get('/surveys/survey-1/questions/question-2')).toBeDefined(),
+      expect(apiClient).toHaveBeenCalledWith(
+        'PATCH',
+        '/surveys/survey-1/questions/question-2',
+        expect.objectContaining({
+          body: expect.objectContaining({ prompt: '언브랜치 중 수정' }),
+        }),
+      ),
     );
-    fireEvent.click(screen.getByText('Q3'));
-    fireEvent.change(screen.getByLabelText('분기 부모 질문'), {
-      target: { value: '' },
-    });
-    await waitFor(() =>
-      expect(resolveDelete.get('/surveys/survey-1/questions/question-3')).toBeDefined(),
-    );
-
-    await act(async () => resolveDelete.get('/surveys/survey-1/questions/question-2')?.());
-
-    expect(screen.getByDisplayValue('세 번째 질문')).toBeDisabled();
+    await act(async () => resolvePatch?.());
   });
 
   it('uses the selected parent option to reveal a branched preview question', async () => {

--- a/apps/frontend/src/features/surveys/types.ts
+++ b/apps/frontend/src/features/surveys/types.ts
@@ -39,7 +39,12 @@ export interface Survey {
   questions?: SurveyQuestion[];
 }
 
-/** Strict question-route input: absent optional fields must be omitted, never null. */
+/**
+ * Strict question-route input: absent optional fields must be omitted, never
+ * null. `branch_parent_question_id` is the one exception — the route reads
+ * `undefined` as "leave as is" and an explicit `null` as "clear the branch"
+ * (#192), so clearing a branch is the only case that may send a null.
+ */
 export interface QuestionInput {
   kind: QuestionKind;
   prompt: string;
@@ -50,6 +55,6 @@ export interface QuestionInput {
   rating_low_label?: string;
   rating_high_label?: string;
   sort_order?: number;
-  branch_parent_question_id?: string;
+  branch_parent_question_id?: string | null;
   branch_trigger_option_key?: string;
 }


### PR DESCRIPTION
Closes #194.

## Why the workaround existed, and why it can go

#188 shipped unbranching as DELETE + re-POST because the question route had no way to express "clear this field" — an omitted key means "leave as is". #192 gave PATCH `null`-clears-the-branch semantics; this uses them.

The workaround minted a **new question id** on every unbranch, and that is the only reason `busyQuestionIds` existed: an edit landing mid-flight would have targeted a row that no longer existed. With a stable id there is no window to guard, so the `Set`, its two state updates, and the editor lock all go with it.

## Payload shape

The PATCH sends `branch_parent_question_id: null` and **nothing else about the branch**. `normalized()` in `surveys/service.ts` derives `branchDepth` and `branchTriggerOptionKey` from the parent (`branchParent ? trigger : null`), so the backend clears both in the same statement — sending a stale trigger key would only fight it.

The explicit null is scoped to the clearing edit. Every other PATCH keeps the existing strict-payload discipline of omitting absent fields, which the `sends a strict PATCH payload` test still pins.

## Tests

- `recreates a persisted branched question…` → `clears a persisted branch with one PATCH and keeps the question id`, which also asserts DELETE and POST are **not** called.
- The two editor-lock tests described the workaround's failure mode. Replaced by one asserting the editor stays live through an in-flight unbranch and that a mid-flight edit reaches the same row.

Net −1 test (3 removed, 2 added).

## Verification

```
pnpm --filter frontend test             131 files / 651 passed
pnpm --filter frontend test:visual      38/38
pnpm --filter frontend typecheck        24 errors, all pre-existing on develop
pnpm --filter backend test:integration  126 files / 1138 passed, 0 failed
pnpm check:boundaries                   OK
```

Non-vacuity: dropping the null assignment fails the new unbranch test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BfiR55zJ7n8uYpr1s3X6q