### PR TITLE
fix(voc): repair the VOC composer request contract, error visibility, and timeline identity (#266, #294, #267)

### DIFF
--- a/apps/frontend/src/features/voc/components/detail/InternalCommentComposer.tsx
+++ b/apps/frontend/src/features/voc/components/detail/InternalCommentComposer.tsx
@@ -116,6 +116,9 @@ export function InternalCommentComposer({
       setDraftDoc(null); // calls onDraftChange?.(null) when controlled
       toast.success('내부 코멘트가 추가되었습니다.');
     },
+    onError: (error) => {
+      toast.error(`${error.code}: ${error.message}`);
+    },
   });
 
   function handleSubmit() {

--- a/apps/frontend/src/features/voc/components/detail/InternalCommentComposer.tsx
+++ b/apps/frontend/src/features/voc/components/detail/InternalCommentComposer.tsx
@@ -28,6 +28,7 @@
 
 import { useVocInternalCommentMutation } from '@/features/voc/hooks/useVocInternalCommentMutation';
 import { extractMentions } from '@/features/voc/lib/extractMentions';
+import { uploadAttachment } from '@/lib/api/attachments';
 import type { MeResponse } from '@/lib/auth/useMe';
 import type { VocDetailEnvelope } from '@fops/shared';
 import type { TipTapDoc, TipTapEditor } from '@fops/ui';
@@ -35,7 +36,6 @@ import { RichEditor } from '@fops/ui';
 import { useQueryClient } from '@tanstack/react-query';
 import * as React from 'react';
 import { toast } from 'sonner';
-import { uploadAttachment } from '@/lib/api/attachments';
 import { ComposerAttachmentDropzone } from './ComposerAttachmentDropzone';
 import { ComposerFooter } from './ComposerFooter';
 import { MentionPickerButton } from './MentionPickerButton';

--- a/apps/frontend/src/features/voc/components/detail/InternalTimeline.tsx
+++ b/apps/frontend/src/features/voc/components/detail/InternalTimeline.tsx
@@ -5,10 +5,10 @@
 // into the paginated tail. The server already enforces visibility per actor role,
 // so an empty array here for Reporter-only viewers is expected.
 
-import * as React from 'react';
-import type { ConversationEntry } from '@fops/shared';
-import { EmptyState, Button } from '@fops/ui';
 import { useVocConversation } from '@/features/voc/hooks/useVocConversation';
+import type { ConversationEntry } from '@fops/shared';
+import { Button, EmptyState } from '@fops/ui';
+import type * as React from 'react';
 import { TimelineEntry } from './TimelineEntry';
 
 export interface TimelineProps {
@@ -25,8 +25,7 @@ export function InternalTimeline({
   actorNamesById,
 }: TimelineProps): React.ReactElement {
   const query = useVocConversation({ vocId, kind: 'internal_comment' });
-  const paginatedEntries: ConversationEntry[] =
-    query.data?.pages.flatMap((p) => p.items) ?? [];
+  const paginatedEntries: ConversationEntry[] = query.data?.pages.flatMap((p) => p.items) ?? [];
   const seenIds = new Set<string>();
   const entries = [...paginatedEntries, ...inline].filter((entry) => {
     if (seenIds.has(entry.id)) return false;

--- a/apps/frontend/src/features/voc/components/detail/InternalTimeline.tsx
+++ b/apps/frontend/src/features/voc/components/detail/InternalTimeline.tsx
@@ -27,6 +27,12 @@ export function InternalTimeline({
   const query = useVocConversation({ vocId, kind: 'internal_comment' });
   const paginatedEntries: ConversationEntry[] =
     query.data?.pages.flatMap((p) => p.items) ?? [];
+  const seenIds = new Set<string>();
+  const entries = [...paginatedEntries, ...inline].filter((entry) => {
+    if (seenIds.has(entry.id)) return false;
+    seenIds.add(entry.id);
+    return true;
+  });
 
   const showLoadMore = hasMore || query.hasNextPage === true;
 
@@ -46,18 +52,10 @@ export function InternalTimeline({
         </div>
       )}
 
-      {paginatedEntries.map((entry) => (
-        <TimelineEntry
-          key={entry.id}
-          entry={entry}
-          actorDisplayName={actorNamesById?.get(entry.actor_id)}
-        />
-      ))}
-
-      {inline.length === 0 && paginatedEntries.length === 0 ? (
+      {entries.length === 0 ? (
         <EmptyState size="sm" title="아직 대화가 없습니다." />
       ) : (
-        inline.map((entry) => (
+        entries.map((entry) => (
           <TimelineEntry
             key={entry.id}
             entry={entry}

--- a/apps/frontend/src/features/voc/components/detail/PublicTimeline.tsx
+++ b/apps/frontend/src/features/voc/components/detail/PublicTimeline.tsx
@@ -11,10 +11,10 @@
 // stream from the cursor, and the inline entries already arrive pre-filtered to the
 // right visibility surface by the BE.
 
-import * as React from 'react';
-import type { ConversationEntry } from '@fops/shared';
-import { EmptyState, Button } from '@fops/ui';
 import { useVocConversation } from '@/features/voc/hooks/useVocConversation';
+import type { ConversationEntry } from '@fops/shared';
+import { Button, EmptyState } from '@fops/ui';
+import type * as React from 'react';
 import { TimelineEntry } from './TimelineEntry';
 
 export interface TimelineProps {
@@ -33,9 +33,9 @@ export function PublicTimeline({
   const query = useVocConversation({ vocId });
   // The initial page loads on mount and can overlap the inline detail envelope.
   const paginatedEntries: ConversationEntry[] =
-    query.data?.pages.flatMap((p) => p.items).filter(
-      (e) => e.kind === 'public_update' || e.kind === 'reporter_reply',
-    ) ?? [];
+    query.data?.pages
+      .flatMap((p) => p.items)
+      .filter((e) => e.kind === 'public_update' || e.kind === 'reporter_reply') ?? [];
   const seenIds = new Set<string>();
   const entries = [...paginatedEntries, ...inline].filter((entry) => {
     if (seenIds.has(entry.id)) return false;

--- a/apps/frontend/src/features/voc/components/detail/PublicTimeline.tsx
+++ b/apps/frontend/src/features/voc/components/detail/PublicTimeline.tsx
@@ -31,11 +31,17 @@ export function PublicTimeline({
   actorNamesById,
 }: TimelineProps): React.ReactElement {
   const query = useVocConversation({ vocId });
-  // Pages from infinite query: these arrive only after the user clicks 더보기.
+  // The initial page loads on mount and can overlap the inline detail envelope.
   const paginatedEntries: ConversationEntry[] =
     query.data?.pages.flatMap((p) => p.items).filter(
       (e) => e.kind === 'public_update' || e.kind === 'reporter_reply',
     ) ?? [];
+  const seenIds = new Set<string>();
+  const entries = [...paginatedEntries, ...inline].filter((entry) => {
+    if (seenIds.has(entry.id)) return false;
+    seenIds.add(entry.id);
+    return true;
+  });
 
   const showLoadMore = hasMore || query.hasNextPage === true;
 
@@ -55,18 +61,10 @@ export function PublicTimeline({
         </div>
       )}
 
-      {paginatedEntries.map((entry) => (
-        <TimelineEntry
-          key={entry.id}
-          entry={entry}
-          actorDisplayName={actorNamesById?.get(entry.actor_id)}
-        />
-      ))}
-
-      {inline.length === 0 && paginatedEntries.length === 0 ? (
+      {entries.length === 0 ? (
         <EmptyState size="sm" title="아직 대화가 없습니다." />
       ) : (
-        inline.map((entry) => (
+        entries.map((entry) => (
           <TimelineEntry
             key={entry.id}
             entry={entry}

--- a/apps/frontend/src/features/voc/components/detail/PublicUpdateComposer.tsx
+++ b/apps/frontend/src/features/voc/components/detail/PublicUpdateComposer.tsx
@@ -63,6 +63,7 @@
 
 import { useVocPublicUpdateMutation } from '@/features/voc/hooks/useVocPublicUpdateMutation';
 import type { ApiError } from '@/lib/api';
+import { uploadAttachment } from '@/lib/api/attachments';
 import type { MeResponse } from '@/lib/auth/useMe';
 import { REPORTER_STATUS_LABELS } from '@/lib/copy/reporter-status-labels';
 import type { ReporterFacingStatusEnum, VocDetailEnvelope } from '@fops/shared';
@@ -76,7 +77,6 @@ import { ComposerAttachmentDropzone } from './ComposerAttachmentDropzone';
 import { ComposerFooter } from './ComposerFooter';
 import { ComposerPublicPreview } from './ComposerPublicPreview';
 import { ReporterStatusChangeBlock } from './ReporterStatusChangeBlock';
-import { uploadAttachment } from '@/lib/api/attachments';
 import { PublicUpdateToolbar } from './rich-toolbars/PublicUpdateToolbar';
 
 // ── Props ─────────────────────────────────────────────────────────────────────
@@ -117,7 +117,12 @@ function getComposerErrorTone(code: string): 'red' | 'amber' | null {
 
 // ── Component ─────────────────────────────────────────────────────────────────
 
-export function PublicUpdateComposer({ voc, me, draftDoc: controlledDraftDoc, onDraftChange }: PublicUpdateComposerProps): ReactElement {
+export function PublicUpdateComposer({
+  voc,
+  me,
+  draftDoc: controlledDraftDoc,
+  onDraftChange,
+}: PublicUpdateComposerProps): ReactElement {
   const queryClient = useQueryClient();
 
   // REV-1 #7: if parent provides controlled draft, use it; otherwise keep local state

--- a/apps/frontend/src/features/voc/components/detail/PublicUpdateComposer.tsx
+++ b/apps/frontend/src/features/voc/components/detail/PublicUpdateComposer.tsx
@@ -167,6 +167,11 @@ export function PublicUpdateComposer({ voc, me, draftDoc: controlledDraftDoc, on
       setNextStatus(voc.reporter_facing_status);
       toast.success('공개 업데이트가 게시되었습니다.');
     },
+    onError: (error) => {
+      if (getComposerErrorTone(error.code) == null) {
+        toast.error(`${error.code}: ${error.message}`);
+      }
+    },
   });
 
   function handleSubmit() {
@@ -175,10 +180,9 @@ export function PublicUpdateComposer({ voc, me, draftDoc: controlledDraftDoc, on
       vocId: voc.id,
       ifMatch: voc.updated_at,
       body: {
+        skip_public_update: false,
         body_rich_content: draftDoc,
         next_reporter_facing_status: nextStatus,
-        attachments: [],
-        // PLAN-22 C7a (D1): widened body field — schema reconciled in C7b.
         attachment_ids: attachmentIds,
       },
     });

--- a/apps/frontend/src/features/voc/components/detail/ReporterReplyComposer.tsx
+++ b/apps/frontend/src/features/voc/components/detail/ReporterReplyComposer.tsx
@@ -128,6 +128,11 @@ export function ReporterReplyComposer({ voc, me, draftDoc: controlledDraftDoc, o
       setDraftDoc(null); // calls onDraftChange?.(null) when controlled
       toast.success('리포터에게 답장이 전송되었습니다.');
     },
+    onError: (error) => {
+      if (getComposerErrorTone(error.code) == null) {
+        toast.error(`${error.code}: ${error.message}`);
+      }
+    },
   });
 
   function handleSubmit() {
@@ -137,8 +142,6 @@ export function ReporterReplyComposer({ voc, me, draftDoc: controlledDraftDoc, o
       ifMatch: voc.updated_at,
       body: {
         body_rich_content: draftDoc,
-        attachments: [],
-        // PLAN-22 C7a (D1): widened body field — schema reconciled in C7b.
         attachment_ids: attachmentIds,
       },
     });

--- a/apps/frontend/src/features/voc/components/detail/ReporterReplyComposer.tsx
+++ b/apps/frontend/src/features/voc/components/detail/ReporterReplyComposer.tsx
@@ -39,6 +39,7 @@
 
 import { useVocReporterReplyMutation } from '@/features/voc/hooks/useVocReporterReplyMutation';
 import type { ApiError } from '@/lib/api';
+import { uploadAttachment } from '@/lib/api/attachments';
 import type { MeResponse } from '@/lib/auth/useMe';
 import type { VocDetailEnvelope } from '@fops/shared';
 import { Callout, PreviewModal, RichEditor } from '@fops/ui';
@@ -50,7 +51,6 @@ import { toast } from 'sonner';
 import { ComposerAttachmentDropzone } from './ComposerAttachmentDropzone';
 import { ComposerFooter } from './ComposerFooter';
 import { ComposerReplyPreview } from './ComposerReplyPreview';
-import { uploadAttachment } from '@/lib/api/attachments';
 import { ReporterReplyToolbar } from './rich-toolbars/ReporterReplyToolbar';
 
 // ── Props ─────────────────────────────────────────────────────────────────────
@@ -88,7 +88,12 @@ function getComposerErrorTone(code: string): 'amber' | null {
 
 // ── Component ─────────────────────────────────────────────────────────────────
 
-export function ReporterReplyComposer({ voc, me, draftDoc: controlledDraftDoc, onDraftChange }: ReporterReplyComposerProps): ReactElement {
+export function ReporterReplyComposer({
+  voc,
+  me,
+  draftDoc: controlledDraftDoc,
+  onDraftChange,
+}: ReporterReplyComposerProps): ReactElement {
   const queryClient = useQueryClient();
 
   // REV-1 #7: controlled draft support.

--- a/apps/frontend/src/features/voc/components/detail/__tests__/ComposerErrorMatrix.test.tsx
+++ b/apps/frontend/src/features/voc/components/detail/__tests__/ComposerErrorMatrix.test.tsx
@@ -1,6 +1,6 @@
 /// <reference types="@testing-library/jest-dom" />
 // ComposerErrorMatrix.test.tsx — TDD RED
-// Error matrix sweep across PublicUpdateComposer and ReporterReplyComposer.
+// Error matrix sweep across all three composer surfaces.
 //
 // Tests:
 //   1. reporter_facing_status.invalid_transition → red Callout inline (PublicUpdateComposer)
@@ -17,6 +17,10 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
 
 // ── Shared RichEditor mock ─────────────────────────────────────────────────
 
@@ -45,6 +49,7 @@ vi.mock('@fops/ui', async (importActual) => {
 
 const publicMutate = vi.fn();
 const replyMutate = vi.fn();
+const internalMutate = vi.fn();
 
 vi.mock('@/features/voc/hooks/useVocPublicUpdateMutation', () => ({
   useVocPublicUpdateMutation: vi.fn(() => ({
@@ -64,8 +69,19 @@ vi.mock('@/features/voc/hooks/useVocReporterReplyMutation', () => ({
   })),
 }));
 
+vi.mock('@/features/voc/hooks/useVocInternalCommentMutation', () => ({
+  useVocInternalCommentMutation: vi.fn(() => ({
+    mutate: internalMutate,
+    isPending: false,
+    isError: false,
+    error: null,
+  })),
+}));
+
 import type { MeResponse } from '@/lib/auth/useMe';
 import type { VocDetailEnvelope } from '@fops/shared';
+import { toast } from 'sonner';
+import { InternalCommentComposer } from '../InternalCommentComposer';
 import { PublicUpdateComposer } from '../PublicUpdateComposer';
 import { ReporterReplyComposer } from '../ReporterReplyComposer';
 
@@ -142,6 +158,14 @@ function makeIdempotencyReuseError(): ApiError {
   });
 }
 
+function makeValidationError(): ApiError {
+  return new ApiError(422, {
+    code: 'validation.failed',
+    message: 'Request body is invalid',
+    detail: {},
+  });
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe('Composer error matrix (C5.5)', () => {
@@ -174,7 +198,7 @@ describe('Composer error matrix (C5.5)', () => {
     expect(callout).toHaveTextContent('해당 상태로 전환할 수 없습니다.');
   });
 
-  it('2. gate_blocked: shows amber Callout inline in ReporterReplyComposer after mutation error', async () => {
+  it('AC-A2b gate_blocked keeps the existing amber Callout', async () => {
     const { useVocReporterReplyMutation } = await import(
       '@/features/voc/hooks/useVocReporterReplyMutation'
     );
@@ -195,6 +219,81 @@ describe('Composer error matrix (C5.5)', () => {
     // tone should be amber for gate_blocked
     expect(callout.dataset.tone).toBe('amber');
     expect(callout).toHaveTextContent('Task가 검토 중입니다.');
+  });
+
+  it('AC-A2a PublicUpdateComposer surfaces validation.failed in an error toast', async () => {
+    const { useVocPublicUpdateMutation } = await import(
+      '@/features/voc/hooks/useVocPublicUpdateMutation'
+    );
+    const error = makeValidationError();
+    vi.mocked(useVocPublicUpdateMutation).mockImplementation((args = {}) => ({
+      mutate: publicMutate.mockImplementation((vars) => {
+        queueMicrotask(() => args.onError?.(error, vars));
+      }),
+      isPending: false,
+      isError: false,
+      error: null,
+    }) as unknown as ReturnType<typeof useVocPublicUpdateMutation>);
+
+    render(<PublicUpdateComposer voc={BASE_VOC} me={ME_ADMIN} />, { wrapper: makeWrapper() });
+    fireEvent.click(screen.getByRole('textbox'));
+    fireEvent.click(screen.getByRole('button', { name: /publish update/i }));
+
+    await waitFor(() => {
+      expect(publicMutate).toHaveBeenCalledTimes(1);
+      expect(toast.error).toHaveBeenCalledTimes(1);
+      expect(toast.error).toHaveBeenCalledWith(expect.stringContaining('validation.failed'));
+    });
+  });
+
+  it('AC-A2a ReporterReplyComposer surfaces validation.failed in an error toast', async () => {
+    const { useVocReporterReplyMutation } = await import(
+      '@/features/voc/hooks/useVocReporterReplyMutation'
+    );
+    const error = makeValidationError();
+    vi.mocked(useVocReporterReplyMutation).mockImplementation((args = {}) => ({
+      mutate: replyMutate.mockImplementation((vars) => {
+        queueMicrotask(() => args.onError?.(error, vars));
+      }),
+      isPending: false,
+      isError: false,
+      error: null,
+    }) as unknown as ReturnType<typeof useVocReporterReplyMutation>);
+
+    render(<ReporterReplyComposer voc={BASE_VOC} me={ME_ADMIN} />, { wrapper: makeWrapper() });
+    fireEvent.click(screen.getByRole('textbox'));
+    fireEvent.click(screen.getByRole('button', { name: /send reply/i }));
+
+    await waitFor(() => {
+      expect(replyMutate).toHaveBeenCalledTimes(1);
+      expect(toast.error).toHaveBeenCalledTimes(1);
+      expect(toast.error).toHaveBeenCalledWith(expect.stringContaining('validation.failed'));
+    });
+  });
+
+  it('AC-A2a InternalCommentComposer surfaces validation.failed in an error toast', async () => {
+    const { useVocInternalCommentMutation } = await import(
+      '@/features/voc/hooks/useVocInternalCommentMutation'
+    );
+    const error = makeValidationError();
+    vi.mocked(useVocInternalCommentMutation).mockImplementation((args = {}) => ({
+      mutate: internalMutate.mockImplementation((vars) => {
+        queueMicrotask(() => args.onError?.(error, vars));
+      }),
+      isPending: false,
+      isError: false,
+      error: null,
+    }) as unknown as ReturnType<typeof useVocInternalCommentMutation>);
+
+    render(<InternalCommentComposer voc={BASE_VOC} me={ME_ADMIN} />, { wrapper: makeWrapper() });
+    fireEvent.click(screen.getByRole('textbox'));
+    fireEvent.click(screen.getByRole('button', { name: /add note/i }));
+
+    await waitFor(() => {
+      expect(internalMutate).toHaveBeenCalledTimes(1);
+      expect(toast.error).toHaveBeenCalledTimes(1);
+      expect(toast.error).toHaveBeenCalledWith(expect.stringContaining('validation.failed'));
+    });
   });
 
   it('3. idempotency_key_reuse: disables both Submit and Preview buttons after mutation error', async () => {

--- a/apps/frontend/src/features/voc/components/detail/__tests__/ComposerErrorMatrix.test.tsx
+++ b/apps/frontend/src/features/voc/components/detail/__tests__/ComposerErrorMatrix.test.tsx
@@ -226,14 +226,17 @@ describe('Composer error matrix (C5.5)', () => {
       '@/features/voc/hooks/useVocPublicUpdateMutation'
     );
     const error = makeValidationError();
-    vi.mocked(useVocPublicUpdateMutation).mockImplementation((args = {}) => ({
-      mutate: publicMutate.mockImplementation((vars) => {
-        queueMicrotask(() => args.onError?.(error, vars));
-      }),
-      isPending: false,
-      isError: false,
-      error: null,
-    }) as unknown as ReturnType<typeof useVocPublicUpdateMutation>);
+    vi.mocked(useVocPublicUpdateMutation).mockImplementation(
+      (args = {}) =>
+        ({
+          mutate: publicMutate.mockImplementation((vars) => {
+            queueMicrotask(() => args.onError?.(error, vars));
+          }),
+          isPending: false,
+          isError: false,
+          error: null,
+        }) as unknown as ReturnType<typeof useVocPublicUpdateMutation>,
+    );
 
     render(<PublicUpdateComposer voc={BASE_VOC} me={ME_ADMIN} />, { wrapper: makeWrapper() });
     fireEvent.click(screen.getByRole('textbox'));
@@ -251,14 +254,17 @@ describe('Composer error matrix (C5.5)', () => {
       '@/features/voc/hooks/useVocReporterReplyMutation'
     );
     const error = makeValidationError();
-    vi.mocked(useVocReporterReplyMutation).mockImplementation((args = {}) => ({
-      mutate: replyMutate.mockImplementation((vars) => {
-        queueMicrotask(() => args.onError?.(error, vars));
-      }),
-      isPending: false,
-      isError: false,
-      error: null,
-    }) as unknown as ReturnType<typeof useVocReporterReplyMutation>);
+    vi.mocked(useVocReporterReplyMutation).mockImplementation(
+      (args = {}) =>
+        ({
+          mutate: replyMutate.mockImplementation((vars) => {
+            queueMicrotask(() => args.onError?.(error, vars));
+          }),
+          isPending: false,
+          isError: false,
+          error: null,
+        }) as unknown as ReturnType<typeof useVocReporterReplyMutation>,
+    );
 
     render(<ReporterReplyComposer voc={BASE_VOC} me={ME_ADMIN} />, { wrapper: makeWrapper() });
     fireEvent.click(screen.getByRole('textbox'));
@@ -276,14 +282,17 @@ describe('Composer error matrix (C5.5)', () => {
       '@/features/voc/hooks/useVocInternalCommentMutation'
     );
     const error = makeValidationError();
-    vi.mocked(useVocInternalCommentMutation).mockImplementation((args = {}) => ({
-      mutate: internalMutate.mockImplementation((vars) => {
-        queueMicrotask(() => args.onError?.(error, vars));
-      }),
-      isPending: false,
-      isError: false,
-      error: null,
-    }) as unknown as ReturnType<typeof useVocInternalCommentMutation>);
+    vi.mocked(useVocInternalCommentMutation).mockImplementation(
+      (args = {}) =>
+        ({
+          mutate: internalMutate.mockImplementation((vars) => {
+            queueMicrotask(() => args.onError?.(error, vars));
+          }),
+          isPending: false,
+          isError: false,
+          error: null,
+        }) as unknown as ReturnType<typeof useVocInternalCommentMutation>,
+    );
 
     render(<InternalCommentComposer voc={BASE_VOC} me={ME_ADMIN} />, { wrapper: makeWrapper() });
     fireEvent.click(screen.getByRole('textbox'));

--- a/apps/frontend/src/features/voc/components/detail/__tests__/ConversationTimeline.test.tsx
+++ b/apps/frontend/src/features/voc/components/detail/__tests__/ConversationTimeline.test.tsx
@@ -1,7 +1,7 @@
-import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import type * as React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@/features/voc/hooks/useVocConversation', () => ({
   useVocConversation: vi.fn(),
@@ -31,11 +31,11 @@ vi.mock('../TimelineEntry', () => ({
 
 import { useVocConversation } from '@/features/voc/hooks/useVocConversation';
 import { useMe } from '@/lib/auth/useMe';
+import type { ConversationEntry } from '@fops/shared';
 import { ConversationTimeline } from '../ConversationTimeline';
 import { InternalTimeline } from '../InternalTimeline';
 import { PublicTimeline } from '../PublicTimeline';
 import { DETAIL_ENVELOPE, ME_RESPONSE, makeConversationQuery } from './_fixtures';
-import type { ConversationEntry } from '@fops/shared';
 
 const PUBLIC_ENTRY: ConversationEntry = {
   id: 'entry-public-1',
@@ -107,16 +107,16 @@ function renderTimeline(
   inline: ConversationEntry[],
   pages: ConversationEntry[][] | undefined,
 ) {
+  // `Partial<UseInfiniteQueryResult<…>>` distributes over the discriminated
+  // result variants, and the pending variant declares `data?: undefined`. Passing
+  // `data` together with a *computed* `isPending` matches no single variant, so
+  // the two states are built as separate literals instead.
   vi.mocked(useVocConversation).mockReturnValue(
-    makeConversationQuery({
-      // useVocConversation narrows its result to `{ pages: ConversationPage[] }`,
-      // so `pageParams` is an excess property here even though the real
-      // infinite-query data carries it.
-      data: pages
-        ? { pages: pages.map((items) => ({ items, has_more: false })) }
-        : undefined,
-      isPending: pages === undefined,
-    }),
+    pages
+      ? makeConversationQuery({
+          data: { pages: pages.map((items) => ({ items, has_more: false })) },
+        })
+      : makeConversationQuery({ data: undefined, isPending: true }),
   );
   return render(<Component vocId="voc-timeline" inline={inline} hasMore={false} />, {
     wrapper: makeWrapper(),
@@ -175,13 +175,16 @@ describe('deduplicated timeline rendering', () => {
   it.each([
     ['Public', PublicTimeline, publicInline],
     ['Internal', InternalTimeline, internalInline],
-  ] as const)('AC-A3a %s timeline renders identical inline and page ids exactly once', (_, Component, inline) => {
-    const { container } = renderTimeline(Component, inline, [inline]);
-    const ids = renderedIds(container);
+  ] as const)(
+    'AC-A3a %s timeline renders identical inline and page ids exactly once',
+    (_, Component, inline) => {
+      const { container } = renderTimeline(Component, inline, [inline]);
+      const ids = renderedIds(container);
 
-    expect(new Set(ids)).toEqual(new Set(inline.map((entry) => entry.id)));
-    expect(ids).toHaveLength(3);
-  });
+      expect(new Set(ids)).toEqual(new Set(inline.map((entry) => entry.id)));
+      expect(ids).toHaveLength(3);
+    },
+  );
 
   it.each([
     [
@@ -217,11 +220,14 @@ describe('deduplicated timeline rendering', () => {
   it.each([
     ['Public', PublicTimeline, publicInline],
     ['Internal', InternalTimeline, internalInline],
-  ] as const)('AC-A3c %s timeline renders inline entries while the query is pending', (_, Component, inline) => {
-    const { container } = renderTimeline(Component, inline, undefined);
-    const ids = renderedIds(container);
+  ] as const)(
+    'AC-A3c %s timeline renders inline entries while the query is pending',
+    (_, Component, inline) => {
+      const { container } = renderTimeline(Component, inline, undefined);
+      const ids = renderedIds(container);
 
-    expect(ids).toEqual(inline.map((entry) => entry.id));
-    expect(ids).toHaveLength(3);
-  });
+      expect(ids).toEqual(inline.map((entry) => entry.id));
+      expect(ids).toHaveLength(3);
+    },
+  );
 });

--- a/apps/frontend/src/features/voc/components/detail/__tests__/ConversationTimeline.test.tsx
+++ b/apps/frontend/src/features/voc/components/detail/__tests__/ConversationTimeline.test.tsx
@@ -109,11 +109,11 @@ function renderTimeline(
 ) {
   vi.mocked(useVocConversation).mockReturnValue(
     makeConversationQuery({
+      // useVocConversation narrows its result to `{ pages: ConversationPage[] }`,
+      // so `pageParams` is an excess property here even though the real
+      // infinite-query data carries it.
       data: pages
-        ? {
-            pages: pages.map((items) => ({ items, has_more: false })),
-            pageParams: pages.map((_, index) => String(index)),
-          }
+        ? { pages: pages.map((items) => ({ items, has_more: false })) }
         : undefined,
       isPending: pages === undefined,
     }),

--- a/apps/frontend/src/features/voc/components/detail/__tests__/ConversationTimeline.test.tsx
+++ b/apps/frontend/src/features/voc/components/detail/__tests__/ConversationTimeline.test.tsx
@@ -1,5 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import * as React from 'react';
 
 vi.mock('@/features/voc/hooks/useVocConversation', () => ({
   useVocConversation: vi.fn(),
@@ -15,10 +17,23 @@ vi.mock('@fops/ui', async (importOriginal) => {
 vi.mock('@/features/voc/components/list/VocRow', () => ({
   formatVocCreatedAt: () => '방금 전',
 }));
+vi.mock('../TimelineEntry', () => ({
+  TimelineEntry: ({ entry }: { entry: ConversationEntry }) => (
+    <div data-entry-id={entry.id}>
+      {entry.kind === 'public_update'
+        ? '공개 업데이트'
+        : entry.kind === 'reporter_reply'
+          ? 'Reporter 답변'
+          : '내부 코멘트'}
+    </div>
+  ),
+}));
 
 import { useVocConversation } from '@/features/voc/hooks/useVocConversation';
 import { useMe } from '@/lib/auth/useMe';
 import { ConversationTimeline } from '../ConversationTimeline';
+import { InternalTimeline } from '../InternalTimeline';
+import { PublicTimeline } from '../PublicTimeline';
 import { DETAIL_ENVELOPE, ME_RESPONSE, makeConversationQuery } from './_fixtures';
 import type { ConversationEntry } from '@fops/shared';
 
@@ -52,6 +67,68 @@ const INTERNAL_ENTRY: ConversationEntry = {
   attachments: [],
 };
 
+type TimelineComponent = React.ComponentType<{
+  vocId: string;
+  inline: ConversationEntry[];
+  hasMore: boolean;
+}>;
+
+function makeEntry(
+  id: string,
+  kind: ConversationEntry['kind'],
+  text: string,
+  createdAt: string,
+): ConversationEntry {
+  return {
+    id,
+    kind,
+    actor_id: `${id}-actor`,
+    body_rich_content: {
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text }] }],
+    },
+    created_at: createdAt,
+    visibility: kind === 'internal_comment' ? 'internal' : 'public',
+    attachments: [],
+  };
+}
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+function renderTimeline(
+  Component: TimelineComponent,
+  inline: ConversationEntry[],
+  pages: ConversationEntry[][] | undefined,
+) {
+  vi.mocked(useVocConversation).mockReturnValue(
+    makeConversationQuery({
+      data: pages
+        ? {
+            pages: pages.map((items) => ({ items, has_more: false })),
+            pageParams: pages.map((_, index) => String(index)),
+          }
+        : undefined,
+      isPending: pages === undefined,
+    }),
+  );
+  return render(<Component vocId="voc-timeline" inline={inline} hasMore={false} />, {
+    wrapper: makeWrapper(),
+  });
+}
+
+function renderedIds(container: HTMLElement): string[] {
+  return [...container.querySelectorAll<HTMLElement>('[data-entry-id]')].map(
+    (element) => element.dataset.entryId ?? '',
+  );
+}
+
 beforeEach(() => {
   vi.mocked(useVocConversation).mockReturnValue(makeConversationQuery());
   vi.mocked(useMe).mockReturnValue({ data: ME_RESPONSE } as ReturnType<typeof useMe>);
@@ -80,5 +157,71 @@ describe('<ConversationTimeline>', () => {
   it('shows empty state when no entries in public tab', () => {
     render(<ConversationTimeline voc={DETAIL_ENVELOPE} />);
     expect(screen.getByText('아직 대화가 없습니다.')).toBeInTheDocument();
+  });
+});
+
+describe('deduplicated timeline rendering', () => {
+  const publicInline = [
+    makeEntry('public-1', 'reporter_reply', 'first public body', '2026-05-01T01:00:00Z'),
+    makeEntry('public-2', 'public_update', 'second public body', '2026-05-01T02:00:00Z'),
+    makeEntry('public-3', 'reporter_reply', 'third public body', '2026-05-01T03:00:00Z'),
+  ];
+  const internalInline = [
+    makeEntry('internal-1', 'internal_comment', 'first internal body', '2026-05-01T01:30:00Z'),
+    makeEntry('internal-2', 'internal_comment', 'second internal body', '2026-05-01T02:30:00Z'),
+    makeEntry('internal-3', 'internal_comment', 'third internal body', '2026-05-01T03:30:00Z'),
+  ];
+
+  it.each([
+    ['Public', PublicTimeline, publicInline],
+    ['Internal', InternalTimeline, internalInline],
+  ] as const)('AC-A3a %s timeline renders identical inline and page ids exactly once', (_, Component, inline) => {
+    const { container } = renderTimeline(Component, inline, [inline]);
+    const ids = renderedIds(container);
+
+    expect(new Set(ids)).toEqual(new Set(inline.map((entry) => entry.id)));
+    expect(ids).toHaveLength(3);
+  });
+
+  it.each([
+    [
+      'Public',
+      PublicTimeline,
+      publicInline,
+      makeEntry('public-older', 'public_update', 'older public body', '2026-04-30T23:00:00Z'),
+    ],
+    [
+      'Internal',
+      InternalTimeline,
+      internalInline,
+      makeEntry(
+        'internal-older',
+        'internal_comment',
+        'older internal body',
+        '2026-04-30T23:30:00Z',
+      ),
+    ],
+  ] as const)(
+    'AC-A3b %s timeline keeps the older page entry and the deduplicated inline entries in order',
+    (_, Component, inline, older) => {
+      const { container } = renderTimeline(Component, inline, [[older, ...inline]]);
+      const ids = renderedIds(container);
+      const expectedIds = [older.id, ...inline.map((entry) => entry.id)];
+
+      expect(ids).toEqual(expectedIds);
+      expect(new Set(ids)).toEqual(new Set(expectedIds));
+      expect(ids).toHaveLength(4);
+    },
+  );
+
+  it.each([
+    ['Public', PublicTimeline, publicInline],
+    ['Internal', InternalTimeline, internalInline],
+  ] as const)('AC-A3c %s timeline renders inline entries while the query is pending', (_, Component, inline) => {
+    const { container } = renderTimeline(Component, inline, undefined);
+    const ids = renderedIds(container);
+
+    expect(ids).toEqual(inline.map((entry) => entry.id));
+    expect(ids).toHaveLength(3);
   });
 });

--- a/apps/frontend/src/features/voc/components/detail/__tests__/InternalCommentComposer.test.tsx
+++ b/apps/frontend/src/features/voc/components/detail/__tests__/InternalCommentComposer.test.tsx
@@ -7,10 +7,10 @@
 // C5.4 of slice3 #21.
 // Prototype ref: docs/design-prototype/screen-voc.jsx:415-468 (internal variant)
 
-import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import * as React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // ── Module mocks ─────────────────────────────────────────────────────────────
 
@@ -45,9 +45,9 @@ vi.mock('@fops/ui', async (importActual) => {
   };
 });
 
-import { InternalCommentComposer } from '../InternalCommentComposer';
-import { internalCommentRequestSchema, type VocDetailEnvelope } from '@fops/shared';
 import type { MeResponse } from '@/lib/auth/useMe';
+import { type VocDetailEnvelope, internalCommentRequestSchema } from '@fops/shared';
+import { InternalCommentComposer } from '../InternalCommentComposer';
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
 

--- a/apps/frontend/src/features/voc/components/detail/__tests__/InternalCommentComposer.test.tsx
+++ b/apps/frontend/src/features/voc/components/detail/__tests__/InternalCommentComposer.test.tsx
@@ -7,7 +7,7 @@
 // C5.4 of slice3 #21.
 // Prototype ref: docs/design-prototype/screen-voc.jsx:415-468 (internal variant)
 
-import { render, screen, fireEvent, act } from '@testing-library/react';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import * as React from 'react';
@@ -46,7 +46,7 @@ vi.mock('@fops/ui', async (importActual) => {
 });
 
 import { InternalCommentComposer } from '../InternalCommentComposer';
-import type { VocDetailEnvelope } from '@fops/shared';
+import { internalCommentRequestSchema, type VocDetailEnvelope } from '@fops/shared';
 import type { MeResponse } from '@/lib/auth/useMe';
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
@@ -106,7 +106,7 @@ describe('<InternalCommentComposer>', () => {
     capturedOnChange = undefined;
   });
 
-  it('submits body_rich_content and extracted mentions[] on Add click', () => {
+  it('AC-A1e submits a body that passes the canonical internal-comment schema', async () => {
     render(<InternalCommentComposer voc={BASE_VOC} me={ME_ADMIN} />, { wrapper: makeWrapper() });
 
     // Simulate typing content with a mention node.
@@ -117,7 +117,7 @@ describe('<InternalCommentComposer>', () => {
           type: 'paragraph',
           content: [
             { type: 'text', text: 'Hello ' },
-            { type: 'mention', attrs: { actor_id: 'actor-uuid-1' } },
+            { type: 'mention', attrs: { actor_id: REPORTER_ID } },
           ],
         },
       ],
@@ -129,13 +129,17 @@ describe('<InternalCommentComposer>', () => {
     const addBtn = screen.getByRole('button', { name: /add note/i });
     fireEvent.click(addBtn);
 
-    expect(mockMutate).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(mockMutate).toHaveBeenCalledTimes(1));
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const callArg = (mockMutate.mock.calls[0] as unknown[])[0] as {
-      body: { body_rich_content: unknown; mentions: string[] };
+      body: Record<string, unknown>;
     };
-    expect(callArg.body.body_rich_content).toBeDefined();
-    expect(callArg.body.mentions).toContain('actor-uuid-1');
+    expect(callArg.body).toEqual({
+      body_rich_content: docWithMention,
+      mentions: [REPORTER_ID],
+      attachment_ids: [],
+    });
+    expect(internalCommentRequestSchema.safeParse(callArg.body).success).toBe(true);
   });
 
   it('deduplicates duplicate mention nodes in the submitted mentions array', () => {

--- a/apps/frontend/src/features/voc/components/detail/__tests__/PublicUpdateComposer.attachments.test.tsx
+++ b/apps/frontend/src/features/voc/components/detail/__tests__/PublicUpdateComposer.attachments.test.tsx
@@ -5,10 +5,10 @@
 //   - failed upload not included
 //   - Send disabled while uploading
 
-import * as React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import * as React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // RichEditor stub so the composer mounts headlessly.
@@ -44,11 +44,11 @@ vi.mock('@/features/voc/hooks/useVocPublicUpdateMutation', () => ({
 }));
 
 import { useVocPublicUpdateMutation } from '@/features/voc/hooks/useVocPublicUpdateMutation';
-import { PublicUpdateComposer } from '../PublicUpdateComposer';
 import * as attachmentsApi from '@/lib/api/attachments';
 import { ApiError } from '@/lib/api/types';
-import { publicUpdateRequestSchema, type VocDetailEnvelope } from '@fops/shared';
 import type { MeResponse } from '@/lib/auth/useMe';
+import { type VocDetailEnvelope, publicUpdateRequestSchema } from '@fops/shared';
+import { PublicUpdateComposer } from '../PublicUpdateComposer';
 
 const REPORTER_ID = '00000000-0000-0000-0000-000000000001';
 const ADMIN_ID = '00000000-0000-0000-0000-000000000002';
@@ -152,11 +152,10 @@ describe('<PublicUpdateComposer> attachments (PLAN-22 C7a)', () => {
   it('AC-A1b AC-A1c submits the body-present discriminant without attachments and passes the schema', async () => {
     vi.spyOn(attachmentsApi, 'uploadAttachment').mockResolvedValue(ATTACHMENT);
     const mutateMock = vi.fn();
-    vi.mocked(useVocPublicUpdateMutation).mockReturnValue(
-      { ...DEFAULT_MUTATION, mutate: mutateMock } as unknown as ReturnType<
-        typeof useVocPublicUpdateMutation
-      >,
-    );
+    vi.mocked(useVocPublicUpdateMutation).mockReturnValue({
+      ...DEFAULT_MUTATION,
+      mutate: mutateMock,
+    } as unknown as ReturnType<typeof useVocPublicUpdateMutation>);
 
     render(<PublicUpdateComposer voc={BASE_VOC} me={ME_ADMIN} />, { wrapper: wrap() });
 
@@ -177,7 +176,9 @@ describe('<PublicUpdateComposer> attachments (PLAN-22 C7a)', () => {
     await waitFor(() => {
       expect(mutateMock).toHaveBeenCalledTimes(1);
     });
-    const calledVars = mutateMock.mock.calls[0]![0] as {
+    const firstCall = mutateMock.mock.calls[0];
+    if (!firstCall) throw new Error('expected the public-update mutation to have been called');
+    const calledVars = firstCall[0] as {
       body: Record<string, unknown>;
     };
     expect(calledVars.body).toEqual({
@@ -198,11 +199,10 @@ describe('<PublicUpdateComposer> attachments (PLAN-22 C7a)', () => {
       new ApiError(422, { code: 'attachment.unsupported_type', message: 'nope' }),
     );
     const mutateMock = vi.fn();
-    vi.mocked(useVocPublicUpdateMutation).mockReturnValue(
-      { ...DEFAULT_MUTATION, mutate: mutateMock } as unknown as ReturnType<
-        typeof useVocPublicUpdateMutation
-      >,
-    );
+    vi.mocked(useVocPublicUpdateMutation).mockReturnValue({
+      ...DEFAULT_MUTATION,
+      mutate: mutateMock,
+    } as unknown as ReturnType<typeof useVocPublicUpdateMutation>);
 
     render(<PublicUpdateComposer voc={BASE_VOC} me={ME_ADMIN} />, { wrapper: wrap() });
 
@@ -222,7 +222,9 @@ describe('<PublicUpdateComposer> attachments (PLAN-22 C7a)', () => {
     await waitFor(() => {
       expect(mutateMock).toHaveBeenCalled();
     });
-    const calledVars = mutateMock.mock.calls[0]![0] as {
+    const firstCall = mutateMock.mock.calls[0];
+    if (!firstCall) throw new Error('expected the public-update mutation to have been called');
+    const calledVars = firstCall[0] as {
       body: { attachment_ids: string[] };
     };
     expect(calledVars.body.attachment_ids).toEqual([]);

--- a/apps/frontend/src/features/voc/components/detail/__tests__/PublicUpdateComposer.attachments.test.tsx
+++ b/apps/frontend/src/features/voc/components/detail/__tests__/PublicUpdateComposer.attachments.test.tsx
@@ -47,7 +47,7 @@ import { useVocPublicUpdateMutation } from '@/features/voc/hooks/useVocPublicUpd
 import { PublicUpdateComposer } from '../PublicUpdateComposer';
 import * as attachmentsApi from '@/lib/api/attachments';
 import { ApiError } from '@/lib/api/types';
-import type { VocDetailEnvelope } from '@fops/shared';
+import { publicUpdateRequestSchema, type VocDetailEnvelope } from '@fops/shared';
 import type { MeResponse } from '@/lib/auth/useMe';
 
 const REPORTER_ID = '00000000-0000-0000-0000-000000000001';
@@ -149,7 +149,7 @@ describe('<PublicUpdateComposer> attachments (PLAN-22 C7a)', () => {
     vi.restoreAllMocks();
   });
 
-  it('upload → submit body includes attachment_ids[]', async () => {
+  it('AC-A1b AC-A1c submits the body-present discriminant without attachments and passes the schema', async () => {
     vi.spyOn(attachmentsApi, 'uploadAttachment').mockResolvedValue(ATTACHMENT);
     const mutateMock = vi.fn();
     vi.mocked(useVocPublicUpdateMutation).mockReturnValue(
@@ -175,12 +175,22 @@ describe('<PublicUpdateComposer> attachments (PLAN-22 C7a)', () => {
     await user.click(screen.getByRole('button', { name: 'Publish update' }));
 
     await waitFor(() => {
-      expect(mutateMock).toHaveBeenCalled();
+      expect(mutateMock).toHaveBeenCalledTimes(1);
     });
     const calledVars = mutateMock.mock.calls[0]![0] as {
-      body: { attachment_ids: string[] };
+      body: Record<string, unknown>;
     };
-    expect(calledVars.body.attachment_ids).toEqual([ATTACHMENT.id]);
+    expect(calledVars.body).toEqual({
+      skip_public_update: false,
+      body_rich_content: {
+        type: 'doc',
+        content: [{ type: 'paragraph', content: [{ type: 'text', text: 'hello' }] }],
+      },
+      next_reporter_facing_status: 'received',
+      attachment_ids: [ATTACHMENT.id],
+    });
+    expect(calledVars.body).not.toHaveProperty('attachments');
+    expect(publicUpdateRequestSchema.safeParse(calledVars.body).success).toBe(true);
   });
 
   it('failed upload not included in POST body', async () => {

--- a/apps/frontend/src/features/voc/components/detail/__tests__/ReporterReplyComposer.attachments.test.tsx
+++ b/apps/frontend/src/features/voc/components/detail/__tests__/ReporterReplyComposer.attachments.test.tsx
@@ -1,9 +1,9 @@
 // ReporterReplyComposer — attachment dropzone wiring tests (PLAN-22 C7a).
 
-import * as React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import * as React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@fops/ui', async (importOriginal) => {
@@ -38,11 +38,11 @@ vi.mock('@/features/voc/hooks/useVocReporterReplyMutation', () => ({
 }));
 
 import { useVocReporterReplyMutation } from '@/features/voc/hooks/useVocReporterReplyMutation';
-import { ReporterReplyComposer } from '../ReporterReplyComposer';
 import * as attachmentsApi from '@/lib/api/attachments';
 import { ApiError } from '@/lib/api/types';
-import { reporterReplyRequestSchema, type VocDetailEnvelope } from '@fops/shared';
 import type { MeResponse } from '@/lib/auth/useMe';
+import { type VocDetailEnvelope, reporterReplyRequestSchema } from '@fops/shared';
+import { ReporterReplyComposer } from '../ReporterReplyComposer';
 
 const ADMIN_ID = '00000000-0000-0000-0000-000000000002';
 
@@ -145,11 +145,10 @@ describe('<ReporterReplyComposer> attachments (PLAN-22 C7a)', () => {
   it('AC-A1a AC-A1d submits only canonical reporter-reply fields and passes the schema', async () => {
     vi.spyOn(attachmentsApi, 'uploadAttachment').mockResolvedValue(ATTACHMENT);
     const mutateMock = vi.fn();
-    vi.mocked(useVocReporterReplyMutation).mockReturnValue(
-      { ...DEFAULT_MUTATION, mutate: mutateMock } as unknown as ReturnType<
-        typeof useVocReporterReplyMutation
-      >,
-    );
+    vi.mocked(useVocReporterReplyMutation).mockReturnValue({
+      ...DEFAULT_MUTATION,
+      mutate: mutateMock,
+    } as unknown as ReturnType<typeof useVocReporterReplyMutation>);
 
     render(<ReporterReplyComposer voc={BASE_VOC} me={ME_ADMIN} />, { wrapper: wrap() });
 
@@ -169,7 +168,9 @@ describe('<ReporterReplyComposer> attachments (PLAN-22 C7a)', () => {
     await waitFor(() => {
       expect(mutateMock).toHaveBeenCalledTimes(1);
     });
-    const calledVars = mutateMock.mock.calls[0]![0] as {
+    const firstCall = mutateMock.mock.calls[0];
+    if (!firstCall) throw new Error('expected the reporter-reply mutation to have been called');
+    const calledVars = firstCall[0] as {
       body: Record<string, unknown>;
     };
     expect(calledVars.body).toEqual({
@@ -188,11 +189,10 @@ describe('<ReporterReplyComposer> attachments (PLAN-22 C7a)', () => {
       new ApiError(422, { code: 'attachment.unsupported_type', message: 'nope' }),
     );
     const mutateMock = vi.fn();
-    vi.mocked(useVocReporterReplyMutation).mockReturnValue(
-      { ...DEFAULT_MUTATION, mutate: mutateMock } as unknown as ReturnType<
-        typeof useVocReporterReplyMutation
-      >,
-    );
+    vi.mocked(useVocReporterReplyMutation).mockReturnValue({
+      ...DEFAULT_MUTATION,
+      mutate: mutateMock,
+    } as unknown as ReturnType<typeof useVocReporterReplyMutation>);
 
     render(<ReporterReplyComposer voc={BASE_VOC} me={ME_ADMIN} />, { wrapper: wrap() });
 
@@ -212,7 +212,9 @@ describe('<ReporterReplyComposer> attachments (PLAN-22 C7a)', () => {
     await waitFor(() => {
       expect(mutateMock).toHaveBeenCalled();
     });
-    const calledVars = mutateMock.mock.calls[0]![0] as {
+    const firstCall = mutateMock.mock.calls[0];
+    if (!firstCall) throw new Error('expected the reporter-reply mutation to have been called');
+    const calledVars = firstCall[0] as {
       body: { attachment_ids: string[] };
     };
     expect(calledVars.body.attachment_ids).toEqual([]);

--- a/apps/frontend/src/features/voc/components/detail/__tests__/ReporterReplyComposer.attachments.test.tsx
+++ b/apps/frontend/src/features/voc/components/detail/__tests__/ReporterReplyComposer.attachments.test.tsx
@@ -41,7 +41,7 @@ import { useVocReporterReplyMutation } from '@/features/voc/hooks/useVocReporter
 import { ReporterReplyComposer } from '../ReporterReplyComposer';
 import * as attachmentsApi from '@/lib/api/attachments';
 import { ApiError } from '@/lib/api/types';
-import type { VocDetailEnvelope } from '@fops/shared';
+import { reporterReplyRequestSchema, type VocDetailEnvelope } from '@fops/shared';
 import type { MeResponse } from '@/lib/auth/useMe';
 
 const ADMIN_ID = '00000000-0000-0000-0000-000000000002';
@@ -142,7 +142,7 @@ describe('<ReporterReplyComposer> attachments (PLAN-22 C7a)', () => {
     vi.restoreAllMocks();
   });
 
-  it('upload → submit body includes attachment_ids[]', async () => {
+  it('AC-A1a AC-A1d submits only canonical reporter-reply fields and passes the schema', async () => {
     vi.spyOn(attachmentsApi, 'uploadAttachment').mockResolvedValue(ATTACHMENT);
     const mutateMock = vi.fn();
     vi.mocked(useVocReporterReplyMutation).mockReturnValue(
@@ -167,12 +167,20 @@ describe('<ReporterReplyComposer> attachments (PLAN-22 C7a)', () => {
     await user.click(screen.getByRole('button', { name: 'Send reply' }));
 
     await waitFor(() => {
-      expect(mutateMock).toHaveBeenCalled();
+      expect(mutateMock).toHaveBeenCalledTimes(1);
     });
     const calledVars = mutateMock.mock.calls[0]![0] as {
-      body: { attachment_ids: string[] };
+      body: Record<string, unknown>;
     };
-    expect(calledVars.body.attachment_ids).toEqual([ATTACHMENT.id]);
+    expect(calledVars.body).toEqual({
+      body_rich_content: {
+        type: 'doc',
+        content: [{ type: 'paragraph', content: [{ type: 'text', text: 'reply' }] }],
+      },
+      attachment_ids: [ATTACHMENT.id],
+    });
+    expect(calledVars.body).not.toHaveProperty('attachments');
+    expect(reporterReplyRequestSchema.safeParse(calledVars.body).success).toBe(true);
   });
 
   it('failed upload not included in POST body', async () => {

--- a/apps/frontend/src/features/voc/hooks/__tests__/useVocInternalCommentMutation.test.ts
+++ b/apps/frontend/src/features/voc/hooks/__tests__/useVocInternalCommentMutation.test.ts
@@ -14,6 +14,7 @@ import {
   type InternalCommentVars,
 } from '../useVocInternalCommentMutation';
 import { ApiError } from '@/lib/api';
+import { internalCommentRequestSchema } from '@fops/shared';
 
 // ── helpers ────────────────────────────────────────────────────────────────
 
@@ -40,13 +41,18 @@ function jsonResponse(body: unknown, status = 200): Response {
 
 const VOC_ID = '00000000-0000-0000-0000-000000000099';
 const UPDATED_AT = '2026-05-01T00:00:00.000Z';
+const MENTION_IDS = [
+  '30000000-0000-4000-8000-000000000003',
+  '30000000-0000-4000-8000-000000000004',
+];
 
 const BASE_VARS: InternalCommentVars = {
   vocId: VOC_ID,
   ifMatch: UPDATED_AT,
   body: {
     body_rich_content: { type: 'doc', content: [{ type: 'paragraph' }] },
-    mentions: ['actor-1', 'actor-2'],
+    mentions: MENTION_IDS,
+    attachment_ids: ['30000000-0000-4000-8000-000000000005'],
   },
 };
 
@@ -60,7 +66,7 @@ describe('useVocInternalCommentMutation', () => {
     vi.restoreAllMocks();
   });
 
-  it('sends POST with Idempotency-Key, If-Match headers and calls onSuccess', async () => {
+  it('AC-A1e submitted internal-comment body passes the canonical request schema', async () => {
     let capturedUrl = '';
     let capturedMethod = '';
     let capturedHeaders: Record<string, string> = {};
@@ -96,6 +102,7 @@ describe('useVocInternalCommentMutation', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
     expect(capturedUrl).toContain(`/vocs/${VOC_ID}/internal-comments`);
     expect(capturedMethod.toUpperCase()).toBe('POST');
 
@@ -107,10 +114,8 @@ describe('useVocInternalCommentMutation', () => {
     const ifMatchValue = capturedHeaders['If-Match'] ?? capturedHeaders['if-match'];
     expect(ifMatchValue).toBe(UPDATED_AT);
 
-    // Body shape.
-    expect(capturedBody).toMatchObject({
-      mentions: ['actor-1', 'actor-2'],
-    });
+    expect(capturedBody).toEqual(BASE_VARS.body);
+    expect(internalCommentRequestSchema.safeParse(capturedBody).success).toBe(true);
 
     expect(onSuccess).toHaveBeenCalledTimes(1);
   });

--- a/apps/frontend/src/features/voc/hooks/__tests__/useVocInternalCommentMutation.test.ts
+++ b/apps/frontend/src/features/voc/hooks/__tests__/useVocInternalCommentMutation.test.ts
@@ -4,17 +4,16 @@
 //
 // C5.4 of slice3 #21.
 
-import { describe, expect, it, vi, afterEach } from 'vitest';
-import { renderHook, act, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import {
-  useVocInternalCommentMutation,
-  type InternalCommentVars,
-} from '../useVocInternalCommentMutation';
-import { ApiError } from '@/lib/api';
 import { internalCommentRequestSchema } from '@fops/shared';
+import {
+  type InternalCommentVars,
+  useVocInternalCommentMutation,
+} from '../useVocInternalCommentMutation';
 
 // ── helpers ────────────────────────────────────────────────────────────────
 

--- a/apps/frontend/src/features/voc/hooks/__tests__/useVocPublicUpdateMutation.test.ts
+++ b/apps/frontend/src/features/voc/hooks/__tests__/useVocPublicUpdateMutation.test.ts
@@ -15,6 +15,7 @@ import {
   type PublicUpdateVars,
 } from '../useVocPublicUpdateMutation';
 import { ApiError } from '@/lib/api';
+import { publicUpdateRequestSchema } from '@fops/shared';
 
 // ── helpers ────────────────────────────────────────────────────────────────
 
@@ -46,9 +47,10 @@ const BODY_ONLY_VARS: PublicUpdateVars = {
   vocId: VOC_ID,
   ifMatch: UPDATED_AT,
   body: {
+    skip_public_update: false,
     body_rich_content: { type: 'doc', content: [{ type: 'paragraph' }] },
     next_reporter_facing_status: 'received',
-    attachments: [],
+    attachment_ids: ['20000000-0000-4000-8000-000000000002'],
   },
 };
 
@@ -62,7 +64,7 @@ describe('useVocPublicUpdateMutation', () => {
     vi.restoreAllMocks();
   });
 
-  it('sends POST with Idempotency-Key and If-Match headers and calls onSuccess', async () => {
+  it('AC-A1c submitted public-update body passes the canonical request schema', async () => {
     let capturedUrl = '';
     let capturedMethod = '';
     let capturedHeaders: Record<string, string> = {};
@@ -100,6 +102,7 @@ describe('useVocPublicUpdateMutation', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
     expect(capturedUrl).toContain(`/vocs/${VOC_ID}/public-updates`);
     expect(capturedMethod.toUpperCase()).toBe('POST');
 
@@ -112,10 +115,8 @@ describe('useVocPublicUpdateMutation', () => {
     const ifMatchValue = capturedHeaders['If-Match'] ?? capturedHeaders['if-match'];
     expect(ifMatchValue).toBe(UPDATED_AT);
 
-    // Body must include next_reporter_facing_status
-    expect(capturedBody).toMatchObject({
-      next_reporter_facing_status: 'received',
-    });
+    expect(capturedBody).toEqual(BODY_ONLY_VARS.body);
+    expect(publicUpdateRequestSchema.safeParse(capturedBody).success).toBe(true);
 
     expect(onSuccess).toHaveBeenCalledTimes(1);
   });

--- a/apps/frontend/src/features/voc/hooks/__tests__/useVocPublicUpdateMutation.test.ts
+++ b/apps/frontend/src/features/voc/hooks/__tests__/useVocPublicUpdateMutation.test.ts
@@ -5,17 +5,14 @@
 //
 // C5.2 of slice3 #21.
 
-import { describe, expect, it, vi, afterEach } from 'vitest';
-import { renderHook, act, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import {
-  useVocPublicUpdateMutation,
-  type PublicUpdateVars,
-} from '../useVocPublicUpdateMutation';
 import { ApiError } from '@/lib/api';
 import { publicUpdateRequestSchema } from '@fops/shared';
+import { type PublicUpdateVars, useVocPublicUpdateMutation } from '../useVocPublicUpdateMutation';
 
 // ── helpers ────────────────────────────────────────────────────────────────
 
@@ -90,11 +87,9 @@ describe('useVocPublicUpdateMutation', () => {
     const onSuccess = vi.fn();
     const { Wrapper } = makeWrapper();
 
-    const { result } = renderHook(
-      () =>
-        useVocPublicUpdateMutation({ onSuccess }),
-      { wrapper: Wrapper },
-    );
+    const { result } = renderHook(() => useVocPublicUpdateMutation({ onSuccess }), {
+      wrapper: Wrapper,
+    });
 
     await act(async () => {
       result.current.mutate(BODY_ONLY_VARS);
@@ -107,8 +102,7 @@ describe('useVocPublicUpdateMutation', () => {
     expect(capturedMethod.toUpperCase()).toBe('POST');
 
     // Idempotency-Key must be present
-    const idkValue =
-      capturedHeaders['idempotency-key'] ?? capturedHeaders['Idempotency-Key'];
+    const idkValue = capturedHeaders['idempotency-key'] ?? capturedHeaders['Idempotency-Key'];
     expect(idkValue).toBeTruthy();
 
     // If-Match must carry voc.updated_at

--- a/apps/frontend/src/features/voc/hooks/__tests__/useVocReporterReplyMutation.test.ts
+++ b/apps/frontend/src/features/voc/hooks/__tests__/useVocReporterReplyMutation.test.ts
@@ -5,17 +5,17 @@
 //
 // C5.3 of slice3 #21.
 
-import { describe, expect, it, vi, afterEach } from 'vitest';
-import { renderHook, act, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import {
-  useVocReporterReplyMutation,
-  type ReporterReplyVars,
-} from '../useVocReporterReplyMutation';
 import { ApiError } from '@/lib/api';
 import { reporterReplyRequestSchema } from '@fops/shared';
+import {
+  type ReporterReplyVars,
+  useVocReporterReplyMutation,
+} from '../useVocReporterReplyMutation';
 
 // ── helpers ────────────────────────────────────────────────────────────────
 
@@ -75,7 +75,9 @@ describe('useVocReporterReplyMutation', () => {
       if (rawHeaders && typeof rawHeaders === 'object' && !(rawHeaders instanceof Headers)) {
         capturedHeaders = rawHeaders as Record<string, string>;
       } else if (rawHeaders instanceof Headers) {
-        rawHeaders.forEach((v, k) => { capturedHeaders[k] = v; });
+        rawHeaders.forEach((v, k) => {
+          capturedHeaders[k] = v;
+        });
       }
       if (init?.body) {
         capturedBody = JSON.parse(init.body as string);
@@ -86,10 +88,9 @@ describe('useVocReporterReplyMutation', () => {
     const onSuccess = vi.fn();
     const { Wrapper } = makeWrapper();
 
-    const { result } = renderHook(
-      () => useVocReporterReplyMutation({ onSuccess }),
-      { wrapper: Wrapper },
-    );
+    const { result } = renderHook(() => useVocReporterReplyMutation({ onSuccess }), {
+      wrapper: Wrapper,
+    });
 
     await act(async () => {
       result.current.mutate(REPLY_VARS);
@@ -104,8 +105,7 @@ describe('useVocReporterReplyMutation', () => {
     expect(capturedMethod.toUpperCase()).toBe('POST');
 
     // Idempotency-Key must be present (auto-minted by apiClient)
-    const idkValue =
-      capturedHeaders['idempotency-key'] ?? capturedHeaders['Idempotency-Key'];
+    const idkValue = capturedHeaders['idempotency-key'] ?? capturedHeaders['Idempotency-Key'];
     expect(idkValue).toBeTruthy();
 
     // If-Match must carry voc.updated_at

--- a/apps/frontend/src/features/voc/hooks/__tests__/useVocReporterReplyMutation.test.ts
+++ b/apps/frontend/src/features/voc/hooks/__tests__/useVocReporterReplyMutation.test.ts
@@ -15,6 +15,7 @@ import {
   type ReporterReplyVars,
 } from '../useVocReporterReplyMutation';
 import { ApiError } from '@/lib/api';
+import { reporterReplyRequestSchema } from '@fops/shared';
 
 // ── helpers ────────────────────────────────────────────────────────────────
 
@@ -47,7 +48,7 @@ const REPLY_VARS: ReporterReplyVars = {
   ifMatch: UPDATED_AT,
   body: {
     body_rich_content: { type: 'doc', content: [{ type: 'paragraph' }] },
-    attachments: [],
+    attachment_ids: ['10000000-0000-4000-8000-000000000001'],
   },
 };
 
@@ -61,7 +62,7 @@ describe('useVocReporterReplyMutation', () => {
     vi.restoreAllMocks();
   });
 
-  it('sends POST to /vocs/:id/reporter-replies with Idempotency-Key, If-Match, and correct body', async () => {
+  it('AC-A1d submitted reporter-reply body passes the canonical request schema', async () => {
     let capturedUrl = '';
     let capturedMethod = '';
     let capturedHeaders: Record<string, string> = {};
@@ -96,6 +97,8 @@ describe('useVocReporterReplyMutation', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+
     // Correct endpoint
     expect(capturedUrl).toContain(`/vocs/${VOC_ID}/reporter-replies`);
     expect(capturedMethod.toUpperCase()).toBe('POST');
@@ -109,11 +112,8 @@ describe('useVocReporterReplyMutation', () => {
     const ifMatchValue = capturedHeaders['If-Match'] ?? capturedHeaders['if-match'];
     expect(ifMatchValue).toBe(UPDATED_AT);
 
-    // Body must include body_rich_content and attachments
-    expect(capturedBody).toMatchObject({
-      body_rich_content: { type: 'doc' },
-      attachments: [],
-    });
+    expect(capturedBody).toEqual(REPLY_VARS.body);
+    expect(reporterReplyRequestSchema.safeParse(capturedBody).success).toBe(true);
 
     expect(onSuccess).toHaveBeenCalledTimes(1);
   });

--- a/apps/frontend/src/features/voc/hooks/useVocPublicUpdateMutation.ts
+++ b/apps/frontend/src/features/voc/hooks/useVocPublicUpdateMutation.ts
@@ -25,14 +25,12 @@ import { type UseMutationResult, useMutation } from '@tanstack/react-query';
 // ── Types ─────────────────────────────────────────────────────────────────────
 
 export interface PublicUpdateBody {
+  skip_public_update: false;
   body_rich_content: TipTapDoc;
   /** Always sent; backend tolerates no-op when equal to current status. */
   next_reporter_facing_status: ReporterFacingStatusEnum;
-  attachments: unknown[];
   /**
-   * PLAN-22 C7a (D1): widened body field — FE-side list of successfully-uploaded
-   * attachment ids from <ComposerAttachmentDropzone>. Backend schema reconciled
-   * in C7b (legacy `attachments: AttachmentRef[]` deprecated then).
+   * PLAN-22 C7b: uploaded attachment ids accepted by the canonical request schema.
    */
   attachment_ids?: string[];
 }

--- a/apps/frontend/src/features/voc/hooks/useVocReporterReplyMutation.ts
+++ b/apps/frontend/src/features/voc/hooks/useVocReporterReplyMutation.ts
@@ -61,15 +61,11 @@ export function useVocReporterReplyMutation(
 
   return useMutation<ReporterReplySuccess, ApiError, ReporterReplyVars>({
     mutationFn: async ({ vocId, ifMatch, body }) => {
-      const res = await apiClient<ReporterReplySuccess>(
-        'POST',
-        `/vocs/${vocId}/reporter-replies`,
-        {
-          body,
-          ifMatch,
-          // Idempotency-Key is auto-minted by apiClient for POST/PATCH/DELETE
-        },
-      );
+      const res = await apiClient<ReporterReplySuccess>('POST', `/vocs/${vocId}/reporter-replies`, {
+        body,
+        ifMatch,
+        // Idempotency-Key is auto-minted by apiClient for POST/PATCH/DELETE
+      });
       return res.data;
     },
     ...(onSuccess ? { onSuccess } : {}),

--- a/apps/frontend/src/features/voc/hooks/useVocReporterReplyMutation.ts
+++ b/apps/frontend/src/features/voc/hooks/useVocReporterReplyMutation.ts
@@ -5,7 +5,7 @@
 // Prototype ref: docs/design-prototype/screen-voc.jsx:415-468 (reply variant)
 //
 // Endpoint: POST /vocs/:id/reporter-replies
-// Body: { body_rich_content, attachments: [] }
+// Body: { body_rich_content, attachment_ids? }
 //
 // Headers:
 //   Idempotency-Key: auto-minted by apiClient (POST/PATCH/DELETE)
@@ -23,11 +23,8 @@ import { type UseMutationResult, useMutation } from '@tanstack/react-query';
 
 export interface ReporterReplyBody {
   body_rich_content: TipTapDoc;
-  /** Always empty until attachment-deferral lifts in #22. */
-  attachments: unknown[];
   /**
-   * PLAN-22 C7a (D1): widened body field — FE list of uploaded attachment ids
-   * from <ComposerAttachmentDropzone>. BE schema reconciled in C7b.
+   * PLAN-22 C7b: uploaded attachment ids accepted by the canonical request schema.
    */
   attachment_ids?: string[];
 }

--- a/docs/adr/0042-voc-composer-contract-errors-and-timeline-identity.md
+++ b/docs/adr/0042-voc-composer-contract-errors-and-timeline-identity.md
@@ -1,0 +1,25 @@
+# VOC composer request, error, and timeline identity contract
+
+## Status
+
+Accepted 2026-08-03 for issues #266, #294, and #267.
+
+## Context
+
+PLAN-22 C7b established the backend request schemas for Reporter Reply, Public Update, and Internal Comment. The schemas are strict, use `attachment_ids` for uploaded attachments, and require `skip_public_update` as the Public Update discriminant. The frontend retained the retired `attachments` field and omitted that discriminant.
+
+Composer errors had inline Callout treatments only for known reporter-facing status codes. An unmapped code such as `validation.failed` therefore had no user-visible surface. The detail envelope also includes the latest conversation entries inline while the infinite conversation query loads its first, potentially overlapping page on mount, so rendering both collections independently duplicated entries.
+
+## Decision
+
+Frontend request bodies conform to the canonical strict backend schemas. Reporter Reply sends `body_rich_content` and optional `attachment_ids`. Public Update's body-present path additionally sends the literal `skip_public_update: false` and `next_reporter_facing_status`. We reject relaxing the schemas or restoring the retired `attachments` field because that would reverse the PLAN-22 C7b contract and conceal producer drift instead of correcting it.
+
+Known reporter-facing status errors keep their existing inline Callout tone and copy. Unmapped errors use an error toast containing the backend code string and message. We do not assign a default tone in `getComposerErrorTone`: doing so would erase the deliberate distinction between the amber gate-blocked state and other failures, and would turn unknown contract failures into apparently classified inline states.
+
+Public and Internal timeline components merge paginated entries before inline entries and keep the first occurrence of each `entry.id`. This preserves the existing oldest-to-newest render order, retains genuinely older paginated entries, and keeps inline entries visible before the query resolves or when it fails. The inline collection is not discarded, and the query remains enabled so its cursor metadata and `hasNextPage` behavior continue to work.
+
+The `skip_public_update: true` request shape remains unimplemented because the production composer has no skip entry point. Adding a hidden request path without a product interaction would be speculative behavior outside these issues.
+
+## Consequences
+
+Strict schema parsing now detects future frontend/backend request drift. Unknown composer failures remain diagnosable by users and operators without changing established Callout semantics. Conversation entries render once per identity while both delivery sources and pagination remain available.


### PR DESCRIPTION
세 이슈가 같은 파일군에 있었지만 **결함은 서로 독립인 3개**다. 하나를 고쳐도 나머지는 안 고쳐진다.

## 진단이 이슈와 달랐다

| 이슈가 말한 것 | 실측 |
|---|---|
| #266 "동일 상태 전이를 조용히 무시" | 상태 전이와 무관하다. body 자체가 스키마에 걸려 **항상 400**이었다 |
| #294 "권한 vs 배선" | 같은 뿌리. reporter-reply body에 폐기된 필드가 남아 **항상 400** |
| #267 "중복 생성 의심" | 생성은 1회다. **중복 렌더**였다 (이슈 본문도 이 구분을 유보했었다) |

## D1 — 요청 body가 정본 스키마와 어긋나 있었다

`PLAN-22 C7b`가 세 요청 스키마를 `attachment_ids` 기반으로 재조정하며 `.strict()`를 걸었는데,
그 변경이 **BE에만 착륙하고 FE는 따라가지 않았다.** FE 훅 주석에 `BE schema reconciled in C7b`라고
적혀 있는 그 지점이다.

| 스키마 | FE가 보내던 것 | 결과 |
|---|---|---|
| `reporterReplyRequestSchema` `.strict()` | `+ attachments: []` | 미지의 키 → 400 |
| `publicUpdateRequestSchema` (`discriminatedUnion('skip_public_update')`) | 판별자 **부재** + `attachments: []` | 판별 실패 → 400 |
| `internalCommentRequestSchema` `.strict()` | 정확히 일치 | 성공 |

internal-comment만 우연히 맞아 살아남았고, **그래서 세 이슈의 증상이 갈렸다.**

## D2 — 그 400이 완전히 침묵했다

세 composer 모두 mutation에 `onError`가 없었고, 유일한 표면인 `getComposerErrorTone`이
`reporter_facing_status.*`만 매핑하고 나머지엔 `null`을 반환해 Callout 자체가 렌더되지 않았다.

매핑되지 않은 코드는 이제 **코드 문자열이 보이는 토스트**로 표면화한다 — 다음 계약 드리프트를
무음으로 넘기지 않기 위해서다. 알려진 코드의 amber Callout은 그대로 유지했다(회귀 방지 단언 포함).

D1만 고치면 지금 증상은 사라지지만 다음 드리프트가 또 조용히 지나간다. 둘 다 고쳤다.

## D3 — 타임라인이 같은 항목을 두 번 그렸다

상세 봉투가 최신 50건을 `conversation_timeline`에 inline으로 싣고, `useVocConversation`이
`enabled: true` + `initialPageParam: ''`라 **마운트 즉시 1페이지를 가져온다.** 두 배열을 모두
렌더하고 있었으므로 항목이 50건 이하일 때 전부 두 번 보인다.

`PublicTimeline.tsx:37`의 주석 `// these arrive only after the user clicks 더보기` 가
**사실과 달랐고 그것이 결함의 출처다.** 주석도 고쳤다.

이슈는 내부 탭만 관찰했지만 **공개 탭도 같은 결함**이라 함께 고쳤다.

## 기각한 선택지

- `packages/shared` 스키마를 FE에 맞춰 완화 — BE가 정본이다
- `getComposerErrorTone`이 모든 코드에 톤 반환 — `gate_blocked`의 amber 의미가 죽는다
- inline을 렌더에서 제거 — 무한쿼리가 늦거나 실패하면 타임라인이 빈다
- `useVocConversation`의 `enabled`를 끄기 — `hasNextPage` 판정이 죽는다

## 오라클

AC-A1c/A1d/A1e는 **정본 스키마를 import 해서 제출 body를 실제로 `safeParse`** 한다.
이것이 계약 드리프트를 잡는 비-공허 오라클이다. AC-A3a는 카운트가 아니라 **렌더된 id 집합**을
기대 집합과 대조한 뒤 개수를 단언한다.

## 게이트 (4개 청크 통합 기준)

```
frontend vitest      779 passed / 147 files   (develop 745)
frontend typecheck   14 total, 24 baselined, 0 new
frontend biome       0 new
frontend visual      57 passed
backend  integration 1195 passed / 132 files  (develop 1189)
```

ADR: `docs/adr/0042`
판정 근거: `.review/RETRIAGE-2026-08-02.md` §클러스터 1

Closes #266
Closes #294
Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BfiR55zJ7n8uYpr1s3X6q