### PR TITLE
docs(surveys): record Link Finding as out of MVP scope (ADR-0037)

### DIFF
--- a/apps/frontend/src/features/surveys/AGENTS.md
+++ b/apps/frontend/src/features/surveys/AGENTS.md
@@ -22,7 +22,7 @@ It does not own VOC creation, Finding persistence, Task mutation, or permission 
 ## Rules
 
 - Keep builder and result views simple for MVP.
-- Result summaries should expose Create Finding, Link Finding, and Request Task where permitted.
+- Result summaries should expose Create Finding and Request Task where permitted; Link Finding is deferred out of MVP scope (ADR-0037).
 - Permission-limited responses must show approved summaries or request-access paths.
 - Preserve Survey context during linked object creation.
 

--- a/docs/adr/0037-link-finding-deferred-out-of-mvp.md
+++ b/docs/adr/0037-link-finding-deferred-out-of-mvp.md
@@ -1,0 +1,23 @@
+# Survey result Link Finding deferred out of MVP
+
+## Status
+
+Accepted 2026-07-31. Deviates from `docs/design-prototype/screen-survey-result.jsx:106` and `docs/design-prototype/screen-surveys.jsx:250-252`. References issue #252 and root `AGENTS.md` → Prototype Is The Spec.
+
+## Context
+
+The survey-result prototype requires a `Link Finding` CTA and routes it to the `finding-draft` follow-up flow. Nothing implements that CTA: survey-result `next_actions` ships `create_finding` and `request_task`, but not `link_finding`.
+
+`link_finding` was silently deferred out of #187, #189, and #232 three times. The scope audit in `.review/SCOPE-AUDIT-2026-07-30.md` found the gap with no owning issue, which is why issue #252 exists. The sibling `create_finding` and `request_task` CTAs are implemented, so this is a `link_finding` gap rather than a missing CTA row.
+
+## Decision
+
+`link_finding` is out of MVP scope for the survey result screen. Survey-result `next_actions` ships `create_finding` and `request_task` only.
+
+If a later slice implements `link_finding`, it must derive its own availability and permission decision as `create_finding` does; it must not copy that decision or ship unconditionally `allowed`. It must also not widen the Finding read-scope boundary to work, and must split the query instead. Issue #252 Path A defines the required shape for that future implementation.
+
+## Consequences
+
+- The survey-result CTA row remains one action short of the prototype until a future implementation takes up issue #252 Path A.
+- Tracked documentation states the MVP actions and points to this ADR for the deferred `Link Finding` CTA.
+- The prototype is unchanged and remains the spec, so readers find this ADR instead of an unexplained gap.

--- a/docs/design/07-survey-system.md
+++ b/docs/design/07-survey-system.md
@@ -147,7 +147,7 @@ Priority: SHOULD
 Acceptance Criteria:
 
 ```text
-- Result screen has Create Finding, Link Finding, and Request Task CTAs when the actor has permission and the workflow is enabled.
+- Result screen has Create Finding and Request Task CTAs when the actor has permission and the workflow is enabled; Link Finding is deferred out of MVP scope (ADR-0037).
 - Result and Response screens must not show Create VOC.
 - Survey Response can become Evidence Highlight or Finding evidence; it must not become a new VOC.
 - Attach to Existing VOC may be allowed only as evidence attachment to an already existing VOC, not as Survey Response to VOC conversion.
@@ -185,7 +185,7 @@ Layout:
   subtraction attacks.
 - Add Evidence Highlight CTA
 - Create Finding CTA
-- Link Finding CTA
+- Link Finding CTA — deferred out of MVP scope (ADR-0037).
 - Request Task CTA
 - Optional Attach to Existing VOC action when relation is useful and permission allows
 ```

--- a/docs/design/10-cross-system-workflows.md
+++ b/docs/design/10-cross-system-workflows.md
@@ -159,7 +159,7 @@ Acceptance Criteria:
 ```text
 - VOC Detail offers Create Finding / Request Task when appropriate.
 - Finding Detail offers Request Task / Link Existing Task; Create Milestone is future cross-system behavior when enabled.
-- Survey Result offers Create Finding / Link Finding / Request Task.
+- Survey Result offers Create Finding / Request Task; Link Finding is deferred out of MVP scope (ADR-0037).
 - Home and Integration queues deep-link to the next action.
 ```
 

