### PR TITLE
feat(nav): GET /nav/counts for sidebar badges (#143 chunk 1)

### DIFF
--- a/apps/backend/src/modules/nav/AGENTS.md
+++ b/apps/backend/src/modules/nav/AGENTS.md
@@ -1,0 +1,15 @@
+# Navigation Read Model Agent Guide
+
+## Ownership
+
+Navigation owns the read-only aggregation that supplies sidebar badge counts.
+It does not own Dashboard action queues, domain records, or navigation layout.
+
+## Invariants
+
+- A count is obtained through the owning module's list predicate and caller read scope.
+- Do not emit a key without a real backing list filter.
+- `managed_system_id` narrows the same way as the backing list route.
+- A key may be absent only because it has no backing filter or because resolving its
+  backing list scope raises `permission.denied` or `permission.scope_required`.
+  Absence is permission-shaped and is not a zero count; unexpected failures propagate.

--- a/apps/backend/src/modules/nav/__tests__/nav-counts.integration.test.ts
+++ b/apps/backend/src/modules/nav/__tests__/nav-counts.integration.test.ts
@@ -1,0 +1,194 @@
+import type { FastifyInstance } from 'fastify';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import { loadConfig } from '../../../config.js';
+import { type DbHandle, createDb } from '../../../db/client.js';
+import { SESSION_COOKIE_NAME } from '../../../middleware/require-session.js';
+import { buildServer } from '../../../server.js';
+import { insertFindingRow } from '../../findings/__tests__/_seed-helpers.js';
+import {
+  cleanupReadTestTables,
+  grantCapability,
+  insertDevActor,
+  insertMsDirectly,
+  insertVocDirectly,
+  loginAs,
+  uid,
+} from '../../voc/__tests__/_seed-helpers.js';
+import { insertVocClusterRow } from '../../voc-clusters/__tests__/_seed-helpers.js';
+import { createNavCountsService } from '../service.js';
+
+const APP_URL = process.env.DATABASE_URL ?? '';
+const MIGRATE_URL = process.env.DATABASE_URL_MIGRATE ?? '';
+const WORKSPACE_ID = process.env.WORKSPACE_ID ?? '';
+const runIntegration = Boolean(APP_URL && MIGRATE_URL && WORKSPACE_ID);
+const PREFIX = 'it-nav-counts';
+
+describe.skipIf(!runIntegration)('GET /nav/counts (#143)', () => {
+  let dbHandle: DbHandle;
+  let migrateHandle: DbHandle;
+  let app: FastifyInstance;
+  let adminCookie: string;
+  let adminActorId: string;
+  let reporterId: string;
+
+  const headers = (cookie: string) => ({ cookie: `${SESSION_COOKIE_NAME}=${cookie}` });
+  const counts = async (cookie: string, query = '') => {
+    const response = await app.inject({ method: 'GET', url: `/nav/counts${query}`, headers: headers(cookie) });
+    return { response, body: response.json<{ counts: Record<string, number> }>() };
+  };
+
+  beforeAll(async () => {
+    process.env.NODE_ENV = 'test';
+    dbHandle = createDb(APP_URL);
+    migrateHandle = createDb(MIGRATE_URL);
+    app = await buildServer({ config: loadConfig(), dbHandle });
+    await app.ready();
+    adminCookie = await loginAs(app, 'mock-admin-1');
+    const actors = await dbHandle.pool.query<{ id: string }>(
+      `select id from core.actors where external_id = 'mock-admin-1' and workspace_id = $1`, [WORKSPACE_ID],
+    );
+    adminActorId = actors.rows[0]!.id;
+    reporterId = (await dbHandle.pool.query<{ id: string }>(
+      `select id from core.actors where external_id = 'mock-user-1' and workspace_id = $1`, [WORKSPACE_ID],
+    )).rows[0]!.id;
+  });
+
+  async function cleanupNavFixtures() {
+    const managedSystems = `select id from core.managed_systems where workspace_id = $1 and slug like $2`;
+    await migrateHandle.pool.query(
+      `delete from finding.findings where workspace_id = $1 and primary_managed_system_id in (${managedSystems})`,
+      [WORKSPACE_ID, `${PREFIX}%`],
+    );
+    await migrateHandle.pool.query(
+      `delete from voc_cluster.voc_clusters where workspace_id = $1 and primary_managed_system_id in (${managedSystems})`,
+      [WORKSPACE_ID, `${PREFIX}%`],
+    );
+    await migrateHandle.pool.query(
+      `delete from survey.surveys where workspace_id = $1 and primary_managed_system_id in (${managedSystems})`,
+      [WORKSPACE_ID, `${PREFIX}%`],
+    );
+    await cleanupReadTestTables(dbHandle, WORKSPACE_ID, PREFIX);
+  }
+
+  beforeEach(cleanupNavFixtures);
+  afterAll(async () => {
+    await cleanupNavFixtures();
+    await app?.close();
+    await dbHandle?.close();
+    await migrateHandle?.close();
+  });
+
+  it('agrees with inbox, triage, and high-tab list totals', async () => {
+    const ms = await insertMsDirectly(dbHandle, WORKSPACE_ID, `${PREFIX}-agreement`, 'Navigation agreement');
+    await insertVocDirectly(dbHandle, WORKSPACE_ID, ms, reporterId, 'high unassigned', { severity: 'high' });
+    await insertVocDirectly(dbHandle, WORKSPACE_ID, ms, reporterId, 'triaged high', { severity: 'high', triageState: 'triaged' });
+    const badge = await counts(adminCookie);
+    expect(badge.response.statusCode).toBe(200);
+    for (const [url, key] of [
+      ['/vocs?view=inbox', 'voc.inbox'],
+      ['/vocs?view=triage', 'voc.triage'],
+      ['/vocs?view=inbox&tab=high', 'voc.tab.high'],
+    ] as const) {
+      const list = await app.inject({ method: 'GET', url, headers: headers(adminCookie) });
+      expect(list.statusCode).toBe(200);
+      expect(badge.body.counts[key]).toBe(list.json<{ items: unknown[] }>().items.length);
+    }
+  });
+
+  it('filters counts to each actor read scope', async () => {
+    const msA = await insertMsDirectly(dbHandle, WORKSPACE_ID, `${PREFIX}-scope-a`, 'Scope A');
+    const msB = await insertMsDirectly(dbHandle, WORKSPACE_ID, `${PREFIX}-scope-b`, 'Scope B');
+    await insertVocDirectly(dbHandle, WORKSPACE_ID, msA, reporterId, 'visible to developer');
+    await insertVocDirectly(dbHandle, WORKSPACE_ID, msB, reporterId, 'hidden from developer');
+    const dev = await insertDevActor(dbHandle, WORKSPACE_ID, uid('nav-counts'));
+    await grantCapability(dbHandle, WORKSPACE_ID, dev.id, 'voc.read', msA, adminActorId);
+    const devCookie = await loginAs(app, dev.externalId);
+    const admin = await counts(adminCookie);
+    const scoped = await counts(devCookie);
+    expect(admin.response.statusCode).toBe(200);
+    expect(scoped.response.statusCode).toBe(200);
+    if (admin.response.statusCode !== 200 || scoped.response.statusCode !== 200) return;
+    expect(admin.body.counts['voc.inbox']).toBeGreaterThan(scoped.body.counts['voc.inbox']!);
+    expect(scoped.body.counts['voc.inbox']).toBe(1);
+    expect(scoped.body.counts['voc.triage']).toBeUndefined();
+    expect(Object.hasOwn(scoped.body.counts, 'voc.triage')).toBe(false);
+    expect(Object.hasOwn(admin.body.counts, 'voc.triage')).toBe(true);
+  });
+
+  it('narrows by managed_system_id and rejects an invalid value', async () => {
+    const msA = await insertMsDirectly(dbHandle, WORKSPACE_ID, `${PREFIX}-narrow-a`, 'Narrow A');
+    const msB = await insertMsDirectly(dbHandle, WORKSPACE_ID, `${PREFIX}-narrow-b`, 'Narrow B');
+    await insertVocDirectly(dbHandle, WORKSPACE_ID, msA, reporterId, 'A');
+    await insertVocDirectly(dbHandle, WORKSPACE_ID, msB, reporterId, 'B');
+    const all = await counts(adminCookie);
+    const narrowed = await counts(adminCookie, `?managed_system_id=${msA}`);
+    expect(all.body.counts['voc.inbox']).toBeGreaterThan(narrowed.body.counts['voc.inbox']!);
+    expect(narrowed.body.counts['voc.inbox']).toBe(1);
+    const invalid = await app.inject({ method: 'GET', url: '/nav/counts?managed_system_id=not-a-uuid', headers: headers(adminCookie) });
+    expect(invalid.statusCode).toBe(422);
+    expect(invalid.json<{ code: string }>().code).toBe('validation.failed');
+  });
+
+  it('omits keys with no backing filter instead of returning a stub zero', async () => {
+    const result = await counts(adminCookie);
+    expect(result.response.statusCode).toBe(200);
+    expect(Object.hasOwn(result.body.counts, 'voc.tab.similar')).toBe(false);
+    expect(Object.hasOwn(result.body.counts, 'tasks.board')).toBe(false);
+  });
+
+  it('emits backed domain counts from seeded findings, surveys, and clusters', async () => {
+    const ms = await insertMsDirectly(dbHandle, WORKSPACE_ID, `${PREFIX}-domain-counts`, 'Domain counts');
+    const voc = await insertVocDirectly(dbHandle, WORKSPACE_ID, ms, reporterId, 'domain count source');
+    await insertFindingRow(dbHandle, {
+      workspaceId: WORKSPACE_ID,
+      primaryManagedSystemId: ms,
+      sourceId: voc.id,
+      createdBy: adminActorId,
+    });
+    await insertVocClusterRow(dbHandle, {
+      workspaceId: WORKSPACE_ID,
+      primaryManagedSystemId: ms,
+      createdBy: adminActorId,
+    });
+    await dbHandle.pool.query(
+      `insert into survey.surveys (
+        workspace_id, display_id, type, status, title, primary_managed_system_id,
+        operator_actor_id, responses_identity_protected, created_by, opened_at
+      ) values ($1, 'S-nav-counts', 'validation', 'open', 'Navigation count survey', $2, $3, true, $3, now())`,
+      [WORKSPACE_ID, ms, adminActorId],
+    );
+
+    const result = await counts(adminCookie);
+    expect(result.response.statusCode).toBe(200);
+    expect(result.body.counts['findings.all']).toBe(1);
+    expect(result.body.counts['surveys.all']).toBe(1);
+    expect(result.body.counts['voc.clusters']).toBe(1);
+  });
+
+  it('surfaces an unexpected VOC count failure as an error response', async () => {
+    const failingNavCountsService = createNavCountsService({
+      vocReadService: {
+        async countVocs() {
+          throw new Error('injected VOC count failure');
+        },
+      },
+      findingsService: { listFindings: async () => ({ items: [] }) },
+      surveysService: { listSurvey: async () => [] },
+      vocClustersService: { listClusters: async () => ({ items: [] }) },
+    });
+    const failingApp = await buildServer({
+      config: loadConfig(),
+      dbHandle,
+      navCountsService: failingNavCountsService,
+    });
+    await failingApp.ready();
+    try {
+      const response = await failingApp.inject({ method: 'GET', url: '/nav/counts', headers: headers(adminCookie) });
+      expect(response.statusCode).toBe(500);
+      expect(response.json<{ code: string }>().code).toBe('internal.unexpected');
+    } finally {
+      await failingApp.close();
+    }
+  });
+});

--- a/apps/backend/src/modules/nav/index.ts
+++ b/apps/backend/src/modules/nav/index.ts
@@ -1,0 +1,2 @@
+export { navRoutes } from './routes.js';
+export { createNavCountsService, type NavCountsService } from './service.js';

--- a/apps/backend/src/modules/nav/routes.ts
+++ b/apps/backend/src/modules/nav/routes.ts
@@ -1,0 +1,38 @@
+import type { FastifyPluginAsync } from 'fastify';
+import { z } from 'zod';
+
+import { fieldsFromZodIssues, sendError } from '../../lib/errors.js';
+import { requireSession } from '../../middleware/require-session.js';
+import { requireWorkspace } from '../../middleware/require-workspace.js';
+import type { SessionService } from '../auth/session-service.js';
+import type { NavCountsService } from './service.js';
+
+const querySchema = z.object({ managed_system_id: z.string().uuid().optional() });
+
+export const navRoutes: FastifyPluginAsync<{
+  sessionService: SessionService;
+  navCountsService: NavCountsService;
+  workspaceId: string;
+  rateLimitConfig?: { read?: Record<string, unknown> };
+}> = async (app, opts) => {
+  app.get('/nav/counts', {
+    preHandler: [requireSession(opts.sessionService), requireWorkspace(opts.workspaceId)],
+    ...(opts.rateLimitConfig?.read ? { config: { rateLimit: opts.rateLimitConfig.read as never } } : {}),
+  }, async (req, reply) => {
+    const parsed = querySchema.safeParse(req.query);
+    if (!parsed.success) {
+      return sendError(reply, 'validation.failed', 'invalid query parameters', {
+        fields: fieldsFromZodIssues(parsed.error.issues),
+      });
+    }
+    const session = req.session;
+    if (!session) throw new Error('session missing after middleware');
+    return reply.header('cache-control', 'private, no-cache').send({
+      counts: await opts.navCountsService.getCounts({
+        actor_id: session.actor_id,
+        workspace_id: session.workspace_id,
+        role_level: session.role_level,
+      }, parsed.data.managed_system_id),
+    });
+  });
+};

--- a/apps/backend/src/modules/nav/service.ts
+++ b/apps/backend/src/modules/nav/service.ts
@@ -1,0 +1,70 @@
+import { HttpError } from '../../lib/errors.js';
+import type { CountVocsQuery } from '../voc/read-service.js';
+
+export interface NavActor {
+  actor_id: string;
+  workspace_id: string;
+  role_level: 'admin' | 'developer' | 'user';
+}
+
+type NavCountsDeps = {
+  vocReadService: {
+    countVocs(args: { actor: NavActor; query: CountVocsQuery }): Promise<number>;
+  };
+  findingsService: {
+    listFindings(args: { actor: NavActor; managedSystemId?: string }): Promise<{ items: readonly unknown[] }>;
+  };
+  surveysService: {
+    listSurvey(actor: NavActor, managedSystemId?: string): Promise<readonly unknown[]>;
+  };
+  vocClustersService: {
+    listClusters(args: { actor: NavActor; managedSystemId?: string }): Promise<{ items: readonly unknown[] }>;
+  };
+};
+
+function isAuthorizationAbsence(error: unknown): error is HttpError {
+  return error instanceof HttpError
+    && (error.code === 'permission.denied' || error.code === 'permission.scope_required');
+}
+
+export function createNavCountsService(deps: NavCountsDeps) {
+  async function getCounts(actor: NavActor, managedSystemId?: string): Promise<Record<string, number>> {
+    const query = (view: CountVocsQuery['view'], tab?: CountVocsQuery['tab']): CountVocsQuery => ({
+      view,
+      ...(managedSystemId !== undefined ? { managed_system_id: managedSystemId } : {}),
+      ...(tab !== undefined ? { tab } : {}),
+    });
+    const count = (view: CountVocsQuery['view'], tab?: CountVocsQuery['tab']) =>
+      deps.vocReadService.countVocs({ actor, query: query(view, tab) });
+    const vocCountEntries = [
+      ['voc.inbox', 'inbox'],
+      ['voc.triage', 'triage'],
+      ['voc.my', 'my'],
+      ['voc.tab.high', 'inbox', 'high'],
+      ['voc.tab.unassigned', 'inbox', 'unassigned'],
+      ['voc.tab.no-link', 'inbox', 'no-link'],
+    ] as const;
+    const vocCounts = Object.fromEntries((await Promise.all(vocCountEntries.map(async ([key, view, tab]) => {
+      try {
+        return [key, await count(view, tab)] as const;
+      } catch (error) {
+        if (isAuthorizationAbsence(error)) return undefined;
+        throw error;
+      }
+    }))).flatMap((entry) => entry === undefined ? [] : [entry]));
+    const [findings, surveys, vocClusters] = await Promise.all([
+      deps.findingsService.listFindings({ actor, ...(managedSystemId ? { managedSystemId } : {}) }),
+      deps.surveysService.listSurvey(actor, managedSystemId),
+      deps.vocClustersService.listClusters({ actor, ...(managedSystemId ? { managedSystemId } : {}) }),
+    ]);
+    return {
+      ...vocCounts,
+      'findings.all': findings.items.length,
+      'surveys.all': surveys.length,
+      'voc.clusters': vocClusters.items.length,
+    };
+  }
+  return { getCounts };
+}
+
+export type NavCountsService = ReturnType<typeof createNavCountsService>;

--- a/apps/backend/src/modules/voc/read-service.ts
+++ b/apps/backend/src/modules/voc/read-service.ts
@@ -49,6 +49,9 @@ export interface ReadActorContext {
   role_level: 'admin' | 'developer' | 'user';
 }
 
+/** Count queries share list filters, but pagination is list-only. */
+export type CountVocsQuery = Omit<ListVocsQuery, 'limit'>;
+
 // ── Inline conversation cursor (conversation-specific; separate from VOC list cursor) ──
 
 interface ConversationCursor {
@@ -200,9 +203,100 @@ function intersectScopes(a: Scope, b: Scope): Scope {
   return { kind: 'all' };
 }
 
+type ResolvedVocListScope = {
+  scopeFilter: Scope;
+  actorIdForMyFilter?: string;
+};
+
+/** Shared view-to-scope decision for VOC lists and their navigation counts. */
+function resolveVocListScope(args: {
+  actor: ReadActorContext;
+  query: Pick<ListVocsQuery, 'view' | 'managed_system_id'>;
+  readScope: Scope;
+  triageScope: Scope | undefined;
+}): ResolvedVocListScope {
+  const { actor, query, readScope, triageScope } = args;
+  const { view, managed_system_id } = query;
+
+  if (view === 'my') {
+    if (managed_system_id === 'all') {
+      throw new HttpError('validation.failed', 'managed_system_id=all not allowed for view=my', {
+        fields: [{ path: ['managed_system_id'], code: 'invalid' }],
+      });
+    }
+    return {
+      scopeFilter: managed_system_id && managed_system_id !== 'all'
+        ? { kind: 'scoped', managedSystemIds: [managed_system_id] }
+        : { kind: 'all' },
+      actorIdForMyFilter: actor.actor_id,
+    };
+  }
+
+  if (view === 'inbox') {
+    if (readScope.kind === 'scoped' && readScope.managedSystemIds.length === 0) {
+      if (actor.role_level === 'developer') {
+        throw new HttpError('permission.scope_required', 'voc.read capability required; developer needs MS-scoped grant', {
+          requiredScope: [],
+          requestable_permission: { permission: 'voc.read', managed_system_id: null },
+        });
+      }
+      throw new HttpError('permission.denied', 'no voc.read scope for actor', { reason: 'no_grant' });
+    }
+    if (managed_system_id && managed_system_id !== 'all') {
+      if (!msInScope(readScope, managed_system_id)) {
+        throw new HttpError('permission.scope_required', 'managed_system_id not in voc.read scope', {
+          requiredScope: [managed_system_id],
+          requestable_permission: { permission: 'voc.read', managed_system_id },
+        });
+      }
+      return { scopeFilter: { kind: 'scoped', managedSystemIds: [managed_system_id] } };
+    }
+    return { scopeFilter: readScope };
+  }
+
+  const intersected = intersectScopes(readScope, triageScope!);
+  if (intersected.kind === 'scoped' && intersected.managedSystemIds.length === 0) {
+    throw new HttpError('permission.denied', 'no voc.triage scope for actor', {
+      requestable_permission: { permission: 'voc.triage', managed_system_id: null },
+    });
+  }
+  if (managed_system_id && managed_system_id !== 'all') {
+    if (!msInScope(intersected, managed_system_id)) {
+      throw new HttpError('permission.scope_required', 'managed_system_id not in voc.triage scope', {
+        requiredScope: [managed_system_id],
+        requestable_permission: { permission: 'voc.triage', managed_system_id },
+      });
+    }
+    return { scopeFilter: { kind: 'scoped', managedSystemIds: [managed_system_id] } };
+  }
+  return { scopeFilter: intersected };
+}
+
 // ── Service factory ──────────────────────────────────────────────────────────
 
 export function createVocReadService(deps: VocReadServiceDeps) {
+  async function countVocs(args: { actor: ReadActorContext; query: CountVocsQuery }): Promise<number> {
+    const { actor, query } = args;
+    const { view, tab } = query;
+    if (tab === 'waiting' && view !== 'triage') {
+      throw new HttpError('validation.failed', 'tab=waiting is only valid for view=triage', {
+        fields: [{ path: ['tab'], code: 'invalid_for_view' }],
+      });
+    }
+    const [readScope, triageScope] = await Promise.all([
+      repoRead.actorReadScope(deps.db, actor),
+      view === 'triage' ? repoRead.actorTriageScope(deps.db, actor) : Promise.resolve(undefined),
+    ]);
+    const { scopeFilter, actorIdForMyFilter } = resolveVocListScope({ actor, query, readScope, triageScope });
+    return repoRead.countVocsForRead(deps.db, {
+      workspaceId: actor.workspace_id,
+      scopeFilter,
+      view,
+      ...(actorIdForMyFilter !== undefined ? { actorIdForMyFilter } : {}),
+      ...(tab !== undefined ? { tab } : {}),
+    });
+  }
+
   // ── listVocs ───────────────────────────────────────────────────────────────
 
   async function listVocs(args: {
@@ -257,14 +351,7 @@ export function createVocReadService(deps: VocReadServiceDeps) {
       decodedCursor = { sv: cursor.sv, id: cursor.id };
     }
 
-    // ── 5. view=my: reject managed_system_id='all' ────────────────────────────
-    if (view === 'my' && managed_system_id === 'all') {
-      throw new HttpError('validation.failed', 'managed_system_id=all not allowed for view=my', {
-        fields: [{ path: ['managed_system_id'], code: 'invalid' }],
-      });
-    }
-
-    // ── 6. Resolve scopes (skip triageScope for non-triage views) ─────────────
+    // ── 5. Resolve scopes (skip triageScope for non-triage views) ─────────────
     let readScope: Scope;
     let effectiveScope: Scope;
     let triageScope: Scope | undefined;
@@ -282,101 +369,15 @@ export function createVocReadService(deps: VocReadServiceDeps) {
       ]);
     }
 
-    // ── 7. View-specific scope validation + scope filter selection ─────────────
-    let scopeFilter: Scope;
-    let actorIdForMyFilter: string | undefined;
+    // ── 6. Resolve view-specific scope and validation ─────────────────────────
+    const { scopeFilter, actorIdForMyFilter } = resolveVocListScope({
+      actor,
+      query,
+      readScope,
+      triageScope,
+    });
 
-    if (view === 'my') {
-      // No scope filter for 'my' view (reporter_id filter is applied in repo).
-      // Allow managed_system_id=<uuid> narrowing.
-      if (managed_system_id && managed_system_id !== 'all') {
-        scopeFilter = { kind: 'scoped', managedSystemIds: [managed_system_id] };
-      } else {
-        scopeFilter = { kind: 'all' };
-      }
-      actorIdForMyFilter = actor.actor_id;
-    } else if (view === 'inbox') {
-      // Validate read scope is non-empty.
-      if (readScope.kind === 'scoped' && readScope.managedSystemIds.length === 0) {
-        if (actor.role_level === 'developer') {
-          throw new HttpError(
-            'permission.scope_required',
-            'voc.read capability required; developer needs MS-scoped grant',
-            {
-              requiredScope: [],
-              requestable_permission: {
-                permission: 'voc.read',
-                managed_system_id: null,
-              },
-            },
-          );
-        }
-        throw new HttpError(
-          'permission.denied',
-          'no voc.read scope for actor',
-          { reason: 'no_grant' },
-        );
-      }
-
-      // managed_system_id narrowing for inbox view.
-      if (managed_system_id && managed_system_id !== 'all') {
-        // Must be in actor's read scope.
-        if (!msInScope(readScope, managed_system_id)) {
-          throw new HttpError(
-            'permission.scope_required',
-            'managed_system_id not in voc.read scope',
-            {
-              requiredScope: [managed_system_id],
-              requestable_permission: {
-                permission: 'voc.read',
-                managed_system_id,
-              },
-            },
-          );
-        }
-        scopeFilter = { kind: 'scoped', managedSystemIds: [managed_system_id] };
-      } else {
-        scopeFilter = readScope;
-      }
-    } else {
-      // view === 'triage'
-      const tScope = triageScope!;
-      const intersected = intersectScopes(readScope, tScope);
-      if (intersected.kind === 'scoped' && intersected.managedSystemIds.length === 0) {
-        throw new HttpError(
-          'permission.denied',
-          'no voc.triage scope for actor',
-          {
-            requestable_permission: {
-              permission: 'voc.triage',
-              managed_system_id: null,
-            },
-          },
-        );
-      }
-
-      // managed_system_id narrowing for triage view.
-      if (managed_system_id && managed_system_id !== 'all') {
-        if (!msInScope(intersected, managed_system_id)) {
-          throw new HttpError(
-            'permission.scope_required',
-            'managed_system_id not in voc.triage scope',
-            {
-              requiredScope: [managed_system_id],
-              requestable_permission: {
-                permission: 'voc.triage',
-                managed_system_id,
-              },
-            },
-          );
-        }
-        scopeFilter = { kind: 'scoped', managedSystemIds: [managed_system_id] };
-      } else {
-        scopeFilter = intersected;
-      }
-    }
-
-    // ── 8. Call repo ──────────────────────────────────────────────────────────
+    // ── 7. Call repo ──────────────────────────────────────────────────────────
     const repoArgs: repoRead.ListVocsRepoArgs = {
       workspaceId: actor.workspace_id,
       scopeFilter,
@@ -831,7 +832,7 @@ export function createVocReadService(deps: VocReadServiceDeps) {
     };
   }
 
-  return { listVocs, getVocDetail, getConversation, composeDetailEnvelope };
+  return { listVocs, countVocs, getVocDetail, getConversation, composeDetailEnvelope };
 }
 
 export type VocReadService = ReturnType<typeof createVocReadService>;

--- a/apps/backend/src/modules/voc/repo-read.ts
+++ b/apps/backend/src/modules/voc/repo-read.ts
@@ -146,6 +146,69 @@ export interface ListVocsRepoArgs {
   limit: number;
 }
 
+type VocListPredicateArgs = Omit<ListVocsRepoArgs, 'sort' | 'cursor' | 'limit'>;
+
+/**
+ * The canonical list/count predicate.  Keep navigation counts on this path so
+ * a badge cannot silently drift from the corresponding VOC list.
+ */
+export function buildVocListPredicate(args: VocListPredicateArgs): ReturnType<typeof sql>[] | null {
+  const {
+    workspaceId,
+    scopeFilter,
+    view,
+    actorIdForMyFilter,
+    tab,
+    filterSeverity,
+    filterReporterFacingStatus,
+    filterOwner,
+  } = args;
+  if (scopeFilter.kind === 'scoped' && scopeFilter.managedSystemIds.length === 0) return null;
+  if (tab === 'similar') return null;
+
+  const wheres: ReturnType<typeof sql>[] = [
+    sql`workspace_id = ${workspaceId}`,
+    sql`archived_at IS NULL`,
+  ];
+  if (scopeFilter.kind === 'scoped') {
+    wheres.push(sql`primary_managed_system_id = ANY(${sqlUuidArray(scopeFilter.managedSystemIds)})`);
+  }
+  if (view === 'my') {
+    if (!actorIdForMyFilter) throw new Error('actorIdForMyFilter required for view=my');
+    wheres.push(sql`reporter_id = ${actorIdForMyFilter}`);
+  } else if (view === 'triage') {
+    wheres.push(sql`triage_state IN ('untriaged','needs_more_information')`);
+  }
+  if (tab === 'untriaged') wheres.push(sql`triage_state = 'untriaged'`);
+  else if (tab === 'high') wheres.push(sql`severity = 'high'`);
+  else if (tab === 'unassigned') wheres.push(sql`owner_user_id IS NULL AND owner_team_id IS NULL`);
+  else if (tab === 'waiting') wheres.push(sql`triage_state = 'untriaged' AND triage_state_review_postponed_at IS NOT NULL`);
+  else if (tab === 'no-link') {
+    wheres.push(sql`NOT EXISTS (
+      SELECT 1 FROM ${entityLinks} el
+      WHERE el.workspace_id = ${workspaceId} AND el.status = 'active'
+        AND ((el.source_type = 'voc' AND el.source_id = ${vocs.id})
+          OR (el.target_type = 'voc' AND el.target_id = ${vocs.id}))
+    )`);
+  }
+  if (filterSeverity && filterSeverity.length > 0) wheres.push(sql`severity = ANY(${sqlTextArray(filterSeverity)})`);
+  if (filterReporterFacingStatus && filterReporterFacingStatus.length > 0) {
+    wheres.push(sql`reporter_facing_status = ANY(${sqlTextArray(filterReporterFacingStatus)})`);
+  }
+  if (filterOwner === 'assigned') wheres.push(sql`(owner_user_id IS NOT NULL OR owner_team_id IS NOT NULL)`);
+  else if (filterOwner === 'unassigned') wheres.push(sql`owner_user_id IS NULL AND owner_team_id IS NULL`);
+  return wheres;
+}
+
+export async function countVocsForRead(db: Db | Tx, args: VocListPredicateArgs): Promise<number> {
+  const wheres = buildVocListPredicate(args);
+  if (wheres === null) return 0;
+  const result = await (db as Db).execute<{ count: number | string }>(sql`
+    SELECT count(*)::int AS count FROM ${vocs} WHERE ${sql.join(wheres, sql` AND `)}
+  `);
+  return Number(result.rows[0]?.count ?? 0);
+}
+
 // Utility: normalise raw postgres row dates.
 function toDate(v: Date | string): Date {
   return v instanceof Date ? v : new Date(v);
@@ -199,72 +262,8 @@ export async function listVocsForRead(
 ): Promise<{ rows: VocReadRow[]; hasMore: boolean; nextCursor: { sv: string | number; id: string } | null }> {
   const { workspaceId, scopeFilter, view, actorIdForMyFilter, tab, filterSeverity, filterReporterFacingStatus, filterOwner, sort, cursor, limit } = args;
 
-  // Short-circuit: empty scoped list → no rows possible, skip DB query.
-  if (scopeFilter.kind === 'scoped' && scopeFilter.managedSystemIds.length === 0) {
-    return { rows: [], hasMore: false, nextCursor: null };
-  }
-
-  // tab='similar' → WHERE false (Slice 3; cluster service not available).
-  if (tab === 'similar') {
-    return { rows: [], hasMore: false, nextCursor: null };
-  }
-
-  // Build the WHERE clauses via raw SQL fragments.
-  // All values are bound via parameterised sql`` tags — never string-interpolated.
-  const wheres: ReturnType<typeof sql>[] = [
-    sql`workspace_id = ${workspaceId}`,
-    sql`archived_at IS NULL`,
-  ];
-
-  // Scope filter.
-  if (scopeFilter.kind === 'scoped') {
-    wheres.push(sql`primary_managed_system_id = ANY(${sqlUuidArray(scopeFilter.managedSystemIds)})`);
-  }
-
-  // View-specific filters.
-  if (view === 'my') {
-    if (!actorIdForMyFilter) throw new Error('actorIdForMyFilter required for view=my');
-    wheres.push(sql`reporter_id = ${actorIdForMyFilter}`);
-  } else if (view === 'triage') {
-    wheres.push(sql`triage_state IN ('untriaged','needs_more_information')`);
-  }
-
-  // Tab filters.
-  if (tab === 'untriaged') {
-    wheres.push(sql`triage_state = 'untriaged'`);
-  } else if (tab === 'high') {
-    wheres.push(sql`severity = 'high'`);
-  } else if (tab === 'unassigned') {
-    wheres.push(sql`owner_user_id IS NULL AND owner_team_id IS NULL`);
-  } else if (tab === 'waiting') {
-    // Only valid for triage view; no extra clause beyond the triage_state filter
-    // since service layer validates view=triage for this tab.
-    wheres.push(sql`triage_state = 'untriaged' AND triage_state_review_postponed_at IS NOT NULL`);
-  } else if (tab === 'no-link') {
-    wheres.push(sql`NOT EXISTS (
-      SELECT 1
-      FROM ${entityLinks} el
-      WHERE el.workspace_id = ${workspaceId}
-        AND el.status = 'active'
-        AND (
-          (el.source_type = 'voc' AND el.source_id = ${vocs.id})
-          OR (el.target_type = 'voc' AND el.target_id = ${vocs.id})
-        )
-    )`);
-  }
-
-  // Scalar column filters.
-  if (filterSeverity && filterSeverity.length > 0) {
-    wheres.push(sql`severity = ANY(${sqlTextArray(filterSeverity)})`);
-  }
-  if (filterReporterFacingStatus && filterReporterFacingStatus.length > 0) {
-    wheres.push(sql`reporter_facing_status = ANY(${sqlTextArray(filterReporterFacingStatus)})`);
-  }
-  if (filterOwner === 'assigned') {
-    wheres.push(sql`(owner_user_id IS NOT NULL OR owner_team_id IS NOT NULL)`);
-  } else if (filterOwner === 'unassigned') {
-    wheres.push(sql`owner_user_id IS NULL AND owner_team_id IS NULL`);
-  }
+  const wheres = buildVocListPredicate(args);
+  if (wheres === null) return { rows: [], hasMore: false, nextCursor: null };
 
   // Determine sort order and cursor predicate.
   // triage_pinned uses a server-pinned composite sort; others use SORT_CONFIG.

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -38,6 +38,7 @@ import {
   createManagedSystemService,
   managedSystemsRoutes,
 } from './modules/managed-systems/index.js';
+import { createNavCountsService, navRoutes, type NavCountsService } from './modules/nav/index.js';
 import {
   createCheckService,
   createDecisionService,
@@ -82,6 +83,8 @@ export interface BuildServerOptions {
    * production this is undefined and `getStorage()` builds the singleton.
    */
   storage?: StorageBackend;
+  /** Route-test seam; production constructs the navigation read model below. */
+  navCountsService?: NavCountsService;
 }
 
 export async function buildServer(opts: BuildServerOptions): Promise<FastifyInstance> {
@@ -592,6 +595,18 @@ export async function buildServer(opts: BuildServerOptions): Promise<FastifyInst
       mutation: app.rateLimitConfig.mutation,
       read: app.rateLimitConfig.read,
     },
+  });
+  const navCountsService = opts.navCountsService ?? createNavCountsService({
+    vocReadService,
+    findingsService,
+    surveysService,
+    vocClustersService,
+  });
+  await app.register(navRoutes, {
+    sessionService,
+    navCountsService,
+    workspaceId,
+    rateLimitConfig: { read: app.rateLimitConfig.read },
   });
 
   const vocRecommendationsService = createVocRecommendationsService({

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -18,6 +18,8 @@ export default defineConfig({
       // Slice 1 #3: auth endpoints + the /me identity probe live at root.
       '/auth': 'http://127.0.0.1:3011',
       '/me': 'http://127.0.0.1:3011',
+      // #143 navigation badge counts are a backend-only root path.
+      '/nav': 'http://127.0.0.1:3011',
       // #197 workspace policy endpoints are backend-only root paths, so
       // forward them unconditionally in development.
       '/workspace': 'http://127.0.0.1:3011',

--- a/docs/implementation/03-api-contracts.md
+++ b/docs/implementation/03-api-contracts.md
@@ -34,6 +34,26 @@ Detailed endpoint schemas may later move into OpenAPI, but this document remains
 - Rich content fields must reference inline images through attachment IDs, not base64 body data or external image URLs.
 ```
 
+## Navigation Count Contract
+
+`GET /nav/counts`
+
+- Authenticated, workspace-scoped read endpoint returning `{ counts: Record<string, integer> }`.
+- Optional `managed_system_id` is a UUID and narrows each emitted count through the same
+  predicate and resolved read scope as its backing list route. Invalid values return
+  `validation.failed` (422).
+- Currently emitted keys are `voc.inbox`, `voc.triage`, `voc.my`, `voc.tab.high`,
+  `voc.tab.unassigned`, `voc.tab.no-link`, `voc.clusters`, `findings.all`, and
+  `surveys.all`. The VOC keys use the shared VOC list predicate; the other keys
+  call their owning list read services. A key is absent only when it has no backing
+  list filter or when scope resolution returns the expected `permission.denied` or
+  `permission.scope_required` authorization outcome. An absent key is not zero and
+  may be permission-shaped; any unexpected failure propagates as an error response
+  rather than omitting the key.
+- `voc.tab.similar` is deliberately absent because that list tab has no backing query.
+- A key without a backing list filter is omitted rather than represented by a synthetic zero.
+- Read-only endpoint: no audit event, entity-link mutation, or dashboard queue side effect.
+
 ## Standard Error Codes
 
 ```text


### PR DESCRIPTION
Chunk 1 of #143 (GlobalRail multi-domain IA). Supplies the per-nav-item counts the sidebar badges render.

## Why it is shaped this way

A badge that disagrees with the list it labels is worse than no badge, so counts reuse the list path instead of restating it:

- `resolveVocListScope` extracted from `listVocs`, shared with the new `countVocs`
- `buildVocListPredicate` shared at the repository layer
- `countVocsForRead` runs `SELECT count(*)`; the count input is `Omit<ListVocsQuery, 'limit'>` so pagination cannot be implied where it does not apply

The scope decision tree is the half that matters most: a divergence there would leak how many records an actor is not allowed to see.

## Contract — an absent key is not zero

A key is absent for exactly two deliberate reasons: it has no backing filter, or the caller is not authorized for it. An unexpected failure produces an error response rather than a missing badge. The authorization branch matches the typed `HttpError` codes the scope resolution already raises, so an unrelated failure can never be reclassified as "not permitted".

**Consumers must not fall back to `0` for an absent key** — render no badge.

Emitted: `voc.inbox`, `voc.triage`, `voc.my`, `voc.tab.{high,unassigned,no-link}`, `voc.clusters`, `findings.all`, `surveys.all`.

Omitted deliberately: `voc.tab.similar` has no backing query; `tasks.*` have no `managed_system_id` filter, so their counts would disagree with their own lists under the scope selector.

## Verification (host)

| Check | Result |
|---|---|
| Backend integration gate | 127 files / 1144 passed / 0 failed (baseline 126 / 1138) |
| Backend `tsc --noEmit` | 3 errors — unchanged from develop baseline |
| Mutation: swallow `findings.all` | killed |
| Mutation: ignore `managed_system_id` | killed |
| Mutation: classifier catches everything | killed |
| Mutation: classifier omits nothing | killed |

Design review for #143 was completed with the user against the rendered prototype: 6 rails (no `home` route exists), scope selector = Managed System filter, sidebar tree stays an FE constant with the backend supplying counts only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BfiR55zJ7n8uYpr1s3X6q