### PR TITLE
fix(tasks): let a backlog task reach todo through the next-status button (#290)

### DIFF
--- a/apps/frontend/src/features/tasks/routes/TaskBoardRoute.test.tsx
+++ b/apps/frontend/src/features/tasks/routes/TaskBoardRoute.test.tsx
@@ -216,6 +216,29 @@ describe('TaskBoardRoute', () => {
     expect(screen.getAllByText('Released').length).toBeGreaterThan(0);
   });
 
+  // #290: ADR-0030 allows every status to reach every other status, but the
+  // board excluded backlog from the next-status button, leaving drag as the
+  // only way out — and drag is closed to keyboard users. Two defects, not one:
+  // the render guard hid the button, and the nextStatus map had no backlog
+  // entry, so removing the guard alone would render a button that does nothing.
+  it('#290 moves a backlog task to todo through the next-status button', async () => {
+    const backlogTask = { ...task, status: 'backlog' as const };
+    const todoTask = { ...backlogTask, status: 'todo' as const };
+    api.listTasks.mockResolvedValue({ items: [backlogTask] });
+    api.getTask.mockResolvedValueOnce({ ...backlogTask, source: null }).mockResolvedValueOnce({ ...todoTask, source: null });
+    api.updateTaskStatus.mockResolvedValue(todoTask);
+
+    renderBoard(backlogTask.id);
+    const footerAction = await screen.findByRole('button', { name: 'Move to next status' });
+
+    fireEvent.click(footerAction);
+
+    await waitFor(() => expect(api.updateTaskStatus).toHaveBeenCalledTimes(1));
+    expect(api.updateTaskStatus.mock.calls[0]?.[0]).toBe(backlogTask.id);
+    expect(api.updateTaskStatus.mock.calls[0]?.[1]).toBe('todo');
+    await waitFor(() => expect(screen.getAllByText('Todo').length).toBeGreaterThan(0));
+  });
+
   it.each(['backlog', 'my', 'inbox'] as const)('keeps the %s view on TaskListRoute', (view) => {
     render(<TasksRouteView search={{ view }} />);
     expect(screen.getByText('task list unchanged')).toBeInTheDocument();

--- a/apps/frontend/src/features/tasks/routes/TaskBoardRoute.tsx
+++ b/apps/frontend/src/features/tasks/routes/TaskBoardRoute.tsx
@@ -152,7 +152,7 @@ export function TaskBoardRoute({ selectedParam }: { selectedParam?: string }) {
   function onDragEnd(event: DragEndEvent) { const task = event.active.data.current?.task as TaskDto | undefined; const target = event.over?.id; if (groupBy !== 'status') { toast.warning('Group by Status 일 때만 드래그로 상태를 변경할 수 있습니다.'); return; } if (!task || typeof target !== 'string') return; if (task.status !== target) mutation.mutate({ task, status: target as TaskStatus }); }
   function moveToNextStatus(taskId: string) {
     const task = items.find((item) => item.id === taskId);
-    const nextStatus: Partial<Record<TaskStatus, TaskStatus>> = { todo: 'doing', doing: 'review', review: 'done', done: 'released', reopened: 'todo' };
+    const nextStatus: Partial<Record<TaskStatus, TaskStatus>> = { backlog: 'todo', todo: 'doing', doing: 'review', review: 'done', done: 'released', reopened: 'todo' };
     const next = task && nextStatus[task.status];
     if (task && next) mutation.mutate({ task, status: next });
   }

--- a/apps/frontend/src/features/tasks/routes/TaskListRoute.tsx
+++ b/apps/frontend/src/features/tasks/routes/TaskListRoute.tsx
@@ -197,7 +197,7 @@ export function TaskDetailPanel({
           </div>
         </div>
       </div>
-      {view === 'board' && task.status !== 'backlog' && task.status !== 'released' && onMoveToNextStatus && (
+      {view === 'board' && task.status !== 'released' && onMoveToNextStatus && (
         <div className="border-t border-border-subtle p-3">
           <Button type="button" variant="primary" className="w-full" onClick={() => onMoveToNextStatus(task.id)}>
             <ArrowRight className="h-4 w-4" />Move to next status


### PR DESCRIPTION
Closes #290.

ADR-0030 정의는 "모든 상태 → 모든 상태 자유 전이"인데 보드가 `backlog`를 다음-상태 버튼에서
제외해 두었다. 남은 유일한 경로가 드래그였고, 드래그는 키보드 사용자에게 닫혀 있다.

## 이슈가 지목한 것보다 결함이 하나 더 있었다

- `TaskListRoute.tsx:200` — `task.status !== 'backlog'` 렌더 가드. **이슈가 지목한 것.**
- `TaskBoardRoute.tsx:155` — `nextStatus` 맵에 `backlog` 항목 자체가 없었다. **가드만 지웠으면
  버튼은 뜨지만 아무 일도 안 하는 상태가 됐다.**

`released` 제외는 그대로 뒀다 — 그건 종점이라 말이 된다.

## 뮤테이션 매트릭스 — 어느 단언이 발화했는지까지

| 뮤테이션 | 발화한 단언 |
|---|---|
| `nextStatus` 맵에서 `backlog` 제거 | `updateTaskStatus`가 1회 기대인데 0회 |
| `backlog` 렌더 가드 복원 | `Move to next status` 버튼을 못 찾음 |

두 뮤테이션이 **서로 다른 단언**을 깨운다 — 한 결함만 고쳤을 때를 각각 잡는다.

## 게이트

```
frontend vitest      725 passed / 136 files   (develop 724)
frontend typecheck   24 total, 24 baselined, 0 new
frontend biome       0 new
```

Tasks 화면에는 비주얼 스펙이 없어 베이스라인 영향이 없다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BfiR55zJ7n8uYpr1s3X6q