### PR TITLE
feat(surveys): revoke an approved response excerpt and correct survey-findings docs (#235)

### DIFF
--- a/apps/backend/src/modules/surveys/__tests__/survey-evidence.integration.test.ts
+++ b/apps/backend/src/modules/surveys/__tests__/survey-evidence.integration.test.ts
@@ -313,6 +313,22 @@ describe.skipIf(!runIntegration)('survey response evidence routes (#187 C3)', ()
       headers: { cookie: `${SESSION_COOKIE_NAME}=${cookie}` },
     });
   }
+  function del(url: string, cookie: string) {
+    return app.inject({
+      method: 'DELETE',
+      url,
+      headers: { cookie: `${SESSION_COOKIE_NAME}=${cookie}` },
+    });
+  }
+  async function approveDirectly(source: Awaited<ReturnType<typeof seed>>) {
+    const approval = await migrateHandle.pool.query<{ id: string }>(
+      `insert into survey.survey_response_excerpt_approvals
+        (workspace_id,survey_id,response_id,question_id,redacted_excerpt,approved_by)
+       values ($1,$2,$3,$4,'Approved safe excerpt',$5) returning id`,
+      [WORKSPACE_ID, source.surveyId, source.responseId, source.questionId, adminId],
+    );
+    return approval.rows[0]?.id ?? '';
+  }
 
   async function seedForeignResponse() {
     const workspaceId = randomUUID();
@@ -624,5 +640,141 @@ describe.skipIf(!runIntegration)('survey response evidence routes (#187 C3)', ()
       (await post(`/survey-responses/${source.responseId}/approved-excerpts`, input, adminCookie))
         .statusCode,
     ).toBe(404);
+  });
+
+  it('revokes one approved excerpt once, keeps its row, hides it from results, and audits IDs only', async () => {
+    expectedSideEffects = {
+      audit: { count: 2, message: 'revocation and results-read personal-read audit rows before cleanup' },
+      approvals: { count: 2, message: 'two retained approval rows before cleanup' },
+    };
+    const source = await seed();
+    const revoker = await actor();
+    await grant(revoker.id, 'survey.read', source.msId);
+    await grant(revoker.id, 'survey.read_personal_responses', source.msId);
+    await grant(revoker.id, 'survey.manage', source.msId);
+    const revokedId = await approveDirectly(source);
+    const survivingId = await approveDirectly(source);
+    const first = await del(
+      `/survey-responses/${source.responseId}/approved-excerpts/${revokedId}`,
+      revoker.cookie,
+    );
+    expect(first.statusCode).toBe(200);
+    expect(approvedExcerptDtoSchema.parse(first.json()).approved_excerpt_id).toBe(revokedId);
+    const beforeRetry = await migrateHandle.pool.query<{ revoked_at: string | null }>(
+      'select revoked_at::text from survey.survey_response_excerpt_approvals where id=$1',
+      [revokedId],
+    );
+    expect(beforeRetry.rows[0]?.revoked_at).not.toBeNull();
+    const results = surveyResultDtoSchema.parse(
+      (
+        await app.inject({
+          method: 'GET',
+          url: `/surveys/${source.surveyId}/results`,
+          headers: { cookie: `${SESSION_COOKIE_NAME}=${revoker.cookie}` },
+        })
+      ).json(),
+    );
+    const question = results.questions.find((item) => item.question_id === source.questionId);
+    if (question?.visibility !== 'visible' || question.kind !== 'text')
+      throw new Error('expected visible text result');
+    expect(question.excerpts.map((excerpt) => excerpt.id)).not.toContain(revokedId);
+    expect(question.excerpts.map((excerpt) => excerpt.id)).toContain(survivingId);
+    const retry = await del(
+      `/survey-responses/${source.responseId}/approved-excerpts/${revokedId}`,
+      revoker.cookie,
+    );
+    expect(retry.statusCode).toBe(200);
+    const afterRetry = await migrateHandle.pool.query<{ revoked_at: string | null }>(
+      'select revoked_at::text from survey.survey_response_excerpt_approvals where id=$1',
+      [revokedId],
+    );
+    expect(afterRetry.rows[0]?.revoked_at).toBe(beforeRetry.rows[0]?.revoked_at);
+    const audit = await migrateHandle.pool.query<{ detail: Record<string, string> }>(
+      "select detail from core.audit_log where event_type='survey_response_excerpt_revoked' and subject_id=$1",
+      [revokedId],
+    );
+    expect(audit.rows).toHaveLength(1);
+    expect(Object.keys(audit.rows[0]?.detail ?? {}).sort()).toEqual([
+      'approved_excerpt_id',
+      'question_id',
+      'survey_id',
+      'survey_response_id',
+    ]);
+  });
+
+  it('returns 404 before survey.manage for personal-read denial and 403 after it, without revocation', async () => {
+    expectedSideEffects = {
+      audit: { count: 0, message: 'denied revocation leaves no audit row before cleanup' },
+      approvals: { count: 1, message: 'unrevoked approval row before cleanup' },
+    };
+    const source = await seed();
+    const approvalId = await approveDirectly(source);
+    const noPersonal = await actor();
+    const personalNoManage = await actor();
+    await grant(noPersonal.id, 'survey.read', source.msId);
+    await grant(personalNoManage.id, 'survey.read', source.msId);
+    await grant(personalNoManage.id, 'survey.read_personal_responses', source.msId);
+    const url = `/survey-responses/${source.responseId}/approved-excerpts/${approvalId}`;
+    expect((await del(url, noPersonal.cookie)).statusCode).toBe(404);
+    expect((await del(url, adminCookie)).statusCode).toBe(404);
+    const denied = await del(url, personalNoManage.cookie);
+    expect(denied.statusCode).toBe(403);
+    expect(denied.json().code).toBe('permission.denied');
+    const approval = await migrateHandle.pool.query<{ revoked_at: string | null }>(
+      'select revoked_at::text from survey.survey_response_excerpt_approvals where id=$1',
+      [approvalId],
+    );
+    expect(approval.rows[0]?.revoked_at).toBeNull();
+  });
+
+  it('returns 422 for an approval belonging to another response without revoking either row', async () => {
+    expectedSideEffects = {
+      audit: { count: 0, message: 'mismatched approval leaves no audit row before cleanup' },
+      approvals: { count: 2, message: 'mismatched approval rows remain before cleanup' },
+    };
+    const source = await seed();
+    const otherRespondent = await actor();
+    const other = await migrateHandle.pool.query<{ id: string }>(
+      'insert into survey.survey_responses (workspace_id,survey_id,respondent_actor_id,identity_protected,submitted_at) values ($1,$2,$3,true,now()) returning id',
+      [WORKSPACE_ID, source.surveyId, otherRespondent.id],
+    );
+    const otherResponseId = other.rows[0]?.id ?? '';
+    await migrateHandle.pool.query(
+      "insert into survey.survey_response_answers (workspace_id,survey_id,response_id,question_id,answer_kind,answer_value) values ($1,$2,$3,$4,'text',$5::jsonb)",
+      [
+        WORKSPACE_ID,
+        source.surveyId,
+        otherResponseId,
+        source.questionId,
+        JSON.stringify('Other private response text'),
+      ],
+    );
+    const sourceApprovalId = await approveDirectly(source);
+    const otherApproval = await migrateHandle.pool.query<{ id: string }>(
+      `insert into survey.survey_response_excerpt_approvals
+        (workspace_id,survey_id,response_id,question_id,redacted_excerpt,approved_by)
+       values ($1,$2,$3,$4,'Other approved excerpt',$5) returning id`,
+      [WORKSPACE_ID, source.surveyId, otherResponseId, source.questionId, adminId],
+    );
+    const revoker = await actor();
+    await grant(revoker.id, 'survey.read', source.msId);
+    await grant(revoker.id, 'survey.read_personal_responses', source.msId);
+    await grant(revoker.id, 'survey.manage', source.msId);
+    const response = await del(
+      `/survey-responses/${source.responseId}/approved-excerpts/${otherApproval.rows[0]?.id}`,
+      revoker.cookie,
+    );
+    expect(response.statusCode).toBe(422);
+    expect(response.json().code).toBe('validation.failed');
+    const approvals = await migrateHandle.pool.query<{ id: string; revoked_at: string | null }>(
+      'select id, revoked_at::text from survey.survey_response_excerpt_approvals where id = any($1::uuid[]) order by id',
+      [[sourceApprovalId, otherApproval.rows[0]?.id]],
+    );
+    expect(
+      approvals.rows.find((approval) => approval.id === sourceApprovalId)?.revoked_at,
+    ).toBeNull();
+    expect(
+      approvals.rows.find((approval) => approval.id === otherApproval.rows[0]?.id)?.revoked_at,
+    ).toBeNull();
   });
 });

