### PR TITLE
chore(agents): record the agent-workflow model-routing block from the toolkit upgrade

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,3 +156,14 @@ When reviewing a PR, prioritize product invariant violations, ownership boundary
 - **Domain docs.** Root `CONTEXT.md` owns the domain glossary and stable invariants; `docs/adr/` owns architectural decisions; per-directory `AGENTS.md` owns technical-layer rules. See `docs/agents/domain.md`.
 - **Workflow.** Model tiers, REV cycles, dispatch patterns: the `/agent-workflow` skill (external toolkit).
 - **Vendored skills.** `.agents/skills/` holds the vendored `mattpocock/skills`, symlinked into `.claude/skills/`. `caveman` and `zoom-out` are local-only additions. Upstream `code-review` is deliberately not vendored, so `/code-review` resolves to the Claude Code built-in.
+
+<!-- agent-workflow:begin (managed by install-into.sh — do not edit) -->
+### Model routing (installed by the agent-workflow toolkit)
+
+Read before any dispatch:
+- .agent-workflow/model-alloc.json — project-owned allocation contract
+- .agent-workflow/docs/agents/multi-agent-workflow.md — Model Allocation
+- .agent-workflow/docs/agents/conductor-persona.md — section 2: CONDUCTOR is read-only on product code
+
+The allocation file is authoritative. CONDUCTOR dispatches artifact-producing work; workers produce code, docs, plans, and recon.
+<!-- agent-workflow:end -->


### PR DESCRIPTION
Upgraded the installed `.agent-workflow/` copy to toolkit `b792ee6` via `install-into.sh /path --profile feedbackops --upgrade`.

The install was several releases behind — 20 differing scripts, all schemas, all agent docs, and three lib modules missing entirely (`pr-draft-check.cjs`, `verify-artifact.cjs`, `worktree-content-id.cjs`). `.agent-workflow/` is gitignored, so nothing about that shows up in git; it rots silently.

**This PR is only the tracked side effect**: the installer appends a marker-delimited managed block to `AGENTS.md` (11 added lines, 0 removed) pointing at the model-allocation contract and the conductor read-only rule. Committing it so it does not read as uncommitted drift next session.

## Post-upgrade checks

| check | result |
|---|---|
| `diff -rq toolkit/{scripts,schemas,docs/agents}` vs install | identical except `scripts/__tests__` (intentionally not installed) |
| preserved project-owned `model-alloc.json` vs **new** `model_alloc.schema.json` | valid |
| toolkit smoke suite (`__tests__/run-all.sh`, run in the toolkit repo) | **36/36** |
| installed `agent-workflow.sh capabilities` | exit 0 — cmux + orca adapters available, codex/claude/opencode runtimes available |

The remembered "33/36 structural baseline" is stale: the two issues behind it (#67 PRODUCT_ROOT path resolution, #68 model-alloc default assertion) are closed upstream, and the toolkit now has zero open issues.

Also created `.agent-workflow/workflow-config.json` (`cmux`/`codex`/`implementation`) — gitignored, not in this diff. Without it every dispatch must pass `--orchestrator` or die on `orchestrator_not_configured`; cmux is the evidence-backed choice after the orca adapter failure that consumed an admission ordinal.

⚠️ The installer warns `VERIFY_CLEAN_COMMAND is not configured`. The probe itself exists at `scripts/verify-clean-state.mjs`; per `apps/backend/AGENTS.md` it is supplied as an environment variable at verification time, not from a config file. No action taken — flagging so the warning is not re-diagnosed.