### PR TITLE
fix(#327): 공백만 있는 필수값이 빈 VOC 정본을 만드는 것을 막는다

### DIFF
--- a/apps/backend/src/modules/voc/__tests__/create-voc-blank-fields.integration.test.ts
+++ b/apps/backend/src/modules/voc/__tests__/create-voc-blank-fields.integration.test.ts
@@ -36,14 +36,19 @@ async function loginAs(app: FastifyInstance, externalId: string): Promise<string
   return cookie;
 }
 
-async function createManagedSystem(app: FastifyInstance, cookie: string, slug: string): Promise<string> {
+async function createManagedSystem(
+  app: FastifyInstance,
+  cookie: string,
+  slug: string,
+): Promise<string> {
   const res = await app.inject({
     method: 'POST',
     url: '/managed-systems',
     headers: { cookie: `${SESSION_COOKIE_NAME}=${cookie}`, 'content-type': 'application/json' },
     payload: { slug, name: slug },
   });
-  if (res.statusCode !== 201) throw new Error(`createManagedSystem failed: ${res.statusCode} ${res.body}`);
+  if (res.statusCode !== 201)
+    throw new Error(`createManagedSystem failed: ${res.statusCode} ${res.body}`);
   return res.json().id;
 }
 
@@ -80,7 +85,9 @@ describe.skipIf(!runIntegration)('POST /vocs blank required fields (#327)', () =
         select id from core.managed_systems where slug = 'it-voc-blank-fields'
       )`,
     );
-    await dbHandle.pool.query(`delete from core.managed_systems where slug = 'it-voc-blank-fields'`);
+    await dbHandle.pool.query(
+      `delete from core.managed_systems where slug = 'it-voc-blank-fields'`,
+    );
     await dbHandle.pool.query('delete from core.idempotency_keys');
     await dbHandle.pool.query('delete from core.rate_limits');
   }
@@ -196,9 +203,10 @@ describe.skipIf(!runIntegration)('POST /vocs blank required fields (#327)', () =
     });
 
     expect(res.statusCode).toBe(201);
-    const stored = await dbHandle.pool.query<{ title: string }>('select title from voc.vocs where id = $1', [
-      res.json().id,
-    ]);
+    const stored = await dbHandle.pool.query<{ title: string }>(
+      'select title from voc.vocs where id = $1',
+      [res.json().id],
+    );
     expect(stored.rows[0]?.title).toBe('실제 제목');
   });
 

--- a/apps/backend/src/modules/voc/__tests__/create-voc-blank-fields.integration.test.ts
+++ b/apps/backend/src/modules/voc/__tests__/create-voc-blank-fields.integration.test.ts
@@ -1,0 +1,218 @@
+// POST /vocs blank required-field contract (#327).
+
+import { randomUUID } from 'node:crypto';
+
+import type { FastifyInstance } from 'fastify';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import { loadConfig } from '../../../config.js';
+import { type DbHandle, createDb } from '../../../db/client.js';
+import { SESSION_COOKIE_NAME } from '../../../middleware/require-session.js';
+import { buildServer } from '../../../server.js';
+
+const APP_URL = process.env.DATABASE_URL ?? '';
+const MIGRATE_URL = process.env.DATABASE_URL_MIGRATE ?? '';
+const WORKSPACE_ID = process.env.WORKSPACE_ID ?? '';
+const runIntegration = Boolean(APP_URL && WORKSPACE_ID);
+
+function extractSessionCookie(setCookie: string | string[] | undefined): string | null {
+  if (!setCookie) return null;
+  for (const cookie of Array.isArray(setCookie) ? setCookie : [setCookie]) {
+    const match = cookie.match(new RegExp(`${SESSION_COOKIE_NAME}=([^;]+)`));
+    if (match?.[1]) return match[1];
+  }
+  return null;
+}
+
+async function loginAs(app: FastifyInstance, externalId: string): Promise<string> {
+  const res = await app.inject({
+    method: 'POST',
+    url: '/auth/mock-login',
+    headers: { 'user-agent': 'integration-test' },
+    payload: { external_id: externalId },
+  });
+  const cookie = extractSessionCookie(res.headers['set-cookie']);
+  if (!cookie) throw new Error(`mock-login failed: ${res.statusCode} ${res.body}`);
+  return cookie;
+}
+
+async function createManagedSystem(app: FastifyInstance, cookie: string, slug: string): Promise<string> {
+  const res = await app.inject({
+    method: 'POST',
+    url: '/managed-systems',
+    headers: { cookie: `${SESSION_COOKIE_NAME}=${cookie}`, 'content-type': 'application/json' },
+    payload: { slug, name: slug },
+  });
+  if (res.statusCode !== 201) throw new Error(`createManagedSystem failed: ${res.statusCode} ${res.body}`);
+  return res.json().id;
+}
+
+function paragraphDoc(text: string) {
+  return {
+    type: 'doc' as const,
+    content: [{ type: 'paragraph', content: [{ type: 'text', text }] }],
+  };
+}
+
+function postVoc(app: FastifyInstance, cookie: string, body: Record<string, unknown>) {
+  return app.inject({
+    method: 'POST',
+    url: '/vocs',
+    headers: {
+      cookie: `${SESSION_COOKIE_NAME}=${cookie}`,
+      'content-type': 'application/json',
+      'idempotency-key': randomUUID(),
+    },
+    payload: body,
+  });
+}
+
+describe.skipIf(!runIntegration)('POST /vocs blank required fields (#327)', () => {
+  let app: FastifyInstance;
+  let dbHandle: DbHandle;
+  let adminCookie: string;
+  let reporterCookie: string;
+  let managedSystemId: string;
+
+  async function cleanupProductTables(): Promise<void> {
+    await dbHandle.pool.query(
+      `delete from voc.vocs where primary_managed_system_id in (
+        select id from core.managed_systems where slug = 'it-voc-blank-fields'
+      )`,
+    );
+    await dbHandle.pool.query(`delete from core.managed_systems where slug = 'it-voc-blank-fields'`);
+    await dbHandle.pool.query('delete from core.idempotency_keys');
+    await dbHandle.pool.query('delete from core.rate_limits');
+  }
+
+  // Deliberately NOT part of the per-test cleanup: the cookies are minted once
+  // in beforeAll, so deleting these rows before each test revokes them and
+  // every request after the first comes back 401.
+  async function cleanupSessions(): Promise<void> {
+    await dbHandle.pool.query(
+      `delete from core.sessions where created_user_agent_summary = 'integration-test'`,
+    );
+  }
+
+  async function cleanupAuditLog(): Promise<void> {
+    if (!MIGRATE_URL) return;
+    const ops = createDb(MIGRATE_URL);
+    try {
+      await ops.pool.query(
+        `delete from core.audit_log where event_type in ('managed_system_registered', 'voc_created')`,
+      );
+    } finally {
+      await ops.close();
+    }
+  }
+
+  beforeAll(async () => {
+    process.env.NODE_ENV = 'test';
+    dbHandle = createDb(APP_URL);
+    app = await buildServer({ config: loadConfig(), dbHandle });
+    await app.ready();
+    adminCookie = await loginAs(app, 'mock-admin-1');
+    reporterCookie = await loginAs(app, 'mock-user-1');
+  });
+
+  beforeEach(async () => {
+    await cleanupProductTables();
+    await cleanupAuditLog();
+    managedSystemId = await createManagedSystem(app, adminCookie, 'it-voc-blank-fields');
+  });
+
+  afterAll(async () => {
+    await cleanupProductTables();
+    await cleanupSessions();
+    await cleanupAuditLog();
+    await app?.close();
+    await dbHandle?.close();
+  });
+
+  it('rejects a whitespace-only title with a title field error', async () => {
+    const res = await postVoc(app, reporterCookie, {
+      primary_managed_system_id: managedSystemId,
+      title: '   ',
+      description_rich_content: paragraphDoc('real body'),
+    });
+
+    expect(res.statusCode).toBe(422);
+    expect(res.json().code).toBe('validation.failed');
+    expect(res.json().detail?.fields?.[0]?.path).toEqual(['title']);
+  });
+
+  it('rejects a whitespace-only description with a description field error and no row', async () => {
+    const before = await dbHandle.pool.query<{ count: number }>(
+      'select count(*)::int as count from voc.vocs where workspace_id = $1',
+      [WORKSPACE_ID],
+    );
+    const res = await postVoc(app, reporterCookie, {
+      primary_managed_system_id: managedSystemId,
+      title: 'real title',
+      description_rich_content: paragraphDoc('   '),
+    });
+    const after = await dbHandle.pool.query<{ count: number }>(
+      'select count(*)::int as count from voc.vocs where workspace_id = $1',
+      [WORKSPACE_ID],
+    );
+
+    expect(res.statusCode).toBe(422);
+    expect(res.json().code).toBe('validation.failed');
+    expect(res.json().detail?.fields?.[0]?.path).toEqual(['description_rich_content']);
+    expect(after.rows[0]?.count).toBe(before.rows[0]?.count);
+  });
+
+  it.each([
+    ['empty content array', { type: 'doc', content: [] }],
+    ['missing content', { type: 'doc' }],
+  ])('rejects a structurally empty description: %s', async (_name, description_rich_content) => {
+    const res = await postVoc(app, reporterCookie, {
+      primary_managed_system_id: managedSystemId,
+      title: 'real title',
+      description_rich_content,
+    });
+
+    expect(res.statusCode).toBe(422);
+    expect(res.json().code).toBe('validation.failed');
+    expect(res.json().detail?.fields?.[0]?.path).toEqual(['description_rich_content']);
+  });
+
+  it('accepts a normal title and text description', async () => {
+    const res = await postVoc(app, reporterCookie, {
+      primary_managed_system_id: managedSystemId,
+      title: 'normal title',
+      description_rich_content: paragraphDoc('normal body'),
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(res.json().id).toEqual(expect.any(String));
+  });
+
+  it('stores a trimmed title', async () => {
+    const res = await postVoc(app, reporterCookie, {
+      primary_managed_system_id: managedSystemId,
+      title: '  실제 제목  ',
+      description_rich_content: paragraphDoc('normal body'),
+    });
+
+    expect(res.statusCode).toBe(201);
+    const stored = await dbHandle.pool.query<{ title: string }>('select title from voc.vocs where id = $1', [
+      res.json().id,
+    ]);
+    expect(stored.rows[0]?.title).toBe('실제 제목');
+  });
+
+  it('accepts a textless attachmentRef description', async () => {
+    const res = await postVoc(app, reporterCookie, {
+      primary_managed_system_id: managedSystemId,
+      title: 'attachment content',
+      description_rich_content: {
+        type: 'doc',
+        content: [{ type: 'attachmentRef', attrs: { id: randomUUID() } }],
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(res.json().id).toEqual(expect.any(String));
+  });
+});

--- a/apps/frontend/src/features/voc/components/create/__tests__/VocCreateScreen.integration.test.tsx
+++ b/apps/frontend/src/features/voc/components/create/__tests__/VocCreateScreen.integration.test.tsx
@@ -33,6 +33,31 @@ vi.mock('@/lib/auth/useMe', () => ({
   useMe: vi.fn(),
 }));
 
+// RichEditor — ProseMirror mounts in jsdom but refuses text: measured here,
+// both userEvent.type and userEvent.paste leave the doc at an empty paragraph.
+// Since #327 made a non-blank description a submit precondition, these tests
+// need some way to supply one, and their subject is submit/routing/error
+// handling, not the editor. The editor's own behaviour is covered by its tests.
+vi.mock('@fops/ui', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@fops/ui')>()),
+  RichEditor: ({ onChange }: { onChange: (doc: unknown) => void }) => (
+    <textarea
+      data-testid="mock-rich-editor"
+      aria-label="상세 설명"
+      onChange={(e) =>
+        onChange(
+          e.target.value
+            ? {
+                type: 'doc',
+                content: [{ type: 'paragraph', content: [{ type: 'text', text: e.target.value }] }],
+              }
+            : { type: 'doc', content: [] },
+        )
+      }
+    />
+  ),
+}));
+
 import { toast } from 'sonner';
 import { useMe } from '@/lib/auth/useMe';
 import type { UseQueryResult } from '@tanstack/react-query';
@@ -225,6 +250,12 @@ describe('VocCreateScreen integration', () => {
     fireEvent.change(titleInput, { target: { value: '테스트 제목입니다' } });
     fireEvent.blur(titleInput);
 
+    // #327: a blank description is now rejected at the schema, which is what
+    // gates `formState.isValid` and therefore the submit button.
+    fireEvent.change(screen.getByTestId('mock-rich-editor'), {
+      target: { value: '재현 절차와 기대 동작' },
+    });
+
     // The description_rich_content has a default emptyTipTapDoc() — zod allows
     // it (type: 'doc', content: []). The form's isValid gate depends on the
     // zodResolver; with a valid MS ID and title the form should become valid.
@@ -267,6 +298,11 @@ describe('VocCreateScreen integration', () => {
     fireEvent.click(screen.getByRole('radio', { name: AA_ITEM.name }));
     fireEvent.change(screen.getByRole('textbox', { name: /제목/i }), { target: { value: '분류와 출처가 독립적인 VOC' } });
     fireEvent.blur(screen.getByRole('textbox', { name: /제목/i }));
+    // #327: a blank description is now rejected at the schema, which is what
+    // gates `formState.isValid` and therefore the submit button.
+    fireEvent.change(screen.getByTestId('mock-rich-editor'), {
+      target: { value: '재현 절차와 기대 동작' },
+    });
 
     await waitFor(() => expect(screen.getByRole('button', { name: 'VOC 제출' })).not.toBeDisabled());
     fireEvent.click(screen.getByRole('button', { name: 'VOC 제출' }));
@@ -314,6 +350,12 @@ describe('VocCreateScreen integration', () => {
     const titleInput = screen.getByRole('textbox', { name: /제목/i });
     fireEvent.change(titleInput, { target: { value: '제목' } });
     fireEvent.blur(titleInput);
+
+    // #327: a blank description is now rejected at the schema, which is what
+    // gates `formState.isValid` and therefore the submit button.
+    fireEvent.change(screen.getByTestId('mock-rich-editor'), {
+      target: { value: '재현 절차와 기대 동작' },
+    });
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'VOC 제출' })).not.toBeDisabled();
@@ -365,6 +407,12 @@ describe('VocCreateScreen integration', () => {
     fireEvent.change(titleInput, { target: { value: '제목' } });
     fireEvent.blur(titleInput);
 
+    // #327: a blank description is now rejected at the schema, which is what
+    // gates `formState.isValid` and therefore the submit button.
+    fireEvent.change(screen.getByTestId('mock-rich-editor'), {
+      target: { value: '재현 절차와 기대 동작' },
+    });
+
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'VOC 제출' })).not.toBeDisabled();
     });
@@ -399,6 +447,12 @@ describe('VocCreateScreen integration', () => {
     const titleInput = screen.getByRole('textbox', { name: /제목/i });
     fireEvent.change(titleInput, { target: { value: '제목' } });
     fireEvent.blur(titleInput);
+
+    // #327: a blank description is now rejected at the schema, which is what
+    // gates `formState.isValid` and therefore the submit button.
+    fireEvent.change(screen.getByTestId('mock-rich-editor'), {
+      target: { value: '재현 절차와 기대 동작' },
+    });
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'VOC 제출' })).not.toBeDisabled();
@@ -437,6 +491,12 @@ describe('VocCreateScreen integration', () => {
     fireEvent.change(titleInput, { target: { value: '제목' } });
     fireEvent.blur(titleInput);
 
+    // #327: a blank description is now rejected at the schema, which is what
+    // gates `formState.isValid` and therefore the submit button.
+    fireEvent.change(screen.getByTestId('mock-rich-editor'), {
+      target: { value: '재현 절차와 기대 동작' },
+    });
+
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'VOC 제출' })).not.toBeDisabled();
     });
@@ -470,6 +530,12 @@ describe('VocCreateScreen integration', () => {
     const titleInput = screen.getByRole('textbox', { name: /제목/i });
     fireEvent.change(titleInput, { target: { value: '제목' } });
     fireEvent.blur(titleInput);
+
+    // #327: a blank description is now rejected at the schema, which is what
+    // gates `formState.isValid` and therefore the submit button.
+    fireEvent.change(screen.getByTestId('mock-rich-editor'), {
+      target: { value: '재현 절차와 기대 동작' },
+    });
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'VOC 제출' })).not.toBeDisabled();

--- a/apps/frontend/src/features/voc/components/detail/ComposerReplyPreview.tsx
+++ b/apps/frontend/src/features/voc/components/detail/ComposerReplyPreview.tsx
@@ -48,7 +48,7 @@
 //   - bg-accent-primary/10 replaces rgba(94,106,210,0.12) (deep-violet @ 12% was the dark-pack
 //     aether-blue; in Pack 17 use bg-accent-primary/10 per PROTOTYPE-TO-PACK17 §1 notes)
 
-import { isTipTapDocStructurallyEmpty, type VocDetailEnvelope } from '@fops/shared';
+import { type VocDetailEnvelope, isTipTapDocStructurallyEmpty } from '@fops/shared';
 import { RichContentRenderer } from '@fops/ui';
 import type { TipTapDoc } from '@fops/ui';
 import type { ReactElement } from 'react';

--- a/apps/frontend/src/features/voc/components/detail/ComposerReplyPreview.tsx
+++ b/apps/frontend/src/features/voc/components/detail/ComposerReplyPreview.tsx
@@ -48,7 +48,7 @@
 //   - bg-accent-primary/10 replaces rgba(94,106,210,0.12) (deep-violet @ 12% was the dark-pack
 //     aether-blue; in Pack 17 use bg-accent-primary/10 per PROTOTYPE-TO-PACK17 §1 notes)
 
-import type { VocDetailEnvelope } from '@fops/shared';
+import { isTipTapDocStructurallyEmpty, type VocDetailEnvelope } from '@fops/shared';
 import { RichContentRenderer } from '@fops/ui';
 import type { TipTapDoc } from '@fops/ui';
 import type { ReactElement } from 'react';
@@ -68,20 +68,6 @@ export interface ComposerReplyPreviewProps {
   draftDoc: TipTapDoc | null;
 }
 
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
-function isDocEmpty(doc: TipTapDoc | null): boolean {
-  if (doc == null) return true;
-  const content = doc.content;
-  if (!Array.isArray(content) || content.length === 0) return true;
-  return content.every((node) => {
-    if (node == null || typeof node !== 'object') return true;
-    const n = node as { type?: string; content?: unknown[] };
-    if (n.type !== 'paragraph') return false;
-    return !Array.isArray(n.content) || n.content.length === 0;
-  });
-}
-
 // ── Component ─────────────────────────────────────────────────────────────────
 
 export function ComposerReplyPreview({
@@ -90,7 +76,7 @@ export function ComposerReplyPreview({
   reporter,
   draftDoc,
 }: ComposerReplyPreviewProps): ReactElement {
-  const empty = isDocEmpty(draftDoc);
+  const empty = isTipTapDocStructurallyEmpty(draftDoc);
 
   // Derive a short text excerpt from the description for the reporter bubble.
   // Prototype: voc.description.slice(0, 140) + '…' — we use voc.title as fallback

--- a/apps/frontend/src/features/voc/components/detail/ComposerSection.tsx
+++ b/apps/frontend/src/features/voc/components/detail/ComposerSection.tsx
@@ -22,7 +22,7 @@
 import { type ComposerSurface, useComposerDraft } from '@/features/voc/hooks/useComposerDraft';
 import { useComposerVisibility } from '@/features/voc/hooks/useComposerVisibility';
 import type { MeResponse } from '@/lib/auth/useMe';
-import { isTipTapDocStructurallyEmpty, type VocDetailEnvelope } from '@fops/shared';
+import { type VocDetailEnvelope, isTipTapDocStructurallyEmpty } from '@fops/shared';
 import { DirtyConfirmation } from '@fops/ui';
 import { X } from 'lucide-react';
 import * as React from 'react';

--- a/apps/frontend/src/features/voc/components/detail/ComposerSection.tsx
+++ b/apps/frontend/src/features/voc/components/detail/ComposerSection.tsx
@@ -22,31 +22,14 @@
 import { type ComposerSurface, useComposerDraft } from '@/features/voc/hooks/useComposerDraft';
 import { useComposerVisibility } from '@/features/voc/hooks/useComposerVisibility';
 import type { MeResponse } from '@/lib/auth/useMe';
-import type { VocDetailEnvelope } from '@fops/shared';
-import { DirtyConfirmation, type TipTapDoc } from '@fops/ui';
+import { isTipTapDocStructurallyEmpty, type VocDetailEnvelope } from '@fops/shared';
+import { DirtyConfirmation } from '@fops/ui';
 import { X } from 'lucide-react';
 import * as React from 'react';
 import { ComposerTabs } from './ComposerTabs';
 import { InternalCommentComposer } from './InternalCommentComposer';
 import { PublicUpdateComposer } from './PublicUpdateComposer';
 import { ReporterReplyComposer } from './ReporterReplyComposer';
-
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
-// Returns true when a TipTapDoc has no meaningful content (null, empty, or
-// only an empty paragraph). Mirrors the same logic the individual composers
-// use to gate their submit buttons.
-function isDocEmpty(doc: TipTapDoc | null): boolean {
-  if (doc == null) return true;
-  const content = doc.content;
-  if (!Array.isArray(content) || content.length === 0) return true;
-  return content.every((node) => {
-    if (node == null || typeof node !== 'object') return true;
-    const n = node as { type?: string; content?: unknown[] };
-    if (n.type !== 'paragraph') return false;
-    return !Array.isArray(n.content) || n.content.length === 0;
-  });
-}
 
 // ── Props ─────────────────────────────────────────────────────────────────────
 
@@ -95,9 +78,9 @@ export function ComposerSection({
   // useComposerDraft → this derivation, so close always sees the correct
   // dirty state regardless of pointer interaction.
   const isDirty =
-    !isDocEmpty(draft.state.public) ||
-    !isDocEmpty(draft.state.reply) ||
-    !isDocEmpty(draft.state.internal);
+    !isTipTapDocStructurallyEmpty(draft.state.public) ||
+    !isTipTapDocStructurallyEmpty(draft.state.reply) ||
+    !isTipTapDocStructurallyEmpty(draft.state.internal);
 
   // Reset tab when VOC changes (drafts auto-clear via useComposerDraft).
   const prevVocIdRef = React.useRef(voc.id);

--- a/apps/frontend/src/features/voc/components/detail/DescriptionSection.tsx
+++ b/apps/frontend/src/features/voc/components/detail/DescriptionSection.tsx
@@ -4,7 +4,7 @@
 // C6.2 of slice3 #21 retains the EditDescriptionModal hook on the reporter
 // affordance below the card.
 
-import { isTipTapDocStructurallyEmpty, type VocDetailEnvelope } from '@fops/shared';
+import { type VocDetailEnvelope, isTipTapDocStructurallyEmpty } from '@fops/shared';
 import { RichContentRenderer, type TipTapDoc } from '@fops/ui';
 import * as React from 'react';
 import { AttachmentChipList } from './AttachmentChip';
@@ -25,9 +25,7 @@ export function DescriptionSection({
 
   return (
     <div>
-      <p className="text-xs font-semibold uppercase tracking-wide text-text-muted mb-2">
-        BODY
-      </p>
+      <p className="text-xs font-semibold uppercase tracking-wide text-text-muted mb-2">BODY</p>
       <div
         data-testid="description-body-card"
         className="rounded-md bg-surface-card-elevated p-4 text-sm text-text-secondary leading-relaxed"

--- a/apps/frontend/src/features/voc/components/detail/DescriptionSection.tsx
+++ b/apps/frontend/src/features/voc/components/detail/DescriptionSection.tsx
@@ -4,7 +4,7 @@
 // C6.2 of slice3 #21 retains the EditDescriptionModal hook on the reporter
 // affordance below the card.
 
-import type { VocDetailEnvelope } from '@fops/shared';
+import { isTipTapDocStructurallyEmpty, type VocDetailEnvelope } from '@fops/shared';
 import { RichContentRenderer, type TipTapDoc } from '@fops/ui';
 import * as React from 'react';
 import { AttachmentChipList } from './AttachmentChip';
@@ -16,28 +16,11 @@ export interface DescriptionSectionProps {
   isReporterOnOwnVoc: boolean;
 }
 
-// A TipTap doc with no meaningful content. The schema requires { type: 'doc',
-// content?: unknown[] }, so we treat any of these as "empty" for UX fallback:
-//   - missing content array
-//   - empty content array
-//   - content with only empty paragraph nodes (no text children)
-function isDocEmpty(doc: unknown): boolean {
-  if (doc == null || typeof doc !== 'object') return true;
-  const content = (doc as { content?: unknown[] }).content;
-  if (!Array.isArray(content) || content.length === 0) return true;
-  return content.every((node) => {
-    if (node == null || typeof node !== 'object') return true;
-    const n = node as { type?: string; content?: unknown[] };
-    if (n.type !== 'paragraph') return false;
-    return !Array.isArray(n.content) || n.content.length === 0;
-  });
-}
-
 export function DescriptionSection({
   voc,
   isReporterOnOwnVoc,
 }: DescriptionSectionProps): React.ReactElement {
-  const empty = isDocEmpty(voc.description_rich_content);
+  const empty = isTipTapDocStructurallyEmpty(voc.description_rich_content);
   const [modalOpen, setModalOpen] = React.useState(false);
 
   return (

--- a/apps/frontend/src/features/voc/components/detail/ReporterReplyComposer.tsx
+++ b/apps/frontend/src/features/voc/components/detail/ReporterReplyComposer.tsx
@@ -41,7 +41,7 @@ import { useVocReporterReplyMutation } from '@/features/voc/hooks/useVocReporter
 import type { ApiError } from '@/lib/api';
 import { uploadAttachment } from '@/lib/api/attachments';
 import type { MeResponse } from '@/lib/auth/useMe';
-import type { VocDetailEnvelope } from '@fops/shared';
+import { isTipTapDocStructurallyEmpty, type VocDetailEnvelope } from '@fops/shared';
 import { Callout, PreviewModal, RichEditor } from '@fops/ui';
 import type { TipTapDoc } from '@fops/ui';
 import { useQueryClient } from '@tanstack/react-query';
@@ -62,20 +62,6 @@ export interface ReporterReplyComposerProps {
   draftDoc?: TipTapDoc | null;
   /** REV-1 #7: called when the editor content changes. */
   onDraftChange?: (doc: TipTapDoc | null) => void;
-}
-
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
-function isDocEmpty(doc: TipTapDoc | null): boolean {
-  if (doc == null) return true;
-  const content = doc.content;
-  if (!Array.isArray(content) || content.length === 0) return true;
-  return content.every((node) => {
-    if (node == null || typeof node !== 'object') return true;
-    const n = node as { type?: string; content?: unknown[] };
-    if (n.type !== 'paragraph') return false;
-    return !Array.isArray(n.content) || n.content.length === 0;
-  });
 }
 
 // Maps ApiError code to Callout tone for the inline error surface.
@@ -125,7 +111,7 @@ export function ReporterReplyComposer({
     setPreviewOpen(false);
   }
 
-  const isEmpty = isDocEmpty(draftDoc);
+  const isEmpty = isTipTapDocStructurallyEmpty(draftDoc);
 
   const mutation = useVocReporterReplyMutation({
     onSuccess: () => {

--- a/apps/frontend/src/features/voc/components/detail/ReporterReplyComposer.tsx
+++ b/apps/frontend/src/features/voc/components/detail/ReporterReplyComposer.tsx
@@ -41,7 +41,7 @@ import { useVocReporterReplyMutation } from '@/features/voc/hooks/useVocReporter
 import type { ApiError } from '@/lib/api';
 import { uploadAttachment } from '@/lib/api/attachments';
 import type { MeResponse } from '@/lib/auth/useMe';
-import { isTipTapDocStructurallyEmpty, type VocDetailEnvelope } from '@fops/shared';
+import { type VocDetailEnvelope, isTipTapDocStructurallyEmpty } from '@fops/shared';
 import { Callout, PreviewModal, RichEditor } from '@fops/ui';
 import type { TipTapDoc } from '@fops/ui';
 import { useQueryClient } from '@tanstack/react-query';

--- a/apps/frontend/src/features/voc/components/detail/ReporterStatusChangeBlock.tsx
+++ b/apps/frontend/src/features/voc/components/detail/ReporterStatusChangeBlock.tsx
@@ -64,7 +64,11 @@
 import * as React from 'react';
 import { Megaphone, User, Check, ShieldCheck } from 'lucide-react';
 import { Callout, ReporterStatusBadge, RichContentRenderer, UserAvatar, type TipTapDoc } from '@fops/ui';
-import type { VocDetailEnvelope, ReporterFacingStatusEnum } from '@fops/shared';
+import {
+  isTipTapDocStructurallyEmpty,
+  type VocDetailEnvelope,
+  type ReporterFacingStatusEnum,
+} from '@fops/shared';
 import { REPORTER_FACING_STATUS_ALL, REPORTER_STATUS_LABELS } from '@/lib/copy/reporter-status-labels';
 import { useReporterStatusTransitions } from '@/features/voc/hooks/useReporterStatusTransitions';
 
@@ -89,20 +93,6 @@ export interface ReporterStatusChangeBlockProps {
   draftDoc: TipTapDoc | null;
   /** Owner actor for the preview attribution line. */
   owner: OwnerPreview;
-}
-
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
-function isDocEmpty(doc: TipTapDoc | null): boolean {
-  if (doc == null) return true;
-  const content = doc.content;
-  if (!Array.isArray(content) || content.length === 0) return true;
-  return content.every((node) => {
-    if (node == null || typeof node !== 'object') return true;
-    const n = node as { type?: string; content?: unknown[] };
-    if (n.type !== 'paragraph') return false;
-    return !Array.isArray(n.content) || n.content.length === 0;
-  });
 }
 
 // ── Component ─────────────────────────────────────────────────────────────────
@@ -135,7 +125,7 @@ export function ReporterStatusChangeBlock({
   const isGateBlocked =
     gate !== null && gate.blocking_for.includes(nextStatus);
 
-  const showBody = !isDocEmpty(draftDoc);
+  const showBody = !isTipTapDocStructurallyEmpty(draftDoc);
 
   return (
     <div

--- a/docs/implementation/03-api-contracts.md
+++ b/docs/implementation/03-api-contracts.md
@@ -147,6 +147,10 @@ source_context optional enum: direct_use | proxy_report | operational_discovery 
 attachments optional attachment references
 ```
 
+`title` must contain at least one character after trimming; the trimmed value is
+stored. `description_rich_content` must contain non-whitespace content. Either
+required-value violation returns `422 validation.failed`.
+
 `POST /vocs` must not accept:
 
 ```text

--- a/packages/shared/src/vocs/__tests__/create-request.test.ts
+++ b/packages/shared/src/vocs/__tests__/create-request.test.ts
@@ -1,10 +1,18 @@
 import { describe, expect, it } from 'vitest';
 import { createVocRequestSchema, FORBIDDEN_CREATE_FIELDS } from '../create-request.js';
 
+// The body used to be `content: []`, which encoded a weaker contract than the
+// product has: the create form marks 상세 설명 required and the prototype gates
+// submit on `body.trim()`. #327 shipped that rule to the wire, so the shared
+// fixture has to carry a real body. The detail screen's `설명 없음` state stays
+// — it renders rows created before the rule, not new ones.
 const VALID = {
   primary_managed_system_id: '00000000-0000-4000-8000-000000000001',
   title: 'something broke',
-  description_rich_content: { type: 'doc', content: [] },
+  description_rich_content: {
+    type: 'doc',
+    content: [{ type: 'paragraph', content: [{ type: 'text', text: '재현 절차' }] }],
+  },
 };
 
 describe('createVocRequestSchema', () => {
@@ -54,6 +62,39 @@ describe('createVocRequestSchema', () => {
 
   it('rejects title length 0', () => {
     expect(() => createVocRequestSchema.parse({ ...VALID, title: '' })).toThrow();
+  });
+
+  // #327 at the schema boundary. The integration test covers the route; these
+  // pin the contract where both the API and the create form's resolver read it.
+  it('rejects a whitespace-only title', () => {
+    expect(() => createVocRequestSchema.parse({ ...VALID, title: '   ' })).toThrow();
+  });
+
+  it('trims the stored title', () => {
+    expect(createVocRequestSchema.parse({ ...VALID, title: '  실제 제목  ' }).title).toBe(
+      '실제 제목',
+    );
+  });
+
+  it('rejects a whitespace-only description', () => {
+    expect(() =>
+      createVocRequestSchema.parse({
+        ...VALID,
+        description_rich_content: {
+          type: 'doc',
+          content: [{ type: 'paragraph', content: [{ type: 'text', text: '   ' }] }],
+        },
+      }),
+    ).toThrow();
+  });
+
+  it('rejects a structurally empty description', () => {
+    expect(() =>
+      createVocRequestSchema.parse({
+        ...VALID,
+        description_rich_content: { type: 'doc', content: [] },
+      }),
+    ).toThrow();
   });
 
   it('rejects unknown source_context', () => {

--- a/packages/shared/src/vocs/__tests__/rich-content.test.ts
+++ b/packages/shared/src/vocs/__tests__/rich-content.test.ts
@@ -15,17 +15,44 @@ describe('TipTap rich-content emptiness', () => {
     ],
     [
       'multiple whitespace text nodes',
-      { type: 'doc', content: [{ type: 'paragraph', content: [{ type: 'text', text: ' ' }, { type: 'text', text: '\n\t' }] }] },
+      {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [
+              { type: 'text', text: ' ' },
+              { type: 'text', text: '\n\t' },
+            ],
+          },
+        ],
+      },
       true,
     ],
     [
       'text content',
-      { type: 'doc', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'actual text' }] }] },
+      {
+        type: 'doc',
+        content: [{ type: 'paragraph', content: [{ type: 'text', text: 'actual text' }] }],
+      },
       false,
     ],
     [
       'nested text content',
-      { type: 'doc', content: [{ type: 'bulletList', content: [{ type: 'listItem', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'nested' }] }] }] }] },
+      {
+        type: 'doc',
+        content: [
+          {
+            type: 'bulletList',
+            content: [
+              {
+                type: 'listItem',
+                content: [{ type: 'paragraph', content: [{ type: 'text', text: 'nested' }] }],
+              },
+            ],
+          },
+        ],
+      },
       false,
     ],
     ['textless image node', { type: 'doc', content: [{ type: 'image' }] }, false],
@@ -34,15 +61,31 @@ describe('TipTap rich-content emptiness', () => {
     // the surface allowlist keeps ownership of "is this node permitted" and can
     // answer rich_content.disallowed_node. Treating unknowns as nothing made a
     // mention-only document report as blank and swallowed that contract.
-    ['textless mention node', { type: 'doc', content: [{ type: 'mention', attrs: { id: 'u-1' } }] }, false],
+    [
+      'textless mention node',
+      { type: 'doc', content: [{ type: 'mention', attrs: { id: 'u-1' } }] },
+      false,
+    ],
     ['entirely unknown node type', { type: 'doc', content: [{ type: 'somethingNew' }] }, false],
     // Structural scaffolding with nothing in it is still blank.
     [
       'empty list scaffolding',
-      { type: 'doc', content: [{ type: 'bulletList', content: [{ type: 'listItem', content: [{ type: 'paragraph', content: [] }] }] }] },
+      {
+        type: 'doc',
+        content: [
+          {
+            type: 'bulletList',
+            content: [{ type: 'listItem', content: [{ type: 'paragraph', content: [] }] }],
+          },
+        ],
+      },
       true,
     ],
-    ['whitespace-only code block', { type: 'doc', content: [{ type: 'codeBlock', content: [{ type: 'text', text: '  ' }] }] }, true],
+    [
+      'whitespace-only code block',
+      { type: 'doc', content: [{ type: 'codeBlock', content: [{ type: 'text', text: '  ' }] }] },
+      true,
+    ],
   ])('blank: %s', (_name, doc, expected) => {
     expect(isTipTapDocBlank(doc)).toBe(expected);
   });

--- a/packages/shared/src/vocs/__tests__/rich-content.test.ts
+++ b/packages/shared/src/vocs/__tests__/rich-content.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import { isTipTapDocBlank, isTipTapDocStructurallyEmpty } from '../rich-content.js';
+
+describe('TipTap rich-content emptiness', () => {
+  it.each([
+    ['null', null, true],
+    ['non-object', 'text', true],
+    ['missing content', { type: 'doc' }, true],
+    ['empty content', { type: 'doc', content: [] }, true],
+    [
+      'one whitespace text node',
+      { type: 'doc', content: [{ type: 'paragraph', content: [{ type: 'text', text: '   ' }] }] },
+      true,
+    ],
+    [
+      'multiple whitespace text nodes',
+      { type: 'doc', content: [{ type: 'paragraph', content: [{ type: 'text', text: ' ' }, { type: 'text', text: '\n\t' }] }] },
+      true,
+    ],
+    [
+      'text content',
+      { type: 'doc', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'actual text' }] }] },
+      false,
+    ],
+    [
+      'nested text content',
+      { type: 'doc', content: [{ type: 'bulletList', content: [{ type: 'listItem', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'nested' }] }] }] }] },
+      false,
+    ],
+    ['textless image node', { type: 'doc', content: [{ type: 'image' }] }, false],
+    ['textless attachment reference', { type: 'doc', content: [{ type: 'attachmentRef' }] }, false],
+    // A node type this predicate has never heard of must count as content, so
+    // the surface allowlist keeps ownership of "is this node permitted" and can
+    // answer rich_content.disallowed_node. Treating unknowns as nothing made a
+    // mention-only document report as blank and swallowed that contract.
+    ['textless mention node', { type: 'doc', content: [{ type: 'mention', attrs: { id: 'u-1' } }] }, false],
+    ['entirely unknown node type', { type: 'doc', content: [{ type: 'somethingNew' }] }, false],
+    // Structural scaffolding with nothing in it is still blank.
+    [
+      'empty list scaffolding',
+      { type: 'doc', content: [{ type: 'bulletList', content: [{ type: 'listItem', content: [{ type: 'paragraph', content: [] }] }] }] },
+      true,
+    ],
+    ['whitespace-only code block', { type: 'doc', content: [{ type: 'codeBlock', content: [{ type: 'text', text: '  ' }] }] }, true],
+  ])('blank: %s', (_name, doc, expected) => {
+    expect(isTipTapDocBlank(doc)).toBe(expected);
+  });
+
+  it('keeps whitespace text paragraphs structurally non-empty', () => {
+    expect(
+      isTipTapDocStructurallyEmpty({
+        type: 'doc',
+        content: [{ type: 'paragraph', content: [{ type: 'text', text: '   ' }] }],
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/shared/src/vocs/create-request.ts
+++ b/packages/shared/src/vocs/create-request.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+import { isTipTapDocBlank } from './rich-content.js';
+
 export const SOURCE_CONTEXTS = [
   'direct_use',
   'proxy_report',
@@ -56,8 +58,13 @@ export type ForbiddenCreateField = (typeof FORBIDDEN_CREATE_FIELDS)[number];
 
 export const createVocRequestSchema = z.object({
   primary_managed_system_id: z.string().uuid(),
-  title: z.string().min(1).max(200),
-  description_rich_content: tipTapDocSchema,
+  title: z.string().trim().min(1).max(200),
+  // Korean because `VocCreateScreen` renders this message verbatim under the
+  // editor. The schema's other messages are still zod's English defaults —
+  // pre-existing, and not something this change should widen into.
+  description_rich_content: tipTapDocSchema.refine((doc) => !isTipTapDocBlank(doc), {
+    message: '상세 설명을 입력해 주세요.',
+  }),
   analytics_area_id: z.string().uuid().optional(),
   source_context: sourceContextSchema.default('direct_use'),
   attachment_ids: attachmentIdsSchema.optional(),

--- a/packages/shared/src/vocs/index.ts
+++ b/packages/shared/src/vocs/index.ts
@@ -13,3 +13,4 @@ export * from './public-update-review-candidate.js';
 export * from './pre-submit-peers.js';
 export * from './recommendations.js';
 export * from './reporter-reply-request.js';
+export * from './rich-content.js';

--- a/packages/shared/src/vocs/rich-content.ts
+++ b/packages/shared/src/vocs/rich-content.ts
@@ -1,0 +1,56 @@
+export function isTipTapDocStructurallyEmpty(doc: unknown): boolean {
+  if (doc == null || typeof doc !== 'object') return true;
+  const content = (doc as { content?: unknown[] }).content;
+  if (!Array.isArray(content) || content.length === 0) return true;
+  return content.every((node) => {
+    if (node == null || typeof node !== 'object') return true;
+    const n = node as { type?: string; content?: unknown[] };
+    if (n.type !== 'paragraph') return false;
+    return !Array.isArray(n.content) || n.content.length === 0;
+  });
+}
+
+/**
+ * Node types that carry no meaning on their own — they are the document, its
+ * blocks, and its list scaffolding. Everything else (attachmentRef, mention,
+ * image, and any type this list has not heard of) is content even when it has
+ * no text.
+ *
+ * Listing the *structural* types rather than the contentful ones is deliberate.
+ * The surface allowlists in `rich-content/allowlist.ts` decide which node types
+ * are permitted, and they report a precise `rich_content.disallowed_node`. If
+ * this predicate treated unknown types as nothing, a document made only of a
+ * disallowed node would be reported as "blank" instead, and the caller would
+ * lose that error — which is exactly what happened to the mention-node contract
+ * test before this list was inverted.
+ */
+const STRUCTURAL_NODE_TYPES = new Set([
+  'doc',
+  'paragraph',
+  'text',
+  'hardBreak',
+  'heading',
+  'blockquote',
+  'codeBlock',
+  'bulletList',
+  'orderedList',
+  'listItem',
+]);
+
+export function isTipTapDocBlank(doc: unknown): boolean {
+  let text = '';
+  let hasContentNode = false;
+
+  function visit(node: unknown): void {
+    if (node == null || typeof node !== 'object' || Array.isArray(node)) return;
+    const value = node as { type?: unknown; text?: unknown; content?: unknown };
+    if (value.type === 'text' && typeof value.text === 'string') text += value.text;
+    else if (typeof value.type === 'string' && !STRUCTURAL_NODE_TYPES.has(value.type)) {
+      hasContentNode = true;
+    }
+    if (Array.isArray(value.content)) value.content.forEach(visit);
+  }
+
+  visit(doc);
+  return !hasContentNode && text.trim().length === 0;
+}

--- a/scripts/gates/frontend-biome-allowlist.txt
+++ b/scripts/gates/frontend-biome-allowlist.txt
@@ -114,3 +114,11 @@ docs/design-prototype/affordances.jsx lint/a11y/useKeyWithClickEvents -- pre-exi
 docs/design-prototype/affordances.jsx lint/a11y/useButtonType -- pre-existing on develop (4x, unchanged)
 docs/design-prototype/affordances.jsx lint/complexity/useOptionalChain -- pre-existing on develop (2x, unchanged)
 docs/design-prototype/affordances.jsx lint/correctness/noUnusedVariables -- pre-existing on develop (2x, unchanged)
+apps/frontend/src/features/voc/components/detail/DescriptionSection.tsx format -- pre-existing on develop (1x, unchanged; measured against `git show develop:` of the same file)
+apps/frontend/src/features/voc/components/detail/ReporterStatusChangeBlock.tsx format -- pre-existing on develop (1x, unchanged)
+apps/frontend/src/features/voc/components/detail/ReporterStatusChangeBlock.tsx organizeImports -- pre-existing on develop; import order predates biome
+apps/frontend/src/features/voc/components/detail/ReporterStatusChangeBlock.tsx lint/complexity/useOptionalChain -- pre-existing on develop (1x, unchanged)
+apps/frontend/src/features/voc/components/detail/ReporterStatusChangeBlock.tsx lint/style/useImportType -- pre-existing on develop (1x, unchanged)
+packages/shared/src/vocs/create-request.ts format -- pre-existing on develop (1x, unchanged)
+packages/shared/src/vocs/__tests__/create-request.test.ts format -- pre-existing on develop (1x, unchanged)
+packages/shared/src/vocs/__tests__/create-request.test.ts organizeImports -- pre-existing on develop; import order predates biome


### PR DESCRIPTION
Slice 19 클러스터 C2. 블랙박스에서 제목·본문에 공백 3칸을 넣고 제출해 빈 정본 VOC-1683이 생겼다.

## 뿌리 — 한 파일

`packages/shared/src/vocs/create-request.ts`:
- `title: z.string().min(1)` — `.trim()`이 없어 `'   '`가 통과
- `description_rich_content` — TipTap 봉투 구조만 보고 내용이 있는지는 묻지 않음

작성 화면의 제출 버튼도 **같은 뿌리**다. `formState.isValid`가 이 resolver를 읽는다. **FE만 고쳤으면 API 직접 호출로 그대로 재현됐다.**

## 들어간 것

- `title`은 `.trim().min(1)`. trim을 앞에 둬서 **저장되는 값도 trim된다.**
- 본문에 blank 검사. 거부 메시지는 한국어다 — `VocCreateScreen`이 그 문자열을 그대로 렌더한다.
- `components/detail/`에 **바이트 단위로 동일하게 5벌** 있던 `isDocEmpty`를 shared `isTipTapDocStructurallyEmpty` 하나로 합쳤다.

## 판정이 왜 둘인가

기존 `isDocEmpty`는 **구조만** 본다 — `paragraph`에 자식이 있으면 "비어 있지 않다". 공백 3칸은 `text: "   "` 노드를 가진 paragraph를 만들므로 **그 판정으로는 안 비어 있다.** 그게 이 버그가 통과한 이유다. 그래서 검증용 `isTipTapDocBlank`를 따로 만들었고, **두 판정이 그 문서에서 서로 다른 답을 낸다는 것을 단언하는 테스트**를 넣었다.

`isTipTapDocBlank`는 **구조 노드 타입을 나열하고 나머지를 전부 내용으로 취급**한다. 처음엔 반대로 `image`·`attachmentRef`만 내용으로 셌는데, 그러면 mention만 있는 문서가 "blank"로 읽혀 **sanitizer의 `rich_content.disallowed_node`를 삼켜버린다** — 이미 테스트까지 있는 계약이다. "이 노드가 허용되나"는 surface allowlist가 소유하고, 이 판정은 "뭐라도 있나"만 소유한다.

## 낡은 픽스처 2건 — 우회하지 않고 갱신했다

- shared 스키마 테스트가 `content: []`를 **유효한 본문**으로 박아뒀다. 프로토타입은 `isValid = title.trim() && body.trim() && ms`로 본문을 필수로 계약한다. 픽스처가 제품보다 약한 계약을 인코딩하고 있었다.
- `VocCreateScreen` 통합 테스트 7건이 **본문을 아예 안 채웠고**, "zod가 허용한다"는 주석까지 달려 있었다. 이제 채운다 — 단, ProseMirror는 jsdom에서 텍스트를 받지 않는다(실측: `userEvent.type`·`userEvent.paste` 둘 다 빈 paragraph). 그래서 해당 파일 안에서만 `RichEditor`를 대역으로 바꿨다. 이 7건의 주제는 제출·라우팅·오류 처리이고 편집기 자체는 자기 테스트가 있다.

## 워커 산출물 결함

통합 테스트가 `beforeEach`에서 `core.sessions`를 지워 **`beforeAll`에서 만든 쿠키를 revoke**했다. 첫 요청부터 401이었다. 세션 정리를 `afterAll`로 옮겼다.

## 뮤테이션 매트릭스 (각각 단독 적용 후 되돌림)

| 뮤테이션 | 발화한 단언 |
|---|---|
| title에서 `.trim()` 제거 | 공백 제목 거부; trim된 제목 저장 |
| blank refine을 항상 통과로 | 본문 거부 3건 전부 |
| blank 판정에서 `trim()` 제거 | 공백만 있는 본문 케이스 |
| 내용 노드 규칙을 image/attachmentRef로 축소 | mention·미지의 타입 단위 테스트 + **기존 sanitizer 계약 테스트** |

## 게이트 실측

```
shared               437 passed
frontend vitest      796 passed / 149 files
backend integration  src/modules/voc — 42 files / 429 tests passed
frontend typecheck   0 errors
frontend visual      58 passed, 변화 없음
frontend biome       0 unexpected errors, 112 allowlisted
check:boundaries     OK
```

allowlist 추가분은 전부 develop 대조로 확인한 기존 부채다. 이 브랜치가 만든 것(새 테스트 파일 2건의 포맷, shared 헬퍼 import로 깨진 detail 컴포넌트 4건의 import 순서)은 **고쳤다.**

## 의도적으로 남긴 것

`reporter-reply`, `public-update`, `internal-comment`, `edit-description` 요청 스키마에 **같은 구멍이 있다.** 이 PR은 #327이 지목한 VOC 생성만 고친다. 별도 이슈로 뗄지 판단이 필요하다.

또 하나: 클라이언트 측 zod 메시지는 본문 하나만 한국어이고 나머지(예: 제목 `min(1)`)는 zod 영어 기본값이다. 기존 상태이고 이 변경이 넓히지 않았다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BfiR55zJ7n8uYpr1s3X6q