### PR TITLE
test(db): widen the role-grants guard from 2 to 8 product schemas (#216)

### DIFF
--- a/apps/backend/src/db/__tests__/role-grants-product-tables.integration.test.ts
+++ b/apps/backend/src/db/__tests__/role-grants-product-tables.integration.test.ts
@@ -1,10 +1,10 @@
 /**
  * Slice 3 #22 — DB role grants drift check for product tables.
  *
- * Asserts that `fops_app` holds exactly the DML privileges each `voc.*` base
- * table is designed for — no more, no less. Most product tables are full-DML
- * (SELECT/INSERT/UPDATE/DELETE), but several are intentionally append-only or
- * read-only per migration 0010 (`0010_slice3_voc_foundation.sql`):
+ * Asserts that `fops_app` holds exactly the DML privileges each product-schema
+ * base table is designed for — no more, no less. Most product tables are
+ * full-DML (SELECT/INSERT/UPDATE/DELETE), but several are intentionally
+ * append-only or read-only per migration 0010 (`0010_slice3_voc_foundation.sql`):
  *
  *   - voc_public_updates / voc_reporter_replies / voc_internal_comments:
  *     SELECT + INSERT only. These are immutable conversation-feed rows; the
@@ -38,7 +38,16 @@ const WORKSPACE_ID = process.env.WORKSPACE_ID ?? '';
 
 const runIntegration = Boolean(APP_URL && MIGRATE_URL && WORKSPACE_ID);
 
-const PRODUCT_SCHEMAS = ['voc', 'survey'] as const;
+const PRODUCT_SCHEMAS = [
+  'core',
+  'finding',
+  'permission',
+  'survey',
+  'task',
+  'task_request',
+  'voc',
+  'voc_cluster',
+] as const;
 const DML_PRIVILEGES = ['SELECT', 'INSERT', 'UPDATE', 'DELETE'] as const;
 type DmlPrivilege = (typeof DML_PRIVILEGES)[number];
 
@@ -50,14 +59,45 @@ const SURVEY_AGGREGATE_FUNCTIONS = [
 ] as const;
 
 // Tables intentionally narrower than full-DML for fops_app, keyed by the
-// fully-qualified `schema.table` name. Grants come from migrations 0010, 0037,
-// 0039, and 0044.
+// fully-qualified `schema.table` name. Grants come from the cited migrations.
 //
 // A table absent from this map is asserted as full-DML. That default is why a
 // new narrower table shows up here as a missing-DELETE failure rather than as
 // silence: the entry is the design record, and adding one is a decision, not
 // paperwork (#207).
 const EXPECTED_GRANTS: Record<string, readonly DmlPrivilege[]> = {
+  // Migration 0000 makes the audit log append-only so application writes retain
+  // an immutable history.
+  'core.audit_log': ['SELECT', 'INSERT'],
+  // Migration 0027 keeps counter mutation inside next_display_id, a SECURITY
+  // DEFINER function; the application can only read the backing counter rows.
+  'core.display_counters': ['SELECT'],
+  // Migrations 0018 and 0019 record canonical link history by inserting and
+  // soft-detaching links (status='detached'), never hard-deleting them.
+  'core.entity_links': ['SELECT', 'INSERT', 'UPDATE'],
+  // Migration 0009 revokes writes per ADR-0019 Section C: teams remain a
+  // read-only placeholder until a team-management service ships.
+  'core.teams': ['SELECT'],
+  // Migration 0041 grants the settings upsert path; settings are updated in
+  // place and are not deleted by the application.
+  'core.workspace_settings': ['SELECT', 'INSERT', 'UPDATE'],
+  // Migration 0021 models evidence as maintained finding context, allowing
+  // creation and correction but no application hard-delete path.
+  'finding.evidence_highlights': ['SELECT', 'INSERT', 'UPDATE'],
+  // Migration 0020 uses Finding status transitions (including archived) rather
+  // than application hard deletes.
+  'finding.findings': ['SELECT', 'INSERT', 'UPDATE'],
+  // Migration 0025 models Task lifecycle through status updates, not deletion.
+  'task.tasks': ['SELECT', 'INSERT', 'UPDATE'],
+  // Migration 0023 preserves Task Request review/conversion history through
+  // status transitions rather than application hard deletes.
+  'task_request.task_requests': ['SELECT', 'INSERT', 'UPDATE'],
+  // Migration 0022 makes clusters draft/confirmed records, updated in place
+  // rather than deleted by the application.
+  'voc_cluster.voc_clusters': ['SELECT', 'INSERT', 'UPDATE'],
+  // Migration 0022 treats membership as a mutable set: members are added or
+  // removed, but their immutable join rows are never updated.
+  'voc_cluster.voc_cluster_members': ['SELECT', 'INSERT', 'DELETE'],
   'survey.surveys': ['SELECT', 'INSERT', 'UPDATE'],
   'survey.survey_questions': ['SELECT', 'INSERT', 'UPDATE', 'DELETE'],
   'survey.survey_responses': ['INSERT'],
@@ -94,7 +134,7 @@ describe.skipIf(!runIntegration)('ADR-0008 role grants — product tables (Slice
     await appHandle?.close();
   });
 
-  it('fops_app holds exactly the designed DML privileges on every voc.* base table', async () => {
+  it('fops_app holds exactly the designed DML privileges on every product-schema base table', async () => {
     const { rows: tables } = await migrateHandle.pool.query<{
       table_schema: string;
       table_name: string;
@@ -106,7 +146,14 @@ describe.skipIf(!runIntegration)('ADR-0008 role grants — product tables (Slice
           order by table_schema, table_name`,
       [PRODUCT_SCHEMAS as unknown as string[]],
     );
-    expect(tables.length, 'should discover at least one product table').toBeGreaterThan(0);
+    const schemasWithoutTables = PRODUCT_SCHEMAS.filter(
+      (schema) => !tables.some((table) => table.table_schema === schema),
+    );
+    expect(
+      schemasWithoutTables,
+      `product schemas without discovered base tables: ${schemasWithoutTables.join(', ')}`,
+    ).toEqual([]);
+    expect(tables.length, 'should discover at least 38 product tables').toBeGreaterThanOrEqual(38);
 
     const failures: string[] = [];
     for (const t of tables) {


### PR DESCRIPTION
Closes #216.

`role-grants-product-tables.integration.test.ts` asserts `fops_app` holds exactly the designed DML privileges on every product table — an unlisted table is expected to be full-DML, and a narrower one must be registered in `EXPECTED_GRANTS`. That is the guard #207 relied on. But the scan was scoped by `PRODUCT_SCHEMAS = ['voc', 'survey']`, so `core`, `finding`, `task`, `task_request`, `permission`, and `voc_cluster` were never examined. A table in any of those could be granted privileges it was never designed to have and the guard stayed green.

#207 fixed the *registration rule*, not the scan scope. The two look identical from a passing test.

## Change

`PRODUCT_SCHEMAS` now lists all eight product schemas. Widening the scan surfaced eleven previously unaudited narrow grants; each is now a registered `EXPECTED_GRANTS` entry with the migration that created it and the design reason:

| table | granted | migration |
|---|---|---|
| `core.audit_log` | SELECT, INSERT | 0000 — append-only audit history |
| `core.display_counters` | SELECT | 0027 — mutation lives in the `next_display_id` SECURITY DEFINER function |
| `core.entity_links` | SELECT, INSERT, UPDATE | 0018 + 0019 — soft-detach via `status`, never hard delete |
| `core.teams` | SELECT | 0009 — writes revoked per ADR-0019 Section C |
| `core.workspace_settings` | SELECT, INSERT, UPDATE | 0041 — upsert in place |
| `finding.evidence_highlights` | SELECT, INSERT, UPDATE | 0021 |
| `finding.findings` | SELECT, INSERT, UPDATE | 0020 — archived is a status, not a delete |
| `task.tasks` | SELECT, INSERT, UPDATE | 0025 — lifecycle via status |
| `task_request.task_requests` | SELECT, INSERT, UPDATE | 0023 — review/conversion history preserved |
| `voc_cluster.voc_clusters` | SELECT, INSERT, UPDATE | 0022 |
| `voc_cluster.voc_cluster_members` | SELECT, INSERT, DELETE | 0022 — membership is a mutable set of immutable join rows |

Every `permission.*` table is full-DML and needs no entry. No new column-level grant exists in the widened schemas beyond the two already handled.

None of the eleven is an under-grant defect: no code under `apps/backend/src/modules/` issues a `DELETE` against a table lacking the DELETE grant, and nothing updates `voc_cluster_members`. The only raw deletes are `core.idempotency_keys`, `core.rate_limits`, `core.saved_views`, `voc.vocs`, and `voc_cluster.voc_cluster_members` — all of which hold the grant.

The `it(...)` title and file header, which both described a `voc.*`-only scan, are updated to match.

## Non-vacuity

`expect(tables.length).toBeGreaterThan(0)` was nearly worthless with eight schemas listed — seven could be misspelled and it still passed on the survivor, silently un-auditing whole schemas. Replaced with two independent checks: every entry of `PRODUCT_SCHEMAS` must contribute at least one discovered table (naming the ones that did not), and the total must be at least 38.

## Verification

```
pnpm --filter backend test:integration   129 files / 1159 passed / 0 failed
pnpm check:boundaries                    OK
BE tsc                                   3 errors, all pre-existing
```

All eleven migration citations were checked against the actual `GRANT` statements in `apps/backend/migrations/`.

Mutation matrix — the DB mutations were applied to the live dev database and reverted; the assertion that fired is recorded, since order determines which diagnostic is reachable:

| mutation | assertion that fired |
|---|---|
| `GRANT DELETE ON finding.findings` | `fops_app has unexpected GRANT DELETE ON finding.findings` |
| `REVOKE UPDATE ON task.tasks` | `fops_app missing GRANT UPDATE ON task.tasks` |
| `PRODUCT_SCHEMAS` typo `finding` → `findng` | `product schemas without discovered base tables: findng` |
| drop the `core.entity_links` entry | `fops_app missing GRANT DELETE ON core.entity_links` |
| revert scan to `['voc','survey']` | `should discover at least 38 product tables: expected 16` |