### PR TITLE
fix(nav): make every shipped deep link and sidebar count resolve

### DIFF
--- a/apps/backend/src/modules/dashboard/__tests__/summary.integration.test.ts
+++ b/apps/backend/src/modules/dashboard/__tests__/summary.integration.test.ts
@@ -254,10 +254,10 @@ describe.skipIf(!runIntegration)('GET /dashboard/summary (#217)', () => {
     expect(body.kpis.coverage_percent).toBe(coverage(body, 'voc-task')?.percent);
     expect(queue(body, 'unassigned-voc')).toMatchObject({ severity: 'urgent', next_action: { route: '/vocs?view=inbox&tab=unassigned' } });
     expect(queue(body, 'high-severity-unlinked')).toMatchObject({ severity: 'urgent', next_action: { route: '/vocs?view=inbox&tab=high-no-link' } });
-    expect(queue(body, 'actionable-finding-no-execution')).toMatchObject({ severity: 'warn', next_action: { route: '/findings?status=active' } });
-    expect(queue(body, 'released-task-unresolved-voc')).toMatchObject({ severity: 'warn', next_action: { route: '/tasks?status=released' } });
-    expect(queue(body, 'bad-outcome-no-followup')).toMatchObject({ severity: 'urgent', next_action: { route: '/surveys?type=outcome' } });
-    expect(queue(body, 'permission-requests-pending')).toMatchObject({ severity: 'info', next_action: { route: '/admin/permission-requests' } });
+    expect(queue(body, 'actionable-finding-no-execution')).toMatchObject({ severity: 'warn', next_action: { route: '/findings' } });
+    expect(queue(body, 'released-task-unresolved-voc')).toMatchObject({ severity: 'warn', next_action: { route: '/tasks?view=board' } });
+    expect(queue(body, 'bad-outcome-no-followup')).toMatchObject({ severity: 'urgent', next_action: { route: '/surveys' } });
+    expect(queue(body, 'permission-requests-pending')).toMatchObject({ severity: 'info', next_action: { route: '/admin/permissions/requests' } });
     expectQueueDelta(body, before, 'unassigned-voc', 11);
     expectQueueDelta(body, before, 'high-severity-unlinked', 5);
     expectQueueDelta(body, before, 'actionable-finding-no-execution', 8);

--- a/apps/backend/src/modules/dashboard/service.ts
+++ b/apps/backend/src/modules/dashboard/service.ts
@@ -1,4 +1,12 @@
-import type { DashboardSummary } from '@fops/shared';
+import {
+  DASHBOARD_ACTIONABLE_FINDINGS_ROUTE,
+  DASHBOARD_HIGH_SEVERITY_UNLINKED_ROUTE,
+  DASHBOARD_OUTCOME_SURVEYS_ROUTE,
+  DASHBOARD_PERMISSION_REQUESTS_ROUTE,
+  DASHBOARD_RELEASED_TASKS_ROUTE,
+  DASHBOARD_UNASSIGNED_VOC_ROUTE,
+  type DashboardSummary,
+} from '@fops/shared';
 
 import type { Db } from '../../db/client.js';
 import { HttpError } from '../../lib/errors.js';
@@ -90,10 +98,10 @@ export function createDashboardService(deps: DashboardDeps) {
     const [openVoc, unassigned, highUnlinked] = await Promise.all([voc(), voc('unassigned'), voc('high-no-link')]);
     if (openVoc !== undefined) kpis.open_voc = openVoc;
     if (unassigned !== undefined) queues.push({ id: 'unassigned-voc', severity: 'urgent', count: unassigned,
-      next_action: { label: 'Review VOCs', route: '/vocs?view=inbox&tab=unassigned', intent: 'triage' },
-      secondary_action: { label: 'Bulk assign', route: '/vocs?view=inbox&tab=unassigned', intent: 'bulk_assign' } });
+      next_action: { label: 'Review VOCs', route: DASHBOARD_UNASSIGNED_VOC_ROUTE, intent: 'triage' },
+      secondary_action: { label: 'Bulk assign', route: DASHBOARD_UNASSIGNED_VOC_ROUTE, intent: 'bulk_assign' } });
     if (highUnlinked !== undefined) queues.push({ id: 'high-severity-unlinked', severity: 'urgent', count: highUnlinked,
-      next_action: { label: 'Review high severity VOCs', route: '/vocs?view=inbox&tab=high-no-link', intent: 'triage' }, secondary_action: null });
+      next_action: { label: 'Review high severity VOCs', route: DASHBOARD_HIGH_SEVERITY_UNLINKED_ROUTE, intent: 'triage' }, secondary_action: null });
 
     if (findingScope !== undefined && (findingScope.kind === 'all' || findingScope.managedSystemIds.length > 0)) {
       const [active, noExecution] = await Promise.all([
@@ -102,7 +110,7 @@ export function createDashboardService(deps: DashboardDeps) {
       ]);
       kpis.active_finding = active;
       queues.push({ id: 'actionable-finding-no-execution', severity: 'warn', count: noExecution,
-        next_action: { label: 'Review Findings', route: '/findings?status=active', intent: 'plan_execution' }, secondary_action: null });
+        next_action: { label: 'Review Findings', route: DASHBOARD_ACTIONABLE_FINDINGS_ROUTE, intent: 'plan_execution' }, secondary_action: null });
       const executed = await repo.countActiveFindingsWithExecution(deps.db, actor.workspace_id, findingScope, selectedManagedSystemId);
       coverage.push({ id: 'finding-execution', value: executed, total: active, percent: percent(executed, active), status: coverageStatus(percent(executed, active)) });
     }
