### PR TITLE
test(db): guard that every migration .sql has a _journal.json entry (#222)

### DIFF
--- a/apps/backend/src/db/__tests__/migration.test.ts
+++ b/apps/backend/src/db/__tests__/migration.test.ts
@@ -323,3 +323,45 @@ describe('migrations directory', () => {
     );
   });
 });
+
+describe('migration journal', () => {
+  it('keeps every migration file and journal entry in lockstep', () => {
+    const files = readdirSync(MIGRATIONS_DIR)
+      .filter((file) => file.endsWith('.sql'))
+      .sort();
+    const journal = JSON.parse(
+      readFileSync(join(MIGRATIONS_DIR, 'meta', '_journal.json'), 'utf8'),
+    ) as { entries: Array<{ idx: number; tag: string }> };
+    const tags = journal.entries.map((entry) => entry.tag);
+    const tagSet = new Set(tags);
+    const fileTags = files.map((file) => file.slice(0, -'.sql'.length));
+    const fileTagSet = new Set(fileTags);
+    const missingJournalEntries = files.filter((file) => !tagSet.has(file.slice(0, -'.sql'.length)));
+    const missingMigrationFiles = tags.filter((tag) => !fileTagSet.has(tag));
+    const unexpectedIndexes = journal.entries
+      .filter((entry, expectedIdx) => entry.idx !== expectedIdx)
+      .map((entry) => `${entry.idx}:${entry.tag}`);
+    const mismatchedTags = journal.entries
+      .filter((entry) => !entry.tag.startsWith(`${String(entry.idx).padStart(4, '0')}_`))
+      .map((entry) => `${entry.idx}:${entry.tag}`);
+
+    expect(files.length).toBeGreaterThanOrEqual(40);
+    expect(journal.entries.length).toBe(files.length);
+    expect(
+      missingJournalEntries,
+      `Migration file(s) missing _journal.json entry: ${missingJournalEntries.join(', ')}`,
+    ).toEqual([]);
+    expect(
+      missingMigrationFiles,
+      `_journal.json tag(s) missing migration file: ${missingMigrationFiles.join(', ')}`,
+    ).toEqual([]);
+    expect(
+      unexpectedIndexes,
+      `_journal.json entry idx values must be contiguous and ordered: ${unexpectedIndexes.join(', ')}`,
+    ).toEqual([]);
+    expect(
+      mismatchedTags,
+      `_journal.json tag(s) must start with their zero-padded idx: ${mismatchedTags.join(', ')}`,
+    ).toEqual([]);
+  });
+});

--- a/apps/backend/src/db/__tests__/migration.test.ts
+++ b/apps/backend/src/db/__tests__/migration.test.ts
@@ -346,7 +346,6 @@ describe('migration journal', () => {
       .map((entry) => `${entry.idx}:${entry.tag}`);
 
     expect(files.length).toBeGreaterThanOrEqual(40);
-    expect(journal.entries.length).toBe(files.length);
     expect(
       missingJournalEntries,
       `Migration file(s) missing _journal.json entry: ${missingJournalEntries.join(', ')}`,
@@ -355,6 +354,7 @@ describe('migration journal', () => {
       missingMigrationFiles,
       `_journal.json tag(s) missing migration file: ${missingMigrationFiles.join(', ')}`,
     ).toEqual([]);
+    expect(journal.entries.length).toBe(files.length);
     expect(
       unexpectedIndexes,
       `_journal.json entry idx values must be contiguous and ordered: ${unexpectedIndexes.join(', ')}`,


### PR DESCRIPTION
Closes #222.

`drizzle-kit migrate` reads `apps/backend/migrations/meta/_journal.json`, not the migrations directory. A `.sql` file with no journal entry is skipped and the command still prints `[✓] migrations applied successfully!` with exit 0 — no error, no warning. The failure surfaces much later as a missing table, column, or function, where it reads as an application bug.

This happened in #217: `0046_dashboard_survey_gap_aggregate.sql` was written without a journal entry, `db:migrate` reported success twice, and the function did not exist. A dispatched worker cannot run migrations at all, so it can never notice; a CI or deploy path that trusts the exit code would report success while the schema silently diverges.

## Change

One new `describe` in `apps/backend/src/db/__tests__/migration.test.ts`, next to the existing structural guards. Pure filesystem + JSON — no database, no env gate — so it runs in the default `pnpm --filter backend test` and fails fast for anyone who adds a migration by hand.

Asserts, in this order:

1. at least 40 `.sql` files found — non-vacuity, so an empty read goes red rather than green
2. every `.sql` file has a matching journal `tag`, naming the offending file
3. every journal `tag` has a matching `.sql` file, naming the offending tag
4. entry count equals file count
5. `idx` values are contiguous and ordered
6. each `tag` starts with its own zero-padded `idx` (entry `idx: 46` ⇒ `0046_`)

Assertion order is load-bearing. With the count check placed first, the exact #217 scenario failed on `expected 47 to be 46` and the message naming the file was unreachable — it only fired when the two counts happened to be equal, which is the least likely shape of this bug.

## Verification

```
pnpm --filter backend test:integration   129 files / 1159 passed / 0 failed   (baseline 129/1158)
pnpm check:boundaries                    OK
BE tsc                                   3 errors, all pre-existing
```

Mutation matrix — every mutation was applied to real repo state, run, then reverted:

| mutation | diagnostic produced |
|---|---|
| remove the last journal entry (the #217 bug) | `Migration file(s) missing _journal.json entry: 0046_dashboard_survey_gap_aggregate.sql` |
| add a journal tag pointing at a deleted file | `_journal.json tag(s) missing migration file: 0047_does_not_exist` |
| add a stray `0047_orphan_test.sql` with no entry | `Migration file(s) missing _journal.json entry: 0047_orphan_test.sql` |
| set an entry's `idx` to 99 | `_journal.json entry idx values must be contiguous and ordered: 99:0046_…` |
| retag entry 46 with counts left equal | `Migration file(s) missing _journal.json entry: 0046_dashboard_survey_gap_aggregate.sql` |