### PR TITLE
feat(permissions): add bulk capability scope endpoint (#215)

### DIFF
--- a/apps/backend/src/modules/permissions/__tests__/capability-scope-route.integration.test.ts
+++ b/apps/backend/src/modules/permissions/__tests__/capability-scope-route.integration.test.ts
@@ -1,0 +1,263 @@
+import type { FastifyInstance } from 'fastify';
+import { Pool } from 'pg';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import { loadConfig } from '../../../config.js';
+import { type DbHandle, createDb } from '../../../db/client.js';
+import { SESSION_COOKIE_NAME } from '../../../middleware/require-session.js';
+import { buildServer } from '../../../server.js';
+import { createCheckService } from '../check-service.js';
+
+const APP_URL = process.env.DATABASE_URL ?? '';
+const MIGRATE_URL = process.env.DATABASE_URL_MIGRATE ?? '';
+const WORKSPACE_ID = process.env.WORKSPACE_ID ?? '';
+const runIntegration = Boolean(APP_URL && MIGRATE_URL && WORKSPACE_ID);
+const A = '21500000-0000-4000-8000-000000000001';
+const B = '21500000-0000-4000-8000-000000000002';
+const C = '21500000-0000-4000-8000-000000000003';
+const ACTORS = {
+  admin: {
+    id: '21500000-0000-4000-8000-000000000011',
+    external: 'scope-215-admin',
+    role: 'admin',
+  },
+  developer: {
+    id: '21500000-0000-4000-8000-000000000012',
+    external: 'scope-215-developer',
+    role: 'developer',
+  },
+  wide: {
+    id: '21500000-0000-4000-8000-000000000013',
+    external: 'scope-215-wide',
+    role: 'developer',
+  },
+  wideDeny: {
+    id: '21500000-0000-4000-8000-000000000014',
+    external: 'scope-215-wide-deny',
+    role: 'developer',
+  },
+  denied: {
+    id: '21500000-0000-4000-8000-000000000015',
+    external: 'scope-215-denied',
+    role: 'admin',
+  },
+  inactive: {
+    id: '21500000-0000-4000-8000-000000000016',
+    external: 'scope-215-inactive',
+    role: 'developer',
+  },
+} as const;
+
+function cookie(setCookie: string | string[] | undefined): string {
+  const value = (Array.isArray(setCookie) ? setCookie : [setCookie])
+    .find(Boolean)
+    ?.match(new RegExp(`${SESSION_COOKIE_NAME}=([^;]+)`))?.[1];
+  if (!value) throw new Error('mock-login did not return a session');
+  return value;
+}
+
+describe.skipIf(!runIntegration)('GET /me/permissions/scope', () => {
+  let dbHandle: DbHandle;
+  let app: FastifyInstance;
+  let migratePool: Pool;
+  const ids = Object.values(ACTORS).map((actor) => actor.id);
+  const login = async (external: string) =>
+    cookie(
+      (
+        await app.inject({
+          method: 'POST',
+          url: '/auth/mock-login',
+          headers: { 'user-agent': 'scope-215' },
+          payload: { external_id: external },
+        })
+      ).headers['set-cookie'],
+    );
+  const scope = async (external: string) =>
+    (
+      await app.inject({
+        method: 'GET',
+        url: '/me/permissions/scope?capability=voc.read',
+        headers: { cookie: `${SESSION_COOKIE_NAME}=${await login(external)}` },
+      })
+    ).json().scope as { kind: 'all' } | { kind: 'scoped'; managed_system_ids: string[] };
+  const grant = async (actorId: string, managedSystemId: string | null, extra = '') =>
+    dbHandle.pool.query(
+      `insert into permission.permission_grants (workspace_id, actor_id, capability, managed_system_id, granted_by_actor_id, ${extra || 'granted_at'}) values ($1,$2,'voc.read',$3,$4${extra ? ", now() - interval '1 day'" : ', now()'})`,
+      [WORKSPACE_ID, actorId, managedSystemId, ACTORS.admin.id],
+    );
+
+  beforeAll(async () => {
+    process.env.NODE_ENV = 'test';
+    dbHandle = createDb(APP_URL);
+    migratePool = new Pool({ connectionString: MIGRATE_URL });
+    app = await buildServer({ config: loadConfig(), dbHandle });
+    await app.ready();
+    for (const actor of Object.values(ACTORS))
+      await dbHandle.pool.query(
+        'insert into core.actors (id, workspace_id, external_id, email, display_name, role_level) values ($1,$2,$3,$4,$3,$5)',
+        [actor.id, WORKSPACE_ID, actor.external, `${actor.external}@test.invalid`, actor.role],
+      );
+    for (const [id, slug] of [
+      [A, 'scope-215-a'],
+      [B, 'scope-215-b'],
+      [C, 'scope-215-c'],
+    ] as const)
+      await dbHandle.pool.query(
+        'insert into core.managed_systems (id, workspace_id, slug, name) values ($1,$2,$3,$3)',
+        [id, WORKSPACE_ID, slug],
+      );
+  });
+  beforeEach(async () => {
+    await dbHandle.pool.query(
+      `delete from core.sessions where created_user_agent_summary = 'scope-215'`,
+    );
+    await dbHandle.pool.query(
+      'delete from permission.permission_denies where actor_id = any($1::uuid[])',
+      [ids],
+    );
+    await dbHandle.pool.query(
+      'delete from permission.permission_grants where actor_id = any($1::uuid[])',
+      [ids],
+    );
+  });
+  afterAll(async () => {
+    await dbHandle.pool.query('delete from core.sessions where actor_id = any($1::uuid[])', [ids]);
+    await dbHandle.pool.query(
+      'delete from permission.permission_denies where actor_id = any($1::uuid[])',
+      [ids],
+    );
+    await dbHandle.pool.query(
+      'delete from permission.permission_grants where actor_id = any($1::uuid[])',
+      [ids],
+    );
+    await migratePool.query('delete from core.audit_log where actor_id = any($1::uuid[])', [ids]);
+    await dbHandle.pool.query('delete from core.managed_systems where id = any($1::uuid[])', [
+      [A, B, C],
+    ]);
+    await dbHandle.pool.query('delete from core.actors where id = any($1::uuid[])', [ids]);
+    await app.close();
+    await dbHandle.close();
+    await migratePool.end();
+  });
+
+  it('returns all for an admin without enumerating managed systems', async () => {
+    expect(await scope(ACTORS.admin.external)).toEqual({ kind: 'all' });
+  });
+  it('returns the developer grant id and excludes sibling ids before checking count', async () => {
+    await grant(ACTORS.developer.id, A);
+    const result = await scope(ACTORS.developer.external);
+    expect(result).toMatchObject({ kind: 'scoped' });
+    if (result.kind === 'scoped') {
+      expect(result.managed_system_ids).toContain(A);
+      expect(result.managed_system_ids).not.toContain(B);
+      expect(result.managed_system_ids).not.toContain(C);
+      expect(result.managed_system_ids).toHaveLength(1);
+    }
+  });
+  it('returns all for a workspace grant but enumerates around an MS deny', async () => {
+    await grant(ACTORS.wide.id, null);
+    expect(await scope(ACTORS.wide.external)).toEqual({ kind: 'all' });
+    await grant(ACTORS.wideDeny.id, null);
+    await dbHandle.pool.query(
+      `insert into permission.permission_denies (workspace_id, actor_id, capability, managed_system_id, reason, created_by_actor_id) values ($1,$2,'voc.read',$3,'test',$4)`,
+      [WORKSPACE_ID, ACTORS.wideDeny.id, B, ACTORS.admin.id],
+    );
+    const result = await scope(ACTORS.wideDeny.external);
+    if (result.kind !== 'scoped') throw new Error('expected scoped');
+    expect(result.managed_system_ids).toContain(A);
+    expect(result.managed_system_ids).toContain(C);
+    expect(result.managed_system_ids).not.toContain(B);
+    const workspaceManagedSystemIds = new Set(
+      (
+        await dbHandle.pool.query('select id from core.managed_systems where workspace_id = $1', [
+          WORKSPACE_ID,
+        ])
+      ).rows.map((row) => row.id as string),
+    );
+    workspaceManagedSystemIds.delete(B);
+    const returnedIds = new Set(result.managed_system_ids);
+    const unexpectedIds = [...returnedIds].filter((id) => !workspaceManagedSystemIds.has(id));
+    const missingIds = [...workspaceManagedSystemIds].filter((id) => !returnedIds.has(id));
+    expect(unexpectedIds, `unexpected managed system ids: ${unexpectedIds.join(', ')}`).toEqual([]);
+    expect(missingIds, `missing managed system ids: ${missingIds.join(', ')}`).toEqual([]);
+  });
+  it('returns no ids for a workspace deny and ignores revoked or expired grants', async () => {
+    await grant(ACTORS.denied.id, null);
+    await dbHandle.pool.query(
+      `insert into permission.permission_denies (workspace_id, actor_id, capability, managed_system_id, reason, created_by_actor_id) values ($1,$2,'voc.read',null,'test',$3)`,
+      [WORKSPACE_ID, ACTORS.denied.id, ACTORS.admin.id],
+    );
+    expect(
+      await scope(ACTORS.denied.external),
+      'workspace-wide deny overrides general allow',
+    ).toEqual({
+      kind: 'scoped',
+      managed_system_ids: [],
+    });
+    await dbHandle.pool.query(
+      `insert into permission.permission_grants (workspace_id, actor_id, capability, managed_system_id, granted_by_actor_id, revoked_at) values ($1,$2,'voc.read',$3,$4,now())`,
+      [WORKSPACE_ID, ACTORS.inactive.id, A, ACTORS.admin.id],
+    );
+    await dbHandle.pool.query(
+      `insert into permission.permission_grants (workspace_id, actor_id, capability, managed_system_id, granted_by_actor_id, expires_at) values ($1,$2,'voc.read',$3,$4,now() - interval '1 second')`,
+      [WORKSPACE_ID, ACTORS.inactive.id, B, ACTORS.admin.id],
+    );
+    expect(await scope(ACTORS.inactive.external)).toEqual({
+      kind: 'scoped',
+      managed_system_ids: [],
+    });
+  });
+  it('matches checkCapability for every actor and managed system pair', async () => {
+    await grant(ACTORS.developer.id, A);
+    await grant(ACTORS.wide.id, null);
+    await grant(ACTORS.wideDeny.id, null);
+    await dbHandle.pool.query(
+      `insert into permission.permission_denies (workspace_id, actor_id, capability, managed_system_id, reason, created_by_actor_id) values ($1,$2,'voc.read',$3,'test',$4)`,
+      [WORKSPACE_ID, ACTORS.wideDeny.id, B, ACTORS.admin.id],
+    );
+    await dbHandle.pool.query(
+      `insert into permission.permission_denies (workspace_id, actor_id, capability, managed_system_id, reason, created_by_actor_id) values ($1,$2,'voc.read',null,'test',$3)`,
+      [WORKSPACE_ID, ACTORS.denied.id, ACTORS.admin.id],
+    );
+    await grant(ACTORS.denied.id, null);
+    const check = createCheckService({ db: dbHandle.db });
+    for (const actor of Object.values(ACTORS)) {
+      const result = await scope(actor.external);
+      const idsInScope =
+        result.kind === 'all' ? new Set([A, B, C]) : new Set(result.managed_system_ids);
+      for (const managedSystemId of [A, B, C])
+        expect(idsInScope.has(managedSystemId), `${actor.external} ${managedSystemId}`).toBe(
+          (
+            await check.checkCapability(
+              {
+                actor_id: actor.id,
+                workspace_id: WORKSPACE_ID,
+                role_level: actor.role,
+              },
+              'voc.read',
+              {
+                workspace_id: WORKSPACE_ID,
+                managed_system_id: managedSystemId,
+              },
+            )
+          ).allow,
+        );
+    }
+  });
+  it('returns the check validation envelope for unknown capability and 401 without a session', async () => {
+    const authorized = await app.inject({
+      method: 'GET',
+      url: '/me/permissions/scope?capability=nope',
+      headers: {
+        cookie: `${SESSION_COOKIE_NAME}=${await login(ACTORS.admin.external)}`,
+      },
+    });
+    expect(authorized.statusCode).toBe(422);
+    expect(authorized.json().code).toBe('validation.unknown_capability');
+    const unauthenticated = await app.inject({
+      method: 'GET',
+      url: '/me/permissions/scope?capability=voc.read',
+    });
+    expect(unauthenticated.statusCode).toBe(401);
+  });
+});

--- a/apps/backend/src/modules/permissions/check-service.ts
+++ b/apps/backend/src/modules/permissions/check-service.ts
@@ -30,8 +30,9 @@ import { and, eq, isNull } from 'drizzle-orm';
 
 import type { Capability } from '@fops/shared';
 import type { Db } from '../../db/client.js';
-import type { Tx } from '../../db/tx.js';
 import { permissionDenies, permissionGrants } from '../../db/schema/permission.js';
+import type { Tx } from '../../db/tx.js';
+import { allManagedSystemIds } from '../core/managed-systems/read-projections.js';
 
 // ──────────────────────────────────────────────────────────────────────────
 // Decision shape — locked verbatim by issue #4. Do not extend without an
@@ -55,6 +56,8 @@ export interface RequestableScope {
 export type Decision =
   | { allow: true; via: 'direct_grant' | 'role' | 'managed_system_scope'; grant_id?: string }
   | { allow: false; reason: DenyReason; requestable: RequestableScope[] | null };
+
+export type CapabilityScope = { kind: 'all' } | { kind: 'scoped'; managed_system_ids: string[] };
 
 export interface ActorContext {
   actor_id: string;
@@ -204,7 +207,75 @@ export function createCheckService(deps: CheckServiceDeps) {
     return { allow: false, reason: 'no_grant', requestable };
   }
 
-  return { checkCapability };
+  async function capabilityScope(
+    actor: ActorContext,
+    capability: Capability,
+    scope: { workspace_id: string },
+    options: { tx?: Tx } = {},
+  ): Promise<CapabilityScope> {
+    const db: Tx = options.tx ?? deps.db;
+    if (actor.workspace_id !== scope.workspace_id)
+      return { kind: 'scoped', managed_system_ids: [] };
+
+    const denyRows = await db
+      .select({ managedSystemId: permissionDenies.managedSystemId })
+      .from(permissionDenies)
+      .where(
+        and(
+          eq(permissionDenies.workspaceId, actor.workspace_id),
+          eq(permissionDenies.actorId, actor.actor_id),
+          eq(permissionDenies.capability, capability),
+          isNull(permissionDenies.revokedAt),
+        ),
+      );
+    if (denyRows.some((row) => row.managedSystemId === null)) {
+      return { kind: 'scoped', managed_system_ids: [] };
+    }
+    const deniedIds = new Set(
+      denyRows.map((row) => row.managedSystemId).filter((id): id is string => id !== null),
+    );
+
+    const grantRows = await db
+      .select({
+        managedSystemId: permissionGrants.managedSystemId,
+        revokedAt: permissionGrants.revokedAt,
+        expiresAt: permissionGrants.expiresAt,
+      })
+      .from(permissionGrants)
+      .where(
+        and(
+          eq(permissionGrants.workspaceId, actor.workspace_id),
+          eq(permissionGrants.actorId, actor.actor_id),
+          eq(permissionGrants.capability, capability),
+        ),
+      );
+    const rightNow = now();
+    const isActive = (row: {
+      revokedAt: Date | null;
+      expiresAt: Date | null;
+    }) =>
+      row.revokedAt === null &&
+      (row.expiresAt === null || row.expiresAt.getTime() > rightNow.getTime());
+    const broadAllow =
+      grantRows.some((row) => row.managedSystemId === null && isActive(row)) ||
+      roleSatisfies(actor.role_level, capability);
+    if (broadAllow && deniedIds.size === 0) return { kind: 'all' };
+
+    const allowedIds = broadAllow
+      ? await allManagedSystemIds(db, actor.workspace_id)
+      : grantRows
+          .filter(
+            (row): row is typeof row & { managedSystemId: string } =>
+              row.managedSystemId !== null && isActive(row),
+          )
+          .map((row) => row.managedSystemId);
+    return {
+      kind: 'scoped',
+      managed_system_ids: allowedIds.filter((id) => !deniedIds.has(id)),
+    };
+  }
+
+  return { checkCapability, capabilityScope };
 }
 
 function roleSatisfies(roleLevel: string, capability: Capability): boolean {

--- a/apps/backend/src/modules/permissions/index.ts
+++ b/apps/backend/src/modules/permissions/index.ts
@@ -6,6 +6,7 @@ export {
   type CheckService,
   type CheckServiceDeps,
   type Decision,
+  type CapabilityScope,
   type DenyReason,
   type RequestableScope,
   type ActorContext,

--- a/apps/backend/src/modules/permissions/routes.ts
+++ b/apps/backend/src/modules/permissions/routes.ts
@@ -129,6 +129,40 @@ export const permissionsRoutes: FastifyPluginAsync<PermissionsRoutesOptions> = a
   // Slice 1 #5 — the first audited mutation. Idempotency-Key honored
   // (ADR-0015), audit row committed in the same transaction (ADR-0008).
   app.route({
+    method: 'GET',
+    url: '/me/permissions/scope',
+    preHandler: [requireSession(sessionService), requireWorkspace(workspaceId)],
+    schema: { querystring: z.object({ capability: z.string().min(1) }) },
+    handler: async (req, reply) => {
+      const sess = req.session;
+      if (!sess)
+        throw new HttpError(
+          'internal.unexpected',
+          'session missing after middleware',
+        );
+      const q = req.query as { capability: string };
+      if (!isCapability(q.capability)) {
+        return sendError(
+          reply,
+          'validation.unknown_capability',
+          'unknown capability',
+          { capability: q.capability },
+        );
+      }
+      const scope = await checkService.capabilityScope(
+        {
+          actor_id: sess.actor_id,
+          workspace_id: sess.workspace_id,
+          role_level: sess.role_level,
+        },
+        q.capability,
+        { workspace_id: sess.workspace_id },
+      );
+      return { scope };
+    },
+  });
+
+  app.route({
     method: 'POST',
     url: '/permission-requests',
     preHandler: [requireSession(sessionService), requireWorkspace(workspaceId)],

--- a/apps/frontend/src/lib/api/permissions.ts
+++ b/apps/frontend/src/lib/api/permissions.ts
@@ -33,6 +33,25 @@ export interface PermissionCheckResponse {
   decision: PermissionDecision;
 }
 
+export type CapabilityScope =
+  | { kind: 'all' }
+  | { kind: 'scoped'; managed_system_ids: string[] };
+
+export async function fetchCapabilityScope(
+  capability: string,
+  options?: { signal?: AbortSignal },
+): Promise<{ scope: CapabilityScope }> {
+  const init: RequestInit = { credentials: 'same-origin' };
+  if (options?.signal) init.signal = options.signal;
+  const res = await fetch(
+    `/me/permissions/scope?${new URLSearchParams({ capability }).toString()}`,
+    init,
+  );
+  if (res.status === 401) throw new UnauthenticatedError();
+  if (!res.ok) throw new Error(`/me/permissions/scope failed: ${res.status}`);
+  return (await res.json()) as { scope: CapabilityScope };
+}
+
 export interface CreatePermissionRequestBody {
   requested_capability: string;
   requested_managed_system_id?: string;

--- a/apps/frontend/src/lib/layout/AppFrame.tsx
+++ b/apps/frontend/src/lib/layout/AppFrame.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { DetailPanelSlotContext, cn } from '@fops/ui';
 import { useQuery } from '@tanstack/react-query';
-import { createSavedView, deleteSavedView, fetchManagedSystems, fetchNavCounts, fetchPermissionCheck, fetchSavedViews, type SavedView, type SavedViewSurface } from '@/lib/api';
+import { createSavedView, deleteSavedView, fetchCapabilityScope, fetchManagedSystems, fetchNavCounts, fetchSavedViews, type SavedView, type SavedViewSurface } from '@/lib/api';
 import { useMe } from '@/lib/auth/useMe';
 import { AppRail, type RailDomain } from './AppRail';
 import { AppSidebar, type SidebarNavEntry } from './AppSidebar';
@@ -48,14 +48,10 @@ export function AppFrame({ sidebarEntries, activeDomain, managedSystemId, syncMa
     staleTime: 5 * 60_000,
     retry: false,
   });
-  const systemIds = systemsQuery.data?.items.map((system) => system.id) ?? [];
   const grantsQuery = useQuery({
-    queryKey: ['managed-system-scope', actorId, systemIds] as const,
-    enabled: actorId !== undefined && systemIds.length > 0 && !isAdmin,
-    queryFn: async ({ signal }) => {
-      const decisions = await Promise.all(systemIds.map(async (id) => [id, await fetchPermissionCheck('voc.read', { managedSystemId: id, signal })] as const));
-      return new Set(decisions.filter(([, response]) => response.decision.allow).map(([id]) => id));
-    },
+    queryKey: ['managed-system-scope', actorId, 'voc.read'] as const,
+    enabled: actorId !== undefined && !isAdmin,
+    queryFn: ({ signal }) => fetchCapabilityScope('voc.read', { signal }),
     staleTime: 60_000,
     retry: false,
   });
@@ -82,7 +78,11 @@ export function AppFrame({ sidebarEntries, activeDomain, managedSystemId, syncMa
   const managedSystems = (systemsQuery.data?.items ?? []).map((system) => ({
     id: system.id,
     name: system.name,
-    granted: isAdmin || grantsQuery.data?.has(system.id) === true,
+    granted:
+      isAdmin ||
+      grantsQuery.data?.scope.kind === 'all' ||
+      (grantsQuery.data?.scope.kind === 'scoped' &&
+        grantsQuery.data.scope.managed_system_ids.includes(system.id)),
   }));
   const systemMeta: Record<RailDomain, { label: string; subtitle: string }> = {
     home: { label: 'Home', subtitle: '오늘의 운영 갭' },

--- a/apps/frontend/src/lib/layout/__tests__/AppFrame.scope.test.tsx
+++ b/apps/frontend/src/lib/layout/__tests__/AppFrame.scope.test.tsx
@@ -5,6 +5,7 @@ import { AppFrame } from '../AppFrame';
 
 const MS_ONE = '11111111-1111-4111-8111-111111111111';
 const MS_TWO = '22222222-2222-4222-8222-222222222222';
+const MS_THREE = '33333333-3333-4333-8333-333333333333';
 
 describe('AppFrame managed-system scope', () => {
   it('re-fetches nav counts with managed_system_id after scope selection', async () => {
@@ -51,6 +52,57 @@ describe('AppFrame managed-system scope', () => {
       expect(screen.getByTestId('scope-option-all')).toHaveTextContent('union · 0 systems');
       expect(await screen.findByTestId(`scope-option-${MS_ONE}`)).toBeInTheDocument();
       expect(await screen.findByTestId(`scope-option-${MS_TWO}`)).toBeInTheDocument();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('uses one scope request and dims only systems absent from the returned scope', async () => {
+    const requestedUrls: string[] = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      requestedUrls.push(url);
+      if (url === '/me') return json({ actor: { id: 'actor', external_id: 'actor', email: 'actor@test', display_name: 'Actor', role_level: 'developer' }, workspace_id: 'workspace' });
+      if (url === '/managed-systems') return json({ items: [managedSystem(MS_ONE, 'Identity'), managedSystem(MS_TWO, 'Finance'), managedSystem(MS_THREE, 'Sales')], total: 3 });
+      if (url === '/me/permissions/scope?capability=voc.read') return json({ scope: { kind: 'scoped', managed_system_ids: [MS_TWO] } });
+      if (url === '/nav/counts') return json({ counts: {} });
+      if (url === '/saved-views?surface=voc') return json({ items: [] });
+      throw new Error(`unexpected request ${url}`);
+    });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = fetchMock as typeof globalThis.fetch;
+    try {
+      const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+      render(<QueryClientProvider client={client}><AppFrame activeDomain="voc" sidebarEntries={[]}>content</AppFrame></QueryClientProvider>);
+      await waitFor(() => expect(requestedUrls.filter((url) => url === '/me/permissions/scope?capability=voc.read')).toHaveLength(1));
+      expect(requestedUrls.filter((url) => url.startsWith('/me/permissions/check'))).toHaveLength(0);
+      fireEvent.click(screen.getByTestId('scope-selector'));
+      expect(await screen.findAllByLabelText('Outside your grants')).toHaveLength(2);
+      expect(screen.getByTestId(`scope-option-${MS_TWO}`).querySelector('[aria-label="Outside your grants"]')).toBeNull();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('does not dim any system when the returned scope is all', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === '/me') return json({ actor: { id: 'actor', external_id: 'actor', email: 'actor@test', display_name: 'Actor', role_level: 'developer' }, workspace_id: 'workspace' });
+      if (url === '/managed-systems') return json({ items: [managedSystem(MS_ONE, 'Identity'), managedSystem(MS_TWO, 'Finance'), managedSystem(MS_THREE, 'Sales')], total: 3 });
+      if (url === '/me/permissions/scope?capability=voc.read') return json({ scope: { kind: 'all' } });
+      if (url === '/nav/counts') return json({ counts: {} });
+      if (url === '/saved-views?surface=voc') return json({ items: [] });
+      throw new Error(`unexpected request ${url}`);
+    });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = fetchMock as typeof globalThis.fetch;
+    try {
+      const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+      render(<QueryClientProvider client={client}><AppFrame activeDomain="voc" sidebarEntries={[]}>content</AppFrame></QueryClientProvider>);
+      await waitFor(() => expect(screen.getByTestId('scope-selector')).toBeInTheDocument());
+      fireEvent.click(screen.getByTestId('scope-selector'));
+      expect(await screen.findAllByTestId(/^scope-option-[0-9]/)).toHaveLength(3);
+      await waitFor(() => expect(screen.queryByLabelText('Outside your grants')).not.toBeInTheDocument());
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/apps/frontend/tests/visual/support/mock-api.ts
+++ b/apps/frontend/tests/visual/support/mock-api.ts
@@ -282,6 +282,16 @@ export async function installMockApi(
       return;
     }
 
+    if (isRequest(route, 'GET', '/me/permissions/scope')) {
+      await json(route, 200, {
+        scope:
+          role === 'admin'
+            ? { kind: 'all' }
+            : { kind: 'scoped', managed_system_ids: [] },
+      });
+      return;
+    }
+
     if (isRequest(route, 'GET', '/workspace/settings')) {
       const settingsFixture = options.adminSettingsScenario
         ? adminSettingsFixture

--- a/docs/implementation/03-api-contracts.md
+++ b/docs/implementation/03-api-contracts.md
@@ -906,6 +906,12 @@ lists yield empty arrays. Response:
 ### Permission
 
 ```text
+GET /me/permissions/scope?capability={capability}
+  -> 200 { scope: { kind: "all" } }
+  -> 200 { scope: { kind: "scoped", managed_system_ids: [uuid, ...] } }
+  -> 401 auth.session_invalid
+  -> 422 validation.unknown_capability
+
 POST /permission-requests
 GET /permission-requests          # admin-only workspace list (#87)
 GET /permission-requests/mine     # caller's open requests
@@ -913,6 +919,12 @@ POST /permission-requests/:id/approve   # 미구현 as of Slice 6 — permission
 POST /permission-requests/:id/reject    # 미구현 as of Slice 6 — permission request rejection workflow not started
 POST /permission-requests/:id/revoke    # 미구현 as of Slice 6 — permission grant/request revoke workflow not started
 ```
+
+`GET /me/permissions/scope` (Slice 11 #215) is the per-Managed-System bulk
+equivalent of `GET /me/permissions/check` and resolves in the same order, so
+membership in its result is identical to a point check on every Managed System.
+`all` is returned only when every Managed System is allowed; an active
+Managed-System-scoped deny forces `scoped` enumeration.
 
 `GET /permission-requests` (Slice 3 #87) — admin-only workspace-wide list of
 open (`pending` | `needs_more_info`) requests, plus a `count`. Guarded by the

--- a/docs/implementation/05-permission-policy.md
+++ b/docs/implementation/05-permission-policy.md
@@ -67,6 +67,15 @@ capability checks locally.
 
 Explicit Deny overrides general Allow.
 
+`GET /me/permissions/scope` resolves a capability over every Managed System
+using the same order as a point check: workspace mismatch denies; active
+workspace-wide or matching Managed-System denies deny before grants; active
+workspace-wide grants allow; role-derived capability allows; then active
+matching Managed-System grants allow. A workspace-wide grant or role match
+returns `kind: all` only when there are no active Managed-System-scoped denies.
+When such denies exist, the scope is the workspace Managed System list minus
+the denied ids so its membership remains identical to point checks.
+
 Managed System Permission Scope is the MVP authorization boundary for
 Developer access. Access to one Managed System does not grant access to sibling
 Managed Systems. Analytics Area is not an MVP permission boundary.


### PR DESCRIPTION
Closes #215.

`AppFrame` resolved the scope selector's grants with one
`GET /me/permissions/check?capability=voc.read&managed_system_id=<id>` **per
Managed System**, in parallel, for every non-admin. That fan-out sat on the app
shell. This collapses it to one request.

## Contract

`GET /me/permissions/scope?capability=<cap>`

```json
{ "scope": { "kind": "all" } }
{ "scope": { "kind": "scoped", "managed_system_ids": ["uuid", "uuid"] } }
```

Backed by a new `capabilityScope` on the check service, exported as
`CapabilityScope` from the permissions barrel.

## Three decisions worth stating

**It mirrors `checkCapability`, not `actorScopeForCapability`.** The latter
short-circuits *every* capability to `all` for `role_level` admin, which is
broader than `roleSatisfies`. That is harmless while `voc.read` is the only
caller and silently widens the day a second capability is passed. `scope-service.ts`
and its ten callers are untouched.

**`all` stays a distinct kind rather than an enumerated list.** A workspace-wide
grant is not the same fact as an explicit list, and enumerating would bind the
answer to an archived-Managed-System question the caller did not ask.

**An MS-scoped deny forces enumeration.** `checkCapability` evaluates explicit
denies before grants and role, so returning `all` with denies present would
disagree with the per-MS endpoint on exactly the denied system.

## Verification

| Gate | Result |
|---|---|
| `pnpm --filter backend test:integration` | 130 files / 1165 passed (develop: 129 / 1159) |
| `pnpm --filter frontend exec vitest run` | 134 files / 674 passed (develop: 672) |
| `playwright test` visual harness | 43 passed, no baseline changed |
| `pnpm check:boundaries` | OK |
| backend `tsc` | 3 errors, all pre-existing |
| frontend `tsc` | 26 errors, identical to develop, none in changed files |
| `biome check` on touched paths | 49 errors, identical to develop |

## Mutation matrix

Eight mutations applied against the merged tests; all eight now die with a
diagnostic that names the offending system or actor.

| Mutation | Firing assertion |
|---|---|
| drop `roleSatisfies` from `broadAllow` | `expected {kind:'scoped'} to deeply equal {kind:'all'}`; parity names `scope-215-admin <MS>` |
| drop denied-id subtraction | `expected [...] to not include '…0002'` |
| return `all` despite denies | parity: `scope-215-wide-deny …0002: expected true to be false` |
| `isActive` ignores `revoked_at` | revoked/expired case |
| `isActive` ignores `expires_at` | revoked/expired case |
| drop workspace-wide deny short-circuit | `workspace-wide deny overrides general allow: expected {kind:'all'} to deeply equal {kind:'scoped'}` |
| FE: drop `kind === 'all'` branch | all-scope dimming case |
| FE: ignore returned ids | per-system dimming case |

The last two survived the first passing round. Both were vacuous oracles rather
than implementation defects: the deny fixture held no grant and no allowing
role, so the deny never had to override anything; and the frontend all-scope
test asserted a negative before `systemsQuery` resolved, so it passed over an
empty option list. Both fixtures were strengthened without adding a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BfiR55zJ7n8uYpr1s3X6q