### PR TITLE
chore(frontend): remove 3 unused imports in VOC tests, drop their biome allowlist entries

### DIFF
--- a/apps/frontend/src/features/voc/components/detail/__tests__/ReporterStatusChangeBlock.test.tsx
+++ b/apps/frontend/src/features/voc/components/detail/__tests__/ReporterStatusChangeBlock.test.tsx
@@ -4,8 +4,7 @@
 //
 // Prototype ref: docs/design-prototype/screen-voc.jsx:537-655
 
-import * as React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { ReporterStatusChangeBlock } from '../ReporterStatusChangeBlock';
 import type { VocDetailEnvelope } from '@fops/shared';

--- a/apps/frontend/src/features/voc/components/triage/__tests__/TriageQueue.test.tsx
+++ b/apps/frontend/src/features/voc/components/triage/__tests__/TriageQueue.test.tsx
@@ -2,7 +2,6 @@
 // Covers: renders rows, empty state, OutOfScopeSummary.
 // TDD RED: these tests are written before the implementation file exists.
 
-import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { TriageQueue } from '../TriageQueue';

--- a/scripts/gates/frontend-biome-allowlist.txt
+++ b/scripts/gates/frontend-biome-allowlist.txt
@@ -88,7 +88,5 @@ apps/frontend/src/features/voc/hooks/__tests__/useTriagePanelState.test.ts forma
 apps/frontend/src/features/voc/hooks/__tests__/useTriagePanelState.test.ts organizeImports -- pre-existing on develop; import order predates biome
 apps/frontend/src/features/voc/components/triage/__tests__/TriageQueue.test.tsx format -- pre-existing on develop; the file predates biome formatting and this branch only adds two fixture fields
 apps/frontend/src/features/voc/components/triage/__tests__/TriageQueue.test.tsx organizeImports -- pre-existing on develop; import order predates biome
-apps/frontend/src/features/voc/components/triage/__tests__/TriageQueue.test.tsx lint/correctness/noUnusedImports -- pre-existing on develop (1x, unchanged); genuine cleanup, tracked as a follow-up rather than widening this fixture-only diff
 apps/frontend/src/features/voc/components/detail/__tests__/ReporterStatusChangeBlock.test.tsx organizeImports -- pre-existing on develop; import order predates biome
-apps/frontend/src/features/voc/components/detail/__tests__/ReporterStatusChangeBlock.test.tsx lint/correctness/noUnusedImports -- pre-existing on develop (2x, unchanged); genuine cleanup, tracked as a follow-up rather than widening this fixture-only diff
 apps/frontend/src/features/voc/components/detail/__tests__/ReporterStatusChangeBlock.test.tsx lint/style/noNonNullAssertion -- pre-existing on develop (5x, unchanged); test helpers assert non-null after an explicit lookup


### PR DESCRIPTION
Closes #321.

## 변경

| 파일 | 지운 것 |
|---|---|
| `TriageQueue.test.tsx` | `import * as React` |
| `ReporterStatusChangeBlock.test.tsx` | `import * as React`, `fireEvent` |
| `scripts/gates/frontend-biome-allowlist.txt` | 위 두 파일의 `noUnusedImports` 2줄 |

`format` · `organizeImports` · `noNonNullAssertion` 항목은 남겼다 — 여전히 미해결 부채다.
포매터는 돌리지 않았다. diff는 삭제된 3줄 + allowlist 2줄뿐이다.

## 게이트 (실측)

```
frontend vitest      779 passed / 147 files        (변동 없음)
frontend biome       0 unexpected errors, 81 allowlisted   ← 83에서 정확히 2 감소
frontend typecheck   1 total, 1 baselined, 0 new
check:boundaries     OK
```

비주얼 하네스와 백엔드 통합은 돌리지 않았다 — diff가 테스트 파일과 게이트 메타데이터뿐이라 제품 렌더·백엔드 경로에 닿지 않는다.

## 기각한 선택지

- **`biome check --write`로 자동 수정** — 같은 패스에서 `organizeImports`·`format`이 붙어 건드리지 않은 줄을 재작성한다(#253/PR #319에서 되돌린 전례). 손으로 3줄만 지웠다.
- **allowlist의 나머지 항목도 함께 정리** — 이 이슈 범위 밖이고, 각각 별도의 포매팅 부채다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BfiR55zJ7n8uYpr1s3X6q