### PR TITLE
docs(adr): decide external survey responses and link distribution (#236)

### DIFF
--- a/docs/adr/0035-external-survey-responses.md
+++ b/docs/adr/0035-external-survey-responses.md
@@ -1,0 +1,118 @@
+# ADR-0035: External survey responses
+
+Date: 2026-07-30
+
+## Status
+
+Proposed
+
+Supersedes the authenticated-Actor-only respondent rule for the new public-link
+surface described here. It does not supersede ADR-0033's identity-protection,
+safe-summary, permission, or audit decisions.
+
+## Context
+
+Today every Survey route uses the `requireSession` plus
+`requireWorkspace(WORKSPACE_ID)` preHandler pair. The only routes without that
+pair are `GET /health`, `GET /auth/mock-login`, `POST /auth/mock-login`, and
+`POST /auth/logout`. `requireSession` reads the opaque `fops_session` cookie;
+without it, it returns `401 auth.session_invalid` before a handler runs.
+
+Workspace scope is exclusively `req.session.workspace_id`, and survey route
+`actor(req)` also requires that session. Every survey repository predicate is
+therefore session-scoped today. An unauthenticated respondent has neither an
+Actor nor a workspace ID.
+
+`survey.survey_responses.respondent_actor_id` is currently a NOT NULL foreign
+key to `core.actors`, with the only one-response guarantee being unique
+`(survey_id, respondent_actor_id)`. There is no anonymous identity, invitee,
+recipient, audience, or link-token model. ADR-0006 provisions an
+`internal_member` Actor only on first login; it is not an external respondent
+provisioning mechanism.
+
+ADR-0033 explicitly names “truly anonymous responses with no stored Actor” as
+a reopening trigger at
+`docs/adr/0033-survey-evidence-anonymity-safe-summary-contract.md:74`.
+
+`docs/design/07-survey-system.md:95` says that Survey supports link
+distribution, while `docs/implementation/03-api-contracts.md:846` and `:853`
+limit the existing form and response endpoints to an authenticated Actor in the
+same Workspace. The API contract remains authoritative for those existing
+endpoints; this ADR and ADR-0036 define separate public-link endpoints rather
+than silently widening them.
+
+## Decision
+
+### D1 — External responses store no Actor
+
+The migration makes `survey_responses.respondent_actor_id` nullable for public
+responses. It adds a nullable immutable `external_respondent_id` opaque UUID
+and a nullable `response_link_id` foreign key to the link table defined in
+ADR-0036. Authenticated submissions continue to store an Actor and leave
+`external_respondent_id` null; public submissions do the inverse. No Actor row
+is auto-provisioned for an external respondent.
+
+### D2 — Deduplication is per presented identity, not per real person
+
+The migration replaces the current unqualified
+`(survey_id, respondent_actor_id)` unique index with partial unique indexes on
+`(survey_id, respondent_actor_id)` when the Actor is present and
+`(survey_id, external_respondent_id)` when it is present. The external UUID is
+held in a first-party, HttpOnly response cookie and is never returned in a DTO.
+
+This preserves one response for a retained browser identity, but it does not
+guarantee one response per real-world respondent: a user can clear the cookie,
+use another browser, or receive a shared link. That guarantee is deliberately
+lost for anonymous links and must not be claimed by reporting or product copy.
+
+### D3 — A valid link supplies public workspace scope
+
+Public form and submission routes resolve a non-expired, non-revoked link
+before reading a Survey. `survey_links.workspace_id` and `survey_links.survey_id`
+are the sole public request scope; the handler passes that resolved scope to
+public-specific application services and repositories. The token is never
+accepted as a workspace ID supplied by the client, and public routes do not
+call session `actor(req)`.
+
+### D4 — Public submissions use token-plus-IP rate limiting
+
+Public form reads and submissions have a route-level limiter keyed by the
+resolved link ID plus `req.ip`; submission limits use the mutation tier or a
+stricter dedicated public-mutation tier. The global limiter currently keys
+authenticated traffic by session Actor and otherwise by IP, and exempts only
+`/health`; that is insufficient as the public-link abuse control. Proxy trust
+must remain bounded so `req.ip` cannot be client-spoofed.
+
+### D5 — ADR-0033 remains the protection contract
+
+This ADR realizes ADR-0033's line-74 reopening trigger only for the stored
+Actor assumption. `identity_protected`, safe-summary restrictions, personal
+read capability, and audit/logging prohibitions remain unchanged. Public
+responses are identity-protected by default and cannot make the new opaque
+external identifier visible on any linked surface.
+
+## Consequences
+
+- This is a schema and route-boundary migration; no existing authenticated
+  endpoint becomes public.
+- Abuse prevention is link and browser-identity based, not person verified.
+- Operators can revoke a link to stop future public reads and submissions, but
+  revocation does not delete already submitted responses.
+
+## Alternatives rejected
+
+- Auto-provisioning external Actors: rejected because ADR-0006 defines Actors
+  as first-login internal members and fabricated Actors would imply identity
+  and permission semantics that do not exist.
+- Keeping `respondent_actor_id` NOT NULL with a shared anonymous Actor:
+  rejected because it makes all anonymous responses collide under the current
+  uniqueness rule and creates a misleading identity record.
+- Widening `/surveys/:id/form` and `/surveys/:id/responses`: rejected because
+  it would contradict the authenticated-Actor API contract and expose a
+  session-scoped route without a workspace credential.
+
+## Reopening triggers
+
+Reopen for verified individual invitations, SSO-gated external portals,
+cross-workspace links, a requirement to restore one-response-per-person, or a
+need to retain identifiable respondent data.

--- a/docs/adr/0036-survey-link-distribution-and-respondent-model.md
+++ b/docs/adr/0036-survey-link-distribution-and-respondent-model.md
@@ -1,0 +1,85 @@
+# ADR-0036: Survey link distribution and respondent model
+
+Date: 2026-07-30
+
+## Status
+
+Proposed
+
+## Context
+
+The Survey design acceptance criterion says “Survey supports link distribution”
+at `docs/design/07-survey-system.md:95`, but the implemented API contract at
+`docs/implementation/03-api-contracts.md:846` and `:853` defines the current
+form and response routes for authenticated Actors in the same Workspace only.
+ADR-0035 establishes the anonymous response and public-scope boundary needed
+for a separate link surface.
+
+No audience, recipient, invitee, target, or link-token table exists today.
+
+## Decision
+
+### D1 — Distribution links are opaque, bounded credentials
+
+Introduce `survey.survey_links` with `id`, `workspace_id`, `survey_id`,
+`token_digest`, `expires_at`, `revoked_at`, `created_by_actor_id`, and
+`created_at`. A link token is a cryptographically random 32-byte value encoded
+base64url; only its digest is stored. Each link expires 30 days after creation
+and may be revoked at any time. Expired or revoked tokens are invalid for both
+form reads and submissions.
+
+### D2 — Links are anonymous distribution, not an audience model
+
+Do not introduce audience, recipient, invitee, or target tables in this slice.
+The new `survey_links` table is the whole distribution model: a Survey operator
+creates a shareable public link, and possession is not evidence of a named
+recipient. `survey_responses.response_link_id` and
+`external_respondent_id`, as decided in ADR-0035, record provenance without
+inventing a recipient directory.
+
+### D3 — Token possession replaces session authentication only on public routes
+
+On the new public form and submission routes, a valid link token replaces
+`requireSession` and supplies the workspace/survey scope described in ADR-0035.
+It does not grant an Actor session, any Survey management capability, personal
+response access, results access, or access to the existing
+`/surveys/:id/form` and `/surveys/:id/responses` endpoints. Those endpoints
+remain authenticated exactly as pinned by
+`docs/implementation/03-api-contracts.md:846` and `:853`.
+
+### D4 — Delivery channels are out of scope
+
+This ADR covers creating, revoking, and resolving a link only. Email, SMS,
+chat, CRM, webhook, QR-code delivery, recipient imports, send history, and
+delivery status are out of scope.
+
+### D5 — This realizes the design link-distribution criterion
+
+The public link model in D1-D4 is the decision that realizes
+`docs/design/07-survey-system.md:95`. It does not override the API-contract
+wording for existing authenticated routes; instead it adds the explicitly
+separate public-link contract required by ADR-0035.
+
+## Consequences
+
+- A copied link can be used by anyone until expiry or revocation.
+- There is no named-recipient completion report and no person-level response
+  guarantee; the anonymous deduplication limit is stated in ADR-0035.
+- Later delivery work can add recipients and deliveries without changing the
+  link credential's workspace and Survey binding.
+
+## Alternatives rejected
+
+- Requiring authentication in addition to the token: rejected because it does
+  not satisfy external unauthenticated responses.
+- Embedding workspace or survey IDs in a signed URL as the only credential:
+  rejected because individual revocation and opaque resource discovery require
+  a server-side link record.
+- Building recipients and sending channels now: rejected because link
+  distribution does not require a delivery system.
+
+## Reopening triggers
+
+Reopen for named invitations, delivery tracking, configurable link lifetime,
+multiple submissions per link, password-protected links, or a requirement to
+identify respondents.


### PR DESCRIPTION
## Summary

- ADR-0035 (Proposed): external/unauthenticated survey responses — decides the Actor-less respondent model, the deduplication index replacement, link-derived workspace scope, and token+IP rate limiting.
- ADR-0036 (Proposed): survey link distribution — opaque revocable link credential, deliberately no audience/recipient model, delivery channels out of scope.

Documentation only; no code, no migration, no existing ADR modified.

Closes #236

## Verification

- REVIEW: pass, final, at `d6c321b` (independent codex/gpt-5.6-sol reviewer seat; all three checklist items met).
- VERIFY: PASS 68/68, exit 0, at `d6c321b`, database `verify_issue_236`, role `fops_app`, clean-state sentinel and migration hash both matched.
- Conductor independently re-checked every repository fact the ADRs assert, including the rate limiter's IP fallback (`apps/backend/src/server.ts:216`) and `/health`-only allowList (`:227`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BfiR55zJ7n8uYpr1s3X6q