@@ -118,7 +126,7 @@ export function createDashboardService(deps: DashboardDeps) {
         selectedManagedSystemId,
       );
       queues.push({ id: 'released-task-unresolved-voc', severity: 'warn', count: unresolved,
-        next_action: { label: 'Review released Tasks', route: '/tasks?status=released', intent: 'request_reporter_update' }, secondary_action: null });
+        next_action: { label: 'Review released Tasks', route: DASHBOARD_RELEASED_TASKS_ROUTE, intent: 'request_reporter_update' }, secondary_action: null });
       const releasedUpdate = await repo.countReleasedTasksWithPublicUpdate(
         deps.db,
         actor.workspace_id,
@@ -137,14 +145,14 @@ export function createDashboardService(deps: DashboardDeps) {
     if (surveyScopeForDashboard !== undefined && canSeeSurveyQueue) {
       const gaps = await repo.countSurveyGaps(deps.db, actor.workspace_id, surveyScopeForDashboard, selectedManagedSystemId);
       queues.push({ id: 'bad-outcome-no-followup', severity: 'urgent', count: gaps,
-        next_action: { label: 'Review outcome surveys', route: '/surveys?type=outcome', intent: 'create_followup' }, secondary_action: null });
+        next_action: { label: 'Review outcome surveys', route: DASHBOARD_OUTCOME_SURVEYS_ROUTE, intent: 'create_followup' }, secondary_action: null });
     }
 
     const permissionRequests = await authorizationAbsent(() => deps.requestService.listAllActive(actor));
     if (permissionRequests !== undefined) {
       kpis.pending_request = (kpis.pending_request ?? 0) + permissionRequests.count;
       queues.push({ id: 'permission-requests-pending', severity: 'info', count: permissionRequests.count,
-        next_action: { label: 'Open Requests', route: '/admin/permission-requests', intent: 'review_permissions' }, secondary_action: null });
+        next_action: { label: 'Open Requests', route: DASHBOARD_PERMISSION_REQUESTS_ROUTE, intent: 'review_permissions' }, secondary_action: null });
     }
 
     if (openVoc !== undefined) {

--- a/apps/backend/src/modules/nav/__tests__/nav-counts.integration.test.ts
+++ b/apps/backend/src/modules/nav/__tests__/nav-counts.integration.test.ts
@@ -29,6 +29,7 @@ describe.skipIf(!runIntegration)('GET /nav/counts (#143)', () => {
   let migrateHandle: DbHandle;
   let app: FastifyInstance;
   let adminCookie: string;
+  let userCookie: string;
   let adminActorId: string;
   let reporterId: string;
 
@@ -45,6 +46,7 @@ describe.skipIf(!runIntegration)('GET /nav/counts (#143)', () => {
     app = await buildServer({ config: loadConfig(), dbHandle });
     await app.ready();
     adminCookie = await loginAs(app, 'mock-admin-1');
+    userCookie = await loginAs(app, 'mock-user-1');
     const actors = await dbHandle.pool.query<{ id: string }>(
       `select id from core.actors where external_id = 'mock-admin-1' and workspace_id = $1`, [WORKSPACE_ID],
     );
@@ -88,7 +90,7 @@ describe.skipIf(!runIntegration)('GET /nav/counts (#143)', () => {
     for (const [url, key] of [
       ['/vocs?view=inbox', 'voc.inbox'],
       ['/vocs?view=triage', 'voc.triage'],
-      ['/vocs?view=inbox&tab=high', 'voc.tab.high'],
+      ['/vocs?view=triage&tab=high', 'voc.tab.high'],
     ] as const) {
       const list = await app.inject({ method: 'GET', url, headers: headers(adminCookie) });
       expect(list.statusCode).toBe(200);
@@ -164,6 +166,17 @@ describe.skipIf(!runIntegration)('GET /nav/counts (#143)', () => {
     expect(result.body.counts['findings.all']).toBe(1);
     expect(result.body.counts['surveys.all']).toBe(1);
     expect(result.body.counts['voc.clusters']).toBe(1);
+  });
+
+  it('omits inaccessible domain counts while preserving the User VOC count', async () => {
+    const ms = await insertMsDirectly(dbHandle, WORKSPACE_ID, `${PREFIX}-user-counts`, 'User counts');
+    await insertVocDirectly(dbHandle, WORKSPACE_ID, ms, reporterId, 'visible to its reporter');
+
+    const result = await counts(userCookie);
+
+    expect(result.response.statusCode).toBe(200);
+    expect(result.body.counts['voc.my']).toBe(1);
+    expect(Object.hasOwn(result.body.counts, 'findings.all')).toBe(false);
   });
 
   it('surfaces an unexpected VOC count failure as an error response', async () => {

--- a/apps/backend/src/modules/nav/service.ts
+++ b/apps/backend/src/modules/nav/service.ts
@@ -29,6 +29,15 @@ function isAuthorizationAbsence(error: unknown): error is HttpError {
 
 export function createNavCountsService(deps: NavCountsDeps) {
   async function getCounts(actor: NavActor, managedSystemId?: string): Promise<Record<string, number>> {
+    async function authorizationAbsent<T>(read: () => Promise<T>): Promise<T | undefined> {
+      try {
+        return await read();
+      } catch (error) {
+        if (isAuthorizationAbsence(error)) return undefined;
+        throw error;
+      }
+    }
+
     const query = (view: CountVocsQuery['view'], tab?: CountVocsQuery['tab']): CountVocsQuery => ({
       view,
       ...(managedSystemId !== undefined ? { managed_system_id: managedSystemId } : {}),
@@ -40,28 +49,24 @@ export function createNavCountsService(deps: NavCountsDeps) {
       ['voc.inbox', 'inbox'],
       ['voc.triage', 'triage'],
       ['voc.my', 'my'],
-      ['voc.tab.high', 'inbox', 'high'],
-      ['voc.tab.unassigned', 'inbox', 'unassigned'],
-      ['voc.tab.no-link', 'inbox', 'no-link'],
+      ['voc.tab.high', 'triage', 'high'],
+      ['voc.tab.unassigned', 'triage', 'unassigned'],
+      ['voc.tab.no-link', 'triage', 'no-link'],
     ] as const;
     const vocCounts = Object.fromEntries((await Promise.all(vocCountEntries.map(async ([key, view, tab]) => {
-      try {
-        return [key, await count(view, tab)] as const;
-      } catch (error) {
-        if (isAuthorizationAbsence(error)) return undefined;
-        throw error;
-      }
+      const value = await authorizationAbsent(() => count(view, tab));
+      return value === undefined ? undefined : [key, value] as const;
     }))).flatMap((entry) => entry === undefined ? [] : [entry]));
     const [findings, surveys, vocClusters] = await Promise.all([
-      deps.findingsService.listFindings({ actor, ...(managedSystemId ? { managedSystemId } : {}) }),
-      deps.surveysService.listSurvey(actor, managedSystemId),
-      deps.vocClustersService.listClusters({ actor, ...(managedSystemId ? { managedSystemId } : {}) }),
+      authorizationAbsent(() => deps.findingsService.listFindings({ actor, ...(managedSystemId ? { managedSystemId } : {}) })),
+      authorizationAbsent(() => deps.surveysService.listSurvey(actor, managedSystemId)),
+      authorizationAbsent(() => deps.vocClustersService.listClusters({ actor, ...(managedSystemId ? { managedSystemId } : {}) })),
     ]);
     return {
       ...vocCounts,
-      'findings.all': findings.items.length,
-      'surveys.all': surveys.length,
-      'voc.clusters': vocClusters.items.length,
+      ...(findings === undefined ? {} : { 'findings.all': findings.items.length }),
+      ...(surveys === undefined ? {} : { 'surveys.all': surveys.length }),
+      ...(vocClusters === undefined ? {} : { 'voc.clusters': vocClusters.items.length }),
     };
   }
   return { getCounts };

--- a/apps/frontend/src/features/home/HomeScreen.tsx
+++ b/apps/frontend/src/features/home/HomeScreen.tsx
@@ -9,6 +9,8 @@ import { type MinePermissionRequestRow, fetchDashboardSummary, fetchPermissionRe
 import { useMe } from '@/lib/auth/useMe';
 import { HOME_COVERAGE_COPY, HOME_COPY, HOME_KPI_COPY, HOME_QUEUE_COPY, homeSeverityLabel } from '@/lib/copy/home';
 
+export const HOME_COVERAGE_HREF = '/integration/links';
+
 export function HomeScreen({ managedSystemId }: { managedSystemId?: string }): React.ReactElement {
   const me = useMe();
   const queryClient = useQueryClient();
@@ -118,7 +120,7 @@ function MyWorkPanel({ tasks, requests }: { tasks: TaskDto[]; requests: TaskRequ
 }
 
 function CoveragePanel({ coverage }: { coverage: DashboardSummary['coverage'] }): React.ReactElement {
-  return <section><PanelHeading title={HOME_COPY.coverage} action={HOME_COPY.viewCoverage} href="/integration" />
+  return <section><PanelHeading title={HOME_COPY.coverage} action={HOME_COPY.viewCoverage} href={HOME_COVERAGE_HREF} />
     <div className="space-y-4 rounded-md border border-border-subtle bg-surface-card p-4" data-testid="home-coverage">
       {coverage.map((item) => <div key={item.id}><div className="flex justify-between gap-2 text-xs"><span className="text-text-primary">{HOME_COVERAGE_COPY[item.id]}</span><span className="shrink-0 tabular-nums text-text-muted">{item.value} / {item.total} · {item.percent}%</span></div><div className="mt-2 h-1 rounded-full bg-surface-row-selected"><div className={item.status === 'bad' ? 'h-1 rounded-full bg-accent-danger' : item.status === 'warn' ? 'h-1 rounded-full bg-accent-warn' : 'h-1 rounded-full bg-accent-success'} style={{ width: `${item.percent}%` }} /></div></div>)}
     </div>

--- a/apps/frontend/src/routes/__tests__/deep-links.test.tsx
+++ b/apps/frontend/src/routes/__tests__/deep-links.test.tsx
@@ -1,0 +1,70 @@
+import {
+  DASHBOARD_ACTIONABLE_FINDINGS_ROUTE,
+  DASHBOARD_HIGH_SEVERITY_UNLINKED_ROUTE,
+  DASHBOARD_OUTCOME_SURVEYS_ROUTE,
+  DASHBOARD_PERMISSION_REQUESTS_ROUTE,
+  DASHBOARD_RELEASED_TASKS_ROUTE,
+  DASHBOARD_UNASSIGNED_VOC_ROUTE,
+} from '@fops/shared';
+import { createRouter } from '@tanstack/react-router';
+import { describe, expect, test } from 'vitest';
+
+import { HOME_COVERAGE_HREF } from '@/features/home/HomeScreen';
+import { routeTree } from '@/routeTree.gen';
+import { ALL_SIDEBAR_ENTRIES } from '../_authed';
+
+const router = createRouter({ routeTree });
+const dashboardLinks = [
+  DASHBOARD_UNASSIGNED_VOC_ROUTE,
+  DASHBOARD_HIGH_SEVERITY_UNLINKED_ROUTE,
+  DASHBOARD_ACTIONABLE_FINDINGS_ROUTE,
+  DASHBOARD_RELEASED_TASKS_ROUTE,
+  DASHBOARD_OUTCOME_SURVEYS_ROUTE,
+  DASHBOARD_PERMISSION_REQUESTS_ROUTE,
+];
+const links = [
+  ...new Set([
+    ...dashboardLinks,
+    ...ALL_SIDEBAR_ENTRIES.map((entry) => entry.href),
+    HOME_COVERAGE_HREF,
+  ]),
+];
+
+function assertResolvable(link: string): void {
+  const url = new URL(link, 'http://localhost');
+  expect(
+    router.getMatchedRoutes(url.pathname).foundRoute,
+    `No registered route for ${link}`,
+  ).toBeDefined();
+  try {
+    router.matchRoutes(url.pathname, Object.fromEntries(url.searchParams), { throwOnError: true });
+  } catch (error) {
+    throw new Error(`Route search validation failed for ${link}: ${String(error)}`);
+  }
+}
+
+describe('shipped deep-link contract', () => {
+  test('matches every dashboard, sidebar, and Home deep link with valid search', () => {
+    expect(links.length).toBeGreaterThan(0);
+    links.forEach(assertResolvable);
+  });
+
+  test('rejects a missing route and an invalid VOC tab', () => {
+    const missingRoute = '/missing-deep-link-route';
+    const invalidVocTab = '/vocs?view=inbox&tab=not-a-voc-tab';
+
+    expect(
+      router.getMatchedRoutes(missingRoute).foundRoute,
+      `Expected ${missingRoute} to have no route`,
+    ).toBeUndefined();
+    expect(
+      () =>
+        router.matchRoutes(
+          '/vocs',
+          { view: 'inbox', tab: 'not-a-voc-tab' },
+          { throwOnError: true },
+        ),
+      `Expected ${invalidVocTab} to fail route search validation`,
+    ).toThrow();
+  });
+});

--- a/apps/frontend/src/routes/_authed/integration/index.tsx
+++ b/apps/frontend/src/routes/_authed/integration/index.tsx
@@ -1,0 +1,8 @@
+import { createFileRoute, redirect } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/_authed/integration/')({
+  beforeLoad: () => {
+    throw redirect({ to: '/integration/links' });
+  },
+  component: () => null,
+});

--- a/apps/frontend/src/routes/_authed/vocs.tsx
+++ b/apps/frontend/src/routes/_authed/vocs.tsx
@@ -4,6 +4,7 @@
 // action=create → PageShell. Feature content (list rows, detail panel,
 // create form, triage queue) lands in #19 / #20 / #21.
 
+import { vocTabEnumSchema } from '@fops/shared';
 import { ListShell, PageShell, WorkbenchShell } from '@fops/ui';
 import { createFileRoute, Link, useSearch } from '@tanstack/react-router';
 import { ChevronLeft } from 'lucide-react';
@@ -18,10 +19,8 @@ const vocSearchSchema = z
     action: z.enum(['create']).optional(),
     selected: z.string().uuid().optional(),
     managedSystem: z.string().optional(),
-    // D-1.1: 'waiting' appended (Chunk 1 — S3-008 decision); existing values stay.
-    // All four triage tabs (unassigned/untriaged/high/waiting) share the same tab= param
-    // as inbox tabs per the #18 schema lock.
-    tab: z.enum(['untriaged', 'high', 'unassigned', 'similar', 'no-link', 'waiting']).optional(),
+    // D-1.1: shared VOC list-query schema owns every supported tab value.
+    tab: vocTabEnumSchema.optional(),
     sort: z.enum([
       'created_at:desc',
       'created_at:asc',
@@ -112,4 +111,3 @@ function InboxShell({ view }: { view: 'inbox' | 'my' }) {
     />
   );
 }
-

--- a/packages/shared/src/dashboard.ts
+++ b/packages/shared/src/dashboard.ts
@@ -1,5 +1,12 @@
 import { z } from 'zod';
 
+export const DASHBOARD_UNASSIGNED_VOC_ROUTE = '/vocs?view=inbox&tab=unassigned';
+export const DASHBOARD_HIGH_SEVERITY_UNLINKED_ROUTE = '/vocs?view=inbox&tab=high-no-link';
+export const DASHBOARD_ACTIONABLE_FINDINGS_ROUTE = '/findings';
+export const DASHBOARD_RELEASED_TASKS_ROUTE = '/tasks?view=board';
+export const DASHBOARD_OUTCOME_SURVEYS_ROUTE = '/surveys';
+export const DASHBOARD_PERMISSION_REQUESTS_ROUTE = '/admin/permissions/requests';
+
 const dashboardActionSchema = z.object({
   label: z.string(),
   route: z.string(),

--- a/packages/shared/src/vocs/list-query.ts
+++ b/packages/shared/src/vocs/list-query.ts
@@ -26,6 +26,16 @@ function commaListOf<T extends z.ZodTypeAny>(itemSchema: T) {
     );
 }
 
+export const vocTabEnumSchema = z.enum([
+  'untriaged',
+  'high',
+  'unassigned',
+  'similar',
+  'no-link',
+  'high-no-link',
+  'waiting',
+]);
+
 export const listVocsQuerySchema = z.object({
   // view is required — the route determines which data set to return.
   view: z.enum(['inbox', 'my', 'triage']),
@@ -34,9 +44,7 @@ export const listVocsQuerySchema = z.object({
   managed_system_id: z
     .union([z.string().uuid(), z.literal('all')])
     .optional(),
-  tab: z
-    .enum(['untriaged', 'high', 'unassigned', 'similar', 'no-link', 'high-no-link', 'waiting'])
-    .optional(),
+  tab: vocTabEnumSchema.optional(),
   // Dot-key filter fields — Fastify query params are flat strings.
   'filter.severity': commaListOf(severityEnumSchema).optional(),
   'filter.reporter_facing_status': commaListOf(reporterFacingStatusEnumSchema).optional(),

--- a/scripts/gates/frontend-biome-allowlist.txt
+++ b/scripts/gates/frontend-biome-allowlist.txt
@@ -10,3 +10,23 @@ apps/frontend/src/routes/login.test.tsx format -- pre-existing on develop; long 
 apps/frontend/tests/visual/fixtures/home.ts format -- pre-existing on develop; long fixture literals predate biome formatting
 apps/frontend/tests/visual/support/mock-api.ts format -- pre-existing on develop; long route handler lines predate biome formatting
 apps/frontend/tests/visual/support/mock-api.ts organizeImports -- pre-existing on develop; import order predates biome
+# Added for the deep-link contract branch (#279 et al). Every identity below was
+# measured on develop with the gate's own invocation --
+#   pnpm exec biome check --reporter=json --max-diagnostics=500 <same file list>
+# -- and reproduced identically, counts included. Note that `biome check <file>`
+# in text mode under-reports (it omits the file-level `format` diagnostic), so
+# comparing with that command will wrongly look like the branch introduced them.
+apps/backend/src/modules/dashboard/service.ts format -- pre-existing on develop; the file predates biome formatting
+apps/backend/src/modules/dashboard/service.ts organizeImports -- pre-existing on develop; import order predates biome
+apps/backend/src/modules/dashboard/__tests__/summary.integration.test.ts format -- pre-existing on develop; long single-line expectations predate biome formatting
+apps/backend/src/modules/dashboard/__tests__/summary.integration.test.ts lint/style/noNonNullAssertion -- pre-existing on develop (12x, unchanged); test helpers assert non-null after an explicit status check
+apps/backend/src/modules/dashboard/__tests__/summary.integration.test.ts lint/style/noUnusedTemplateLiteral -- pre-existing on develop (9x, unchanged)
+apps/backend/src/modules/nav/service.ts format -- pre-existing on develop; the file predates biome formatting
+apps/backend/src/modules/nav/__tests__/nav-counts.integration.test.ts format -- pre-existing on develop; long single-line expectations predate biome formatting
+apps/backend/src/modules/nav/__tests__/nav-counts.integration.test.ts lint/style/noNonNullAssertion -- pre-existing on develop (4x, unchanged)
+apps/backend/src/modules/nav/__tests__/nav-counts.integration.test.ts lint/style/noUnusedTemplateLiteral -- pre-existing on develop (1x, unchanged)
+apps/backend/src/modules/nav/__tests__/nav-counts.integration.test.ts organizeImports -- pre-existing on develop; import order predates biome
+apps/frontend/src/routes/_authed/vocs.tsx format -- pre-existing on develop; the file predates biome formatting
+apps/frontend/src/routes/_authed/vocs.tsx organizeImports -- pre-existing on develop; import order predates biome
+packages/shared/src/dashboard.ts format -- pre-existing on develop; the file predates biome formatting
+packages/shared/src/vocs/list-query.ts format -- pre-existing on develop; the file predates biome formatting


### PR DESCRIPTION
Closes #275, #279, #296, #297, #300, #301, #302, #303.

## Why these eight are one chunk

Deep-link strings and count queries were authored in three places — `dashboard/service.ts`, `nav/service.ts`, and the frontend `NAV_TREE` — with nothing comparing them to the frontend router. Of the six backend-authored links, **three were broken and two were inert**. Fixing the strings without a contract just resets the clock.

## Measured before the fix (dd8c77d, real app, personas seeded)

| link | observed |
|---|---|
| `/integration` | bare `Not Found`, no shell |
| `/admin/permission-requests` | no such route |
| `/vocs?view=inbox&tab=high-no-link` | `Something went wrong!` — invalid enum |
| `/tasks?status=released` | `.strict()` schema rejects `status` |
| `/findings?status=active`, `/surveys?type=outcome` | parameter silently ignored |

| sidebar badge | badge (`view=inbox`) | destination (`view=triage`) |
|---|---|---|
| High severity | 2 | **0** |
| Unassigned | 4 | **3** |
| No follow-up | 13 | **4** |

```
mock-user-1  GET /nav/counts → 403 permission.denied "finding.read capability required"
mock-admin-1 GET /nav/counts → 200, 9 counts
```

## What changed

- **#296** was not a typo. `packages/shared/src/vocs/list-query.ts` already listed `high-no-link`; the frontend route had hand-copied the enum and dropped it. The enum is now `vocTabEnumSchema` in shared and the route imports it, so the two cannot drift again.
- **#297 / #303** the three VIEWS badges now count the view they link to. Only `high` was reported; all three were wrong.
- **#301** `nav/service.ts` guarded only the VOC counts. Findings, Surveys and VOC Clusters are guarded the same way now, and **absent keys stay absent** — no zero fallback, per the existing `/nav/counts` contract.
- **#279** `/integration` redirects to `/integration/links`. No screen was invented; the sidebar entry's label and href are untouched.
- **#300 / #302** none of the three advertised filters is implemented, so the parameters are removed rather than faked. Implementing real filters is separate scope.

## The durable part

`apps/frontend/src/routes/__tests__/deep-links.test.tsx` resolves all 21 shipped links — every shared dashboard constant, every `ALL_SIDEBAR_ENTRIES` href, and the Home coverage href — against the generated router, asserting the route exists and `validateSearch` does not throw. Non-empty assertion plus two negative controls guard the oracle; failure messages name the offending link.

## Verification

| gate | result |
|---|---|
| frontend vitest (full) | 700 passed / 135 files |
| backend integration (full) | 1188 passed, **1 failed — pre-existing, see #304** |
| backend integration (nav + dashboard) | 15 passed |
| visual harness | 44 passed, baselines byte-identical |
| frontend typecheck gate | 24 total, 24 baselined, **0 new** |
| backend typecheck | 3 errors — the known residual three, **0 new** |
| biome gate | **0 unexpected** (14 identities added to the allowlist, each reproduced on develop) |

`develop` fails the same single integration test (1187 passed / 1 failed), so this branch adds a test and no failure. Filed as #304.

## Mutation matrix — 5/5 killed

| mutation | firing assertion |
|---|---|
| drop `high-no-link` from the frontend tab enum | `Route search validation failed for /vocs?view=inbox&tab=high-no-link` |
| revert the permission-request path | `No registered route for /admin/permission-requests` |
| restore `/tasks?status=released` | `Route search validation failed for /tasks?status=released` |
| revert nav counts to `view=inbox` | nav-counts backing-list agreement, `expected 4 to be 1` |
| unwrap the findings authorization guard | `expected 403 to be 200` |

## Real-app smoke

```
/integration                      → /integration/links
/vocs?view=inbox&tab=high-no-link → 3 rows, all high/critical, matching the queue count of 3
Admin  /nav/counts → voc.tab.high 0 = destination 0; unassigned 3 = 3; no-link 4 = 4
User   /nav/counts → 200, voc.my present, findings.all and voc.clusters keys absent
```

## Known residual

`/vocs?view=inbox&tab=high-no-link` renders the correct rows but no toolbar tab appears selected — `INBOX_TABS` has the prototype's five tabs and `high-no-link` is not one of them. Adding a sixth tab is a deviation from `docs/design-prototype/screen-voc.jsx`, so it was deliberately not done here. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BfiR55zJ7n8uYpr1s3X6q