### PR TITLE
feat(surveys): produce request_task with its own permission model

### DIFF
--- a/apps/backend/src/modules/surveys/__tests__/slice8-exit-criteria-evidence-visibility.integration.test.ts
+++ b/apps/backend/src/modules/surveys/__tests__/slice8-exit-criteria-evidence-visibility.integration.test.ts
@@ -702,7 +702,19 @@ describe.skipIf(!runIntegration)(
       expect(after.next_actions).toEqual(
         expect.arrayContaining([expect.objectContaining({ id: "create_finding" })]),
       );
-      expect(after.next_actions.map((action) => action.id)).not.toContain("request_task");
+      expect(after.next_actions).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: "request_task",
+            availability: "blocked_requestable",
+            source_finding_id: findingId,
+            requestable_permission: {
+              permission: "finding.manage",
+              managed_system_id: source.msId,
+            },
+          }),
+        ]),
+      );
       const targetMs = await insertMsDirectly(
         migrateHandle,
         WORKSPACE_ID,

--- a/apps/backend/src/modules/surveys/__tests__/survey-results.integration.test.ts
+++ b/apps/backend/src/modules/surveys/__tests__/survey-results.integration.test.ts
@@ -217,6 +217,17 @@ describe.skipIf(!runIntegration)('survey result read route (#186)', () => {
       cookie: await loginAs(app, externalId),
     };
   }
+  async function user() {
+    const externalId = `${SLUG}-user-${randomUUID()}`;
+    const row = await migrateHandle.pool.query<{ id: string }>(
+      "insert into core.actors (workspace_id,external_id,email,display_name,role_level,actor_type) values ($1,$2,$3,'Results user','user','internal_member') returning id",
+      [WORKSPACE_ID, externalId, `${externalId}@example.test`],
+    );
+    return {
+      id: row.rows[0]?.id ?? '',
+      cookie: await loginAs(app, externalId),
+    };
+  }
   async function grant(actorId: string, capability: string, msId: string) {
     await migrateHandle.pool.query(
       'insert into permission.permission_grants (workspace_id,actor_id,capability,managed_system_id,granted_by_actor_id) values ($1,$2,$3,$4,$5)',
@@ -482,12 +493,20 @@ describe.skipIf(!runIntegration)('survey result read route (#186)', () => {
     ]);
   });
 
-  it('AC-7 never returns request_task, including after a Finding is derived', async () => {
+  it('emits request_task only for elevated actors who can read the derived Finding', async () => {
     const survey = await seed(full(5));
     const responseId = survey.responseIds[0];
     if (!responseId) throw new Error('response seed failed');
     const excerptId = await approveExcerpt(survey, responseId);
     await grant(adminId, 'survey.read_personal_responses', survey.msId);
+    const beforeDerivation = parse2xx(await get(survey.id));
+    expect(beforeDerivation.next_actions.map((action) => action.id)).not.toContain('request_task');
+    const findingMsId = await insertMsDirectly(
+      appHandle,
+      WORKSPACE_ID,
+      uid(SLUG),
+      'Derived Finding MS',
+    );
     const created = await app.inject({
       method: 'POST',
       url: `/survey-responses/${responseId}/create-finding`,
@@ -496,12 +515,61 @@ describe.skipIf(!runIntegration)('survey result read route (#186)', () => {
         'content-type': 'application/json',
         'idempotency-key': randomUUID(),
       },
-      payload: { severity: 'medium', approved_excerpt_ids: [excerptId] },
+      payload: {
+        severity: 'medium',
+        primary_managed_system_id: findingMsId,
+        approved_excerpt_ids: [excerptId],
+      },
     });
     expect(created.statusCode).toBe(201);
-    expect(parse2xx(await get(survey.id)).next_actions.map((action) => action.id)).not.toContain(
-      'request_task',
+    const findingId = created.json<{ id: string }>().id;
+
+    const elevatedManage = parse2xx(await get(survey.id));
+    expect(elevatedManage.next_actions).toContainEqual(
+      expect.objectContaining({
+        id: 'request_task',
+        availability: 'allowed',
+        intent: 'open_task_request_draft',
+        source_finding_id: findingId,
+      }),
     );
+
+    const nonElevatedManage = await user();
+    for (const capability of ['survey.read', 'survey.read_personal_responses', 'finding.manage'])
+      await grant(nonElevatedManage.id, capability, survey.msId);
+    await grant(nonElevatedManage.id, 'finding.manage', findingMsId);
+    // Deliberately grants Finding scope so this User actor exercises the elevated-role guard.
+    await grant(nonElevatedManage.id, 'finding.read', findingMsId);
+    const nonElevatedBody = parse2xx(await get(survey.id, nonElevatedManage.cookie));
+    expect(nonElevatedBody.next_actions).toContainEqual(
+      expect.objectContaining({ id: 'create_finding', availability: 'allowed' }),
+    );
+    expect(nonElevatedBody.next_actions.map((action) => action.id)).not.toContain('request_task');
+    expect(JSON.stringify(nonElevatedBody)).not.toContain(findingId);
+
+    const elevatedReadOnly = await dev();
+    for (const capability of ['survey.read', 'survey.read_personal_responses'])
+      await grant(elevatedReadOnly.id, capability, survey.msId);
+    await grant(elevatedReadOnly.id, 'finding.read', findingMsId);
+    const elevatedReadOnlyBody = parse2xx(await get(survey.id, elevatedReadOnly.cookie));
+    expect(elevatedReadOnlyBody.next_actions).toContainEqual(
+      expect.objectContaining({
+        id: 'request_task',
+        availability: 'blocked_requestable',
+        source_finding_id: findingId,
+        requestable_permission: {
+          permission: 'finding.manage',
+          managed_system_id: findingMsId,
+        },
+      }),
+    );
+
+    const outOfScope = await dev();
+    for (const capability of ['survey.read', 'survey.read_personal_responses'])
+      await grant(outOfScope.id, capability, survey.msId);
+    const outOfScopeBody = parse2xx(await get(survey.id, outOfScope.cookie));
+    expect(outOfScopeBody.next_actions.map((action) => action.id)).not.toContain('request_task');
+    expect(JSON.stringify(outOfScopeBody)).not.toContain(findingId);
   });
 
   it('enforces the actor matrix and parses every successful result', async () => {

--- a/apps/backend/src/modules/surveys/repo-evidence.ts
+++ b/apps/backend/src/modules/surveys/repo-evidence.ts
@@ -103,6 +103,33 @@ export async function readApprovedResultExcerptsPersonal(
   return result.rows;
 }
 
+export async function listDerivedFindingsForResponses(
+  tx: Tx,
+  workspaceId: string,
+  responseIds: string[],
+): Promise<Array<{ finding_id: string; primary_managed_system_id: string }>> {
+  if (responseIds.length === 0) return [];
+  const ids = sql`ARRAY[${sql.join(
+    responseIds.map((id) => sql`${id}`),
+    sql`, `,
+  )}]::uuid[]`;
+  const result = await tx.execute<{ finding_id: string; primary_managed_system_id: string }>(sql`
+    select distinct f.id as finding_id, f.primary_managed_system_id
+      from core.entity_links el
+      join finding.findings f
+        on f.id = el.target_id
+       and f.workspace_id = el.workspace_id
+     where el.workspace_id = ${workspaceId}
+       and el.source_type = 'survey_response'
+       and el.target_type = 'finding'
+       and el.relation_type = 'generated_finding'
+       and el.status = 'active'
+       and el.source_id = any(${ids})
+     order by f.id
+  `);
+  return result.rows;
+}
+
 /** Safe approval projection for one response. It never reads response answers. */
 export async function readApprovedResponseExcerpts(
   tx: Tx,

--- a/apps/backend/src/modules/surveys/service.ts
+++ b/apps/backend/src/modules/surveys/service.ts
@@ -14,8 +14,12 @@ import type { Tx } from '../../db/tx.js';
 import { HttpError } from '../../lib/errors.js';
 import type { AuditService } from '../core/audit/audit-service.js';
 import type { IdempotencyService } from '../core/idempotency/idempotency-service.js';
+import {
+  actorFindingReadScope,
+  checkFindingManage,
+  isFindingInReadScope,
+} from '../findings/authorization.js';
 import type { CheckService } from '../permissions/check-service.js';
-import { checkFindingManage } from '../findings/authorization.js';
 import {
   actorSurveyReadScope,
   checkSurveyManage,
@@ -27,9 +31,9 @@ import {
   type SurveyResponseEvidenceSubject,
   hasActiveApprovedResponseExcerpt,
   insertApprovedExcerpt,
+  listDerivedFindingsForResponses,
   lockResponseEvidenceSubject,
   readApprovedResponseExcerpts,
-  readApprovedResultExcerpts,
   readApprovedResultExcerptsPersonal,
   readResponseTextCandidate,
   readSurveyQuestionLabel,
@@ -52,9 +56,9 @@ import {
   lockQuestions,
   lockSurvey,
   setSurveyStatus,
-  updateSurvey,
   updateQuestion,
   updateQuestionSortOrders,
+  updateSurvey,
 } from './repo.js';
 
 export interface SurveysActor {
@@ -1014,9 +1018,13 @@ export function createSurveysService(deps: SurveysServiceDeps) {
     return deps.db.transaction(async (tx) => {
       const workspaceSettings = await deps.resolveWorkspaceSettings(tx, actor.workspace_id);
       const anonymityThreshold = workspaceSettings.survey_anonymity_threshold;
-      const excerptRows: Promise<ResultExcerptRow[]> = holder
-        ? readApprovedResultExcerptsPersonal(tx, actor.workspace_id, survey.id)
-        : readApprovedResultExcerpts(tx, actor.workspace_id, survey.id);
+      // Response IDs stay payload-gated below; this internal projection only
+      // supplies the IDs needed to resolve already-derived Finding links.
+      const excerptRows: Promise<ResultExcerptRow[]> = readApprovedResultExcerptsPersonal(
+        tx,
+        actor.workspace_id,
+        survey.id,
+      );
       const [questions, responseCount, aggregateRows, approvedExcerpts, findingManage] =
         await Promise.all([
           listQuestions(tx, actor.workspace_id, survey.id),
@@ -1027,6 +1035,46 @@ export function createSurveysService(deps: SurveysServiceDeps) {
             requireElevatedRole: false,
           }),
         ]);
+      const derivedFindings = await listDerivedFindingsForResponses(
+        tx,
+        actor.workspace_id,
+        approvedExcerpts.flatMap((excerpt) => (excerpt.response_id ? [excerpt.response_id] : [])),
+      );
+      const findingReadScope = await actorFindingReadScope(tx, actor, {
+        requireElevatedRole: true,
+      });
+      // blocked_requestable is elevated + readable + not manageable; a user
+      // cannot receive this action because Finding read scope is elevated-only.
+      const requestTaskActions = await Promise.all(
+        derivedFindings
+          .filter((finding) =>
+            isFindingInReadScope(findingReadScope, finding.primary_managed_system_id),
+          )
+          .map(async (finding) => {
+            const decision = await checkFindingManage(
+              deps.checkService,
+              actor,
+              finding.primary_managed_system_id,
+              { requireElevatedRole: true },
+            );
+            return {
+              id: 'request_task' as const,
+              availability: decision.allow
+                ? ('allowed' as const)
+                : ('blocked_requestable' as const),
+              intent: 'open_task_request_draft' as const,
+              source_finding_id: finding.finding_id,
+              ...(!decision.allow && decision.requestable !== null
+                ? {
+                    requestable_permission: {
+                      permission: 'finding.manage' as const,
+                      managed_system_id: finding.primary_managed_system_id,
+                    },
+                  }
+                : {}),
+            };
+          }),
+      );
       const rowsByQuestion = new Map<string, typeof aggregateRows>();
       for (const row of aggregateRows) {
         const rows = rowsByQuestion.get(row.question_id) ?? [];
@@ -1141,6 +1189,7 @@ export function createSurveysService(deps: SurveysServiceDeps) {
             intent: 'open_finding_draft' as const,
             ...actionPermission,
           },
+          ...requestTaskActions,
         ],
       });
       if (holder) {


### PR DESCRIPTION
Closes #239.

## What

`next_actions` was a hardcoded single `create_finding` entry. `request_task` now joins it — derived **per Finding**, not per survey, with a decision that is deliberately *not* `create_finding`'s.

Every Task Request path uses `requireElevatedRole: true` against the derived Finding's own `primary_managed_system_id` (`task-requests/service.ts:306, 361, 410, 460, 526`); `create_finding` uses `requireElevatedRole: false` against the survey's (`findings/service.ts:191-201`). Sharing one decision would make availability lie to a non-elevated grantee and to any Finding derived into a different Managed System.

## No new privileges, no migration

The existing definer `survey.read_approved_result_excerpts_personal` already returns `response_id`, and `fops_app` already reads `core.entity_links` — so the app role joins `generated_finding` links itself. Neither `fops_survey_evidence_reader_owner` nor `fops_app` gains anything, and no migration was needed.

Findings outside the actor's elevated read scope are filtered before the action is built, so an unreadable Finding's id never reaches the payload.

## AC-2 was unsatisfiable and was amended

`actorFindingReadScope(..., { requireElevatedRole: true })` returns an empty scope for any non-elevated actor (`findings/authorization.ts:27-29`), and `source_finding_id` is **required** on the variant (`packages/shared/src/surveys/results.ts:119`). A `user` actor can therefore never receive this action at any availability — emitting it would leak a Finding id outside the very scope AC-3 protects. A dispatched worker blocked on this correctly; the amendment is recorded on the issue.

- **AC-2a** — user actor: `create_finding` allowed, no `request_task`, Finding id absent from the body.
- **AC-2b** — elevated, readable, not manageable: `request_task` `blocked_requestable` with `requestable_permission` naming the **Finding's** MS.

On this action `blocked_requestable` only ever means *elevated + readable + not manageable*.

## Evidence

Clean `verify_issue_239`, canonical `verify.sh surveys`:

| Gate | Branch | develop |
|---|---|---|
| surveys vitest | 84 passed / 0 failed | — |
| clean probe | PASS, `clean_state` populated | — |
| typecheck | 3 errors | **same 3** → 0 new |
| biome, changed files | 0 | 0 |
| boundaries | OK | — |

## Mutation matrix — which assertion fired

| Mutation | Result | Assertion |
|---|---|---|
| read scope `requireElevatedRole` `true`→`false` | killed | `:547` `not.toContain('request_task')` |
| `requestable_permission` uses the survey's MS | killed | `:553` `toContainEqual({ requestable_permission: … })` |
| read-scope filter removed | killed | `:547` plus the Finding-id absence assert |
| `checkFindingManage` `requireElevatedRole` flag | **survives by design** | none — the read-scope filter already excludes every non-elevated actor, so that flag is an unreachable second layer |

The first mutation **survived round 1**: the non-elevated actor held no `finding.read`, so the action was absent for a missing grant rather than for the elevation rule — a vacuous assertion. Round 2 granted it `finding.read` on the Finding's MS, which is what makes the assertion attributable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BfiR55zJ7n8uYpr1s3X6q