### PR TITLE
perf(dashboard): batch the released-Task VOC link lookup (#220)

### DIFF
--- a/apps/backend/src/modules/dashboard/__tests__/summary.integration.test.ts
+++ b/apps/backend/src/modules/dashboard/__tests__/summary.integration.test.ts
@@ -361,6 +361,36 @@ describe.skipIf(!runIntegration)('GET /dashboard/summary (#217)', () => {
     expect(response.statusCode).toBe(422);
     expect(response.json<{ code: string }>().code).toBe('validation.failed');
   });
+
+  it('counts each released Task once only when it has an active unresolved VOC link', async () => {
+    const seed = await createDashboardScope();
+    const before = (await get(adminCookie)).json<Summary>();
+    const archivedVoc = await insertVocDirectly(migrateHandle, WORKSPACE_ID, seed.msA, reporterActorId, 'archived released-task VOC');
+    await migrateHandle.pool.query('update voc.vocs set archived_at = now() where id = $1', [archivedVoc.id]);
+    const archivedTask = await insertTaskRow(migrateHandle, { workspaceId: WORKSPACE_ID, primaryManagedSystemId: seed.msA, status: 'released', createdBy: adminActorId });
+    await link('voc', archivedVoc.id, 'task', archivedTask.id, 'evidence_of', seed.msA);
+
+    const resolvedVoc = await insertVocDirectly(migrateHandle, WORKSPACE_ID, seed.msA, reporterActorId, 'resolved released-task VOC');
+    await migrateHandle.pool.query("update voc.vocs set reporter_facing_status = 'resolved' where id = $1", [resolvedVoc.id]);
+    const resolvedTask = await insertTaskRow(migrateHandle, { workspaceId: WORKSPACE_ID, primaryManagedSystemId: seed.msA, status: 'released', createdBy: adminActorId });
+    await link('voc', resolvedVoc.id, 'task', resolvedTask.id, 'evidence_of', seed.msA);
+
+    const closedVoc = await insertVocDirectly(migrateHandle, WORKSPACE_ID, seed.msA, reporterActorId, 'closed released-task VOC');
+    await migrateHandle.pool.query("update voc.vocs set reporter_facing_status = 'closed' where id = $1", [closedVoc.id]);
+    const mixedUnresolvedVoc = await insertVocDirectly(migrateHandle, WORKSPACE_ID, seed.msA, reporterActorId, 'unresolved mixed released-task VOC');
+    const mixedTask = await insertTaskRow(migrateHandle, { workspaceId: WORKSPACE_ID, primaryManagedSystemId: seed.msA, status: 'released', createdBy: adminActorId });
+    await link('voc', closedVoc.id, 'task', mixedTask.id, 'evidence_of', seed.msA);
+    await link('voc', mixedUnresolvedVoc.id, 'task', mixedTask.id, 'evidence_of', seed.msA);
+
+    const firstUnresolvedVoc = await insertVocDirectly(migrateHandle, WORKSPACE_ID, seed.msA, reporterActorId, 'first duplicated released-task VOC');
+    const secondUnresolvedVoc = await insertVocDirectly(migrateHandle, WORKSPACE_ID, seed.msA, reporterActorId, 'second duplicated released-task VOC');
+    const duplicatedTask = await insertTaskRow(migrateHandle, { workspaceId: WORKSPACE_ID, primaryManagedSystemId: seed.msA, status: 'released', createdBy: adminActorId });
+    await link('voc', firstUnresolvedVoc.id, 'task', duplicatedTask.id, 'evidence_of', seed.msA);
+    await link('voc', secondUnresolvedVoc.id, 'task', duplicatedTask.id, 'evidence_of', seed.msA);
+
+    const after = (await get(adminCookie)).json<Summary>();
+    expectQueueDelta(after, before, 'released-task-unresolved-voc', 2);
+  });
 });
 
 describe.skipIf(!runIntegration)('dashboard authorization absence', () => {

--- a/apps/backend/src/modules/dashboard/repo.ts
+++ b/apps/backend/src/modules/dashboard/repo.ts
@@ -58,17 +58,34 @@ export async function countPendingTaskRequests(db: Db, workspaceId: string, scop
     AND tr.status = 'pending_review' AND ${scopePredicate('tr.primary_managed_system_id', scope, managedSystemId)}`);
 }
 
-export async function releasedTaskIds(db: Db, workspaceId: string, scope: Scope, managedSystemId?: string): Promise<string[]> {
-  const result = await db.execute<{ id: string }>(sql`SELECT id FROM task.tasks t WHERE t.workspace_id = ${workspaceId}
-    AND t.status = 'released' AND ${scopePredicate('t.primary_managed_system_id', scope, managedSystemId)}`);
-  return result.rows.map((row) => row.id);
-}
-
-export async function unresolvedVocIds(db: Db, workspaceId: string, vocIds: readonly string[]): Promise<Set<string>> {
-  if (vocIds.length === 0) return new Set();
-  const result = await db.execute<{ id: string }>(sql`SELECT id FROM voc.vocs WHERE workspace_id = ${workspaceId}
-    AND id = ANY(${sqlUuidArray(vocIds)}) AND reporter_facing_status NOT IN ('resolved', 'closed')`);
-  return new Set(result.rows.map((row) => row.id));
+export async function countReleasedTasksWithUnresolvedVoc(
+  db: Db,
+  workspaceId: string,
+  scope: Scope,
+  managedSystemId?: string,
+) {
+  return count(db, sql`
+    SELECT count(*)::int AS count
+    FROM task.tasks t
+    WHERE t.workspace_id = ${workspaceId}
+      AND t.status = 'released'
+      AND ${scopePredicate('t.primary_managed_system_id', scope, managedSystemId)}
+      AND EXISTS (
+        SELECT 1
+        FROM core.entity_links link
+        JOIN voc.vocs voc
+          ON voc.id = link.source_id
+         AND voc.workspace_id = link.workspace_id
+         AND voc.archived_at IS NULL
+        WHERE link.workspace_id = t.workspace_id
+          AND link.source_type = 'voc'
+          AND link.target_type = 'task'
+          AND link.target_id = t.id
+          AND link.relation_type = 'evidence_of'
+          AND link.status = 'active'
+          AND voc.reporter_facing_status NOT IN ('resolved', 'closed')
+      )
+  `);
 }
 
 /**

--- a/apps/backend/src/modules/dashboard/service.ts
+++ b/apps/backend/src/modules/dashboard/service.ts
@@ -2,7 +2,6 @@ import type { DashboardSummary } from '@fops/shared';
 
 import type { Db } from '../../db/client.js';
 import { HttpError } from '../../lib/errors.js';
-import { selectEligibleVocLinksForReleasedTask } from '../entity-links/repo.js';
 import { actorFindingReadScope } from '../findings/authorization.js';
 import type { CheckService } from '../permissions/check-service.js';
 import { actorScopeForCapability, type Scope } from '../permissions/scope-service.js';
@@ -112,13 +111,12 @@ export function createDashboardService(deps: DashboardDeps) {
       kpis.tasks_in_flight = await repo.countTasksInFlight(deps.db, actor.workspace_id, taskScope, selectedManagedSystemId);
       const pendingTaskRequests = await repo.countPendingTaskRequests(deps.db, actor.workspace_id, taskScope, selectedManagedSystemId);
       kpis.pending_request = (kpis.pending_request ?? 0) + pendingTaskRequests;
-      const released = await repo.releasedTaskIds(deps.db, actor.workspace_id, taskScope, selectedManagedSystemId);
-      const unresolvedTasks = await Promise.all(released.map(async (taskId) => {
-        const links = await selectEligibleVocLinksForReleasedTask(deps.db, { workspaceId: actor.workspace_id, taskId });
-        const unresolved = await repo.unresolvedVocIds(deps.db, actor.workspace_id, links.map((link) => link.voc_id));
-        return unresolved.size > 0;
-      }));
-      const unresolved = unresolvedTasks.filter(Boolean).length;
+      const unresolved = await repo.countReleasedTasksWithUnresolvedVoc(
+        deps.db,
+        actor.workspace_id,
+        taskScope,
+        selectedManagedSystemId,
+      );
       queues.push({ id: 'released-task-unresolved-voc', severity: 'warn', count: unresolved,
         next_action: { label: 'Review released Tasks', route: '/tasks?status=released', intent: 'request_reporter_update' }, secondary_action: null });
       const releasedUpdate = await repo.countReleasedTasksWithPublicUpdate(


### PR DESCRIPTION
Closes #220.

`GET /dashboard/summary` ran `1 + 2N` queries to count released Tasks with an unresolved linked VOC — one link lookup and one VOC-status lookup per released Task, on a route that renders on every Home page load.

## Change

- `dashboard/repo.ts`: new `countReleasedTasksWithUnresolvedVoc(db, workspaceId, scope, managedSystemId?)` — one correlated `EXISTS` over `core.entity_links` joined to `voc.vocs`, mirroring the existing `countReleasedTasksWithPublicUpdate` shape. It counts Tasks, not links.
- `dashboard/service.ts`: the per-Task loop becomes a single call; the now-unused `selectEligibleVocLinksForReleasedTask` import is dropped. `entity-links/repo.ts` is untouched — the Task release job still owns that function.
- `releasedTaskIds` and `unresolvedVocIds` had no remaining caller and were removed.

Semantics are unchanged: a released Task counts once when at least one active `evidence_of` link points from a non-archived VOC whose `reporter_facing_status` is not `resolved`/`closed`.

## Tests

The pre-existing fixture could not distinguish a correct batch from a wrong one — it never seeded an archived VOC, never seeded a resolved/closed VOC on a released Task, and linked exactly one VOC per Task. One new case covers all four:

| fixture | expected |
|---|---|
| released Task linked only to an archived VOC | not counted |
| released Task linked only to a `resolved` VOC | not counted |
| released Task linked to a `closed` VOC **and** an unresolved VOC | counted |
| released Task with two unresolved linked VOCs | counted once |

Asserted as a single delta of `2`. Existing deltas are unchanged — a correct batch is observationally identical.

## Verification

```
pnpm --filter backend test:integration   129 files / 1158 passed / 0 failed   (baseline 129/1157)
pnpm check:boundaries                    OK
BE tsc                                   3 errors, all pre-existing
```

Mutation matrix, all run against the dashboard suite:

| mutation | result |
|---|---|
| drop `voc.archived_at IS NULL` | killed (1) |
| drop `reporter_facing_status NOT IN ('resolved','closed')` | killed (1) |
| drop `scopePredicate` on the Task | killed (2) |
| count links instead of Tasks (`EXISTS` → `JOIN`) | killed (1) — `expected 3 to be 2` |