--- a/apps/backend/src/modules/surveys/repo-evidence.ts
+++ b/apps/backend/src/modules/surveys/repo-evidence.ts
@@ -67,6 +67,43 @@ export async function insertApprovedExcerpt(
   return row;
 }
 
+export async function revokeApprovedExcerpt(
+  tx: Tx,
+  input: { workspaceId: string; responseId: string; approvedExcerptId: string },
+): Promise<{
+  approved_excerpt_id: string;
+  question_id: string;
+  redacted_excerpt: string;
+  revoked_now: boolean;
+} | null> {
+  const result = await tx.execute<{
+    approved_excerpt_id: string;
+    question_id: string;
+    redacted_excerpt: string;
+    revoked_now: boolean;
+  }>(sql`
+    with revoked as (
+      update survey.survey_response_excerpt_approvals
+         set revoked_at = now()
+       where workspace_id = ${input.workspaceId}
+         and response_id = ${input.responseId}
+         and id = ${input.approvedExcerptId}
+         and revoked_at is null
+      returning id, question_id, redacted_excerpt
+    )
+    select id as approved_excerpt_id, question_id, redacted_excerpt, true as revoked_now
+      from revoked
+    union all
+    select a.id as approved_excerpt_id, a.question_id, a.redacted_excerpt, false as revoked_now
+      from survey.survey_response_excerpt_approvals a
+     where a.workspace_id = ${input.workspaceId}
+       and a.response_id = ${input.responseId}
+       and a.id = ${input.approvedExcerptId}
+       and not exists (select 1 from revoked)
+  `);
+  return result.rows[0] ?? null;
+}
+
 export async function readApprovedResultExcerpts(
   tx: Tx,
   workspaceId: string,

--- a/apps/backend/src/modules/surveys/routes.ts
+++ b/apps/backend/src/modules/surveys/routes.ts
@@ -170,6 +170,21 @@ export const surveysRoutes: FastifyPluginAsync<SurveysRoutesOptions> = async (ap
       return reply.code(r.status).send(r.body);
     },
   );
