### PR TITLE
feat(#325,#326): 액터/세션 생명주기 — 로그아웃 노출 + 액터 경계에서 캐시 초기화

### DIFF
--- a/apps/frontend/src/lib/layout/AppRail.tsx
+++ b/apps/frontend/src/lib/layout/AppRail.tsx
@@ -9,7 +9,19 @@ import {
   UserRound,
   UsersRound,
 } from 'lucide-react';
-import { cn } from '@fops/ui';
+import { ROLE_LEVEL_LABELS, type RoleLevel } from '@fops/shared';
+import {
+  cn,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from '@fops/ui';
+import { useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
+import { logout } from '@/lib/api/auth';
+import { useMe } from '@/lib/auth/useMe';
 
 export type RailDomain = 'home' | 'voc' | 'findings' | 'tasks' | 'integration' | 'surveys' | 'admin';
 
@@ -47,6 +59,23 @@ export interface AppRailProps {
 export function AppRail({ activeDomain = 'voc', className }: AppRailProps) {
   const head = RAIL_ITEMS.filter((item) => item.key !== 'admin');
   const admin = RAIL_ITEMS.find((item) => item.key === 'admin');
+  const { data: me } = useMe();
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+  const [isLoggingOut, setIsLoggingOut] = React.useState(false);
+
+  async function handleLogout() {
+    if (isLoggingOut) return;
+    setIsLoggingOut(true);
+    try {
+      await logout();
+    } catch {
+      // Navigation still ends the local session when the revoke request cannot finish.
+    } finally {
+      queryClient.clear();
+      navigate({ to: '/login' });
+    }
+  }
 
   return (
     <nav
@@ -78,13 +107,32 @@ export function AppRail({ activeDomain = 'voc', className }: AppRailProps) {
       >
         <Bell className="h-4 w-4" />
       </button>
-      <div
-        className="flex h-8 w-8 items-center justify-center rounded-full bg-accent-primary/15 text-xs font-semibold text-accent-primary"
-        title="Profile"
-        aria-label="Profile"
-      >
-        <UserRound className="h-4 w-4" />
-      </div>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            className="flex h-8 w-8 items-center justify-center rounded-full bg-accent-primary/15 text-xs font-semibold text-accent-primary"
+            title="Profile"
+            aria-label="Profile"
+          >
+            <UserRound className="h-4 w-4" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent side="top" align="center">
+          {/* `/me` can answer without an `actor` — guarding only on `me` here
+              crashed the whole frame through the error boundary, which is
+              strictly worse than showing no label. The rail must survive any
+              /me shape; logout below stays reachable either way. */}
+          {me?.actor && (
+            <DropdownMenuLabel>
+              {me.actor.display_name} · {ROLE_LEVEL_LABELS[me.actor.role_level as RoleLevel]}
+            </DropdownMenuLabel>
+          )}
+          <DropdownMenuItem disabled={isLoggingOut} onSelect={handleLogout}>
+            로그아웃
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
     </nav>
   );
 }

--- a/apps/frontend/src/lib/layout/__tests__/AppRail.test.tsx
+++ b/apps/frontend/src/lib/layout/__tests__/AppRail.test.tsx
@@ -1,6 +1,62 @@
-import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ComponentProps } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// vi.mock factories are hoisted above module-level const declarations, so the
+// doubles have to be created inside vi.hoisted or the factories close over
+// uninitialised bindings.
+const { navigate, logout, useMe } = vi.hoisted(() => ({
+  navigate: vi.fn(),
+  logout: vi.fn(),
+  useMe: vi.fn(),
+}));
+
+vi.mock('@tanstack/react-router', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@tanstack/react-router')>()),
+  useNavigate: () => navigate,
+}));
+vi.mock('@/lib/api/auth', () => ({ logout }));
+vi.mock('@/lib/auth/useMe', () => ({ useMe }));
+
 import { AppRail, railForPathname } from '../AppRail';
+
+const ACTOR = {
+  actor: {
+    id: 'actor-1',
+    external_id: 'actor-1',
+    email: 'jiwon@example.test',
+    display_name: '김지원',
+    role_level: 'admin',
+  },
+  workspace_id: 'workspace-1',
+};
+
+function renderRail(props: ComponentProps<typeof AppRail> = {}) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={queryClient}>
+      <AppRail {...props} />
+    </QueryClientProvider>,
+  );
+  return queryClient;
+}
+
+// The menu is opened with the keyboard on purpose. Radix's trigger opens on
+// `pointerdown`, which jsdom cannot synthesise convincingly — measured here:
+// fireEvent.pointerDown leaves aria-expanded="false", while Enter flips it to
+// "true". Driving it by keyboard is both the interaction that works in this
+// environment and the one worth asserting: a logout that only pointers can
+// reach is the same accessibility failure as #335's native prompt.
+function openAccountMenu() {
+  fireEvent.keyDown(screen.getByRole('button', { name: 'Profile' }), { key: 'Enter' });
+}
+
+beforeEach(() => {
+  navigate.mockReset();
+  logout.mockReset();
+  useMe.mockReturnValue({ data: ACTOR });
+});
 
 describe('AppRail', () => {
   it.each([
@@ -13,14 +69,76 @@ describe('AppRail', () => {
     ['/surveys', 'surveys'],
     ['/admin/settings', 'admin'],
   ] as const)('marks %s as the active %s rail', (pathname, domain) => {
-    render(<AppRail activeDomain={railForPathname(pathname)} />);
+    renderRail({ activeDomain: railForPathname(pathname) });
     expect(screen.getByTestId(`rail-${domain}`)).toHaveAttribute('aria-current', 'page');
   });
 
   it('keeps Home as the first rail entry', () => {
     expect(screen.queryByTestId('rail-home')).toBeNull();
-    render(<AppRail activeDomain="home" />);
+    renderRail({ activeDomain: 'home' });
     const railButtons = screen.getAllByRole('link');
     expect(railButtons[0]).toHaveAttribute('data-testid', 'rail-home');
+  });
+});
+
+describe('AppRail account menu', () => {
+  it('shows logout after opening the avatar menu', () => {
+    renderRail();
+    openAccountMenu();
+    expect(screen.getByRole('menuitem', { name: '로그아웃' })).toBeInTheDocument();
+  });
+
+  it('revokes once, then clears cached data and routes to login', async () => {
+    const calls: string[] = [];
+    logout.mockImplementation(async () => {
+      calls.push('logout');
+    });
+    navigate.mockImplementation(() => {
+      calls.push('navigate');
+    });
+    const queryClient = renderRail();
+    vi.spyOn(queryClient, 'clear').mockImplementation(() => {
+      calls.push('clear');
+    });
+
+    openAccountMenu();
+    fireEvent.click(screen.getByRole('menuitem', { name: '로그아웃' }));
+
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith({ to: '/login' }));
+    expect(logout).toHaveBeenCalledOnce();
+    expect(queryClient.clear).toHaveBeenCalledOnce();
+    expect(calls).toEqual(['logout', 'clear', 'navigate']);
+  });
+
+  it('clears cached data and routes to login when revocation fails', async () => {
+    logout.mockRejectedValue(new Error('network failed'));
+    const queryClient = renderRail();
+    const clear = vi.spyOn(queryClient, 'clear');
+
+    openAccountMenu();
+    fireEvent.click(screen.getByRole('menuitem', { name: '로그아웃' }));
+
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith({ to: '/login' }));
+    expect(clear).toHaveBeenCalledOnce();
+  });
+
+  it('shows the Actor display name and Role Level in the account menu', () => {
+    renderRail();
+    openAccountMenu();
+    expect(screen.getByText('김지원 · Admin')).toBeInTheDocument();
+  });
+
+  // Both /me shapes that omit an actor, not just the unresolved one. The
+  // second case is the one that actually crashed the frame: `data` present,
+  // `data.actor` absent — the same response AppFrame.scope.test.tsx exercises.
+  it.each([
+    ['no data at all', undefined],
+    ['data without an actor', { workspace_id: 'workspace-1' }],
+  ])('keeps logout available when Actor data is unavailable (%s)', (_label, data) => {
+    useMe.mockReturnValue({ data });
+    renderRail();
+    openAccountMenu();
+    expect(screen.getByRole('menuitem', { name: '로그아웃' })).toBeInTheDocument();
+    expect(screen.queryByText('김지원 · Admin')).not.toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/routes/login.test.tsx
+++ b/apps/frontend/src/routes/login.test.tsx
@@ -79,6 +79,28 @@ describe('/login dev (mock auth)', () => {
     await waitFor(() => expect(fetchMock).toHaveBeenCalledWith('/auth/mock-login', expect.objectContaining({ body: JSON.stringify({ external_id: 'mock-admin-1' }) })));
     expect(fetchMock).toHaveBeenCalledWith('/auth/mock-login', expect.objectContaining({ body: JSON.stringify({ external_id: 'mock-developer-1' }) }));
   });
+
+  test('clears cached data before routing after mock login succeeds', async () => {
+    const calls: string[] = [];
+    globalThis.fetch = vi.fn(async () => new Response(JSON.stringify({ actor: { id: 'actor', external_id: 'mock-user-1', email: 'user@example.test', display_name: 'Mock User', role_level: 'user' }, workspace_id: 'workspace' }), { status: 200, headers: { 'content-type': 'application/json' } })) as typeof globalThis.fetch;
+    const { router, qc } = buildHarness({ initialPath: '/login' });
+    vi.spyOn(qc, 'clear').mockImplementation(() => { calls.push('clear'); });
+    const originalNavigate = router.navigate.bind(router);
+    vi.spyOn(router, 'navigate').mockImplementation((options) => {
+      calls.push('navigate');
+      return originalNavigate(options);
+    });
+    const invalidateQueries = vi.spyOn(qc, 'invalidateQueries');
+
+    render(<QueryClientProvider client={qc}><RouterProvider router={router} /></QueryClientProvider>);
+    await screen.findByRole('button', { name: 'Mock User (User)' });
+    fireEvent.click(screen.getByRole('button', { name: 'Mock User (User)' }));
+
+    await waitFor(() => expect(router.state.location.pathname).toBe('/'));
+    expect(qc.clear).toHaveBeenCalledOnce();
+    expect(calls).toEqual(['clear', 'navigate']);
+    expect(invalidateQueries).not.toHaveBeenCalled();
+  });
 });
 
 describe('/login prod guard (F-015)', () => {

--- a/apps/frontend/src/routes/login.tsx
+++ b/apps/frontend/src/routes/login.tsx
@@ -17,7 +17,7 @@
 
 import { ROLE_LEVEL_LABELS, type RoleLevel } from '@fops/shared';
 import { Button } from '@fops/ui';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { Navigate, createFileRoute, useNavigate } from '@tanstack/react-router';
 import { mockLogin } from '../lib/api';
 
@@ -78,9 +78,12 @@ export function LoginPage() {
 
 function MockLoginPicker() {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const mutation = useMutation({
     mutationFn: mockLogin,
     onSuccess: () => {
+      // An actor boundary must drop all prior actor-scoped data before navigation.
+      queryClient.clear();
       navigate({ to: '/' });
     },
   });

--- a/docs/design-prototype/affordances.jsx
+++ b/docs/design-prototype/affordances.jsx
@@ -95,7 +95,10 @@ function useFullscreenPanel() {
 // ------------------------------------------------------------
 // Popover — anchored to an element by ref.
 // ------------------------------------------------------------
-function Popover({ open, anchorRef, onClose, align = 'left', children, width, offset = 6 }) {
+// `placement="top"` opens upward instead. Every existing consumer is a toolbar
+// near the top of the screen, so downward is still the default; the rail's
+// account menu sits at the bottom edge and would otherwise open off-screen.
+function Popover({ open, anchorRef, onClose, align = 'left', placement = 'bottom', children, width, offset = 6 }) {
   const popoverRef = useRef(null);
   const [pos, setPos] = useState(null);
   useEffect(() => {
@@ -105,8 +108,9 @@ function Popover({ open, anchorRef, onClose, align = 'left', children, width, of
       if (!a) return;
       const r = a.getBoundingClientRect();
       const top = r.bottom + offset;
+      const bottom = window.innerHeight - r.top + offset;
       const left = align === 'right' ? r.right : r.left;
-      setPos({ top, left, align });
+      setPos({ top, bottom, left, align });
     };
     update();
     window.addEventListener('resize', update);
@@ -133,7 +137,7 @@ function Popover({ open, anchorRef, onClose, align = 'left', children, width, of
   }, [open, onClose, anchorRef]);
   if (!open || !pos) return null;
   const style = {
-    top: pos.top,
+    ...(placement === 'top' ? { bottom: pos.bottom } : { top: pos.top }),
     width,
     ...(align === 'right' ? { right: window.innerWidth - pos.left } : { left: pos.left }),
   };

--- a/docs/design-prototype/shell.jsx
+++ b/docs/design-prototype/shell.jsx
@@ -263,14 +263,16 @@ function GlobalRail({ activeRoute, onNavigate, role = 'admin' }) {
             Tweaks panel, not a product surface. So this records the copy and
             placement of the control; production wires it to POST /auth/logout
             and returns to the login picker (ADR-0006). */}
-        <div
+        <button
+          type="button"
+          role="menuitem"
           className="popover-item"
           onClick={() => {
             setAccountOpen(false);
             window.__toast({ message: '로그아웃 (mock)', tone: 'default' });
           }}>
           로그아웃
-        </div>
+        </button>
       </Popover>
     </aside>
   );

--- a/docs/design-prototype/shell.jsx
+++ b/docs/design-prototype/shell.jsx
@@ -201,6 +201,8 @@ const RAIL_ITEMS = [
 // Global rail (system selector)
 // ============================================================
 function GlobalRail({ activeRoute, onNavigate, role = 'admin' }) {
+  const avatarRef = useRef(null);
+  const [accountOpen, setAccountOpen] = useStateShell(false);
   // map route → rail
   const activeKey = useMemo(() => {
     if (activeRoute === 'home' || activeRoute === 'my-work') return 'home';
@@ -212,6 +214,8 @@ function GlobalRail({ activeRoute, onNavigate, role = 'admin' }) {
     if (activeRoute.startsWith('admin')) return 'admin';
     return 'home';
   }, [activeRoute]);
+
+  const roleLabel = role === 'admin' ? '김지원 · Admin' : role === 'dev' ? '김지원 · Developer' : '김지원 · User';
 
   const allowed = ROLE_RAIL_VISIBILITY[role] || ROLE_RAIL_VISIBILITY.admin;
   const visibleRail = RAIL_ITEMS.filter(item => allowed.includes(item.key));
@@ -242,7 +246,32 @@ function GlobalRail({ activeRoute, onNavigate, role = 'admin' }) {
       ))}
       <div className="rail-spacer" />
       <button className="rail-item" title="Notifications"><Icon name="bell" size={15} /></button>
-      <div className="rail-avatar" title={`${role === 'admin' ? '김지원 · Admin' : role === 'dev' ? '김지원 · Developer' : '김지원 · User'}`}>김</div>
+      <button
+        ref={avatarRef}
+        type="button"
+        className="rail-avatar"
+        aria-haspopup="menu"
+        aria-expanded={accountOpen}
+        title={`${roleLabel} · 계정`}
+        onClick={() => setAccountOpen(o => !o)}>
+        김
+      </button>
+      <Popover open={accountOpen} anchorRef={avatarRef} onClose={() => setAccountOpen(false)} placement="top" width={200}>
+        <div className="popover-section-title">{roleLabel}</div>
+        <div className="popover-divider" />
+        {/* The prototype has no login screen — role is switched through the dev
+            Tweaks panel, not a product surface. So this records the copy and
+            placement of the control; production wires it to POST /auth/logout
+            and returns to the login picker (ADR-0006). */}
+        <div
+          className="popover-item"
+          onClick={() => {
+            setAccountOpen(false);
+            window.__toast({ message: '로그아웃 (mock)', tone: 'default' });
+          }}>
+          로그아웃
+        </div>
+      </Popover>
     </aside>
   );
 }

--- a/docs/design-prototype/styles.css
+++ b/docs/design-prototype/styles.css
@@ -378,6 +378,13 @@ a {
   font-size: var(--text-sm);
   color: var(--text-primary);
   user-select: none;
+  /* Reset so a real <button> can carry this class and stay keyboard-reachable
+     without changing how the existing div-based items look. */
+  border: 0;
+  width: 100%;
+  text-align: left;
+  background: none;
+  font-family: inherit;
 }
 .popover-item:hover { background: var(--surface-row-hover); }
 .popover-item .check-box {

--- a/docs/design-prototype/styles.css
+++ b/docs/design-prototype/styles.css
@@ -496,6 +496,10 @@ a {
   place-items: center;
   font-weight: 600;
   font-size: 12px;
+  border: 0;
+  padding: 0;
+  font-family: inherit;
+  cursor: pointer;
 }
 
 /* --- Sidebar --- */

--- a/docs/frontend/routes-and-layout.md
+++ b/docs/frontend/routes-and-layout.md
@@ -83,6 +83,8 @@ Admin:
 
 Current sidebar entries live in `SIDEBAR_ENTRIES` (`apps/frontend/src/routes/_authed.tsx`) — that array is authoritative; this paragraph describes it. Entries are grouped under the section labels `VOC` (Inbox, Triage, My VOCs, Clusters, Findings, New VOC), `TASKS` (Task Requests, Tasks, My Tasks), and `MANAGED SYSTEMS` (Managed Systems, Analytics Areas). Per the AGENTS.md two-consumer rule, each feature adds its entry in the slice that owns it.
 
+The bottom avatar in the global rail opens an account menu with the current Actor display name and Role Level plus logout. Logout revokes the session, clears the client query cache, then routes to `/login`; successful login also clears that cache before routing so a new Actor never sees prior Actor data.
+
 Count badges and global Managed System scope selection are still absent — they are the scope of #143 (GlobalRail multi-domain IA).
 
 Routes may exist without being visible in navigation. Direct route access must restore AppShell and render allowed content, summary-visible content, request-access state, not_found, or permission_denied according to backend response.

--- a/scripts/gates/frontend-biome-allowlist.txt
+++ b/scripts/gates/frontend-biome-allowlist.txt
@@ -105,3 +105,12 @@ apps/frontend/src/features/voc/components/create/__tests__/AttachmentDropzone.te
 apps/frontend/src/lib/layout/AppRail.tsx organizeImports -- pre-existing on develop; import order predates biome
 apps/frontend/src/lib/layout/AppRail.tsx format -- pre-existing on develop (1x, unchanged; measured against `git show develop:` of the same file)
 apps/frontend/src/routes/login.test.tsx format -- pre-existing on develop (1x, unchanged); the file's long harness lines predate biome. AppRail.test.tsx was format-clean on develop, so the violation this branch introduced there was formatted rather than allowlisted
+docs/design-prototype/shell.jsx format -- pre-existing on develop (1x, unchanged; measured against `git show develop:` of the same file)
+docs/design-prototype/shell.jsx lint/a11y/useButtonType -- pre-existing on develop (11x, unchanged); the avatar trigger this branch adds does carry type="button"
+docs/design-prototype/shell.jsx lint/complexity/useOptionalChain -- pre-existing on develop (1x, unchanged)
+docs/design-prototype/shell.jsx lint/suspicious/noArrayIndexKey -- pre-existing on develop (1x, unchanged)
+docs/design-prototype/affordances.jsx format -- pre-existing on develop (1x, unchanged)
+docs/design-prototype/affordances.jsx lint/a11y/useKeyWithClickEvents -- pre-existing on develop (8x, unchanged); the filter/sort popovers' div items predate this branch
+docs/design-prototype/affordances.jsx lint/a11y/useButtonType -- pre-existing on develop (4x, unchanged)
+docs/design-prototype/affordances.jsx lint/complexity/useOptionalChain -- pre-existing on develop (2x, unchanged)
+docs/design-prototype/affordances.jsx lint/correctness/noUnusedVariables -- pre-existing on develop (2x, unchanged)

--- a/scripts/gates/frontend-biome-allowlist.txt
+++ b/scripts/gates/frontend-biome-allowlist.txt
@@ -102,3 +102,6 @@ apps/frontend/src/features/integration/routes/LinksRoute.tsx format -- pre-exist
 apps/frontend/src/features/voc/components/create/__tests__/AttachmentDropzone.test.tsx format -- pre-existing on develop (1x, unchanged); the violations are the file's own long expect/render lines, none of them in the multi-file test this branch adds
 apps/frontend/src/features/voc/components/create/__tests__/AttachmentDropzone.test.tsx organizeImports -- pre-existing on develop; import order predates biome
 apps/frontend/src/features/voc/components/create/__tests__/AttachmentDropzone.test.tsx lint/style/noNonNullAssertion -- pre-existing on develop (1x at the unchanged `spy.mock.calls[0]!` line, verified identical on develop)
+apps/frontend/src/lib/layout/AppRail.tsx organizeImports -- pre-existing on develop; import order predates biome
+apps/frontend/src/lib/layout/AppRail.tsx format -- pre-existing on develop (1x, unchanged; measured against `git show develop:` of the same file)
+apps/frontend/src/routes/login.test.tsx format -- pre-existing on develop (1x, unchanged); the file's long harness lines predate biome. AppRail.test.tsx was format-clean on develop, so the violation this branch introduced there was formatted rather than allowlisted


### PR DESCRIPTION
Slice 19 클러스터 C1. 블랙박스 두 건은 **한 뿌리**다 — 이 앱에는 액터/세션 생명주기가 없었다.

## 뿌리 (코드 실측, 이슈 진단과 다름)

**#326 — Mock User를 골랐는데 Mock Admin이 보인다.** 백엔드 버그가 아니다. `POST /auth/mock-login`은 새 세션을 발급하고 쿠키를 덮어쓴다(`auth/routes.ts:47-79`). 바뀌지 않은 건 클라이언트다: `login.tsx`가 성공 후 react-query를 건드리지 않고 이동만 해서, `['me']`(staleTime 5분)와 모든 액터 스코프 쿼리가 이전 액터 응답을 계속 서빙했다.

**#325 — 세션 경계가 없다.** 없던 건 기능이 아니라 컨트롤이다. `POST /auth/logout`과 FE 래퍼가 **호출자 0**으로 이미 있었고, ADR-0006이 "logout... take effect immediately"를 계약하고 있었다. 즉 발명이 아니라 미구현.

## 들어간 것

- `login.tsx` onSuccess가 이동 **전에** `queryClient.clear()`. `invalidateQueries`가 아니다 — invalidate는 캐시된 데이터를 화면에 둔 채 재조회하므로, 액터 경계에서는 깜빡임이 아니라 **정보 노출**이다. 순서까지 단언한다.
- 레일 하단 아바타(지금까지 `title`에 액터 이름만 들고 있던 비대화형 div)가 `DropdownMenu`가 된다. 액터 라벨 + `로그아웃` 두 줄뿐이다.
- 로그아웃은 revoke → clear → `/login`. clear와 이동은 `finally`에 있어서 **revoke가 실패해도 사용자가 인증된 화면에 갇히지 않는다.**

프로토타입은 로그아웃이 없었다. ADR-0006이 동작을 계약하고 있고 배치·카피는 어디에도 없어서, 사용자 승인을 받아 **프로토타입을 먼저 수정**했다(`d063516`, `de1a4e5`). 아바타는 이미 액터 정체성을 들고 있던 자리라 편차는 "div → 메뉴 버튼" 한 줄로 줄었다.

## 워커 산출물에서 잡은 결함 3건 (전부 테스트를 돌려야만 보이는 것)

1. **`vi.mock` 팩토리가 `const` 선언 위로 호이스팅**돼 스위트 자체가 로드 실패했다. → `vi.hoisted`.
2. **메뉴를 `mouseDown`으로 열었다.** Radix는 `pointerdown`으로 열리고 jsdom은 그걸 합성하지 못한다 — 실측: `fireEvent.pointerDown`은 `aria-expanded="false"`, `Enter`는 `"true"`. 헬퍼를 키보드로 바꿨고, 이건 마침 단언할 가치가 있는 상호작용이다(포인터로만 닿는 로그아웃은 #335의 네이티브 prompt와 같은 실패다).
3. **라벨이 `me`만 검사하고 `me.actor.display_name`을 읽었다.** `/me`는 `actor` 없이 응답할 수 있고, 그때 **프레임 전체가 에러 바운더리로 죽었다** — 고치려던 것보다 나쁜 버그다. 다른 스위트 2개가 잡아줬다. `me?.actor`로 막고, "액터 없음" 테스트를 두 형태로 확장했다(기존엔 `data: undefined`만 모킹해 재현 자체가 안 됐다).

## 뮤테이션 매트릭스 (각각 단독 적용 후 되돌림)

| 뮤테이션 | 발화한 단언 |
|---|---|
| login이 `clear()`를 빠뜨림 | 로그인 캐시 초기화 단언 |
| login이 `invalidateQueries()`로 바뀜 | 같은 단언(스파이가 `clear`에 걸려 있음) |
| logout이 `clear()`를 빠뜨림 | 로그아웃 테스트 2건 |
| logout이 `try/finally`를 잃음 | revoke 실패해도 이동한다 단언 |
| 라벨 가드를 `me &&`로 되돌림 | actor 없는 응답 케이스 + AppFrame.scope |

## 게이트 실측

```
frontend typecheck   0 errors
frontend vitest      796 passed / 149 files   (develop 789)
frontend visual      58 passed, 변화 없음
frontend biome       0 unexpected errors, 104 allowlisted
check:boundaries     OK
```

allowlist 추가분은 전부 `git show develop:`으로 같은 파일을 측정해 **개수까지 동일함을 확인한 기존 부채**다. 이 브랜치가 실제로 만든 2건(`AppRail.test.tsx` 포맷, `shell.jsx`의 클릭 가능한 div)은 allowlist가 아니라 **고쳤다.**

## 기각한 선택지

- **`invalidateQueries`** — 위 참조. 액터 경계에서 이전 데이터를 한 프레임이라도 보이면 안 된다.
- **`Popover`로 계정 메뉴 구성** — 메뉴 시맨틱과 키보드 동작이 필요해서 `DropdownMenu`를 썼다. 프로토타입은 Popover 프리미티브밖에 없어 그걸 썼지만, 프로덕션엔 Radix 메뉴가 이미 있다.
- **사이드바 푸터에 로그아웃 항목 추가** — 계정 행동을 워크스페이스 관리 항목과 섞게 된다. 사용자 판정으로 아바타 메뉴를 골랐다.

## 남은 것

- `#325`는 이 PR로 컨트롤이 생기지만, **블랙박스가 요구한 "완전히 새 세션" 보장**(탭/back stack 인계 없음)은 별개다. 로그아웃이 세션을 revoke하고 캐시를 비우므로 실질적 경계는 생겼지만, 브라우저 히스토리까지는 제품이 통제하지 않는다. 이슈에 남길 판단이 필요하다.
- `isLoggingOut`은 성공 시 리셋하지 않는다(이동하므로). 이동이 실패하면 항목이 비활성인 채 남는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BfiR55zJ7n8uYpr1s3X6q