--- a/docs/design/12-ui-ux-principles.md
+++ b/docs/design/12-ui-ux-principles.md
@@ -135,7 +135,7 @@ Survey:
 - simple builder
 - readable result summary
 - Survey Result is result summary-first, not action queue-first
-- Create Finding / Link Finding / Request Task CTAs
+- Create Finding / Request Task CTAs; Link Finding is deferred out of MVP scope (ADR-0037)
 - Poor Outcome Survey or configured follow-up may highlight next action near the top without replacing result interpretation
 ```
 
@@ -180,7 +180,7 @@ Allowed Survey Result / Response follow-up actions:
 ```text
 - Add Evidence Highlight
 - Create Finding
-- Link Finding
+- Link Finding — deferred out of MVP scope (ADR-0037)
 - Request Task
 - Attach to Existing VOC when attaching evidence to an already existing VOC is useful and permitted
 ```

--- a/docs/frontend/interaction-patterns.md
+++ b/docs/frontend/interaction-patterns.md
@@ -118,7 +118,7 @@ Common Survey follow-up action ids:
 ```text
 - add_evidence_highlight
 - create_finding
-- link_finding
+- link_finding (deferred out of MVP scope; ADR-0037)
 - request_task
 - attach_evidence_to_existing_voc
 - mark_no_follow_up
@@ -180,7 +180,7 @@ UX rules:
 
 ```text
 - Survey Result and Survey Response surfaces must not show Create VOC.
-- Allowed follow-up actions are Create Finding, Link Finding, Request Task, Add Evidence Highlight, and optional Attach to Existing VOC.
+- Allowed follow-up actions are Create Finding, Link Finding (deferred out of MVP scope; ADR-0037), Request Task, Add Evidence Highlight, and optional Attach to Existing VOC.
 - Attach to Existing VOC uses action id `attach_evidence_to_existing_voc` and links survey evidence to an already existing VOC; it must not create a new VOC.
 - Do not label this action Create VOC, Convert to VOC, Generate VOC from Response, or Link Existing VOC.
 - Survey-derived Request Task follows the Task Request flow and review boundary.


### PR DESCRIPTION
Closes #252 via **Path B** (user decision, 2026-07-31).

## What

The survey-result `Link Finding` CTA is required by the prototype but nothing implements it. Rather than implement a second permission-modelled CTA while Slice 13 closes, this records the deviation and stops the tracked docs asserting a CTA no code produces.

- **New** `docs/adr/0037-link-finding-deferred-out-of-mvp.md` — records the prototype deviation per root `AGENTS.md` → Prototype Is The Spec, and pins the shape a future implementation must take (derive its own availability/permission decision like `create_finding`; do not copy it, do not ship unconditionally `allowed`, do not widen the Finding read-scope boundary — split the query).
- **8 documentation lines across 5 files** now state the MVP actions and reference ADR-0037.

| File | Lines |
|---|---|
| `apps/frontend/src/features/surveys/AGENTS.md` | 25 |
| `docs/design/07-survey-system.md` | 150, 188 |
| `docs/design/12-ui-ux-principles.md` | 138, 183 |
| `docs/design/10-cross-system-workflows.md` | 162 |
| `docs/frontend/interaction-patterns.md` | 121, 183 |

## Why this shape

`features/surveys/AGENTS.md:25` is the line that let this slip three times — an agent guide that asserts an absent feature. It is corrected first; the rest follow so the claim does not survive elsewhere.

## Deliberately not touched

- **`docs/design-prototype/**`** — the prototype is the spec and is never edited to match the implementation. It still shows the CTA; ADR-0037 is what a reader now finds.
- **`apps/frontend/src/features/admin/settings/WorkspaceSettingsScreen.tsx:40`** — verbatim prototype copy (`screen-admin-settings.jsx:263`), stays verbatim.
- **`apps/frontend/src/lib/copy/home.ts:19`, `apps/frontend/tests/visual/fixtures/home.ts:10`** — "Link Finding" on a VOC home card, a different feature that works.
- **Allowlist lines keep every other action verbatim.** A first pass narrowed `interaction-patterns.md:183` by dropping `Add Evidence Highlight` and `Attach to Existing VOC` from the allowed-actions contract; that was rejected in review and restored. Only `Link Finding` is marked deferred.

## Verification

Documentation only — no source, test, migration, or fixture changed. `git diff --stat` touches 6 files, all `.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BfiR55zJ7n8uYpr1s3X6q