+  app.delete(
+    '/survey-responses/:id/approved-excerpts/:approved_excerpt_id',
+    { preHandler: pre, ...rate('mutation') },
+    async (req, reply) => {
+      const { id, approved_excerpt_id } = req.params as {
+        id: string;
+        approved_excerpt_id: string;
+      };
+      if (!validId(id) || !validId(approved_excerpt_id))
+        return sendError(reply, 'validation.failed', 'id must be a valid UUID');
+      return reply.send(
+        await opts.surveysService.revokeEvidenceExcerpt(actor(req), id, approved_excerpt_id),
+      );
+    },
+  );
   app.post(
     '/survey-responses/:id/evidence-excerpt-candidates',
     { preHandler: pre, ...rate('mutation') },

--- a/apps/backend/src/modules/surveys/service.ts
+++ b/apps/backend/src/modules/surveys/service.ts
@@ -37,6 +37,7 @@ import {
   readApprovedResultExcerptsPersonal,
   readResponseTextCandidate,
   readSurveyQuestionLabel,
+  revokeApprovedExcerpt,
 } from './repo-evidence.js';
 import {
   type QuestionKind,
@@ -1320,6 +1321,49 @@ export function createSurveysService(deps: SurveysServiceDeps) {
       return approvedExcerptDtoSchema.parse(approved);
     });
   }
