### PR TITLE
feat(dashboard): GET /dashboard/summary — action queues, coverage, KPI strip (#217)

### DIFF
--- a/apps/backend/migrations/0046_dashboard_survey_gap_aggregate.sql
+++ b/apps/backend/migrations/0046_dashboard_survey_gap_aggregate.sql
@@ -1,0 +1,81 @@
+-- Existing environments must run these prerequisites before applying this migration:
+--   CREATE ROLE fops_survey_aggregate_owner WITH NOLOGIN NOINHERIT;
+--   GRANT fops_survey_aggregate_owner TO fops_migrate;
+-- See scripts/db/init.sql for the empty-database bootstrap equivalent.
+--
+-- Issue #217: dashboard outcome-follow-up counts remain aggregate-only. Text
+-- answer bodies and response identities must never cross this privilege boundary.
+
+-- PostgreSQL requires temporary CREATE on the containing schema to transfer
+-- ownership. It is revoked immediately after the transfer completes.
+GRANT CREATE ON SCHEMA "survey" TO fops_survey_aggregate_owner;
+--> statement-breakpoint
+GRANT SELECT ("type", "primary_managed_system_id") ON "survey"."surveys"
+  TO fops_survey_aggregate_owner;
+--> statement-breakpoint
+GRANT SELECT ("rating_min") ON "survey"."survey_questions"
+  TO fops_survey_aggregate_owner;
+--> statement-breakpoint
+GRANT USAGE ON SCHEMA "core" TO fops_survey_aggregate_owner;
+--> statement-breakpoint
+GRANT SELECT ("workspace_id", "status", "source_type", "source_id", "target_type")
+  ON "core"."entity_links" TO fops_survey_aggregate_owner;
+--> statement-breakpoint
+
+CREATE FUNCTION "survey"."count_negative_outcome_without_followup"(
+  p_workspace_id uuid,
+  p_managed_system_ids uuid[]
+)
+RETURNS bigint
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+  SELECT pg_catalog.count(DISTINCT r.id)
+    FROM survey.surveys AS s
+    JOIN survey.survey_responses AS r
+      ON r.survey_id = s.id
+     AND r.workspace_id = s.workspace_id
+    JOIN survey.survey_response_answers AS a
+      ON a.survey_id = r.survey_id
+     AND a.response_id = r.id
+     AND a.workspace_id = r.workspace_id
+    JOIN survey.survey_questions AS q
+      ON q.id = a.question_id
+     AND q.survey_id = a.survey_id
+     AND q.workspace_id = a.workspace_id
+   WHERE s.workspace_id = p_workspace_id
+     AND s.type = 'outcome'
+     AND q.kind = 'rating'
+     AND a.answer_kind = 'rating'
+     AND (a.answer_value #>> '{}')::numeric <= q.rating_min
+     AND (
+       p_managed_system_ids IS NULL
+       OR pg_catalog.cardinality(p_managed_system_ids) = 0
+       OR s.primary_managed_system_id = ANY(p_managed_system_ids)
+     )
+     AND NOT EXISTS (
+       SELECT 1
+         FROM core.entity_links AS el
+        WHERE el.workspace_id = r.workspace_id
+          AND el.status = 'active'
+          AND el.source_type = 'survey_response'
+          AND el.source_id = r.id
+          AND el.target_type IN ('finding', 'task')
+     )
+$$;
+--> statement-breakpoint
+
+ALTER FUNCTION "survey"."count_negative_outcome_without_followup"(uuid, uuid[])
+  OWNER TO fops_survey_aggregate_owner;
+--> statement-breakpoint
+REVOKE CREATE ON SCHEMA "survey" FROM fops_survey_aggregate_owner;
+--> statement-breakpoint
+SET ROLE fops_survey_aggregate_owner;
+--> statement-breakpoint
+REVOKE ALL ON FUNCTION "survey"."count_negative_outcome_without_followup"(uuid, uuid[]) FROM PUBLIC;
+--> statement-breakpoint
+GRANT EXECUTE ON FUNCTION "survey"."count_negative_outcome_without_followup"(uuid, uuid[]) TO fops_app;
+--> statement-breakpoint
+RESET ROLE;

--- a/apps/backend/migrations/meta/_journal.json
+++ b/apps/backend/migrations/meta/_journal.json
@@ -323,6 +323,13 @@
       "when": 1783400000000,
       "tag": "0045_saved_views",
       "breakpoints": true
+    },
+    {
+      "idx": 46,
+      "version": "7",
+      "when": 1783500000000,
+      "tag": "0046_dashboard_survey_gap_aggregate",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/db/__tests__/role-grants-product-tables.integration.test.ts
+++ b/apps/backend/src/db/__tests__/role-grants-product-tables.integration.test.ts
@@ -43,6 +43,11 @@ const DML_PRIVILEGES = ['SELECT', 'INSERT', 'UPDATE', 'DELETE'] as const;
 type DmlPrivilege = (typeof DML_PRIVILEGES)[number];
 
 const FULL_DML: readonly DmlPrivilege[] = DML_PRIVILEGES;
+const SURVEY_AGGREGATE_FUNCTIONS = [
+  'count_negative_outcome_without_followup',
+  'read_result_aggregates',
+  'read_result_response_count',
+] as const;
 
 // Tables intentionally narrower than full-DML for fops_app, keyed by the
 // fully-qualified `schema.table` name. Grants come from migrations 0010, 0037,
@@ -130,6 +135,30 @@ describe.skipIf(!runIntegration)('ADR-0008 role grants — product tables (Slice
     }
 
     expect(failures, failures.join('\n')).toEqual([]);
+  });
+
+  it('fops_app reaches survey response aggregates only through the registered definer functions', async () => {
+    const { rows } = await migrateHandle.pool.query<{
+      proname: string;
+      app_execute: boolean;
+      public_execute: boolean;
+    }>(
+      `select p.proname,
+              pg_catalog.has_function_privilege('fops_app', p.oid, 'EXECUTE') as app_execute,
+              pg_catalog.has_function_privilege('public', p.oid, 'EXECUTE') as public_execute
+         from pg_catalog.pg_proc p
+         join pg_catalog.pg_namespace n on n.oid = p.pronamespace
+         join pg_catalog.pg_roles owner_role on owner_role.oid = p.proowner
+        where n.nspname = 'survey'
+          and owner_role.rolname = 'fops_survey_aggregate_owner'
+        order by p.proname`,
+    );
+    expect(rows.map((row) => row.proname)).toEqual(SURVEY_AGGREGATE_FUNCTIONS);
+    expect(rows).toEqual(SURVEY_AGGREGATE_FUNCTIONS.map((proname) => ({
+      proname,
+      app_execute: true,
+      public_execute: false,
+    })));
   });
 
   it('fops_app UPDATE on review candidates is limited to resolution columns', async () => {

--- a/apps/backend/src/db/__tests__/survey-result-aggregate.integration.test.ts
+++ b/apps/backend/src/db/__tests__/survey-result-aggregate.integration.test.ts
@@ -20,7 +20,7 @@ function requiredId(row: { id: string } | undefined, label: string): string {
   return row.id;
 }
 
-describe.skipIf(!runIntegration)('Survey result aggregate migration 0038', () => {
+describe.skipIf(!runIntegration)('Survey aggregate security boundary (0038, 0046)', () => {
   let appHandle: DbHandle;
   let migrateHandle: DbHandle;
   const workspaceId = randomUUID();
@@ -230,6 +230,7 @@ describe.skipIf(!runIntegration)('Survey result aggregate migration 0038', () =>
       rolinherit: boolean;
       schema_create: boolean;
       schema_usage: boolean;
+      core_schema_usage: boolean;
       execute_principals: string[];
     }>(
       `select p.proname, owner_role.rolname as owner, p.prosecdef, p.proconfig, p.provolatile,
@@ -238,6 +239,7 @@ describe.skipIf(!runIntegration)('Survey result aggregate migration 0038', () =>
               aggregate_owner.rolcanlogin, aggregate_owner.rolinherit,
               pg_catalog.has_schema_privilege('fops_survey_aggregate_owner', 'survey', 'CREATE') as schema_create,
               pg_catalog.has_schema_privilege('fops_survey_aggregate_owner', 'survey', 'USAGE') as schema_usage,
+              pg_catalog.has_schema_privilege('fops_survey_aggregate_owner', 'core', 'USAGE') as core_schema_usage,
               coalesce((
                 select array_agg(privilege_principal order by privilege_principal)
                   from (
@@ -254,10 +256,14 @@ describe.skipIf(!runIntegration)('Survey result aggregate migration 0038', () =>
          join pg_catalog.pg_roles owner_role on owner_role.oid = p.proowner
          join pg_catalog.pg_roles aggregate_owner on aggregate_owner.rolname = 'fops_survey_aggregate_owner'
         where n.nspname = 'survey'
-          and p.proname in ('read_result_aggregates', 'read_result_response_count')
+          and p.proname in (
+            'count_negative_outcome_without_followup',
+            'read_result_aggregates',
+            'read_result_response_count'
+          )
         order by p.proname`,
     );
-    expect(rows).toHaveLength(2);
+    expect(rows).toHaveLength(3);
     for (const row of rows) {
       expect(row.owner).toBe('fops_survey_aggregate_owner');
       expect(row.prosecdef).toBe(true);
@@ -269,6 +275,7 @@ describe.skipIf(!runIntegration)('Survey result aggregate migration 0038', () =>
       expect(row.rolinherit).toBe(false);
       expect(row.schema_create).toBe(false);
       expect(row.schema_usage).toBe(true);
+      expect(row.core_schema_usage).toBe(true);
       expect(row.execute_principals).toEqual(['fops_app', 'fops_survey_aggregate_owner']);
     }
 
@@ -282,6 +289,7 @@ describe.skipIf(!runIntegration)('Survey result aggregate migration 0038', () =>
     expect(columnPrivileges.rows.map((row) => row.privilege)).toEqual([
       'survey_questions.id.SELECT',
       'survey_questions.kind.SELECT',
+      'survey_questions.rating_min.SELECT',
       'survey_questions.survey_id.SELECT',
       'survey_questions.workspace_id.SELECT',
       'survey_response_answers.answer_kind.SELECT',
@@ -294,7 +302,25 @@ describe.skipIf(!runIntegration)('Survey result aggregate migration 0038', () =>
       'survey_responses.survey_id.SELECT',
       'survey_responses.workspace_id.SELECT',
       'surveys.id.SELECT',
+      'surveys.primary_managed_system_id.SELECT',
+      'surveys.type.SELECT',
       'surveys.workspace_id.SELECT',
+    ]);
+
+    const linkColumnPrivileges = await migrateHandle.pool.query<{ privilege: string }>(
+      `select table_name || '.' || column_name || '.' || privilege_type as privilege
+         from information_schema.column_privileges
+        where grantee = 'fops_survey_aggregate_owner'
+          and table_schema = 'core'
+          and table_name = 'entity_links'
+        order by table_name, column_name, privilege_type`,
+    );
+    expect(linkColumnPrivileges.rows.map((row) => row.privilege)).toEqual([
+      'entity_links.source_id.SELECT',
+      'entity_links.source_type.SELECT',
+      'entity_links.status.SELECT',
+      'entity_links.target_type.SELECT',
+      'entity_links.workspace_id.SELECT',
     ]);
 
     const tablePrivileges = await migrateHandle.pool.query<{

--- a/apps/backend/src/modules/dashboard/__tests__/summary.integration.test.ts
+++ b/apps/backend/src/modules/dashboard/__tests__/summary.integration.test.ts
@@ -1,0 +1,376 @@
+import type { DashboardSummary } from '@fops/shared';
+import type { FastifyInstance } from 'fastify';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import { loadConfig } from '../../../config.js';
+import { type DbHandle, createDb } from '../../../db/client.js';
+import { HttpError } from '../../../lib/errors.js';
+import { SESSION_COOKIE_NAME } from '../../../middleware/require-session.js';
+import { buildServer } from '../../../server.js';
+import { insertFindingRow } from '../../findings/__tests__/_seed-helpers.js';
+import { insertTaskRequestRow } from '../../task-requests/__tests__/_seed-helpers.js';
+import { insertTaskRow } from '../../tasks/__tests__/_seed-helpers.js';
+import {
+  grantCapability,
+  insertDevActor,
+  insertMsDirectly,
+  insertVocDirectly,
+  loginAs,
+  uid,
+} from '../../voc/__tests__/_seed-helpers.js';
+import { createDashboardService } from '../service.js';
+
+const APP_URL = process.env.DATABASE_URL ?? '';
+const MIGRATE_URL = process.env.DATABASE_URL_MIGRATE ?? '';
+const WORKSPACE_ID = process.env.WORKSPACE_ID ?? '';
+const runIntegration = Boolean(APP_URL && MIGRATE_URL && WORKSPACE_ID);
+const SLUG_PREFIX = 'it-dashboard-217';
+
+type Summary = DashboardSummary;
+type Seed = { msA: string; msB: string; devCookie: string; devActorId: string };
+type QueueId = Summary['action_queues'][number]['id'];
+type CoverageId = Summary['coverage'][number]['id'];
+
+const queue = (body: Summary, id: QueueId) =>
+  body.action_queues.find((entry) => entry.id === id);
+const coverage = (body: Summary, id: CoverageId) =>
+  body.coverage.find((entry) => entry.id === id);
+
+function expectDelta(after: number | undefined, before: number | undefined, seeded: number, label: string) {
+  expect(after, `${label} after`).toBeTypeOf('number');
+  expect(before, `${label} before`).toBeTypeOf('number');
+  expect(after! - before!).toBe(seeded);
+}
+
+function expectQueueDelta(after: Summary, before: Summary, id: QueueId, seeded: number) {
+  expectDelta(queue(after, id)?.count, queue(before, id)?.count, seeded, id);
+}
+
+function expectCoverageDelta(after: Summary, before: Summary, id: CoverageId, value: number, total: number) {
+  const afterEntry = coverage(after, id);
+  const beforeEntry = coverage(before, id);
+  expectDelta(afterEntry?.value, beforeEntry?.value, value, `${id}.value`);
+  expectDelta(afterEntry?.total, beforeEntry?.total, total, `${id}.total`);
+  expect(afterEntry?.percent).toBe(afterEntry ? Math.round((afterEntry.value / afterEntry.total) * 100) : undefined);
+}
+
+describe.skipIf(!runIntegration)('GET /dashboard/summary (#217)', () => {
+  let dbHandle: DbHandle;
+  let migrateHandle: DbHandle;
+  let app: FastifyInstance;
+  let adminCookie: string;
+  let adminActorId: string;
+  let reporterActorId: string;
+
+  const headers = (cookie: string) => ({ cookie: `${SESSION_COOKIE_NAME}=${cookie}` });
+  const get = (cookie: string, selector = 'all') => app.inject({
+    method: 'GET', url: `/dashboard/summary?managed_system_id=${selector}`, headers: headers(cookie),
+  });
+
+  beforeAll(async () => {
+    process.env.NODE_ENV = 'test';
+    dbHandle = createDb(APP_URL);
+    migrateHandle = createDb(MIGRATE_URL);
+    app = await buildServer({ config: loadConfig(), dbHandle });
+    await app.ready();
+    adminCookie = await loginAs(app, 'mock-admin-1');
+    const actors = await dbHandle.pool.query<{ id: string; external_id: string }>(
+      `select id, external_id from core.actors
+        where workspace_id = $1 and external_id in ('mock-admin-1', 'mock-user-1')`,
+      [WORKSPACE_ID],
+    );
+    adminActorId = actors.rows.find((actor) => actor.external_id === 'mock-admin-1')?.id ?? '';
+    reporterActorId = actors.rows.find((actor) => actor.external_id === 'mock-user-1')?.id ?? '';
+    if (!adminActorId || !reporterActorId) throw new Error('seed actors not found');
+  });
+
+  beforeEach(async () => cleanupFixtures());
+
+  afterAll(async () => {
+    await cleanupFixtures();
+    await app?.close();
+    await dbHandle?.close();
+    await migrateHandle?.close();
+  });
+
+  async function cleanupFixtures(): Promise<void> {
+    if (!migrateHandle) return;
+    const systems = `select id from core.managed_systems where workspace_id = $1 and slug like $2`;
+    await migrateHandle.pool.query(`delete from core.entity_links where managed_system_id in (${systems})`, [WORKSPACE_ID, `${SLUG_PREFIX}%`]);
+    await migrateHandle.pool.query(`delete from survey.survey_response_answers where survey_id in (select id from survey.surveys where primary_managed_system_id in (${systems}))`, [WORKSPACE_ID, `${SLUG_PREFIX}%`]);
+    await migrateHandle.pool.query(`delete from survey.survey_responses where survey_id in (select id from survey.surveys where primary_managed_system_id in (${systems}))`, [WORKSPACE_ID, `${SLUG_PREFIX}%`]);
+    await migrateHandle.pool.query(`delete from survey.survey_questions where survey_id in (select id from survey.surveys where primary_managed_system_id in (${systems}))`, [WORKSPACE_ID, `${SLUG_PREFIX}%`]);
+    await migrateHandle.pool.query(`delete from survey.surveys where primary_managed_system_id in (${systems})`, [WORKSPACE_ID, `${SLUG_PREFIX}%`]);
+    await migrateHandle.pool.query(`delete from task.tasks where primary_managed_system_id in (${systems})`, [WORKSPACE_ID, `${SLUG_PREFIX}%`]);
+    await migrateHandle.pool.query(`delete from task_request.task_requests where primary_managed_system_id in (${systems})`, [WORKSPACE_ID, `${SLUG_PREFIX}%`]);
+    await migrateHandle.pool.query(`delete from finding.findings where primary_managed_system_id in (${systems})`, [WORKSPACE_ID, `${SLUG_PREFIX}%`]);
+    await migrateHandle.pool.query(`delete from permission.permission_requests where workspace_id = $1 and reason like $2`, [WORKSPACE_ID, `${SLUG_PREFIX}%`]);
+    await migrateHandle.pool.query(`delete from voc.vocs where primary_managed_system_id in (${systems})`, [WORKSPACE_ID, `${SLUG_PREFIX}%`]);
+    await migrateHandle.pool.query(`delete from permission.permission_grants where actor_id in (select id from core.actors where workspace_id = $1 and external_id like $2)`, [WORKSPACE_ID, 'mock-dev-read-dashboard-217%']);
+    await migrateHandle.pool.query(`delete from core.rate_limits where key in (select id::text from core.actors where workspace_id = $1 and external_id like $2)`, [WORKSPACE_ID, 'mock-dev-read-dashboard-217%']);
+    await migrateHandle.pool.query(`delete from core.sessions where actor_id in (select id from core.actors where workspace_id = $1 and external_id like $2)`, [WORKSPACE_ID, 'mock-dev-read-dashboard-217%']);
+    await migrateHandle.pool.query(`delete from core.audit_log where actor_id in (select id from core.actors where workspace_id = $1 and external_id like $2)`, [WORKSPACE_ID, 'mock-dev-read-dashboard-217%']);
+    await migrateHandle.pool.query(`delete from core.actors where workspace_id = $1 and external_id like $2`, [WORKSPACE_ID, 'mock-dev-read-dashboard-217%']);
+    await migrateHandle.pool.query(`delete from core.analytics_areas where managed_system_id in (${systems})`, [WORKSPACE_ID, `${SLUG_PREFIX}%`]);
+    await migrateHandle.pool.query(`delete from core.managed_systems where workspace_id = $1 and slug like $2`, [WORKSPACE_ID, `${SLUG_PREFIX}%`]);
+  }
+
+  async function createDashboardScope(): Promise<Seed> {
+    const msA = await insertMsDirectly(migrateHandle, WORKSPACE_ID, `${SLUG_PREFIX}-${uid('a')}`, 'Dashboard A');
+    const msB = await insertMsDirectly(migrateHandle, WORKSPACE_ID, `${SLUG_PREFIX}-${uid('b')}`, 'Dashboard B');
+    const dev = await insertDevActor(migrateHandle, WORKSPACE_ID, `dashboard-217-${uid('scope')}`);
+    for (const capability of ['voc.read', 'finding.read', 'finding.manage', 'survey.read']) {
+      await grantCapability(migrateHandle, WORKSPACE_ID, dev.id, capability, msA, adminActorId);
+    }
+    return { msA, msB, devCookie: await loginAs(app, dev.externalId), devActorId: dev.id };
+  }
+
+  async function seedDashboard(seed: Seed): Promise<void> {
+    const { msA, msB } = seed;
+    const vocsA = await seedVocs(msA, 10, 6, 4, 3);
+    const vocsB = await seedVocs(msB, 7, 5, 3, 3);
+    // Two high VOCs have a backing link: one Task link and one Finding link.
+    const linkedTask = await insertTaskRow(migrateHandle, { workspaceId: WORKSPACE_ID, primaryManagedSystemId: msA, status: 'done', createdBy: adminActorId, title: 'linked VOC task' });
+    await link('voc', vocsA.high[0]!, 'task', linkedTask.id, 'evidence_of', msA);
+    await link('voc', vocsB.high[0]!, 'finding', (await insertFindingRow(migrateHandle, { workspaceId: WORKSPACE_ID, primaryManagedSystemId: msB, sourceId: vocsB.all[0]!, status: 'draft', createdBy: adminActorId })).id, 'created_finding', msB);
+
+    await seedFindings(msA, vocsA.all[0]!, 7, 2);
+    await seedFindings(msB, vocsB.all[0]!, 5, 2);
+    const releasedA = await seedTasks(msA, vocsA.all, 9, 4, 2);
+    const releasedB = await seedTasks(msB, vocsB.all, 5, 3, 2);
+    // One linked VOC has a reporter-visible update. A skip row proves that a
+    // status transition without public content does not count as coverage.
+    await seedPublicUpdate(releasedA[0]!, false);
+    await seedPublicUpdate(releasedB[0]!, true);
+    await seedRequests(msA, vocsA.all[0]!, 6);
+    await seedRequests(msB, vocsB.all[0]!, 4);
+    await seedSurveyGaps(msA, 4);
+    await seedSurveyGaps(msB, 2);
+    for (let index = 0; index < 9; index += 1) {
+      await migrateHandle.pool.query(
+        `insert into permission.permission_requests (workspace_id, requester_actor_id, requested_capability, reason, status)
+         values ($1, $2, $3, $4, 'pending')`,
+        [WORKSPACE_ID, adminActorId, `dashboard.review.${index}`, `${SLUG_PREFIX} pending ${index}`],
+      );
+    }
+  }
+
+  async function seedVocs(msId: string, total: number, unassigned: number, high: number, analytics: number) {
+    const all: string[] = []; const highIds: string[] = [];
+    for (let index = 0; index < total; index += 1) {
+      const voc = await insertVocDirectly(migrateHandle, WORKSPACE_ID, msId, reporterActorId, `dashboard voc ${msId} ${index}`, {
+        severity: index < high ? 'high' : 'low',
+        ...(index < unassigned ? {} : { ownerUserId: adminActorId }),
+      });
+      all.push(voc.id); if (index < high) highIds.push(voc.id);
+      if (index < analytics) await migrateHandle.pool.query('update voc.vocs set analytics_area_id = $1 where id = $2', [await analyticsArea(msId), voc.id]);
+    }
+    return { all, high: highIds };
+  }
+
+  const analyticsAreas = new Map<string, string>();
+  async function analyticsArea(msId: string) {
+    const saved = analyticsAreas.get(msId); if (saved) return saved;
+    const result = await migrateHandle.pool.query<{ id: string }>('insert into core.analytics_areas (workspace_id, managed_system_id, slug, name) values ($1, $2, $3, $4) returning id', [WORKSPACE_ID, msId, uid('dashboard-aa'), 'Dashboard area']);
+    const id = result.rows[0]?.id; if (!id) throw new Error('analytics area seed failed'); analyticsAreas.set(msId, id); return id;
+  }
+
+  async function link(sourceType: string, sourceId: string, targetType: string, targetId: string, relationType: string, msId: string) {
+    await migrateHandle.pool.query(
+      `insert into core.entity_links (workspace_id, source_type, source_id, target_type, target_id, relation_type, managed_system_id, created_by)
+       values ($1, $2, $3, $4, $5, $6, $7, $8)`,
+      [WORKSPACE_ID, sourceType, sourceId, targetType, targetId, relationType, msId, adminActorId],
+    );
+  }
+
+  async function seedFindings(msId: string, sourceId: string, total: number, executed: number) {
+    for (let index = 0; index < total; index += 1) {
+      const finding = await insertFindingRow(migrateHandle, { workspaceId: WORKSPACE_ID, primaryManagedSystemId: msId, sourceId, status: 'active', createdBy: adminActorId, title: `dashboard finding ${msId} ${index}` });
+      if (index < executed) await migrateHandle.pool.query('update finding.findings set linked_task_id = $1 where id = $2', [(await insertTaskRow(migrateHandle, { workspaceId: WORKSPACE_ID, primaryManagedSystemId: msId, status: 'done', createdBy: adminActorId })).id, finding.id]);
+    }
+  }
+
+  async function seedTasks(msId: string, vocIds: string[], inFlight: number, released: number, unresolved: number) {
+    const linkedVocIds: string[] = [];
+    for (let index = 0; index < inFlight; index += 1) await insertTaskRow(migrateHandle, { workspaceId: WORKSPACE_ID, primaryManagedSystemId: msId, status: 'todo', createdBy: adminActorId });
+    for (let index = 0; index < released; index += 1) {
+      const task = await insertTaskRow(migrateHandle, { workspaceId: WORKSPACE_ID, primaryManagedSystemId: msId, status: 'released', createdBy: adminActorId });
+      if (index < unresolved) {
+        const vocId = vocIds[vocIds.length - 1 - index]!;
+        await link('voc', vocId, 'task', task.id, 'evidence_of', msId);
+        linkedVocIds.push(vocId);
+      }
+    }
+    return linkedVocIds;
+  }
+
+  async function seedPublicUpdate(vocId: string, skipped: boolean) {
+    await migrateHandle.pool.query(
+      `insert into voc.voc_public_updates (
+        voc_id, actor_id, body_rich_content, reporter_facing_status_before,
+        reporter_facing_status_after, skip_public_update, skip_reason
+      ) values ($1, $2, $3::jsonb, 'received', $4, $5, $6)`,
+      [
+        vocId,
+        adminActorId,
+        skipped ? null : JSON.stringify({ type: 'doc', content: [] }),
+        skipped ? 'reviewing' : 'received',
+        skipped,
+        skipped ? 'No reporter-visible update is needed for this fixture.' : null,
+      ],
+    );
+  }
+
+  async function seedRequests(msId: string, sourceId: string, total: number) {
+    for (let index = 0; index < total; index += 1) await insertTaskRequestRow(migrateHandle, { workspaceId: WORKSPACE_ID, primaryManagedSystemId: msId, sourceId, requesterActorId: adminActorId });
+  }
+
+  async function seedSurveyGaps(msId: string, total: number) {
+    for (let index = 0; index < total; index += 1) {
+      const survey = await migrateHandle.pool.query<{ id: string }>(`insert into survey.surveys (workspace_id, display_id, type, status, title, primary_managed_system_id, operator_actor_id, responses_identity_protected, created_by, opened_at) values ($1, $2, 'outcome', 'open', $3, $4, $5, true, $5, now()) returning id`, [WORKSPACE_ID, `SRV-${uid('dashboard')}`, `dashboard outcome ${index}`, msId, adminActorId]);
+      const surveyId = survey.rows[0]?.id; if (!surveyId) throw new Error('survey seed failed');
+      const question = await migrateHandle.pool.query<{ id: string }>(`insert into survey.survey_questions (workspace_id, survey_id, kind, prompt, is_required, rating_min, rating_max, sort_order, branch_depth) values ($1, $2, 'rating', 'Outcome', false, 1, 5, 0, 0) returning id`, [WORKSPACE_ID, surveyId]);
+      const questionId = question.rows[0]?.id; if (!questionId) throw new Error('question seed failed');
+      const response = await migrateHandle.pool.query<{ id: string }>(`insert into survey.survey_responses (workspace_id, survey_id, respondent_actor_id, identity_protected, submitted_at) values ($1, $2, $3, true, now()) returning id`, [WORKSPACE_ID, surveyId, reporterActorId]);
+      await migrateHandle.pool.query(`insert into survey.survey_response_answers (workspace_id, survey_id, response_id, question_id, answer_kind, answer_value) values ($1, $2, $3, $4, 'rating', '1'::jsonb)`, [WORKSPACE_ID, surveyId, response.rows[0]?.id, questionId]);
+    }
+  }
+
+  it('returns distinct, non-zero admin counts with all rendered queue and coverage metadata', async () => {
+    const before = (await get(adminCookie)).json<Summary>();
+    const seed = await createDashboardScope();
+    await seedDashboard(seed);
+    const beforeAudit = await dbHandle.pool.query<{ count: string }>('select count(*)::text as count from core.audit_log where actor_id = $1', [adminActorId]);
+    const response = await get(adminCookie);
+    const body = response.json<Summary>();
+    const afterAudit = await dbHandle.pool.query<{ count: string }>('select count(*)::text as count from core.audit_log where actor_id = $1', [adminActorId]);
+
+    expect(response.statusCode).toBe(200);
+    expect(afterAudit.rows[0]?.count).toBe(beforeAudit.rows[0]?.count);
+    expectDelta(body.kpis.open_voc, before.kpis.open_voc, 17, 'open_voc');
+    expectDelta(body.kpis.active_finding, before.kpis.active_finding, 12, 'active_finding');
+    expectDelta(body.kpis.pending_request, before.kpis.pending_request, 19, 'pending_request');
+    expectDelta(body.kpis.tasks_in_flight, before.kpis.tasks_in_flight, 14, 'tasks_in_flight');
+    expect(body.kpis.coverage_percent).toBe(coverage(body, 'voc-task')?.percent);
+    expect(queue(body, 'unassigned-voc')).toMatchObject({ severity: 'urgent', next_action: { route: '/vocs?view=inbox&tab=unassigned' } });
+    expect(queue(body, 'high-severity-unlinked')).toMatchObject({ severity: 'urgent', next_action: { route: '/vocs?view=inbox&tab=high-no-link' } });
+    expect(queue(body, 'actionable-finding-no-execution')).toMatchObject({ severity: 'warn', next_action: { route: '/findings?status=active' } });
+    expect(queue(body, 'released-task-unresolved-voc')).toMatchObject({ severity: 'warn', next_action: { route: '/tasks?status=released' } });
+    expect(queue(body, 'bad-outcome-no-followup')).toMatchObject({ severity: 'urgent', next_action: { route: '/surveys?type=outcome' } });
+    expect(queue(body, 'permission-requests-pending')).toMatchObject({ severity: 'info', next_action: { route: '/admin/permission-requests' } });
+    expectQueueDelta(body, before, 'unassigned-voc', 11);
+    expectQueueDelta(body, before, 'high-severity-unlinked', 5);
+    expectQueueDelta(body, before, 'actionable-finding-no-execution', 8);
+    expectQueueDelta(body, before, 'released-task-unresolved-voc', 4);
+    expectQueueDelta(body, before, 'bad-outcome-no-followup', 6);
+    expectQueueDelta(body, before, 'permission-requests-pending', 9);
+    expectCoverageDelta(body, before, 'voc-task', 5, 17);
+    expectCoverageDelta(body, before, 'finding-execution', 4, 12);
+    expectCoverageDelta(body, before, 'high-followup', 2, 7);
+    expectCoverageDelta(body, before, 'released-update', 1, 4);
+    expectCoverageDelta(body, before, 'analytics-area', 6, 17);
+    expect(body.coverage.map((entry) => entry.id)).not.toContain('milestone-outcome');
+    expect(coverage(body, 'milestone-outcome')).toBeUndefined();
+    expect(seed.msA).not.toBe(seed.msB);
+  });
+
+  it('keeps bad-outcome-no-followup present at zero for an admin with no outcome surveys', async () => {
+    const outcomeSurveys = await migrateHandle.pool.query<{ count: string }>(
+      `select count(*)::text as count from survey.surveys where workspace_id = $1 and type = 'outcome'`,
+      [WORKSPACE_ID],
+    );
+    const response = await get(adminCookie);
+
+    expect(outcomeSurveys.rows[0]?.count).toBe('0');
+    expect(response.statusCode).toBe(200);
+    expect(queue(response.json<Summary>(), 'bad-outcome-no-followup')).toMatchObject({ count: 0 });
+  });
+
+  it('limits a developer to their one Managed System and omits unavailable entries', async () => {
+    const seed = await createDashboardScope();
+    const before = (await get(seed.devCookie)).json<Summary>();
+    await seedDashboard(seed);
+    const beforeAudit = await dbHandle.pool.query<{ count: string }>('select count(*)::text as count from core.audit_log where actor_id = $1', [seed.devActorId]);
+    const visible = (await get(seed.devCookie)).json<Summary>();
+    const afterAudit = await dbHandle.pool.query<{ count: string }>('select count(*)::text as count from core.audit_log where actor_id = $1', [seed.devActorId]);
+    expectDelta(visible.kpis.open_voc, before.kpis.open_voc, 10, 'developer open_voc');
+    expectDelta(visible.kpis.active_finding, before.kpis.active_finding, 7, 'developer active_finding');
+    expectDelta(visible.kpis.pending_request, before.kpis.pending_request, 6, 'developer pending_request');
+    expectDelta(visible.kpis.tasks_in_flight, before.kpis.tasks_in_flight, 9, 'developer tasks_in_flight');
+    expect(visible.kpis.coverage_percent).toBe(coverage(visible, 'voc-task')?.percent);
+    expectQueueDelta(visible, before, 'unassigned-voc', 6);
+    expectQueueDelta(visible, before, 'high-severity-unlinked', 3);
+    expectQueueDelta(visible, before, 'actionable-finding-no-execution', 5);
+    expectQueueDelta(visible, before, 'released-task-unresolved-voc', 2);
+    expectQueueDelta(visible, before, 'bad-outcome-no-followup', 4);
+    expectCoverageDelta(visible, before, 'voc-task', 3, 10);
+    expectCoverageDelta(visible, before, 'finding-execution', 2, 7);
+    expectCoverageDelta(visible, before, 'high-followup', 1, 4);
+    expectCoverageDelta(visible, before, 'released-update', 1, 2);
+    expectCoverageDelta(visible, before, 'analytics-area', 3, 10);
+    expect(queue(visible, 'permission-requests-pending')).toBeUndefined();
+    expect(visible.action_queues.map((entry) => entry.id)).not.toContain('permission-requests-pending');
+    expect((await get(seed.devCookie, seed.msB)).json<Summary>().action_queues.map((entry) => entry.id)).not.toContain('unassigned-voc');
+    expect(queue((await get(seed.devCookie, seed.msB)).json<Summary>(), 'unassigned-voc')).toBeUndefined();
+    expect(afterAudit.rows[0]?.count).toBe(beforeAudit.rows[0]?.count);
+  });
+
+  it('applies managed_system_id selectors and returns no scoped data for an outside system', async () => {
+    const seed = await createDashboardScope();
+    const beforeAll = (await get(adminCookie)).json<Summary>();
+    const beforeA = (await get(adminCookie, seed.msA)).json<Summary>();
+    const beforeB = (await get(adminCookie, seed.msB)).json<Summary>();
+    await seedDashboard(seed);
+    const all = (await get(adminCookie)).json<Summary>();
+    const a = (await get(adminCookie, seed.msA)).json<Summary>();
+    const b = (await get(adminCookie, seed.msB)).json<Summary>();
+    expectQueueDelta(all, beforeAll, 'unassigned-voc', 11);
+    expectQueueDelta(a, beforeA, 'unassigned-voc', 6);
+    expectQueueDelta(b, beforeB, 'unassigned-voc', 5);
+    expectQueueDelta(all, beforeAll, 'bad-outcome-no-followup', 6);
+    expectQueueDelta(a, beforeA, 'bad-outcome-no-followup', 4);
+    expectQueueDelta(b, beforeB, 'bad-outcome-no-followup', 2);
+    expectQueueDelta(all, beforeAll, 'released-task-unresolved-voc', 4);
+    expectQueueDelta(a, beforeA, 'released-task-unresolved-voc', 2);
+    expectQueueDelta(b, beforeB, 'released-task-unresolved-voc', 2);
+    expectCoverageDelta(all, beforeAll, 'finding-execution', 4, 12);
+    expectCoverageDelta(a, beforeA, 'finding-execution', 2, 7);
+    expectCoverageDelta(b, beforeB, 'finding-execution', 2, 5);
+    expectCoverageDelta(all, beforeAll, 'released-update', 1, 4);
+    expectCoverageDelta(a, beforeA, 'released-update', 1, 2);
+    expectCoverageDelta(b, beforeB, 'released-update', 0, 2);
+    const outside = await get(seed.devCookie, seed.msB);
+    expect(outside.statusCode).toBe(200);
+    expect(outside.json<Summary>().action_queues).toEqual([]);
+    expect(outside.json<Summary>().coverage).toEqual([]);
+  });
+
+  it('keeps the zero-grant actor empty and writes no audit row', async () => {
+    const actor = await insertDevActor(migrateHandle, WORKSPACE_ID, `dashboard-217-no-grants-${uid('actor')}`);
+    const cookie = await loginAs(app, actor.externalId);
+    const before = await dbHandle.pool.query<{ count: string }>('select count(*)::text as count from core.audit_log where actor_id = $1', [actor.id]);
+    const response = await get(cookie);
+    const after = await dbHandle.pool.query<{ count: string }>('select count(*)::text as count from core.audit_log where actor_id = $1', [actor.id]);
+    expect(response.statusCode).toBe(200);
+    expect(response.json<Summary>()).toEqual({ kpis: {}, action_queues: [], coverage: [] });
+    expect(after.rows[0]?.count).toBe(before.rows[0]?.count);
+  });
+
+  it('rejects an invalid scope selector', async () => {
+    const response = await app.inject({ method: 'GET', url: '/dashboard/summary?managed_system_id=not-a-uuid', headers: headers(adminCookie) });
+    expect(response.statusCode).toBe(422);
+    expect(response.json<{ code: string }>().code).toBe('validation.failed');
+  });
+});
+
+describe.skipIf(!runIntegration)('dashboard authorization absence', () => {
+  it('propagates a non-authorization downstream failure rather than omitting an entry', async () => {
+    const service = createDashboardService({
+      db: { execute: async () => ({ rows: [] }) } as never,
+      checkService: { checkCapability: async () => ({ allow: true, via: 'role' }) } as never,
+      requestService: { listAllActive: async () => ({ count: 0, requests: [] }) },
+      vocReadService: { countVocs: async () => { throw new HttpError('internal.unexpected', 'dashboard dependency failed'); } },
+    });
+    await expect(service.getSummary({ actor_id: 'actor', workspace_id: 'workspace', role_level: 'admin' })).rejects.toMatchObject({ code: 'internal.unexpected' });
+  });
+});

--- a/apps/backend/src/modules/dashboard/index.ts
+++ b/apps/backend/src/modules/dashboard/index.ts
@@ -1,0 +1,2 @@
+export { dashboardRoutes } from './routes.js';
+export { createDashboardService, type DashboardService } from './service.js';

--- a/apps/backend/src/modules/dashboard/repo.ts
+++ b/apps/backend/src/modules/dashboard/repo.ts
@@ -1,0 +1,153 @@
+import { sql } from 'drizzle-orm';
+
+import type { Db } from '../../db/client.js';
+import type { Scope } from '../permissions/scope-service.js';
+
+function sqlUuidArray(ids: readonly string[]): ReturnType<typeof sql> {
+  if (ids.length === 0) return sql`ARRAY[]::uuid[]`;
+  return sql`ARRAY[${sql.join(ids.map((id) => sql`${id}::uuid`), sql`, `)}]::uuid[]`;
+}
+
+function scopePredicate(column: string, scope: Scope, managedSystemId?: string): ReturnType<typeof sql> {
+  const columnRef = sql.raw(column);
+  if (managedSystemId !== undefined) return sql`${columnRef} = ${managedSystemId}::uuid`;
+  if (scope.kind === 'all') return sql`TRUE`;
+  if (scope.managedSystemIds.length === 0) return sql`FALSE`;
+  return sql`${columnRef} = ANY(${sqlUuidArray(scope.managedSystemIds)})`;
+}
+
+async function count(db: Db, query: ReturnType<typeof sql>): Promise<number> {
+  const result = await db.execute<{ count: number | string }>(query);
+  return Number(result.rows[0]?.count ?? 0);
+}
+
+export async function countActiveFindingsWithoutExecution(db: Db, workspaceId: string, scope: Scope, managedSystemId?: string) {
+  return count(db, sql`
+    SELECT count(*)::int AS count FROM finding.findings f
+    WHERE f.workspace_id = ${workspaceId} AND f.status = 'active'
+      AND ${scopePredicate('f.primary_managed_system_id', scope, managedSystemId)}
+      AND f.linked_task_id IS NULL
+      AND NOT EXISTS (SELECT 1 FROM core.entity_links el WHERE el.workspace_id = f.workspace_id
+        AND el.status = 'active' AND el.source_type = 'finding' AND el.source_id = f.id
+        AND el.target_type = 'task_request' AND el.relation_type = 'requested_task')
+  `);
+}
+
+export async function countActiveFindings(db: Db, workspaceId: string, scope: Scope, managedSystemId?: string) {
+  return count(db, sql`SELECT count(*)::int AS count FROM finding.findings f
+    WHERE f.workspace_id = ${workspaceId} AND f.status = 'active'
+      AND ${scopePredicate('f.primary_managed_system_id', scope, managedSystemId)}`);
+}
+
+export async function countActiveFindingsWithExecution(db: Db, workspaceId: string, scope: Scope, managedSystemId?: string) {
+  return count(db, sql`SELECT count(*)::int AS count FROM finding.findings f
+    WHERE f.workspace_id = ${workspaceId} AND f.status = 'active'
+      AND ${scopePredicate('f.primary_managed_system_id', scope, managedSystemId)}
+      AND (f.linked_task_id IS NOT NULL OR EXISTS (SELECT 1 FROM core.entity_links el
+        WHERE el.workspace_id = f.workspace_id AND el.status = 'active' AND el.source_type = 'finding'
+          AND el.source_id = f.id AND el.target_type = 'task_request' AND el.relation_type = 'requested_task'))`);
+}
+
+export async function countTasksInFlight(db: Db, workspaceId: string, scope: Scope, managedSystemId?: string) {
+  return count(db, sql`SELECT count(*)::int AS count FROM task.tasks t WHERE t.workspace_id = ${workspaceId}
+    AND t.status IN ('todo', 'doing', 'review') AND ${scopePredicate('t.primary_managed_system_id', scope, managedSystemId)}`);
+}
+
+export async function countPendingTaskRequests(db: Db, workspaceId: string, scope: Scope, managedSystemId?: string) {
+  return count(db, sql`SELECT count(*)::int AS count FROM task_request.task_requests tr WHERE tr.workspace_id = ${workspaceId}
+    AND tr.status = 'pending_review' AND ${scopePredicate('tr.primary_managed_system_id', scope, managedSystemId)}`);
+}
+
+export async function releasedTaskIds(db: Db, workspaceId: string, scope: Scope, managedSystemId?: string): Promise<string[]> {
+  const result = await db.execute<{ id: string }>(sql`SELECT id FROM task.tasks t WHERE t.workspace_id = ${workspaceId}
+    AND t.status = 'released' AND ${scopePredicate('t.primary_managed_system_id', scope, managedSystemId)}`);
+  return result.rows.map((row) => row.id);
+}
+
+export async function unresolvedVocIds(db: Db, workspaceId: string, vocIds: readonly string[]): Promise<Set<string>> {
+  if (vocIds.length === 0) return new Set();
+  const result = await db.execute<{ id: string }>(sql`SELECT id FROM voc.vocs WHERE workspace_id = ${workspaceId}
+    AND id = ANY(${sqlUuidArray(vocIds)}) AND reporter_facing_status NOT IN ('resolved', 'closed')`);
+  return new Set(result.rows.map((row) => row.id));
+}
+
+/**
+ * Coverage for the dashboard's "Released Task with public update" label.
+ * A skipped row records a deliberate status transition without publishing a
+ * reporter-visible update, so it cannot satisfy this coverage metric.
+ */
+export async function countReleasedTasksWithPublicUpdate(
+  db: Db,
+  workspaceId: string,
+  scope: Scope,
+  managedSystemId?: string,
+) {
+  const result = await db.execute<{ value: number | string; total: number | string }>(sql`
+    SELECT
+      count(*) FILTER (WHERE EXISTS (
+        SELECT 1
+        FROM core.entity_links link
+        JOIN voc.vocs voc
+          ON voc.id = link.source_id
+         AND voc.workspace_id = link.workspace_id
+         AND voc.archived_at IS NULL
+        JOIN voc.voc_public_updates public_update
+          ON public_update.voc_id = voc.id
+         AND public_update.skip_public_update = false
+        WHERE link.workspace_id = t.workspace_id
+          AND link.source_type = 'voc'
+          AND link.target_type = 'task'
+          AND link.target_id = t.id
+          AND link.relation_type = 'evidence_of'
+          AND link.status = 'active'
+      ))::int AS value,
+      count(*)::int AS total
+    FROM task.tasks t
+    WHERE t.workspace_id = ${workspaceId}
+      AND t.status = 'released'
+      AND ${scopePredicate('t.primary_managed_system_id', scope, managedSystemId)}
+      AND EXISTS (
+        SELECT 1
+        FROM core.entity_links link
+        JOIN voc.vocs voc
+          ON voc.id = link.source_id
+         AND voc.workspace_id = link.workspace_id
+         AND voc.archived_at IS NULL
+        WHERE link.workspace_id = t.workspace_id
+          AND link.source_type = 'voc'
+          AND link.target_type = 'task'
+          AND link.target_id = t.id
+          AND link.relation_type = 'evidence_of'
+          AND link.status = 'active'
+      )
+  `);
+  return { value: Number(result.rows[0]?.value ?? 0), total: Number(result.rows[0]?.total ?? 0) };
+}
+
+export async function countSurveyGaps(db: Db, workspaceId: string, scope: Scope, managedSystemId?: string) {
+  const selectedManagedSystemId = managedSystemId === 'all' ? undefined : managedSystemId;
+  const managedSystemIds = selectedManagedSystemId === undefined
+    ? (scope.kind === 'all' ? undefined : scope.managedSystemIds)
+    : [selectedManagedSystemId];
+  const filter = managedSystemIds === undefined ? sql`NULL::uuid[]` : sqlUuidArray(managedSystemIds);
+  return count(db, sql`SELECT survey.count_negative_outcome_without_followup(
+    ${workspaceId}::uuid, ${filter}
+  )::int AS count`);
+}
+
+export async function countAnalyticsAreaVocCoverage(db: Db, workspaceId: string, scope: Scope, managedSystemId?: string) {
+  const result = await db.execute<{ value: number | string; total: number | string }>(sql`
+    SELECT count(*) FILTER (WHERE v.analytics_area_id IS NOT NULL)::int AS value, count(*)::int AS total
+    FROM voc.vocs v WHERE v.workspace_id = ${workspaceId} AND v.archived_at IS NULL
+      AND ${scopePredicate('v.primary_managed_system_id', scope, managedSystemId)}`);
+  return { value: Number(result.rows[0]?.value ?? 0), total: Number(result.rows[0]?.total ?? 0) };
+}
+
+export async function countVocsWithTask(db: Db, workspaceId: string, scope: Scope, managedSystemId?: string) {
+  const result = await db.execute<{ value: number | string; total: number | string }>(sql`
+    SELECT count(*) FILTER (WHERE EXISTS (SELECT 1 FROM core.entity_links el WHERE el.workspace_id = v.workspace_id
+      AND el.status = 'active' AND el.source_type = 'voc' AND el.source_id = v.id AND el.target_type = 'task'))::int AS value,
+      count(*)::int AS total FROM voc.vocs v WHERE v.workspace_id = ${workspaceId} AND v.archived_at IS NULL
+      AND ${scopePredicate('v.primary_managed_system_id', scope, managedSystemId)}`);
+  return { value: Number(result.rows[0]?.value ?? 0), total: Number(result.rows[0]?.total ?? 0) };
+}

--- a/apps/backend/src/modules/dashboard/routes.ts
+++ b/apps/backend/src/modules/dashboard/routes.ts
@@ -1,0 +1,34 @@
+import type { FastifyPluginAsync } from 'fastify';
+import { z } from 'zod';
+
+import { fieldsFromZodIssues, sendError } from '../../lib/errors.js';
+import { requireSession } from '../../middleware/require-session.js';
+import { requireWorkspace } from '../../middleware/require-workspace.js';
+import type { SessionService } from '../auth/session-service.js';
+import type { DashboardService } from './service.js';
+
+const querySchema = z.object({ managed_system_id: z.union([z.string().uuid(), z.literal('all')]).optional() });
+
+export const dashboardRoutes: FastifyPluginAsync<{
+  sessionService: SessionService;
+  dashboardService: DashboardService;
+  workspaceId: string;
+  rateLimitConfig?: { read?: Record<string, unknown> };
+}> = async (app, opts) => {
+  app.get('/dashboard/summary', {
+    preHandler: [requireSession(opts.sessionService), requireWorkspace(opts.workspaceId)],
+    ...(opts.rateLimitConfig?.read ? { config: { rateLimit: opts.rateLimitConfig.read as never } } : {}),
+  }, async (req, reply) => {
+    const parsed = querySchema.safeParse(req.query);
+    if (!parsed.success) return sendError(reply, 'validation.failed', 'invalid query parameters', {
+      fields: fieldsFromZodIssues(parsed.error.issues),
+    });
+    const session = req.session;
+    if (!session) throw new Error('session missing after middleware');
+    return reply.header('cache-control', 'private, no-cache').send(await opts.dashboardService.getSummary({
+      actor_id: session.actor_id,
+      workspace_id: session.workspace_id,
+      role_level: session.role_level,
+    }, parsed.data.managed_system_id));
+  });
+};

--- a/apps/backend/src/modules/dashboard/service.ts
+++ b/apps/backend/src/modules/dashboard/service.ts
@@ -1,0 +1,186 @@
+import type { DashboardSummary } from '@fops/shared';
+
+import type { Db } from '../../db/client.js';
+import { HttpError } from '../../lib/errors.js';
+import { selectEligibleVocLinksForReleasedTask } from '../entity-links/repo.js';
+import { actorFindingReadScope } from '../findings/authorization.js';
+import type { CheckService } from '../permissions/check-service.js';
+import { actorScopeForCapability, type Scope } from '../permissions/scope-service.js';
+import type { RequestService } from '../permissions/request-service.js';
+import type { CountVocsQuery } from '../voc/read-service.js';
+import { actorSurveyReadScope } from '../surveys/authorization.js';
+import * as repo from './repo.js';
+
+export interface DashboardActor {
+  actor_id: string;
+  workspace_id: string;
+  role_level: 'admin' | 'developer' | 'user';
+}
+
+type DashboardDeps = {
+  db: Db;
+  checkService: CheckService;
+  requestService: Pick<RequestService, 'listAllActive'>;
+  vocReadService: { countVocs(args: { actor: DashboardActor; query: CountVocsQuery }): Promise<number> };
+};
+
+function isAuthorizationAbsence(error: unknown): error is HttpError {
+  return error instanceof HttpError
+    && (error.code === 'permission.denied' || error.code === 'permission.scope_required');
+}
+
+function inRequestedScope(scope: Scope, managedSystemId?: string): Scope | undefined {
+  if (managedSystemId === undefined || managedSystemId === 'all') return scope;
+  if (scope.kind === 'all' || scope.managedSystemIds.includes(managedSystemId)) {
+    return { kind: 'scoped', managedSystemIds: [managedSystemId] };
+  }
+  return undefined;
+}
+
+function percent(value: number, total: number) {
+  return total === 0 ? 0 : Math.round((value / total) * 100);
+}
+
+function coverageStatus(value: number): 'good' | 'warn' | 'bad' {
+  return value >= 75 ? 'good' : value >= 40 ? 'warn' : 'bad';
+}
+
+export function createDashboardService(deps: DashboardDeps) {
+  async function authorizationAbsent<T>(read: () => Promise<T>): Promise<T | undefined> {
+    try {
+      return await read();
+    } catch (error) {
+      if (isAuthorizationAbsence(error)) return undefined;
+      throw error;
+    }
+  }
+
+  async function getSummary(actor: DashboardActor, managedSystemId?: string): Promise<DashboardSummary> {
+    // `all` is the public selector for no backing filter; repositories receive
+    // undefined so they apply the actor's resolved scope rather than cast it as a UUID.
+    const selectedManagedSystemId = managedSystemId === 'all' ? undefined : managedSystemId;
+    const voc = (tab?: CountVocsQuery['tab']) => authorizationAbsent(() => deps.vocReadService.countVocs({
+      actor,
+      query: {
+        view: 'inbox',
+        ...(selectedManagedSystemId !== undefined ? { managed_system_id: selectedManagedSystemId } : {}),
+        ...(tab !== undefined ? { tab } : {}),
+      },
+    }));
+
+    const [findingScopeRaw, taskScopeRaw, surveyScopeRaw] = await Promise.all([
+      actorFindingReadScope(deps.db, actor, { requireElevatedRole: true }),
+      actorScopeForCapability(deps.db, actor, 'finding.manage'),
+      actorSurveyReadScope(deps.db, deps.checkService, actor),
+    ]);
+    const findingScope = inRequestedScope(findingScopeRaw, selectedManagedSystemId);
+    const taskScope = inRequestedScope(taskScopeRaw, selectedManagedSystemId);
+    const surveyScope = inRequestedScope(surveyScopeRaw, selectedManagedSystemId);
+    const surveyScopeForDashboard = surveyScope
+      ?? (actor.role_level === 'admin' ? surveyScopeRaw : undefined);
+    // Survey read scope is data-derived for survey listing. Dashboard queue
+    // visibility is permission-derived: an Admin can truthfully see an empty
+    // outcome queue even when no survey exists to contribute an MS id.
+    const canSeeSurveyQueue = actor.role_level === 'admin'
+      || (surveyScopeForDashboard !== undefined
+        && (surveyScopeForDashboard.kind === 'all' || surveyScopeForDashboard.managedSystemIds.length > 0));
+    const queues: DashboardSummary['action_queues'] = [];
+    const coverage: DashboardSummary['coverage'] = [];
+    const kpis: DashboardSummary['kpis'] = {};
+
+    const [openVoc, unassigned, highUnlinked] = await Promise.all([voc(), voc('unassigned'), voc('high-no-link')]);
+    if (openVoc !== undefined) kpis.open_voc = openVoc;
+    if (unassigned !== undefined) queues.push({ id: 'unassigned-voc', severity: 'urgent', count: unassigned,
+      next_action: { label: 'Review VOCs', route: '/vocs?view=inbox&tab=unassigned', intent: 'triage' },
+      secondary_action: { label: 'Bulk assign', route: '/vocs?view=inbox&tab=unassigned', intent: 'bulk_assign' } });
+    if (highUnlinked !== undefined) queues.push({ id: 'high-severity-unlinked', severity: 'urgent', count: highUnlinked,
+      next_action: { label: 'Review high severity VOCs', route: '/vocs?view=inbox&tab=high-no-link', intent: 'triage' }, secondary_action: null });
+
+    if (findingScope !== undefined && (findingScope.kind === 'all' || findingScope.managedSystemIds.length > 0)) {
+      const [active, noExecution] = await Promise.all([
+        repo.countActiveFindings(deps.db, actor.workspace_id, findingScope, selectedManagedSystemId),
+        repo.countActiveFindingsWithoutExecution(deps.db, actor.workspace_id, findingScope, selectedManagedSystemId),
+      ]);
+      kpis.active_finding = active;
+      queues.push({ id: 'actionable-finding-no-execution', severity: 'warn', count: noExecution,
+        next_action: { label: 'Review Findings', route: '/findings?status=active', intent: 'plan_execution' }, secondary_action: null });
+      const executed = await repo.countActiveFindingsWithExecution(deps.db, actor.workspace_id, findingScope, selectedManagedSystemId);
+      coverage.push({ id: 'finding-execution', value: executed, total: active, percent: percent(executed, active), status: coverageStatus(percent(executed, active)) });
+    }
+
+    if (taskScope !== undefined && (taskScope.kind === 'all' || taskScope.managedSystemIds.length > 0)) {
+      kpis.tasks_in_flight = await repo.countTasksInFlight(deps.db, actor.workspace_id, taskScope, selectedManagedSystemId);
+      const pendingTaskRequests = await repo.countPendingTaskRequests(deps.db, actor.workspace_id, taskScope, selectedManagedSystemId);
+      kpis.pending_request = (kpis.pending_request ?? 0) + pendingTaskRequests;
+      const released = await repo.releasedTaskIds(deps.db, actor.workspace_id, taskScope, selectedManagedSystemId);
+      const unresolvedTasks = await Promise.all(released.map(async (taskId) => {
+        const links = await selectEligibleVocLinksForReleasedTask(deps.db, { workspaceId: actor.workspace_id, taskId });
+        const unresolved = await repo.unresolvedVocIds(deps.db, actor.workspace_id, links.map((link) => link.voc_id));
+        return unresolved.size > 0;
+      }));
+      const unresolved = unresolvedTasks.filter(Boolean).length;
+      queues.push({ id: 'released-task-unresolved-voc', severity: 'warn', count: unresolved,
+        next_action: { label: 'Review released Tasks', route: '/tasks?status=released', intent: 'request_reporter_update' }, secondary_action: null });
+      const releasedUpdate = await repo.countReleasedTasksWithPublicUpdate(
+        deps.db,
+        actor.workspace_id,
+        taskScope,
+        selectedManagedSystemId,
+      );
+      const releasedUpdatePercent = percent(releasedUpdate.value, releasedUpdate.total);
+      coverage.push({
+        id: 'released-update',
+        ...releasedUpdate,
+        percent: releasedUpdatePercent,
+        status: coverageStatus(releasedUpdatePercent),
+      });
+    }
+
+    if (surveyScopeForDashboard !== undefined && canSeeSurveyQueue) {
+      const gaps = await repo.countSurveyGaps(deps.db, actor.workspace_id, surveyScopeForDashboard, selectedManagedSystemId);
+      queues.push({ id: 'bad-outcome-no-followup', severity: 'urgent', count: gaps,
+        next_action: { label: 'Review outcome surveys', route: '/surveys?type=outcome', intent: 'create_followup' }, secondary_action: null });
+    }
+
+    const permissionRequests = await authorizationAbsent(() => deps.requestService.listAllActive(actor));
+    if (permissionRequests !== undefined) {
+      kpis.pending_request = (kpis.pending_request ?? 0) + permissionRequests.count;
+      queues.push({ id: 'permission-requests-pending', severity: 'info', count: permissionRequests.count,
+        next_action: { label: 'Open Requests', route: '/admin/permission-requests', intent: 'review_permissions' }, secondary_action: null });
+    }
+
+    if (openVoc !== undefined) {
+      const vocScope = await actorScopeForCapability(deps.db, actor, 'voc.read');
+      const selectedVocScope = inRequestedScope(vocScope, selectedManagedSystemId);
+      if (selectedVocScope !== undefined && (selectedVocScope.kind === 'all' || selectedVocScope.managedSystemIds.length > 0)) {
+        const [vocTask, analytics] = await Promise.all([
+          repo.countVocsWithTask(deps.db, actor.workspace_id, selectedVocScope, selectedManagedSystemId),
+          repo.countAnalyticsAreaVocCoverage(deps.db, actor.workspace_id, selectedVocScope, selectedManagedSystemId),
+        ]);
+        const vocTaskPercent = percent(vocTask.value, vocTask.total);
+        coverage.push({ id: 'voc-task', ...vocTask, percent: vocTaskPercent, status: coverageStatus(vocTaskPercent) });
+        const analyticsPercent = percent(analytics.value, analytics.total);
+        coverage.push({ id: 'analytics-area', ...analytics, percent: analyticsPercent, status: coverageStatus(analyticsPercent) });
+        kpis.coverage_percent = vocTaskPercent;
+      }
+    }
+
+    // milestone-outcome has no MVP Milestone table or backing filter. Omit it.
+    // high-followup has the same absence rule as the high-severity queue.
+    if (highUnlinked !== undefined && openVoc !== undefined) {
+      const totalHigh = await authorizationAbsent(() => deps.vocReadService.countVocs({ actor, query: {
+        view: 'inbox', ...(selectedManagedSystemId !== undefined ? { managed_system_id: selectedManagedSystemId } : {}),
+        'filter.severity': ['high', 'critical'],
+      } }));
+      if (totalHigh !== undefined) {
+        const followed = totalHigh - highUnlinked;
+        const highPercent = percent(followed, totalHigh);
+        coverage.push({ id: 'high-followup', value: followed, total: totalHigh, percent: highPercent, status: coverageStatus(highPercent) });
+      }
+    }
+    return { kpis, action_queues: queues, coverage };
+  }
+  return { getSummary };
+}
+
+export type DashboardService = ReturnType<typeof createDashboardService>;

--- a/apps/backend/src/modules/voc/__tests__/list-vocs.integration.test.ts
+++ b/apps/backend/src/modules/voc/__tests__/list-vocs.integration.test.ts
@@ -15,6 +15,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { loadConfig } from '../../../config.js';
 import { type DbHandle, createDb } from '../../../db/client.js';
 import { buildServer } from '../../../server.js';
+import { createVocReadService, type CountVocsQuery } from '../read-service.js';
 import {
   SESSION_COOKIE_NAME,
   cleanupReadTestTables,
@@ -117,6 +118,26 @@ describe.skipIf(!runIntegration)('GET /vocs (#15 C4 — list)', () => {
     const msIds = body.items.map((i) => i.primary_managed_system_id);
     expect(msIds).toContain(msAId);
     expect(msIds).not.toContain(msBId);
+  });
+
+  it('countVocs forwards filter.severity to the shared read predicate', async () => {
+    const msId = await insertMsDirectly(dbHandle, WORKSPACE_ID, `${uid(SLUG_PREFIX)}-count-severity`, 'Count Severity MS');
+    // countVocs only resolves scope and calls the repo predicate, so its other
+    // service dependencies are intentionally not reached by this direct test.
+    const vocReadService = createVocReadService({
+      db: dbHandle.db,
+      checkService: undefined as never,
+      entityLinksService: undefined as never,
+    });
+    const actor = { actor_id: adminActorId, workspace_id: WORKSPACE_ID, role_level: 'admin' as const };
+    const query: CountVocsQuery = { view: 'inbox', 'filter.severity': ['high'] };
+    const before = await vocReadService.countVocs({ actor, query });
+
+    await insertVocDirectly(dbHandle, WORKSPACE_ID, msId, reporterId, 'Count high one', { severity: 'high' });
+    await insertVocDirectly(dbHandle, WORKSPACE_ID, msId, reporterId, 'Count high two', { severity: 'high' });
+    await insertVocDirectly(dbHandle, WORKSPACE_ID, msId, reporterId, 'Count low', { severity: 'low' });
+
+    await expect(vocReadService.countVocs({ actor, query })).resolves.toBe(before + 2);
   });
 
   // ── AC3: view=my filters by reporter_id ───────────────────────────────────

--- a/apps/backend/src/modules/voc/read-service.ts
+++ b/apps/backend/src/modules/voc/read-service.ts
@@ -49,8 +49,16 @@ export interface ReadActorContext {
   role_level: 'admin' | 'developer' | 'user';
 }
 
-/** Count queries share list filters, but pagination is list-only. */
-export type CountVocsQuery = Omit<ListVocsQuery, 'limit'>;
+/** Count queries use the same predicates as the list, without list-only fields. */
+export type CountVocsQuery = Pick<
+  ListVocsQuery,
+  | 'view'
+  | 'managed_system_id'
+  | 'tab'
+  | 'filter.severity'
+  | 'filter.reporter_facing_status'
+  | 'filter.owner'
+>;
 
 // ── Inline conversation cursor (conversation-specific; separate from VOC list cursor) ──
 
@@ -278,6 +286,9 @@ export function createVocReadService(deps: VocReadServiceDeps) {
   async function countVocs(args: { actor: ReadActorContext; query: CountVocsQuery }): Promise<number> {
     const { actor, query } = args;
     const { view, tab } = query;
+    const filterSeverity = query['filter.severity'];
+    const filterReporterFacingStatus = query['filter.reporter_facing_status'];
+    const filterOwner = query['filter.owner'];
     if (tab === 'waiting' && view !== 'triage') {
       throw new HttpError('validation.failed', 'tab=waiting is only valid for view=triage', {
         fields: [{ path: ['tab'], code: 'invalid_for_view' }],
@@ -294,6 +305,9 @@ export function createVocReadService(deps: VocReadServiceDeps) {
       view,
       ...(actorIdForMyFilter !== undefined ? { actorIdForMyFilter } : {}),
       ...(tab !== undefined ? { tab } : {}),
+      ...(filterSeverity !== undefined ? { filterSeverity } : {}),
+      ...(filterReporterFacingStatus !== undefined ? { filterReporterFacingStatus } : {}),
+      ...(filterOwner !== undefined ? { filterOwner } : {}),
     });
   }
 

--- a/apps/backend/src/modules/voc/repo-read.ts
+++ b/apps/backend/src/modules/voc/repo-read.ts
@@ -137,7 +137,7 @@ export interface ListVocsRepoArgs {
   scopeFilter: Scope;
   view: 'inbox' | 'my' | 'triage';
   actorIdForMyFilter?: string; // required when view='my'
-  tab?: 'untriaged' | 'high' | 'unassigned' | 'similar' | 'no-link' | 'waiting';
+  tab?: 'untriaged' | 'high' | 'unassigned' | 'similar' | 'no-link' | 'high-no-link' | 'waiting';
   filterSeverity?: ('low' | 'medium' | 'high' | 'critical')[];
   filterReporterFacingStatus?: string[];
   filterOwner?: 'assigned' | 'unassigned';
@@ -183,7 +183,8 @@ export function buildVocListPredicate(args: VocListPredicateArgs): ReturnType<ty
   else if (tab === 'high') wheres.push(sql`severity = 'high'`);
   else if (tab === 'unassigned') wheres.push(sql`owner_user_id IS NULL AND owner_team_id IS NULL`);
   else if (tab === 'waiting') wheres.push(sql`triage_state = 'untriaged' AND triage_state_review_postponed_at IS NOT NULL`);
-  else if (tab === 'no-link') {
+  else if (tab === 'no-link' || tab === 'high-no-link') {
+    if (tab === 'high-no-link') wheres.push(sql`severity IN ('high', 'critical')`);
     wheres.push(sql`NOT EXISTS (
       SELECT 1 FROM ${entityLinks} el
       WHERE el.workspace_id = ${workspaceId} AND el.status = 'active'

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -26,6 +26,7 @@ import {
 } from './modules/analytics-areas/index.js';
 import { MAX_ATTACHMENT_BYTES, attachmentsRoutes } from './modules/attachments/index.js';
 import { createAttachmentsService } from './modules/attachments/service.js';
+import { createDashboardService, dashboardRoutes } from './modules/dashboard/index.js';
 import { listActorsRoutes } from './modules/auth/list-actors-routes.js';
 import { createMockAuthProvider } from './modules/auth/mock-auth-provider.js';
 import { authRoutes } from './modules/auth/routes.js';
@@ -606,6 +607,18 @@ export async function buildServer(opts: BuildServerOptions): Promise<FastifyInst
   await app.register(navRoutes, {
     sessionService,
     navCountsService,
+    workspaceId,
+    rateLimitConfig: { read: app.rateLimitConfig.read },
+  });
+  const dashboardService = createDashboardService({
+    db: dbHandle.db,
+    checkService,
+    requestService,
+    vocReadService,
+  });
+  await app.register(dashboardRoutes, {
+    sessionService,
+    dashboardService,
     workspaceId,
     rateLimitConfig: { read: app.rateLimitConfig.read },
   });

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -22,6 +22,8 @@ export default defineConfig({
       '/nav': 'http://127.0.0.1:3011',
       // #143 actor-private saved-view CRUD is a backend-only root resource.
       '/saved-views': 'http://127.0.0.1:3011',
+      // #217 Home action-dashboard summary is a backend-only root path.
+      '/dashboard': 'http://127.0.0.1:3011',
       // #197 workspace policy endpoints are backend-only root paths, so
       // forward them unconditionally in development.
       '/workspace': 'http://127.0.0.1:3011',

--- a/docs/implementation/03-api-contracts.md
+++ b/docs/implementation/03-api-contracts.md
@@ -54,6 +54,25 @@ Detailed endpoint schemas may later move into OpenAPI, but this document remains
 - A key without a backing list filter is omitted rather than represented by a synthetic zero.
 - Read-only endpoint: no audit event, entity-link mutation, or dashboard queue side effect.
 
+## Dashboard Summary Contract
+
+`GET /dashboard/summary?managed_system_id=<uuid|all>` is an authenticated,
+workspace-scoped read returning KPI, action-queue, and coverage projections.
+`all` resolves to the caller's effective Managed System scope (workspace-wide
+only for an Admin). Each key is independently omitted when its backing read is
+unavailable or returns `permission.denied` / `permission.scope_required`. A
+permitted, empty backing result is present with zero; absence means the actor
+cannot receive that projection, not that its count is zero. The route writes no
+audit row or source record. `milestone-outcome` is absent until the MVP has a
+Milestone backing table and filter.
+
+`coverage.released-update` is **Released Task with public update**: its total
+is released Tasks in scope with at least one active `voc → task` `evidence_of`
+link to a non-archived VOC; its value is the subset with at least one linked
+VOC that has a non-skipped `voc.voc_public_updates` row. A skipped update is a
+recorded status transition without reporter-visible content and does not count
+as coverage.
+
 ## Standard Error Codes
 
 ```text

--- a/docs/implementation/04-database-and-migrations.md
+++ b/docs/implementation/04-database-and-migrations.md
@@ -19,6 +19,10 @@ Applied migrations are the final database authority.
 - Migrations must be reversible when practical.
 - Sensitive decisions append audit log entries.
 - Inline images are stored as governed attachment records and referenced from rich content; never store base64 body images.
+- Survey response and answer tables remain outside `fops_app` read access. Any
+  dashboard or result projection over them must use a narrow `SECURITY DEFINER`
+  aggregate owned by `fops_survey_aggregate_owner`, returning only the contract's
+  aggregate value and never response identifiers or answer bodies.
 ```
 
 ### Database prerequisite: pgvector (ADR-0034 D1)

--- a/packages/shared/src/dashboard.ts
+++ b/packages/shared/src/dashboard.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod';
+
+const dashboardActionSchema = z.object({
+  label: z.string(),
+  route: z.string(),
+  intent: z.string(),
+}).strict();
+
+export const dashboardSummarySchema = z.object({
+  kpis: z.object({
+    open_voc: z.number().int().nonnegative().optional(),
+    active_finding: z.number().int().nonnegative().optional(),
+    pending_request: z.number().int().nonnegative().optional(),
+    tasks_in_flight: z.number().int().nonnegative().optional(),
+    coverage_percent: z.number().int().min(0).max(100).optional(),
+  }).strict(),
+  action_queues: z.array(z.object({
+    id: z.enum([
+      'unassigned-voc',
+      'high-severity-unlinked',
+      'actionable-finding-no-execution',
+      'released-task-unresolved-voc',
+      'bad-outcome-no-followup',
+      'permission-requests-pending',
+    ]),
+    severity: z.enum(['urgent', 'warn', 'info']),
+    count: z.number().int().nonnegative(),
+    next_action: dashboardActionSchema,
+    secondary_action: dashboardActionSchema.nullable(),
+  }).strict()),
+  coverage: z.array(z.object({
+    id: z.enum(['voc-task', 'finding-execution', 'milestone-outcome', 'high-followup', 'released-update', 'analytics-area']),
+    value: z.number().int().nonnegative(),
+    total: z.number().int().nonnegative(),
+    percent: z.number().int().min(0).max(100),
+    status: z.enum(['good', 'warn', 'bad']),
+  }).strict()),
+}).strict();
+
+export type DashboardSummary = z.infer<typeof dashboardSummarySchema>;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -19,3 +19,4 @@ export * from './vocs/index.js';
 export * from './rich-content/index.js';
 export * from './auth/list-actors.js';
 export * from './surveys/results.js';
+export * from './dashboard.js';

--- a/packages/shared/src/vocs/list-query.ts
+++ b/packages/shared/src/vocs/list-query.ts
@@ -35,7 +35,7 @@ export const listVocsQuerySchema = z.object({
     .union([z.string().uuid(), z.literal('all')])
     .optional(),
   tab: z
-    .enum(['untriaged', 'high', 'unassigned', 'similar', 'no-link', 'waiting'])
+    .enum(['untriaged', 'high', 'unassigned', 'similar', 'no-link', 'high-no-link', 'waiting'])
     .optional(),
   // Dot-key filter fields — Fastify query params are flat strings.
   'filter.severity': commaListOf(severityEnumSchema).optional(),

--- a/scripts/db/init.sql
+++ b/scripts/db/init.sql
@@ -15,7 +15,7 @@
 -- per-table GRANT/REVOKE work; this file only creates the roles, the
 -- database, and ensures `fops_migrate` owns it.
 -- Existing databases must provision the matching role and one-way membership
--- before applying migrations 0038 or 0039.
+-- before applying migrations 0038, 0039, or 0046.
 --
 -- The superuser bootstrap user comes from POSTGRES_USER/POSTGRES_PASSWORD on
 -- the container; the Drizzle CLI and the app both connect as the two roles


### PR DESCRIPTION
Closes #217.

Implements the `dashboard` module against the target contract that has been sitting in its `AGENTS.md` since the module was stubbed: six action queues, five coverage metrics, and the KPI strip behind the Home screen prototype (`docs/design-prototype/screenshots/final-baselines/home-action-dashboard.png`).

## Permission contract

Inherited from #143 and non-negotiable: **an absent key is not zero.** An entry is omitted only when there is no backing filter or the caller cannot see it. `permission.denied` and `permission.scope_required` are authorization absence; every other error propagates as an error response. A `0` count asserts "this queue is empty" — a different claim from "you cannot see this queue".

`milestone-outcome` is deliberately unpublished: the MVP schema has no Milestone table to back it.

## Database privilege boundary

Outcome-survey counts cannot be read as `fops_app` — `survey.survey_responses` and `survey_response_answers` are deliberately unreadable by the application role, per migrations 0036–0039. Migration **0046** adds a `SECURITY DEFINER`, count-only aggregate function owned by `fops_survey_aggregate_owner`, following 0038's pattern. `fops_app` receives `EXECUTE` and nothing else. Response bodies never cross that boundary.

## Two defects the tests surfaced

- **`countVocs` silently discarded its filters.** It accepted `filter.severity`, `filter.reporter_facing_status`, and `filter.owner` in its query type and then built repo arguments from `view` and `tab` only, so every filtered count returned the unfiltered total. `listVocs`, immediately below it, forwarded them correctly. Pre-existing, not introduced here. Nav's counts are unaffected — no nav caller passes a shared filter. A direct regression test now names the bug.
- **An admin lost the survey queue on an empty workspace.** `actorSurveyReadScope` derives an admin's scope from *which Managed Systems currently have surveys*; the dashboard read that empty list as a permission denial and omitted the queue. Visibility is now permission-derived and emptiness is `count: 0`. Finding and Task scopes do not share this shape (verified — both resolve through `actorScopeForCapability`, which returns `{kind:'all'}` for an admin regardless of table contents).

`coverage.released-update` now measures what its name claims — released Tasks whose linked VOC carries a non-skipped public update — instead of VOC resolution status. `skip_public_update` rows are not counted as covered; a skip records a transition with no body.

## Verification

| gate | result |
|---|---|
| BE integration | 129 files / 1157 tests |
| FE unit | 133 / 665 |
| visual | 41 / 41 |
| `check:boundaries` | OK |
| tsc | BE 3 / FE 24 — unchanged from develop |

Tests are **seed-relative**: each captures a baseline summary before seeding and asserts per-id deltas, so they do not encode base-seed row counts. Every queue id, coverage id, and KPI is asserted independently with distinct deltas, across a workspace admin, a scope-limited developer, and a zero-grant actor.

Mutation matrix run against the final tests:

| mutation | outcome |
|---|---|
| drop `filterSeverity` forwarding in `countVocs` | killed (2 tests) |
| ignore `skip_public_update` | killed (2) |
| swallow every `HttpError` as authorization absence | killed (1) |
| fall back to `0` for an absent key | killed (3) |
| `inRequestedScope` ignores the selector | killed (1) |
| `repo.scopePredicate` ignores its `managedSystemId` argument | survived — equivalent mutant; the service narrows the scope before the call, so that branch is redundant |

## Follow-ups filed separately

`released-task-unresolved-voc` runs one eligible-link query per released Task. Left as-is here; a batched projection is its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BfiR55zJ7n8uYpr1s3X6q