### PR TITLE
docs(survey): reconcile Survey contract drift (#227)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -143,6 +143,16 @@ FeedbackOps presents a focused light-mode experience, inspired by Samsung's ente
 - **Element gap:** 8px
 - **Entity link inventory object rows:** headerless 4-column object-row grid (`--entity-link-object-row-grid`: checkbox, id, body, trailing), 64px id stem (`--entity-link-object-id-min-width`), and default 60px row rhythm (`--row-height-default`) to mirror the integration-links prototype density.
 
+## Survey
+
+Survey uses the same compact operational rhythm as the rest of FeedbackOps: a
+list-first overview, a full-page WorkbenchShell builder, and a result summary
+that prioritizes question distribution and safe text highlights. Use the shared
+light surfaces, 8px element gaps, and one Samsung-blue primary action per
+context; keep builder outline controls and result follow-up actions dense and
+secondary to the survey content. Personal responses are never rendered as a
+read surface; result content must remain aggregate- or approved-excerpt-safe.
+
 ## Components
 
 ### Primary Action Button

--- a/apps/frontend/tests/visual/surveys.visual.spec.ts
+++ b/apps/frontend/tests/visual/surveys.visual.spec.ts
@@ -1,30 +1,30 @@
-import { expect, test } from "./support/visual-test";
-import { surveyVisualFixture, surveyVisualScenarios } from "./fixtures/surveys";
-import { installMockApi } from "./support/mock-api";
-import { expectVisual } from "./support/screenshot";
+import { surveyVisualFixture, surveyVisualScenarios } from './fixtures/surveys';
+import { installMockApi } from './support/mock-api';
+import { expectVisual } from './support/screenshot';
+import { expect, test } from './support/visual-test';
 
-test.describe("/surveys visual harness", () => {
+test.describe('/surveys visual harness', () => {
   for (const scenario of surveyVisualScenarios) {
     test(`renders ${scenario}`, async ({ page }) => {
       await installMockApi(page, {
         surveyScenario: scenario,
-        role: scenario === "no-permission" ? "user" : "admin",
+        role: scenario === 'no-permission' ? 'user' : 'admin',
       });
       const url =
-        scenario === "detail"
+        scenario === 'detail'
           ? `/surveys/${surveyVisualFixture.id}`
-          : scenario === "builder"
+          : scenario === 'builder'
             ? `/surveys/${surveyVisualFixture.id}?builder=true`
-            : "/surveys";
+            : '/surveys';
       await page.goto(url);
       const target =
-        scenario === "builder"
-          ? page.getByTestId("survey-builder")
-          : scenario === "detail"
-            ? page.getByTestId("survey-detail")
-            : scenario === "error"
-              ? page.getByTestId("survey-list-error")
-              : page.getByTestId("survey-list");
+        scenario === 'builder'
+          ? page.getByTestId('survey-builder')
+          : scenario === 'detail'
+            ? page.getByTestId('survey-detail')
+            : scenario === 'error'
+              ? page.getByTestId('survey-list-error')
+              : page.getByTestId('survey-list');
       await expect(target).toBeVisible();
       await expectVisual(page, target, `surveys-${scenario}.png`);
     });

--- a/docs/design/07-survey-system.md
+++ b/docs/design/07-survey-system.md
@@ -180,7 +180,9 @@ Layout:
 - Question Summary
 - Response Distribution
 - Text Response Highlights
-- Filter by Managed System / Segment / Analytics Area
+- Filter by Managed System / Segment / Analytics Area: deferred until responses
+  retain immutable cohort dimensions and an explicit privacy policy prevents
+  subtraction attacks.
 - Add Evidence Highlight CTA
 - Create Finding CTA
 - Link Finding CTA

--- a/docs/design/13-mvp-roadmap.md
+++ b/docs/design/13-mvp-roadmap.md
@@ -105,7 +105,7 @@ Survey:
 - 기본 Builder: MUST
 - Link 배포: MUST
 - 응답 저장: MUST
-- Response List: MUST
+- 개인 응답 목록: 노출 안 함 (승인된 발췌 경로만 존재)
 - 기본 결과 요약: MUST
 - Finding 생성: SHOULD
 - Task Request / Task 연결: SHOULD

--- a/docs/design/14-api-draft.md
+++ b/docs/design/14-api-draft.md
@@ -29,7 +29,6 @@ Expected behavior:
 ```text
 POST /survey-responses/:id/create-finding
 POST /survey-findings/:id/request-task
-POST /survey-findings/:id/create-task
 POST /survey-findings/:id/link-task
 # future: POST /survey-findings/:id/create-milestone
 # future: POST /survey-findings/:id/link-milestone

--- a/docs/frontend/routes-and-layout.md
+++ b/docs/frontend/routes-and-layout.md
@@ -18,6 +18,7 @@ Reusable component contracts live in `docs/frontend/ui-design-system.md`.
 /voc-clusters?selected=:clusterId
 /surveys
 /surveys/:surveyId
+/surveys/:surveyId?builder=true
 /surveys/:surveyId/results
 /tasks?view=my&managedSystem=:managedSystemId|all&selected=:taskId
 /tasks?view=inbox&managedSystem=:managedSystemId|all

--- a/docs/implementation/03-api-contracts.md
+++ b/docs/implementation/03-api-contracts.md
@@ -442,6 +442,9 @@ API-provided priority or `recommended_action_id`, not inferred by the frontend
 from score thresholds alone. Recommendation reasons must use domain-safe summary
 text and must not expose hidden response detail.
 
+This is a target contract, not current Survey behavior: the implementation does
+not yet produce Survey `next_actions` and currently returns an empty array.
+
 `attach_evidence_to_existing_voc` may be returned only when eligible target VOCs
 exist in the actor's effective Managed System scope, the actor may see
 summary-visible VOC context, Survey evidence attachment is policy-allowed, and
@@ -795,6 +798,11 @@ Slice 6. It is created only through source transition routes:
 POST /surveys
 GET /surveys
 GET /surveys/:id
+POST /surveys/:id/questions
+PATCH /surveys/:id/questions/:question_id
+DELETE /surveys/:id/questions/:question_id
+POST /surveys/:id/open
+POST /surveys/:id/close
 GET /surveys/:id/form
 POST /surveys/:id/responses
 GET /surveys/:id/results
@@ -805,6 +813,35 @@ POST /survey-findings/:id/request-task
 POST /survey-findings/:id/link-task
 # future: POST /survey-findings/:id/link-milestone
 ```
+
+`POST /surveys` requires `survey.manage`, an `Idempotency-Key`, and mutation
+rate limiting. Its strict request body is `{ type: 'discovery' | 'validation' |
+'outcome', title, description?, primary_managed_system_id, analytics_area_id?,
+operator_actor_id?, responses_identity_protected }`. It returns `201` with the
+Survey DTO: `{ id, workspace_id, display_id, type, status, title, description,
+primary_managed_system_id, analytics_area_id, operator_actor_id,
+responses_identity_protected, created_by, opened_at, closed_at, created_at,
+updated_at }`.
+
+`GET /surveys` accepts the optional query
+`managed_system_id=<uuid>|all` and returns a permission-filtered array of the
+same Survey DTO (without `questions`).
+
+The three question commands require `survey.manage`, an `Idempotency-Key`, and
+mutation rate limiting; they are draft-only. They create, update, or delete a
+question at the listed Survey/question IDs.
+
+`POST /surveys/:id/open` and `POST /surveys/:id/close` require
+`survey.manage`, an `Idempotency-Key`, and mutation rate limiting. Both return
+`200` with the Survey DTO. Opening an already open Survey is an idempotent no-op
+that returns its current DTO. Opening is otherwise valid only from `draft`, and
+closing only from `open`; an invalid transition returns `422 validation.failed`
+with `fields: [{ path: ['status'], code: 'invalid_transition' }]`. Opening with
+zero questions returns `422 validation.failed` with
+`fields: [{ path: ['questions'], code: 'required' }]`, then validates the
+questions. A successful open/close updates the status and records respectively
+`survey_opened` (with `survey_id`, `display_id`, `question_count`) or
+`survey_closed` (with `survey_id`, `display_id`).
 
 `GET /surveys/:id/form` is the respondent form read surface. Any authenticated
 Actor in the same Workspace may read an open Survey without `survey.read`; a


### PR DESCRIPTION
Closes #227.

Documents the five Survey routes that were implemented but missing from the API
contract (question create/update/delete, open, close), with semantics read
directly from `service.ts` rather than from the issue's prose: `survey.manage`,
`Idempotency-Key`, mutation rate limiting, `200` with the Survey DTO, the
idempotent re-open no-op, the two `422 validation.failed` shapes
(`invalid_transition`, `questions`/`required`), and the `survey_opened` /
`survey_closed` audit detail. Also fills in the `POST /surveys` and
`GET /surveys` payloads — the only Survey entries listed without one.

Resolves three doc-vs-doc contradictions in favour of the code:

- roadmap "Response List: MUST" vs `07-survey-system.md` "No personal-response
  read surface is exposed" — the code exposes none, so the roadmap line was stale
- the result-filter layout item vs the deliberately strict empty query (deferred
  to prevent subtraction attacks)
- the broad `next_actions` contract vs the implementation, which returns `[]`

Drops the unimplemented `POST /survey-findings/:id/create-task` draft route,
which contradicted the Task-Request-first contract. Adds the builder
query-parameter route to the frontend route contract, and a Survey section to
`DESIGN.md`, which had none.

## Verification

No behaviour change; the only code file touched is the survey visual spec,
reformatted with biome alone (single quotes + import order). biome errors over
the touched paths: **291 on develop → 289 here**. Every documented claim was
checked against source by the conductor: the create body schema
(`routes.ts:19-25`), the `managed_system_id=<uuid>|all` list query
(`routes.ts:105`), and the draft-only question guard (`service.ts:231-234`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BfiR55zJ7n8uYpr1s3X6q