+  async function revokeEvidenceExcerpt(
+    actor: SurveysActor,
+    responseId: string,
+    approvedExcerptId: string,
+  ): Promise<ApprovedExcerptDto> {
+    return deps.db.transaction(async (tx) => {
+      const { subject } = await resolveSurveyResponseEvidenceAccess(
+        deps,
+        tx,
+        actor,
+        responseId,
+        'approve_excerpt',
+      );
+      const revoked = await revokeApprovedExcerpt(tx, {
+        workspaceId: actor.workspace_id,
+        responseId,
+        approvedExcerptId,
+      });
+      if (!revoked)
+        throw new HttpError(
+          'validation.failed',
+          'approved excerpt does not belong to survey response',
+        );
+      const { revoked_now, ...approvedExcerpt } = revoked;
+      if (revoked_now) {
+        await deps.auditService.record(tx, {
+          workspace_id: actor.workspace_id,
+          actor_id: actor.actor_id,
+          event_type: 'survey_response_excerpt_revoked',
+          subject_type: 'survey_response_excerpt_approval',
+          subject_id: approvedExcerptId,
+          summary: 'Survey response excerpt revoked',
+          detail: {
+            survey_id: subject.survey_id,
+            survey_response_id: responseId,
+            question_id: revoked.question_id,
+            approved_excerpt_id: approvedExcerptId,
+          },
+        });
+      }
+      return approvedExcerptDtoSchema.parse(approvedExcerpt);
+    });
+  }
   async function submitResponse(a: {
     actor: SurveysActor;
     surveyId: string;
@@ -1409,6 +1453,7 @@ export function createSurveysService(deps: SurveysServiceDeps) {
     getSurveyResults,
     readEvidenceExcerptCandidate,
     approveEvidenceExcerpt,
+    revokeEvidenceExcerpt,
     listSurvey,
     submitResponse,
   };

--- a/docs/design/14-api-draft.md
+++ b/docs/design/14-api-draft.md
@@ -28,11 +28,13 @@ Expected behavior:
 
 ```text
 POST /survey-responses/:id/create-finding
-POST /survey-findings/:id/request-task
-POST /survey-findings/:id/link-task
+POST /survey-findings/:id/request-task (not implemented)
+POST /survey-findings/:id/link-task (not implemented)
 # future: POST /survey-findings/:id/create-milestone
 # future: POST /survey-findings/:id/link-milestone
 ```
+
+Current reachable Finding task paths are in the `/findings/:id` family.
 
 ## VOC APIs
 

--- a/docs/implementation/03-api-contracts.md
+++ b/docs/implementation/03-api-contracts.md
@@ -581,7 +581,7 @@ events, and dashboard repair signals.
 | `POST /vocs/:id/request-task` | FOP-TASK-001 | VOC | Task Request | `requested_task` | task_request_created_from_voc | moves VOC follow-up to pending execution review | creating Task directly from VOC follow-up |
 | `POST /voc-clusters/:id/request-task` | FOP-TASK-001 | VOC Cluster | Task Request | `requested_task` | task_request_created_from_voc_cluster | moves cluster follow-up to pending execution review | creating Task directly from VOC Cluster follow-up |
 | `POST /findings/:id/request-task` | FOP-TASK-001 | Finding | Task Request | `requested_task` | task_request_created_from_finding | moves Finding to pending execution review | creating Task without review when review is required |
-| `POST /survey-findings/:id/request-task` | FOP-SURVEY-005 | Finding | Task Request | `requested_task` | task_request_created_from_survey_finding | moves survey-derived Finding to pending execution review | Survey Response creates VOC |
+| `POST /survey-findings/:id/request-task` | FOP-SURVEY-005 | Finding | Task Request | `requested_task` | task_request_created_from_survey_finding | moves survey-derived Finding to pending execution review | |
 | `POST /task-requests/:id/convert` | FOP-TASK-002 / FOP-TASK-003 | Task Request | Task | `converted_to` | task_created_from_request | satisfies approved execution candidate | folding conversion into approval |
 | `POST /task-requests/:id/link-task` | FOP-TASK-002 / FOP-TASK-003 | Task Request | Task | `converted_to` | task_linked_to_request | satisfies approved execution candidate with existing work | creating duplicate Task when suitable Task exists |
 | `POST /permission-requests/:id/approve` | FOP-PERM-002 | Permission Request | Permission Grant | none | permission_request_approved (미구현 as of Slice 6) | may restore blocked object visibility | bypassing explicit deny checks |
@@ -810,11 +810,14 @@ POST /surveys/:id/responses
 GET /surveys/:id/results
 POST /survey-responses/:id/evidence-excerpt-candidates
 POST /survey-responses/:id/approved-excerpts
+DELETE /survey-responses/:id/approved-excerpts/:approved_excerpt_id
 POST /survey-responses/:id/create-finding
-POST /survey-findings/:id/request-task
-POST /survey-findings/:id/link-task
+POST /survey-findings/:id/request-task (not implemented)
+POST /survey-findings/:id/link-task (not implemented)
 # future: POST /survey-findings/:id/link-milestone
 ```
+
+Current reachable Finding task paths are in the `/findings/:id` family.
 
 `POST /surveys` requires `survey.manage`, an `Idempotency-Key`, and mutation
 rate limiting. Its strict request body is `{ type: 'discovery' | 'validation' |
@@ -906,9 +909,9 @@ Visible choice results contain configured option `key`, `label`, and count plus 
 
 #### Survey response evidence approval
 
-`POST /survey-responses/:id/evidence-excerpt-candidates` accepts `{ question_id }` and returns the one matching `{ question_id, question_label, raw_text }` candidate. `POST /survey-responses/:id/approved-excerpts` accepts `{ question_id, redacted_excerpt }` and creates an append-only approved excerpt, returning `{ approved_excerpt_id, question_id, redacted_excerpt }`. Both routes resolve the response through the Survey evidence definer, then require `survey.read` and explicit `survey.read_personal_responses`; missing response, cross-workspace response, denied source read, and denied personal read are all `404 not_found.record`. Admin never bypasses personal-response access. A fully authorized actor receives `409 conflict.survey_results_unavailable` for a draft Survey. Approval then requires `survey.manage`; only this post-readable failure is `403 permission.denied`.
+`POST /survey-responses/:id/evidence-excerpt-candidates` accepts `{ question_id }` and returns the one matching `{ question_id, question_label, raw_text }` candidate. `POST /survey-responses/:id/approved-excerpts` accepts `{ question_id, redacted_excerpt }` and creates an append-only approved excerpt, returning `{ approved_excerpt_id, question_id, redacted_excerpt }`. Both routes resolve the response through the Survey evidence definer, then require `survey.read` and explicit `survey.read_personal_responses`; missing response, cross-workspace response, denied source read, and denied personal read are all `404 not_found.record`. Admin never bypasses personal-response access. A fully authorized actor receives `409 conflict.survey_results_unavailable` for a draft Survey. Approval then requires `survey.manage`; only this post-readable failure is `403 permission.denied`. `DELETE /survey-responses/:id/approved-excerpts/:approved_excerpt_id` validates both path IDs, follows the same access order, and returns `{ approved_excerpt_id, question_id, redacted_excerpt }` after revoking the active row or reading back an already-revoked row; an approval belonging to another response is `422 validation.failed`.
 
-Candidate reads write `survey_response_personal_read` in the same transaction; approvals write `survey_response_excerpt_approved` in the same transaction as the approval row. Audit detail contains IDs only—never raw or redacted text. Duplicate approvals are intentional separate rows. Revoked approvals are omitted from results. Aggregate result `next_actions` exposes permission-filtered `create_finding`.
+Candidate reads write `survey_response_personal_read` in the same transaction; approvals write `survey_response_excerpt_approved` in the same transaction as the approval row; first revocations write `survey_response_excerpt_revoked` in the same transaction as the `revoked_at` update. Audit detail contains IDs only—never raw or redacted text. Duplicate approvals are intentional separate rows. Revoked approvals are omitted from results. Aggregate result `next_actions` exposes permission-filtered `create_finding`.
 
 #### POST /survey-responses/:id/create-finding
 

--- a/packages/shared/src/audit/survey.ts
+++ b/packages/shared/src/audit/survey.ts
@@ -149,3 +149,17 @@ export const surveyResponseExcerptApprovedDetailSchema = z
 export type SurveyResponseExcerptApprovedDetail = z.infer<
   typeof surveyResponseExcerptApprovedDetailSchema
 >;
+
+// ── survey_response_excerpt_revoked ──────────────────────────────────────
+// Revocation identifies the approval record but intentionally omits its text.
+export const surveyResponseExcerptRevokedDetailSchema = z
+  .object({
+    survey_id: uuid(),
+    survey_response_id: uuid(),
+    question_id: uuid(),
+    approved_excerpt_id: uuid(),
+  })
+  .strict();
+export type SurveyResponseExcerptRevokedDetail = z.infer<
+  typeof surveyResponseExcerptRevokedDetailSchema
+>;

--- a/packages/shared/src/enums/audit-events.ts
+++ b/packages/shared/src/enums/audit-events.ts
@@ -24,6 +24,7 @@ import {
   surveyQuestionDeletedDetailSchema,
   surveyQuestionUpdatedDetailSchema,
   surveyResponseExcerptApprovedDetailSchema,
+  surveyResponseExcerptRevokedDetailSchema,
   surveyResponsePersonalReadDetailSchema,
   surveyResponseSubmittedDetailSchema,
   surveyQuestionsReorderedDetailSchema,
@@ -126,6 +127,7 @@ export const AUDIT_EVENT_TYPES = [
   // Slice 8 #187: audited personal candidate read and approval lifecycle.
   'survey_response_personal_read',
   'survey_response_excerpt_approved',
+  'survey_response_excerpt_revoked',
   'finding_created_from_survey_response',
   // Slice 9 #195: workspace-level policy singleton mutation.
   'workspace_settings_updated',
@@ -831,6 +833,7 @@ export const AUDIT_EVENT_DETAIL_SCHEMAS = {
   survey_response_submitted: surveyResponseSubmittedDetailSchema,
   survey_response_personal_read: surveyResponsePersonalReadDetailSchema,
   survey_response_excerpt_approved: surveyResponseExcerptApprovedDetailSchema,
+  survey_response_excerpt_revoked: surveyResponseExcerptRevokedDetailSchema,
   finding_created_from_survey_response: findingCreatedFromSurveyResponseDetailSchema,
   workspace_settings_updated: workspaceSettingsUpdatedDetailSchema,
   // #168 step 4.


### PR DESCRIPTION
Closes #235.

## What

`DELETE /survey-responses/:id/approved-excerpts/:approved_excerpt_id` revokes an approved excerpt by setting `revoked_at`. The row is never deleted — `migrations/0039` already grants `fops_app` exactly `UPDATE ("revoked_at")`, and the active partial index plus the two `revoked_at is null` reader filters make a revoked excerpt disappear from results with no reader change.

Access order reuses `resolveSurveyResponseEvidenceAccess(..., 'approve_excerpt')` rather than re-implementing it, so it stays identical to the approve path: `survey.read` and explicit `survey.read_personal_responses` failures are both `404 not_found.record` (Admin included), a draft survey is `409 conflict.survey_results_unavailable`, and only the post-readable `survey.manage` failure is `403 permission.denied`.

A repeat revocation is idempotent: `200`, the original `revoked_at` is preserved, and no second audit event. An `approved_excerpt_id` belonging to a different response is `422 validation.failed` with no write.

New `survey_response_excerpt_revoked` audit event with a `.strict()` ID-only detail schema, registered in both the enum list and the detail-schema map.

`/survey-findings/:id/*` stays unimplemented by decision; only the docs are corrected.

## Gates (host, HEAD `2f24469`)

| Gate | Result |
|---|---|
| `verify.sh survey` (canonical) | **PASS** — 121 passed / 0 failed / exit 0, `clean_state` populated |
| backend `tsc --noEmit` | 3 errors — identical to the pre-existing develop set (`storage-bootstrap.ts:54`, `authorization-boundary.contract.test.ts:254,264`); new: 0 |
| `@fops/shared` `tsc --noEmit` | clean |
| biome (8 changed files) | 4 errors, same files and same line ranges as develop; new: 0 |
| `check-boundaries` | OK |

## Mutation matrix (which assertion fired)

| Mutation | Result | Assertion that fired |
|---|---|---|
| drop `and revoked_at is null` from the UPDATE | killed | AC-3 `expect(afterRetry.revoked_at).toBe(beforeRetry.revoked_at)` (timestamp differed) + audit count 3 vs 2 |
| access purpose `approve_excerpt` → `personal_read` (skips `survey.manage`) | killed | AC-5 `expected 200 to be 403` + denied-path audit count 1 vs 0 |
| audit unconditionally instead of `if (revoked_now)` | killed | AC-7 revocation audit rows `length 1` → got 2 |
| drop the `response_id` filter from both CTE branches | killed | AC-6 `expected 200 to be 422` + mismatched-path audit count 1 vs 0 |

## Rounds

Three worker rounds. Round 1 shipped a `500` (the repository row's extra `revoked_now` key hit the `.strict()` `approvedExcerptDtoSchema`), a fixture that violated `survey_responses_survey_respondent_actor_uq`, and a prose line placed inside a fenced route-list block. Round 2 fixed those; round 3 corrected one side-effect count — `GET /surveys/:id/results` writes one `survey_response_personal_read` per exposed pair, which the teardown query counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BfiR55zJ7n8uYpr1s3X6q