### PR TITLE
fix(tasks): project the converted Task onto its Finding and keep the convert title valid (#291, #289)

### DIFF
--- a/apps/backend/src/modules/tasks/__tests__/task-conversion.integration.test.ts
+++ b/apps/backend/src/modules/tasks/__tests__/task-conversion.integration.test.ts
@@ -159,11 +159,11 @@ describe.skipIf(!runIntegration)('task conversion and link-existing (#134)', () 
     await cleanupReadTestTables(dbHandle, WORKSPACE_ID, SLUG_PREFIX);
   }
 
-  async function seedFinding(msId: string): Promise<string> {
+  async function seedFinding(msId: string, title = 'Seed finding'): Promise<string> {
     const row = await insertFindingRow(migrateHandle, {
       workspaceId: WORKSPACE_ID,
       primaryManagedSystemId: msId,
-      title: 'Seed finding',
+      title,
       summary: 'Finding source summary',
       sourceId: randomUUID(),
       confidence: 'medium',
@@ -178,12 +178,13 @@ describe.skipIf(!runIntegration)('task conversion and link-existing (#134)', () 
       msId?: string;
       status?: 'pending_review' | 'approved' | 'rejected' | 'needs_more_evidence' | 'converted';
       requesterActorId?: string;
+      findingTitle?: string;
     } = {},
   ): Promise<{ id: string; msId: string; findingId: string; findingLinkId: string }> {
     const msId =
       input.msId ??
       (await insertMsDirectly(dbHandle, WORKSPACE_ID, uid(SLUG_PREFIX), 'Task Convert MS'));
-    const findingId = await seedFinding(msId);
+    const findingId = await seedFinding(msId, input.findingTitle);
     const request = await insertTaskRequestRow(migrateHandle, {
       workspaceId: WORKSPACE_ID,
       sourceId: findingId,
@@ -266,6 +267,20 @@ describe.skipIf(!runIntegration)('task conversion and link-existing (#134)', () 
     });
   }
 
+  function getFinding(cookie: string, findingId: string) {
+    return app.inject({
+      method: 'GET',
+      url: `/findings/${findingId}`,
+      headers: { cookie: `${SESSION_COOKIE_NAME}=${cookie}` },
+    });
+  }
+
+  async function seedConversionActor(suffix: string) {
+    const actor = await insertDevActor(dbHandle, WORKSPACE_ID, uid(`mock-dev-read-c7-${suffix}`));
+    const cookie = await loginAs(app, actor.externalId);
+    return { ...actor, cookie };
+  }
+
   function getEntityLinks(cookie: string, query: string) {
     return app.inject({
       method: 'GET',
@@ -334,6 +349,233 @@ describe.skipIf(!runIntegration)('task conversion and link-existing (#134)', () 
       source_task_request_id: request.id,
       primary_managed_system_id: request.msId,
     });
+  });
+
+  it('AC-C7a: conversion projects the exact new task id onto its Finding', async () => {
+    const request = await seedApprovedTaskRequest({ findingTitle: 'C7a projection finding' });
+    const actor = await seedConversionActor('a');
+    await grantCapability(
+      dbHandle,
+      WORKSPACE_ID,
+      actor.id,
+      'finding.manage',
+      request.msId,
+      adminActorId,
+    );
+
+    const converted = await convert(actor.cookie, request.id, {
+      title: 'C7a projected conversion task',
+      priority: 'medium',
+    });
+
+    expect(converted.statusCode).toBe(201);
+    const taskId = converted.json<{ id: string }>().id;
+    const finding = await dbHandle.pool.query<{ linked_task_id: string | null }>(
+      'select linked_task_id from finding.findings where id = $1',
+      [request.findingId],
+    );
+    expect(finding.rows[0]?.linked_task_id).toBe(taskId);
+  });
+
+  it('AC-C7b: conversion creates exactly one complete Finding-to-Task history link', async () => {
+    const request = await seedApprovedTaskRequest({ findingTitle: 'C7b entity link finding' });
+    const actor = await seedConversionActor('b');
+    await grantCapability(
+      dbHandle,
+      WORKSPACE_ID,
+      actor.id,
+      'finding.manage',
+      request.msId,
+      adminActorId,
+    );
+
+    const converted = await convert(actor.cookie, request.id, {
+      title: 'C7b entity link conversion task',
+      priority: 'high',
+    });
+    expect(converted.statusCode).toBe(201);
+    const taskId = converted.json<{ id: string }>().id;
+    const links = await dbHandle.pool.query<{
+      workspace_id: string;
+      source_type: string;
+      source_id: string;
+      target_type: string;
+      target_id: string;
+      relation_type: string;
+      visibility: string;
+      status: string;
+      managed_system_id: string;
+    }>(
+      `select workspace_id, source_type, source_id, target_type, target_id, relation_type,
+              visibility, status, managed_system_id
+         from core.entity_links
+        where workspace_id = $1 and source_type = 'finding' and source_id = $2
+          and target_type = 'task' and target_id = $3 and relation_type = 'requested_task'`,
+      [WORKSPACE_ID, request.findingId, taskId],
+    );
+    expect(links.rows).toEqual([
+      {
+        workspace_id: WORKSPACE_ID,
+        source_type: 'finding',
+        source_id: request.findingId,
+        target_type: 'task',
+        target_id: taskId,
+        relation_type: 'requested_task',
+        visibility: 'internal_only',
+        status: 'active',
+        managed_system_id: request.msId,
+      },
+    ]);
+  });
+
+  it('AC-C7c: VOC conversion succeeds before asserting it creates no Finding backlink', async () => {
+    const msId = await insertMsDirectly(
+      dbHandle,
+      WORKSPACE_ID,
+      uid(SLUG_PREFIX),
+      'C7c VOC conversion MS',
+    );
+    const actor = await seedConversionActor('c');
+    await grantCapability(dbHandle, WORKSPACE_ID, actor.id, 'finding.manage', msId, adminActorId);
+    const voc = await insertVocDirectly(
+      migrateHandle,
+      WORKSPACE_ID,
+      msId,
+      actor.id,
+      'C7c direct VOC',
+    );
+    const request = await insertTaskRequestRow(migrateHandle, {
+      workspaceId: WORKSPACE_ID,
+      sourceType: 'voc',
+      sourceId: voc.id,
+      primaryManagedSystemId: msId,
+      requestedOutcome: 'C7c VOC conversion outcome',
+      requesterActorId: actor.id,
+      status: 'approved',
+      reviewerActorId: adminActorId,
+      decisionReason: 'C7c approved',
+      decided: true,
+    });
+    await migrateHandle.pool.query(
+      `insert into core.entity_links (
+          workspace_id, source_type, source_id, target_type, target_id,
+          relation_type, visibility, status, managed_system_id, created_by
+        ) values ($1, 'voc', $2, 'task_request', $3, 'requested_task',
+                  'internal_only', 'active', $4, $5)`,
+      [WORKSPACE_ID, voc.id, request.id, msId, adminActorId],
+    );
+
+    const converted = await convert(actor.cookie, request.id, {
+      title: 'C7c VOC conversion task',
+      priority: 'low',
+    });
+    expect(converted.statusCode).toBe(201);
+    expect(converted.json<{ id: string }>().id).toEqual(expect.any(String));
+
+    const findingLinks = await dbHandle.pool.query<{ n: number }>(
+      `select count(*)::int as n from core.entity_links
+        where workspace_id = $1 and target_type = 'task' and target_id = $2
+          and source_type = 'finding' and relation_type = 'requested_task'`,
+      [WORKSPACE_ID, converted.json<{ id: string }>().id],
+    );
+    expect(findingLinks.rows[0]?.n).toBe(0);
+  });
+
+  it('AC-C7d: GET Finding projects the task id written by conversion', async () => {
+    const request = await seedApprovedTaskRequest({ findingTitle: 'C7d GET Finding projection' });
+    const actor = await seedConversionActor('d');
+    await grantCapability(
+      dbHandle,
+      WORKSPACE_ID,
+      actor.id,
+      'finding.manage',
+      request.msId,
+      adminActorId,
+    );
+    await grantCapability(
+      dbHandle,
+      WORKSPACE_ID,
+      actor.id,
+      'finding.read',
+      request.msId,
+      adminActorId,
+    );
+    const converted = await convert(actor.cookie, request.id, {
+      title: 'C7d Finding DTO conversion task',
+      priority: 'urgent',
+    });
+    expect(converted.statusCode).toBe(201);
+
+    const finding = await getFinding(actor.cookie, request.findingId);
+    expect(finding.statusCode).toBe(200);
+    expect(finding.json()).toMatchObject({
+      id: request.findingId,
+      linked_task_id: converted.json<{ id: string }>().id,
+    });
+  });
+
+  it('AC-C7e: conversion preserves a pre-existing Finding projection while retaining history', async () => {
+    const request = await seedApprovedTaskRequest({
+      findingTitle: 'C7e conflicting projection finding',
+    });
+    const actor = await seedConversionActor('e');
+    await grantCapability(
+      dbHandle,
+      WORKSPACE_ID,
+      actor.id,
+      'finding.manage',
+      request.msId,
+      adminActorId,
+    );
+    const existingTaskId = await seedTask(request.msId, 'C7e existing linked task');
+    await migrateHandle.pool.query(
+      'update finding.findings set linked_task_id = $1 where id = $2',
+      [existingTaskId, request.findingId],
+    );
+
+    const converted = await convert(actor.cookie, request.id, {
+      title: 'C7e conflicting conversion task',
+      priority: 'medium',
+    });
+    expect(converted.statusCode).toBe(201);
+    const taskId = converted.json<{ id: string }>().id;
+    const finding = await dbHandle.pool.query<{ linked_task_id: string | null }>(
+      'select linked_task_id from finding.findings where id = $1',
+      [request.findingId],
+    );
+    expect(finding.rows[0]?.linked_task_id).toBe(existingTaskId);
+    const history = await dbHandle.pool.query<{ n: number }>(
+      `select count(*)::int as n from core.entity_links
+        where workspace_id = $1 and source_type = 'finding' and source_id = $2
+          and target_type = 'task' and target_id = $3 and relation_type = 'requested_task'
+          and status = 'active'`,
+      [WORKSPACE_ID, request.findingId, taskId],
+    );
+    expect(history.rows[0]?.n).toBe(1);
+  });
+
+  it('AC-C7f: an actor who can read the existing Finding is denied conversion without finding.manage', async () => {
+    const request = await seedApprovedTaskRequest({
+      findingTitle: 'C7f unauthorized existing Finding',
+    });
+    const actor = await seedConversionActor('f');
+    await grantCapability(
+      dbHandle,
+      WORKSPACE_ID,
+      actor.id,
+      'finding.read',
+      request.msId,
+      adminActorId,
+    );
+
+    const readable = await getFinding(actor.cookie, request.findingId);
+    expect(readable.statusCode).toBe(200);
+    const denied = await convert(actor.cookie, request.id, {
+      title: 'C7f denied conversion task',
+      priority: 'medium',
+    });
+    expect(denied.statusCode).toBe(403);
+    expect(denied.json<{ code: string }>().code).toBe('permission.denied');
   });
 
   it.each(['pending_review', 'rejected'] as const)(

--- a/apps/backend/src/modules/tasks/__tests__/task-conversion.integration.test.ts
+++ b/apps/backend/src/modules/tasks/__tests__/task-conversion.integration.test.ts
@@ -12,6 +12,8 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { loadConfig } from '../../../config.js';
 import { type DbHandle, createDb } from '../../../db/client.js';
 import { buildServer } from '../../../server.js';
+import { insertFindingRow } from '../../findings/__tests__/_seed-helpers.js';
+import { insertTaskRequestRow } from '../../task-requests/__tests__/_seed-helpers.js';
 import {
   SESSION_COOKIE_NAME,
   cleanupReadTestTables,
@@ -22,8 +24,6 @@ import {
   loginAs,
   uid,
 } from '../../voc/__tests__/_seed-helpers.js';
-import { insertFindingRow } from '../../findings/__tests__/_seed-helpers.js';
-import { insertTaskRequestRow } from '../../task-requests/__tests__/_seed-helpers.js';
 import { insertTaskRow } from './_seed-helpers.js';
 
 const APP_URL = process.env.DATABASE_URL ?? '';
@@ -685,7 +685,14 @@ describe.skipIf(!runIntegration)('task conversion and link-existing (#134)', () 
 
     const inScopeDev = await insertDevActor(dbHandle, WORKSPACE_ID, uid(SLUG_PREFIX));
     await grantCapability(dbHandle, WORKSPACE_ID, inScopeDev.id, 'voc.read', msId, adminActorId);
-    await grantCapability(dbHandle, WORKSPACE_ID, inScopeDev.id, 'finding.read', msId, adminActorId);
+    await grantCapability(
+      dbHandle,
+      WORKSPACE_ID,
+      inScopeDev.id,
+      'finding.read',
+      msId,
+      adminActorId,
+    );
     const inScope = await getEntityLinks(
       await loginAs(app, inScopeDev.externalId),
       `?source_type=voc&source_id=${voc.id}`,
@@ -736,28 +743,55 @@ describe.skipIf(!runIntegration)('task conversion and link-existing (#134)', () 
   });
 
   it('0035 backfill flips only audit-provenance conversion evidence links', async () => {
-    const msId = await insertMsDirectly(migrateHandle, WORKSPACE_ID, uid(SLUG_PREFIX), 'Backfill conversion MS');
-    const traceableVoc = await insertVocDirectly(migrateHandle, WORKSPACE_ID, msId, userActorId, 'Traceable conversion VOC');
+    const msId = await insertMsDirectly(
+      migrateHandle,
+      WORKSPACE_ID,
+      uid(SLUG_PREFIX),
+      'Backfill conversion MS',
+    );
+    const traceableVoc = await insertVocDirectly(
+      migrateHandle,
+      WORKSPACE_ID,
+      msId,
+      userActorId,
+      'Traceable conversion VOC',
+    );
     const request = await insertTaskRequestRow(migrateHandle, {
       workspaceId: WORKSPACE_ID,
-      sourceType: 'voc', sourceId: traceableVoc.id, primaryManagedSystemId: msId,
-      requesterActorId: userActorId, status: 'converted', reviewerActorId: adminActorId,
-      decisionReason: 'Converted before visibility backfill', decided: true,
+      sourceType: 'voc',
+      sourceId: traceableVoc.id,
+      primaryManagedSystemId: msId,
+      requesterActorId: userActorId,
+      status: 'converted',
+      reviewerActorId: adminActorId,
+      decisionReason: 'Converted before visibility backfill',
+      decided: true,
     });
     const traceableTask = await insertTaskRow(migrateHandle, {
-      workspaceId: WORKSPACE_ID, primaryManagedSystemId: msId,
-      title: 'Traceable conversion task', sourceTaskRequestId: request.id, createdBy: adminActorId,
+      workspaceId: WORKSPACE_ID,
+      primaryManagedSystemId: msId,
+      title: 'Traceable conversion task',
+      sourceTaskRequestId: request.id,
+      createdBy: adminActorId,
     });
     // Matches the old source-shape predicate, but its evidence link is manual.
     const manualLinkRequest = await insertTaskRequestRow(migrateHandle, {
       workspaceId: WORKSPACE_ID,
-      sourceType: 'voc', sourceId: traceableVoc.id, primaryManagedSystemId: msId,
-      requesterActorId: userActorId, status: 'converted', reviewerActorId: adminActorId,
-      decisionReason: 'Converted before visibility backfill', decided: true,
+      sourceType: 'voc',
+      sourceId: traceableVoc.id,
+      primaryManagedSystemId: msId,
+      requesterActorId: userActorId,
+      status: 'converted',
+      reviewerActorId: adminActorId,
+      decisionReason: 'Converted before visibility backfill',
+      decided: true,
     });
     const manualLinkTask = await insertTaskRow(migrateHandle, {
-      workspaceId: WORKSPACE_ID, primaryManagedSystemId: msId,
-      title: 'Task with manually created VOC evidence', sourceTaskRequestId: manualLinkRequest.id, createdBy: adminActorId,
+      workspaceId: WORKSPACE_ID,
+      primaryManagedSystemId: msId,
+      title: 'Task with manually created VOC evidence',
+      sourceTaskRequestId: manualLinkRequest.id,
+      createdBy: adminActorId,
     });
     const finding = await insertFindingRow(migrateHandle, {
       workspaceId: WORKSPACE_ID,
@@ -768,18 +802,34 @@ describe.skipIf(!runIntegration)('task conversion and link-existing (#134)', () 
     });
     const findingRequest = await insertTaskRequestRow(migrateHandle, {
       workspaceId: WORKSPACE_ID,
-      sourceType: 'finding', sourceId: finding.id, primaryManagedSystemId: msId,
-      requesterActorId: userActorId, status: 'converted', reviewerActorId: adminActorId,
-      decisionReason: 'Converted from Finding before visibility backfill', decided: true,
+      sourceType: 'finding',
+      sourceId: finding.id,
+      primaryManagedSystemId: msId,
+      requesterActorId: userActorId,
+      status: 'converted',
+      reviewerActorId: adminActorId,
+      decisionReason: 'Converted from Finding before visibility backfill',
+      decided: true,
     });
     const findingTask = await insertTaskRow(migrateHandle, {
-      workspaceId: WORKSPACE_ID, primaryManagedSystemId: msId,
-      title: 'Finding-propagated conversion task', sourceTaskRequestId: findingRequest.id, createdBy: adminActorId,
+      workspaceId: WORKSPACE_ID,
+      primaryManagedSystemId: msId,
+      title: 'Finding-propagated conversion task',
+      sourceTaskRequestId: findingRequest.id,
+      createdBy: adminActorId,
     });
-    const untraceableVoc = await insertVocDirectly(migrateHandle, WORKSPACE_ID, msId, userActorId, 'Untraceable evidence VOC');
+    const untraceableVoc = await insertVocDirectly(
+      migrateHandle,
+      WORKSPACE_ID,
+      msId,
+      userActorId,
+      'Untraceable evidence VOC',
+    );
     const untraceableTask = await insertTaskRow(migrateHandle, {
-      workspaceId: WORKSPACE_ID, primaryManagedSystemId: msId,
-      title: 'Untraceable evidence task', createdBy: adminActorId,
+      workspaceId: WORKSPACE_ID,
+      primaryManagedSystemId: msId,
+      title: 'Untraceable evidence task',
+      createdBy: adminActorId,
     });
     const seeded = await migrateHandle.pool.query<{ id: string }>(
       `insert into core.entity_links (
@@ -816,21 +866,42 @@ describe.skipIf(!runIntegration)('task conversion and link-existing (#134)', () 
            jsonb_build_object('preserved_links', jsonb_build_array($4::text))),
           ($1, $2, 'task_created_from_request', 'task', $5, 'Task created from approved Task Request',
            jsonb_build_object('preserved_links', jsonb_build_array($6::text)))`,
-      [WORKSPACE_ID, adminActorId, traceableTask.id, directLink.id, findingTask.id, findingPropagatedLink.id],
+      [
+        WORKSPACE_ID,
+        adminActorId,
+        traceableTask.id,
+        directLink.id,
+        findingTask.id,
+        findingPropagatedLink.id,
+      ],
     );
 
     const client = await migrateHandle.pool.connect();
     try {
       await client.query('begin');
-      await client.query(readFileSync(new URL('../../../../migrations/0035_voc_task_conversion_summary_visible.sql', import.meta.url), 'utf8'));
+      await client.query(
+        readFileSync(
+          new URL(
+            '../../../../migrations/0035_voc_task_conversion_summary_visible.sql',
+            import.meta.url,
+          ),
+          'utf8',
+        ),
+      );
       const rows = await client.query<{ id: string; visibility: string }>(
         `select id, visibility from core.entity_links
           where id = any($1::uuid[])`,
         [seeded.rows.map((row) => row.id)],
       );
       expect(rows.rows).toContainEqual({ id: directLink.id, visibility: 'summary_visible' });
-      expect(rows.rows).toContainEqual({ id: findingPropagatedLink.id, visibility: 'summary_visible' });
-      expect(rows.rows).toContainEqual({ id: manualSameVocTaskLink.id, visibility: 'internal_only' });
+      expect(rows.rows).toContainEqual({
+        id: findingPropagatedLink.id,
+        visibility: 'summary_visible',
+      });
+      expect(rows.rows).toContainEqual({
+        id: manualSameVocTaskLink.id,
+        visibility: 'internal_only',
+      });
       expect(rows.rows).toContainEqual({ id: untraceableLink.id, visibility: 'internal_only' });
     } finally {
       await client.query('rollback');

--- a/apps/backend/src/modules/tasks/service.ts
+++ b/apps/backend/src/modules/tasks/service.ts
@@ -22,6 +22,7 @@ import {
   selectEligibleVocLinksForReleasedTask,
 } from '../entity-links/repo.js';
 import { checkFindingManage, hasElevatedFindingRole } from '../findings/authorization.js';
+import { lockFindingById, updateFindingLinkedTask } from '../findings/repo.js';
 import type { CheckService } from '../permissions/check-service.js';
 import { type TaskRequestRow, lockTaskRequestById } from '../task-requests/repo.js';
 import {
@@ -275,6 +276,20 @@ export function createTasksService(deps: TasksServiceDeps) {
             taskRequest,
             task,
           });
+
+          if (taskRequest.source_type === 'finding') {
+            const finding = await lockFindingById(tx, {
+              workspaceId: args.actor.workspace_id,
+              findingId: taskRequest.source_id,
+            });
+            if (finding?.linked_task_id === null) {
+              await updateFindingLinkedTask(tx, {
+                workspaceId: args.actor.workspace_id,
+                findingId: finding.id,
+                taskId: task.id,
+              });
+            }
+          }
 
           await markTaskRequestConverted(tx, {
             workspaceId: args.actor.workspace_id,

--- a/apps/backend/src/modules/tasks/service.ts
+++ b/apps/backend/src/modules/tasks/service.ts
@@ -208,7 +208,9 @@ export function createTasksService(deps: TasksServiceDeps) {
     if (!row) throw new HttpError('not_found.record', 'task not found');
 
     const canManage = (
-      await checkFindingManage(deps.checkService, args.actor, row.primary_managed_system_id, { requireElevatedRole: true })
+      await checkFindingManage(deps.checkService, args.actor, row.primary_managed_system_id, {
+        requireElevatedRole: true,
+      })
     ).allow;
     if (!canManage) {
       throw new HttpError('permission.denied', 'finding.manage capability required');
@@ -519,7 +521,9 @@ export function createTasksService(deps: TasksServiceDeps) {
     const items: TaskDto[] = [];
     for (const row of rows) {
       const canManage = (
-        await checkFindingManage(deps.checkService, args.actor, row.primary_managed_system_id, { requireElevatedRole: true })
+        await checkFindingManage(deps.checkService, args.actor, row.primary_managed_system_id, {
+          requireElevatedRole: true,
+        })
       ).allow;
       if (!canManage) continue;
       items.push(taskToDto(row));

--- a/apps/frontend/src/features/tasks/routes/TaskRequestsRoute.tsx
+++ b/apps/frontend/src/features/tasks/routes/TaskRequestsRoute.tsx
@@ -14,7 +14,13 @@ import {
 import { fetchAnalyticsAreas } from '@/lib/api/analytics-areas';
 import { fetchManagedSystems } from '@/lib/api/managed-systems';
 import { ApiError } from '@/lib/api/types';
-import type { TaskDto, TaskPriority, TaskRequestDto, TaskRequestStatus } from '@fops/shared';
+import {
+  convertTaskRequestRequestSchema,
+  type TaskDto,
+  type TaskPriority,
+  type TaskRequestDto,
+  type TaskRequestStatus,
+} from '@fops/shared';
 import {
   Button,
   DetailPanelHeader,
@@ -75,6 +81,20 @@ const STATUS_SEVERITY: Record<TaskRequestStatus, ObjectRowSeverity> = {
 
 const REVIEW_DECISION_STATUSES = ['pending_review', 'needs_more_evidence'] as const;
 const TASK_PRIORITIES: TaskPriority[] = ['low', 'medium', 'high', 'urgent'];
+const TASK_TITLE_TRUNCATION_MARKER = '…';
+const TASK_TITLE_MAX_LENGTH = convertTaskRequestRequestSchema.shape.title.maxLength;
+
+if (TASK_TITLE_MAX_LENGTH === null) {
+  throw new Error('Task conversion title requires a canonical maximum length.');
+}
+
+function defaultConvertTitle(requestedOutcome: string): string {
+  if (requestedOutcome.length <= TASK_TITLE_MAX_LENGTH) return requestedOutcome;
+  return `${requestedOutcome.slice(
+    0,
+    TASK_TITLE_MAX_LENGTH - TASK_TITLE_TRUNCATION_MARKER.length,
+  )}${TASK_TITLE_TRUNCATION_MARKER}`;
+}
 
 export function canApproveTaskRequest(status: TaskRequestStatus): boolean {
   return REVIEW_DECISION_STATUSES.some((allowed) => allowed === status);
@@ -208,7 +228,11 @@ function TaskRequestPanel({
   const isSelfApproval = currentActorId === item.requester_actor_id;
   const [convertOpen, setConvertOpen] = React.useState(false);
   const [linkOpen, setLinkOpen] = React.useState(false);
-  const [convertTitle, setConvertTitle] = React.useState(item.requested_outcome);
+  const [convertTitle, setConvertTitle] = React.useState(() =>
+    defaultConvertTitle(item.requested_outcome),
+  );
+  const [convertTitleError, setConvertTitleError] = React.useState<string | null>(null);
+  const convertTitleInputRef = React.useRef<HTMLInputElement>(null);
   const [convertPriority, setConvertPriority] = React.useState<TaskPriority>('medium');
   const [convertAssigneeId, setConvertAssigneeId] = React.useState('');
   const [convertDueDate, setConvertDueDate] = React.useState('');
@@ -216,7 +240,8 @@ function TaskRequestPanel({
   const [convertAnalyticsAreaId, setConvertAnalyticsAreaId] = React.useState('');
 
   React.useEffect(() => {
-    setConvertTitle(item.requested_outcome);
+    setConvertTitle(defaultConvertTitle(item.requested_outcome));
+    setConvertTitleError(null);
     setConvertPriority('medium');
     setConvertAssigneeId('');
     setConvertDueDate('');
@@ -301,9 +326,6 @@ function TaskRequestPanel({
   const convertMutation = useMutation<TaskDto, Error, void>({
     mutationFn: async () => {
       const title = convertTitle.trim();
-      if (title.length === 0) {
-        throw new Error('Title is required.');
-      }
       return convertTaskRequest(
         item.id,
         {
@@ -521,17 +543,54 @@ function TaskRequestPanel({
                 className="flex flex-col gap-2 rounded border border-border-subtle bg-surface-card p-3"
                 onSubmit={(event) => {
                   event.preventDefault();
+                  const titleResult = convertTaskRequestRequestSchema.shape.title.safeParse(
+                    convertTitle,
+                  );
+                  if (!titleResult.success) {
+                    setConvertTitleError(
+                      titleResult.error.issues[0]?.message ?? 'Title is invalid.',
+                    );
+                    convertTitleInputRef.current?.focus();
+                    return;
+                  }
+                  setConvertTitleError(null);
                   convertMutation.mutate();
                 }}
               >
                 <label className="flex flex-col gap-1 text-xs text-text-muted">
                   Title
                   <input
+                    ref={convertTitleInputRef}
                     className="rounded border border-border-subtle bg-surface-detail px-2 py-1.5 text-sm text-text-primary"
                     value={convertTitle}
-                    maxLength={200}
-                    onChange={(event) => setConvertTitle(event.target.value)}
+                    aria-invalid={convertTitleError !== null}
+                    aria-describedby={
+                      convertTitleError
+                        ? 'task-request-convert-title-count task-request-convert-title-error'
+                        : 'task-request-convert-title-count'
+                    }
+                    data-testid="task-request-convert-title-input"
+                    onChange={(event) => {
+                      setConvertTitle(event.target.value);
+                      setConvertTitleError(null);
+                    }}
                   />
+                  <span
+                    id="task-request-convert-title-count"
+                    data-testid="task-request-convert-title-count"
+                  >
+                    {convertTitle.length}/{TASK_TITLE_MAX_LENGTH}
+                  </span>
+                  {convertTitleError && (
+                    <span
+                      id="task-request-convert-title-error"
+                      role="alert"
+                      className="text-xs text-accent-danger"
+                      data-testid="task-request-convert-title-error"
+                    >
+                      {convertTitleError}
+                    </span>
+                  )}
                 </label>
                 <div className="grid grid-cols-2 gap-2">
                   <label className="flex flex-col gap-1 text-xs text-text-muted">
@@ -601,6 +660,7 @@ function TaskRequestPanel({
                   size="sm"
                   loading={convertMutation.isPending}
                   disabled={!canConvert}
+                  data-testid="task-request-convert-submit"
                 >
                   Convert to Task
                 </Button>

--- a/apps/frontend/src/features/tasks/routes/TaskRequestsRoute.tsx
+++ b/apps/frontend/src/features/tasks/routes/TaskRequestsRoute.tsx
@@ -82,11 +82,16 @@ const STATUS_SEVERITY: Record<TaskRequestStatus, ObjectRowSeverity> = {
 const REVIEW_DECISION_STATUSES = ['pending_review', 'needs_more_evidence'] as const;
 const TASK_PRIORITIES: TaskPriority[] = ['low', 'medium', 'high', 'urgent'];
 const TASK_TITLE_TRUNCATION_MARKER = '…';
-const TASK_TITLE_MAX_LENGTH = convertTaskRequestRequestSchema.shape.title.maxLength;
+// The module-level null check narrows the statement that follows it, but not the
+// function bodies below — they could run after any later reassignment as far as
+// TS is concerned. Re-binding to a `number` const carries the narrowing into them.
+const canonicalTitleMaxLength = convertTaskRequestRequestSchema.shape.title.maxLength;
 
-if (TASK_TITLE_MAX_LENGTH === null) {
+if (canonicalTitleMaxLength === null) {
   throw new Error('Task conversion title requires a canonical maximum length.');
 }
+
+const TASK_TITLE_MAX_LENGTH: number = canonicalTitleMaxLength;
 
 function defaultConvertTitle(requestedOutcome: string): string {
   if (requestedOutcome.length <= TASK_TITLE_MAX_LENGTH) return requestedOutcome;
@@ -146,8 +151,10 @@ interface NameMaps {
   managedSystemsById: Record<string, { name: string }>;
 }
 
+// `exactOptionalPropertyTypes` is on: an optional property must spell `| undefined`
+// explicitly for a value that may actually be undefined to be assignable.
 type TaskRequestListItem = TaskRequestDto & {
-  source?: TaskRequestDto['source'] & { display_id?: string | null };
+  source?: (NonNullable<TaskRequestDto['source']> & { display_id?: string | null }) | undefined;
 };
 
 interface TaskRequestRowProps {

--- a/apps/frontend/src/features/tasks/routes/TaskRequestsRoute.tsx
+++ b/apps/frontend/src/features/tasks/routes/TaskRequestsRoute.tsx
@@ -15,11 +15,11 @@ import { fetchAnalyticsAreas } from '@/lib/api/analytics-areas';
 import { fetchManagedSystems } from '@/lib/api/managed-systems';
 import { ApiError } from '@/lib/api/types';
 import {
-  convertTaskRequestRequestSchema,
   type TaskDto,
   type TaskPriority,
   type TaskRequestDto,
   type TaskRequestStatus,
+  convertTaskRequestRequestSchema,
 } from '@fops/shared';
 import {
   Button,
@@ -550,9 +550,8 @@ function TaskRequestPanel({
                 className="flex flex-col gap-2 rounded border border-border-subtle bg-surface-card p-3"
                 onSubmit={(event) => {
                   event.preventDefault();
-                  const titleResult = convertTaskRequestRequestSchema.shape.title.safeParse(
-                    convertTitle,
-                  );
+                  const titleResult =
+                    convertTaskRequestRequestSchema.shape.title.safeParse(convertTitle);
                   if (!titleResult.success) {
                     setConvertTitleError(
                       titleResult.error.issues[0]?.message ?? 'Title is invalid.',

--- a/apps/frontend/src/features/tasks/routes/__tests__/TaskRequestsRoute.convert.test.tsx
+++ b/apps/frontend/src/features/tasks/routes/__tests__/TaskRequestsRoute.convert.test.tsx
@@ -106,18 +106,15 @@ describe('TaskRequestsRoute conversion title', () => {
     ).toHaveLength(taskTitleMaxLength);
   });
 
-  it(
-    'AC-C6b shows a truncation marker and character count for a 225-character requested outcome',
-    async () => {
-      const input = await openConvertForm();
-      expect(input).toHaveValue(
-        `${requestedOutcome225.slice(0, taskTitleMaxLength - truncationMarker.length)}${truncationMarker}`,
-      );
-      expect(screen.getByTestId('task-request-convert-title-count')).toHaveTextContent(
-        `${taskTitleMaxLength}/${taskTitleMaxLength}`,
-      );
-    },
-  );
+  it('AC-C6b shows a truncation marker and character count for a 225-character requested outcome', async () => {
+    const input = await openConvertForm();
+    expect(input).toHaveValue(
+      `${requestedOutcome225.slice(0, taskTitleMaxLength - truncationMarker.length)}${truncationMarker}`,
+    );
+    expect(screen.getByTestId('task-request-convert-title-count')).toHaveTextContent(
+      `${taskTitleMaxLength}/${taskTitleMaxLength}`,
+    );
+  });
 
   it('AC-C6c leaves a 69-character requested outcome unchanged', async () => {
     renderRoute(requestedOutcome69);
@@ -128,19 +125,16 @@ describe('TaskRequestsRoute conversion title', () => {
     );
   });
 
-  it(
-    'AC-C6d shows an inline error, focuses the title, and makes no API mutation for an over-limit submit',
-    async () => {
-      const input = await openConvertForm();
-      fireEvent.change(input, { target: { value: overLimitTitle } });
-      fireEvent.click(screen.getByTestId('task-request-convert-submit'));
-      expect(await screen.findByTestId('task-request-convert-title-error')).toBeInTheDocument();
-      expect(input).toHaveFocus();
-      await Promise.resolve();
-      expect(api.convertTaskRequest).toHaveBeenCalledTimes(0);
-      expect(api.apiClient).toHaveBeenCalledTimes(0);
-    },
-  );
+  it('AC-C6d shows an inline error, focuses the title, and makes no API mutation for an over-limit submit', async () => {
+    const input = await openConvertForm();
+    fireEvent.change(input, { target: { value: overLimitTitle } });
+    fireEvent.click(screen.getByTestId('task-request-convert-submit'));
+    expect(await screen.findByTestId('task-request-convert-title-error')).toBeInTheDocument();
+    expect(input).toHaveFocus();
+    await Promise.resolve();
+    expect(api.convertTaskRequest).toHaveBeenCalledTimes(0);
+    expect(api.apiClient).toHaveBeenCalledTimes(0);
+  });
 
   it('AC-C6e keeps submit enabled for an over-limit title', async () => {
     const input = await openConvertForm();

--- a/apps/frontend/src/features/tasks/routes/__tests__/TaskRequestsRoute.convert.test.tsx
+++ b/apps/frontend/src/features/tasks/routes/__tests__/TaskRequestsRoute.convert.test.tsx
@@ -1,0 +1,150 @@
+import { convertTaskRequestRequestSchema } from '@fops/shared';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen } from '@testing-library/react';
+import type * as React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { TaskRequestsRoute } from '../TaskRequestsRoute';
+
+const api = vi.hoisted(() => ({ apiClient: vi.fn(), convertTaskRequest: vi.fn() }));
+const requestedOutcome225 = `핵심 결과 ${'x'.repeat(219)}`;
+const requestedOutcome69 = `업무 결과 ${'x'.repeat(63)}`;
+const truncationMarker = '…';
+const taskTitleMaxLength = convertTaskRequestRequestSchema.shape.title.maxLength;
+
+if (taskTitleMaxLength === null) {
+  throw new Error('Task conversion title requires a canonical maximum length.');
+}
+
+const overLimitTitle = 'x'.repeat(taskTitleMaxLength + 1);
+const taskRequest = {
+  id: '10000000-0000-0000-0000-000000000001',
+  workspace_id: '90000000-0000-0000-0000-000000000009',
+  display_id: 'REQ-42',
+  source_type: 'finding' as const,
+  source_id: '40000000-0000-0000-0000-000000000004',
+  primary_managed_system_id: '30000000-0000-0000-0000-000000000003',
+  evidence_summary: '쿼리 플랜 개선 필요',
+  requested_outcome: requestedOutcome225,
+  requester_actor_id: '20000000-0000-0000-0000-000000000002',
+  status: 'approved' as const,
+  reviewer_actor_id: null,
+  decision_reason: null,
+  decided_at: null,
+  created_at: '2026-07-10T00:00:00.000Z',
+  updated_at: '2026-07-10T00:00:00.000Z',
+  source: null,
+};
+
+vi.mock('@fops/ui', async () => {
+  const actual = await vi.importActual<typeof import('@fops/ui')>('@fops/ui');
+  return {
+    ...actual,
+    ListShell: ({
+      list,
+      detailPanel,
+    }: {
+      list: React.ReactNode;
+      detailPanel?: React.ReactNode;
+    }) => (
+      <div>
+        <main>{list}</main>
+        <aside>{detailPanel}</aside>
+      </div>
+    ),
+  };
+});
+
+vi.mock('@/features/integration/hooks/useFindingDetail', () => ({
+  useFindingDetail: () => ({ data: null }),
+}));
+vi.mock('@/lib/api/analytics-areas', () => ({
+  fetchAnalyticsAreas: vi.fn(async () => ({ items: [] })),
+}));
+vi.mock('@/lib/api/managed-systems', () => ({
+  fetchManagedSystems: vi.fn(async () => ({
+    items: [{ id: taskRequest.primary_managed_system_id, name: 'Billing Ops' }],
+  })),
+}));
+vi.mock('@/lib/api', () => ({
+  apiClient: api.apiClient,
+  approveTaskRequest: vi.fn(),
+  convertTaskRequest: api.convertTaskRequest,
+  fetchMe: vi.fn(async () => ({
+    actor: { id: '60000000-0000-0000-0000-000000000006', role_level: 'admin' },
+  })),
+  fetchPermissionCheck: vi.fn(async () => ({ state: 'approved' })),
+  fetchTaskRequests: vi.fn(async () => ({ items: [taskRequest] })),
+  linkExistingTask: vi.fn(),
+  listTasks: vi.fn(async () => ({ items: [] })),
+  rejectTaskRequest: vi.fn(),
+  requestMoreEvidenceForTaskRequest: vi.fn(),
+  resolveActors: vi.fn(async () => ({ actors: [], teams: [] })),
+}));
+
+function renderRoute(requestedOutcome = requestedOutcome225) {
+  taskRequest.requested_outcome = requestedOutcome;
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <TaskRequestsRoute selectedParam={taskRequest.id} />
+    </QueryClientProvider>,
+  );
+}
+
+async function openConvertForm() {
+  renderRoute();
+  await screen.findByText('REQ-42');
+  fireEvent.click(screen.getByRole('button', { name: 'Convert to Task' }));
+  return screen.findByTestId('task-request-convert-title-input');
+}
+
+describe('TaskRequestsRoute conversion title', () => {
+  it('AC-C6a parses the generated default title with the canonical conversion schema', async () => {
+    const input = await openConvertForm();
+    expect(
+      convertTaskRequestRequestSchema.parse({ title: input.getAttribute('value') }).title,
+    ).toHaveLength(taskTitleMaxLength);
+  });
+
+  it(
+    'AC-C6b shows a truncation marker and character count for a 225-character requested outcome',
+    async () => {
+      const input = await openConvertForm();
+      expect(input).toHaveValue(
+        `${requestedOutcome225.slice(0, taskTitleMaxLength - truncationMarker.length)}${truncationMarker}`,
+      );
+      expect(screen.getByTestId('task-request-convert-title-count')).toHaveTextContent(
+        `${taskTitleMaxLength}/${taskTitleMaxLength}`,
+      );
+    },
+  );
+
+  it('AC-C6c leaves a 69-character requested outcome unchanged', async () => {
+    renderRoute(requestedOutcome69);
+    await screen.findByText('REQ-42');
+    fireEvent.click(screen.getByRole('button', { name: 'Convert to Task' }));
+    expect(await screen.findByTestId('task-request-convert-title-input')).toHaveValue(
+      requestedOutcome69,
+    );
+  });
+
+  it(
+    'AC-C6d shows an inline error, focuses the title, and makes no API mutation for an over-limit submit',
+    async () => {
+      const input = await openConvertForm();
+      fireEvent.change(input, { target: { value: overLimitTitle } });
+      fireEvent.click(screen.getByTestId('task-request-convert-submit'));
+      expect(await screen.findByTestId('task-request-convert-title-error')).toBeInTheDocument();
+      expect(input).toHaveFocus();
+      await Promise.resolve();
+      expect(api.convertTaskRequest).toHaveBeenCalledTimes(0);
+      expect(api.apiClient).toHaveBeenCalledTimes(0);
+    },
+  );
+
+  it('AC-C6e keeps submit enabled for an over-limit title', async () => {
+    const input = await openConvertForm();
+    fireEvent.change(input, { target: { value: overLimitTitle } });
+    expect(screen.getByTestId('task-request-convert-submit')).toBeEnabled();
+  });
+});

--- a/docs/adr/0043-finding-task-conversion-chain-decisions.md
+++ b/docs/adr/0043-finding-task-conversion-chain-decisions.md
@@ -1,0 +1,91 @@
+# Finding-to-Task conversion chain decisions
+
+## Status
+
+Accepted 2026-08-03. Amends ADR-0027's conversion consequences for a Task
+Request whose source is a Finding.
+
+## Context
+
+ADR-0025 introduced the `Finding -> Task Request` tracer, ADR-0026 separated
+approval from conversion, and ADR-0027 made an approved Task Request the
+source of a new Backlog Task. The conversion form needs a useful default title
+and the completed chain must preserve both the operational Finding projection
+and canonical cross-system history.
+
+The source records do not share one universal title contract. In particular,
+the Task title limit belongs to the canonical shared
+`convertTaskRequestRequestSchema`; it is not a frontend-owned value and must
+not be duplicated as a conversion-form literal. Increasing the Task limit to
+absorb a longer source title would silently change the Task entity contract.
+
+`finding.linked_task_id` is the single-field operational projection used by
+the Finding UI and the duplicate Task-request-prevention decision. It is not
+canonical relationship history: that remains an active `entity_links` row, as
+required by the domain and module-boundary contracts.
+
+## Decision
+
+1. Preserve each entity-specific maximum length. Task conversion does not
+   expand the Task title maximum to accommodate another entity's title. The
+   conversion form derives its title maximum from the canonical shared
+   `convertTaskRequestRequestSchema`, rather than declaring a second numeric
+   limit.
+
+2. When a source-derived default exceeds that maximum, create a meaningful,
+   visibly truncated default that fits the Task title contract. The default
+   must make truncation apparent (for example, with an ellipsis) and must not
+   silently submit a clipped source string. The actor may edit the title before
+   submitting.
+
+3. Do not disable Convert to Task merely because the title is empty or
+   invalid. A disabled submit hides the reason and prevents focused recovery.
+   On submit, render an inline validation error and move focus to the title
+   field. This applies the same interaction principle established for issue
+   #277: a recoverable validation failure is explained at the point of action,
+   not represented only by an unavailable control.
+
+4. In the same conversion transaction, when the Task Request source is a
+   Finding and that Finding has no linked Task, write both facts:
+
+   ```text
+   finding.linked_task_id = new Task id
+   (finding, task, requested_task) active entity link
+   ```
+
+   The direct field is the operational projection; the entity link is the
+   canonical, auditable cross-system history. Neither substitutes for the
+   other. The transaction also retains ADR-0027's Task Request -> Task
+   `converted_to` link, Task Request status update, and conversion audit.
+
+5. If that source Finding is already linked to a different Task, approved
+   conversion still succeeds: create the new Task and complete the Task
+   Request -> Task conversion normally. Preserve the existing
+   `linked_task_id`, but still create the new `(finding, task,
+   requested_task)` entity link in the same transaction. The direct field is
+   one operational/UI decision; entity links are the many-record canonical
+   history and must retain this approved conversion. Operational work must not
+   be blocked by a pre-existing Finding link, and the existing projection must
+   not be overwritten.
+
+6. A Task Request sourced from `voc` or `voc_cluster` is a no-op for this
+   Finding-specific projection: conversion writes neither a Finding backlink
+   nor a Finding -> Task entity link. Their existing source provenance rules
+   remain unchanged.
+
+## Consequences
+
+- Task title validation has one canonical runtime source and form behavior
+  stays aligned with it as the contract changes.
+- A Finding can make one operational linked-Task decision while retaining the
+  full cross-system relationship history through entity links.
+- Conversion is resilient to historical or concurrent Finding links: it does
+  not overwrite an earlier operational decision, retains every approved
+  Finding -> Task historical link, and does not prevent work from entering the
+  backlog.
+- For a previously unlinked Finding, its new operational projection and
+  canonical entity link are atomic with conversion. A conflicting existing
+  projection deliberately has no replacement, while its new canonical link is
+  still atomic with conversion.
+- ADR-0027's general conversion, authorization, Task Request -> Task
+  provenance, and source-link preservation rules otherwise remain in force.


### PR DESCRIPTION
## #291 — 진단을 실측이 반박했다 (두 번)

이슈는 "링크가 안 보인다"와 "두 번째 요청이 가능하다"를 **두 증상**으로 적었다.
실측하면 **결함 하나**다. FE는 `finding.linked_task_id` 하나로 둘 다 결정한다:

- `FindingDetailPanel.tsx:1055` — `Linked Task` 표시
- `FindingDetailPanel.tsx:1108` — `linked_task_id === null &&` 조건으로 `Task 요청` 버튼 노출

**그리고 내 최초 재트리아지도 틀렸다.** "entity_link도 안 만든다"고 적었는데, 구현 워커가
실측으로 반박했다 — base `6f9c1c5`의 `preserveSourceLinks()`가 이미
`finding → task / requested_task` 링크를 `insertActiveEntityLink()`로 만들고 있었다.
빠진 것은 **비정규화된 `linked_task_id` 열 하나**다. FE가 entity_link가 아니라 그 열을 읽으므로
증상과 수정 방향은 그대로 유효하다.

변환 트랜잭션 안에서 소스가 Finding일 때 그 열을 새 Task id로 채운다. **FE 수정은 필요 없다.**

### 판단이 필요했던 지점

이미 다른 Task에 링크된 Finding은 **기존 링크를 유지하고 변환은 계속 진행**한다.
승인된 요청의 변환을 링크 충돌로 막으면 운영이 막히고, 이력은 entity_link에 남아 유실되지 않는다.
소스가 `voc`·`voc_cluster`면 Finding이 없으므로 아무것도 하지 않는다.

권한은 넓히지 않았다 — 기존 `checkFindingManage(..., { requireElevatedRole: true })` 뒤다.
**마이그레이션 없음** — 컬럼도 등록된 entity_link 튜플도 이미 존재한다.

## #289 — 폼이 자기 생성 기본값으로 검증을 깼다

| 필드 | 상한 |
|---|---|
| Task Request `requested_outcome` | `.max(4000)` |
| Task `title` | `.max(200)` |

변환 폼이 전자를 후자의 기본값으로 그대로 넣었고, 클라이언트 검증이 없어 그대로 제출돼
`invalid request body`라는 **어느 필드인지 알 수 없는** 오류만 돌아왔다.

이제 기본 제목이 항상 유효하고, 잘렸으면 그 사실과 글자 수가 보이며, 상한 초과는 제출 전에
필드 단위로 지적한다. **상한은 하드코딩하지 않고 정본 스키마에서 끌어온다** — 하드코딩하면
다음에 상한이 바뀔 때 같은 결함이 재발한다.

## 기각한 선택지

- Task title 상한을 4000으로 확대 — 엔티티 경계를 흐린다
- 제출 버튼 비활성화 — 이유가 안 보인다 (#277 판정과 동일 원칙)
- `requested_outcome` 자체를 잘라 저장 — 원본 요청은 보존돼야 한다
- 링크 충돌 시 변환 실패 — 승인된 요청의 실행을 막는다

## 오라클

AC-C6a는 생성된 기본 제목을 **정본 스키마로 실제 파싱**한다.
AC-C7a는 `not.toBeNull()`이 아니라 **새 Task의 id와 대조**한다 — 엉뚱한 Task에 링크돼도 통과하면 안 된다.
AC-C7d는 repo가 아니라 **GET 응답의 프로젝션**까지 확인한다.
AC-C7f는 리소스에 도달 가능한 액터를 만든 뒤 거부를 단언한다(권한이 아니라 부재로 실패하면 공허하다).

## 알려진 미비

Task Requests 화면에 비주얼 하네스 entrypoint가 없어 **비주얼 시나리오를 만들지 못했다.**
#289의 잘린 제목·글자 수 표시는 유닛 테스트로만 덮인다.

## 게이트 (4개 청크 통합 기준)

```
frontend vitest      779 passed / 147 files   (develop 745)
frontend typecheck   14 total, 24 baselined, 0 new
frontend biome       0 new
frontend visual      57 passed, 3회 연속 클린
backend  integration 1195 passed / 132 files  (develop 1189)
backend  tasks 모듈   39 passed (task-conversion 16건 포함)
```

ADR: `docs/adr/0043`
판정 근거: `.review/RETRIAGE-2026-08-02.md` §클러스터 3

Closes #291
Closes #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BfiR55zJ7n8uYpr1s3X6q