### PR TITLE
fix(#335,#336): Task Request 결정 다이얼로그 + 프리뷰에서 공개 업데이트 발행

### DIFF
--- a/apps/frontend/src/features/tasks/routes/TaskRequestsRoute.decision.test.tsx
+++ b/apps/frontend/src/features/tasks/routes/TaskRequestsRoute.decision.test.tsx
@@ -1,0 +1,246 @@
+import type { TaskRequestDto } from '@fops/shared';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type * as React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TaskRequestsRoute } from './TaskRequestsRoute';
+
+const api = vi.hoisted(() => ({
+  approveTaskRequest: vi.fn(),
+  fetchMe: vi.fn(),
+  fetchPermissionCheck: vi.fn(),
+  fetchTaskRequests: vi.fn(),
+  rejectTaskRequest: vi.fn(),
+  requestMoreEvidenceForTaskRequest: vi.fn(),
+  resolveActors: vi.fn(),
+}));
+const toast = vi.hoisted(() => Object.assign(vi.fn(), { error: vi.fn() }));
+
+const requesterId = '20000000-0000-0000-0000-000000000002';
+const reviewerId = '60000000-0000-0000-0000-000000000006';
+const taskRequest: TaskRequestDto = {
+  id: '10000000-0000-0000-0000-000000000001',
+  workspace_id: '90000000-0000-0000-0000-000000000009',
+  display_id: 'REQ-1071',
+  source_type: 'finding',
+  source_id: '40000000-0000-0000-0000-000000000004',
+  primary_managed_system_id: '30000000-0000-0000-0000-000000000003',
+  evidence_summary: 'Evidence summary',
+  requested_outcome: 'Review the candidate task',
+  requester_actor_id: requesterId,
+  status: 'pending_review',
+  reviewer_actor_id: null,
+  decision_reason: null,
+  decided_at: null,
+  created_at: '2026-07-10T00:00:00.000Z',
+  updated_at: '2026-07-10T00:00:00.000Z',
+  source: undefined,
+};
+
+vi.mock('sonner', () => ({ toast }));
+vi.mock('@fops/ui', async () => {
+  const actual = await vi.importActual<typeof import('@fops/ui')>('@fops/ui');
+  return {
+    ...actual,
+    ListShell: ({
+      list,
+      detailPanel,
+    }: { list: React.ReactNode; detailPanel?: React.ReactNode }) => (
+      <div>
+        <main>{list}</main>
+        <aside>{detailPanel}</aside>
+      </div>
+    ),
+  };
+});
+vi.mock('@/features/integration/hooks/useFindingDetail', () => ({
+  useFindingDetail: () => ({ data: null }),
+}));
+vi.mock('@/lib/api/analytics-areas', () => ({
+  fetchAnalyticsAreas: vi.fn(async () => ({ items: [] })),
+}));
+vi.mock('@/lib/api/managed-systems', () => ({
+  fetchManagedSystems: vi.fn(async () => ({
+    items: [{ id: taskRequest.primary_managed_system_id, name: 'Billing Ops' }],
+  })),
+}));
+vi.mock('@/lib/api', () => ({
+  approveTaskRequest: api.approveTaskRequest,
+  convertTaskRequest: vi.fn(),
+  fetchMe: api.fetchMe,
+  fetchPermissionCheck: api.fetchPermissionCheck,
+  fetchTaskRequests: api.fetchTaskRequests,
+  linkExistingTask: vi.fn(),
+  listTasks: vi.fn(async () => ({ items: [] })),
+  rejectTaskRequest: api.rejectTaskRequest,
+  requestMoreEvidenceForTaskRequest: api.requestMoreEvidenceForTaskRequest,
+  resolveActors: api.resolveActors,
+}));
+
+function setActor(id: string) {
+  api.fetchMe.mockResolvedValue({
+    actor: {
+      id,
+      external_id: 'mock-admin',
+      email: 'admin@feedbackops.local',
+      display_name: 'Mock Admin',
+      role_level: 'admin',
+    },
+    workspace_id: taskRequest.workspace_id,
+  });
+}
+
+function renderRoute() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={queryClient}>
+      <TaskRequestsRoute selectedParam={taskRequest.id} />
+    </QueryClientProvider>,
+  );
+}
+
+async function mountRoute() {
+  renderRoute();
+  await screen.findByText('Review decision');
+}
+
+async function openDialog(buttonName: string, dialogName: string) {
+  await mountRoute();
+  fireEvent.click(screen.getByRole('button', { name: buttonName }));
+  return screen.findByRole('dialog', { name: dialogName });
+}
+
+function expectDecisionCall(mock: ReturnType<typeof vi.fn>, payload: object) {
+  expect(mock).toHaveBeenCalledTimes(1);
+  expect(mock).toHaveBeenCalledWith(taskRequest.id, payload, expect.any(String));
+}
+
+describe('TaskRequestsRoute decision dialogs', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    api.approveTaskRequest.mockReset();
+    api.fetchMe.mockReset();
+    api.fetchPermissionCheck.mockReset();
+    api.fetchTaskRequests.mockReset();
+    api.rejectTaskRequest.mockReset();
+    api.requestMoreEvidenceForTaskRequest.mockReset();
+    api.resolveActors.mockReset();
+    api.fetchTaskRequests.mockResolvedValue({ items: [taskRequest] });
+    api.fetchPermissionCheck.mockResolvedValue({ state: 'approved' });
+    api.resolveActors.mockResolvedValue({ actors: [], teams: [] });
+    api.approveTaskRequest.mockResolvedValue(taskRequest);
+    api.rejectTaskRequest.mockResolvedValue(taskRequest);
+    api.requestMoreEvidenceForTaskRequest.mockResolvedValue(taskRequest);
+    setActor(reviewerId);
+    toast.mockReset();
+    toast.error.mockReset();
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it('opens approval without invoking window.prompt', async () => {
+    const prompt = vi.spyOn(window, 'prompt');
+    await openDialog('Approve', 'Approve Task Request');
+    expect(prompt).not.toHaveBeenCalled();
+  });
+
+  it('approves another actor request without an optional reason', async () => {
+    await openDialog('Approve', 'Approve Task Request');
+    fireEvent.click(screen.getByRole('button', { name: 'Approve Task Request' }));
+    await waitFor(() => expectDecisionCall(api.approveTaskRequest, {}));
+  });
+
+  it('trims an approval reason for another actor request', async () => {
+    await openDialog('Approve', 'Approve Task Request');
+    fireEvent.change(screen.getByRole('textbox', { name: 'Approval reason' }), {
+      target: { value: '  Ready for execution.  ' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Approve Task Request' }));
+    await waitFor(() =>
+      expectDecisionCall(api.approveTaskRequest, { reason: 'Ready for execution.' }),
+    );
+  });
+
+  it('keeps a self-approval dialog open when its reason is blank', async () => {
+    setActor(requesterId);
+    await openDialog('Approve', 'Approve Task Request');
+    fireEvent.change(screen.getByRole('textbox', { name: 'Self-approval reason' }), {
+      target: { value: '   ' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Approve Task Request' }));
+    expect(await screen.findByRole('alert')).toHaveTextContent('Self-approval requires a reason.');
+    expect(screen.getByRole('dialog', { name: 'Approve Task Request' })).toBeInTheDocument();
+    expect(api.approveTaskRequest).not.toHaveBeenCalled();
+  });
+
+  it('cancels without dispatching a mutation', async () => {
+    await openDialog('Approve', 'Approve Task Request');
+    fireEvent.click(screen.getByTestId('task-request-decision-cancel'));
+    await waitFor(() =>
+      expect(
+        screen.queryByRole('dialog', { name: 'Approve Task Request' }),
+      ).not.toBeInTheDocument(),
+    );
+    expect(api.approveTaskRequest).not.toHaveBeenCalled();
+  });
+
+  it('validates and trims rejection reasons', async () => {
+    await openDialog('Reject', 'Reject Task Request');
+    fireEvent.click(screen.getByRole('button', { name: 'Reject Task Request' }));
+    expect(await screen.findByRole('alert')).toHaveTextContent('Reason is required.');
+    expect(api.rejectTaskRequest).not.toHaveBeenCalled();
+    fireEvent.change(screen.getByRole('textbox', { name: 'Reject reason' }), {
+      target: { value: '  Out of scope.  ' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Reject Task Request' }));
+    await waitFor(() => expectDecisionCall(api.rejectTaskRequest, { reason: 'Out of scope.' }));
+  });
+
+  it('validates and trims evidence notes', async () => {
+    await openDialog('Need evidence', 'Request more evidence');
+    fireEvent.click(screen.getByRole('button', { name: 'Request evidence' }));
+    expect(await screen.findByRole('alert')).toHaveTextContent('Note is required.');
+    expect(api.requestMoreEvidenceForTaskRequest).not.toHaveBeenCalled();
+    fireEvent.change(screen.getByRole('textbox', { name: 'Evidence note' }), {
+      target: { value: '  Add source metrics.  ' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Request evidence' }));
+    await waitFor(() =>
+      expectDecisionCall(api.requestMoreEvidenceForTaskRequest, { note: 'Add source metrics.' }),
+    );
+  });
+
+  it('locks duplicate submissions while a decision is pending', async () => {
+    let resolveApproval: (value: TaskRequestDto) => void = () => undefined;
+    api.approveTaskRequest.mockImplementationOnce(
+      () =>
+        new Promise<TaskRequestDto>((resolve) => {
+          resolveApproval = resolve;
+        }),
+    );
+    await openDialog('Approve', 'Approve Task Request');
+    const submit = screen.getByRole('button', { name: 'Approve Task Request' });
+    // Both clicks land in one batch, so the pending state has not re-rendered the
+    // button as disabled yet. The synchronous in-flight guard is the only defense
+    // under test here — clicking with a flush in between would be caught by
+    // `disabled` and would not exercise it.
+    await act(async () => {
+      fireEvent.click(submit);
+      fireEvent.click(submit);
+    });
+    expectDecisionCall(api.approveTaskRequest, {});
+    resolveApproval(taskRequest);
+  });
+
+  it('keeps a dialog open and reports a server mutation failure', async () => {
+    api.approveTaskRequest.mockRejectedValueOnce({
+      envelope: { message: 'Approval was rejected by the server.' },
+    });
+    await openDialog('Approve', 'Approve Task Request');
+    fireEvent.click(screen.getByRole('button', { name: 'Approve Task Request' }));
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Approval was rejected by the server.',
+    );
+    expect(screen.getByRole('dialog', { name: 'Approve Task Request' })).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/features/tasks/routes/TaskRequestsRoute.tsx
+++ b/apps/frontend/src/features/tasks/routes/TaskRequestsRoute.tsx
@@ -26,7 +26,14 @@ import {
   DetailPanelHeader,
   DetailPanelHeaderActions,
   DetailPanelSectionNav,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
   FieldRow,
+  Label,
   ListShell,
   ListToolbar,
   type ListToolbarTab,
@@ -38,6 +45,7 @@ import {
   PanelSectionTitle,
   PanelTitleBlock,
   PermissionBlockedPanel,
+  Textarea,
   UserChip,
 } from '@fops/ui';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
@@ -46,6 +54,13 @@ import * as React from 'react';
 import { toast } from 'sonner';
 
 type TaskRequestTab = TaskRequestStatus | 'all';
+type DecisionAction = 'approve' | 'request-more-evidence' | 'reject';
+
+interface DecisionDialogState {
+  action: DecisionAction;
+  value: string;
+  error: string | null;
+}
 
 const TAB_ORDER: Array<{ value: TaskRequestTab; label: string }> = [
   { value: 'pending_review', label: 'Pending' },
@@ -135,6 +150,94 @@ function TaskRequestBadge({ status }: { status: TaskRequestStatus }) {
     <span className={`rounded-sm border px-2 py-0.5 text-xs font-semibold ${STATUS_CLASS[status]}`}>
       {STATUS_LABELS[status]}
     </span>
+  );
+}
+
+function TaskRequestDecisionDialog({
+  dialog,
+  isSelfApproval,
+  isSubmitting,
+  onChange,
+  onClose,
+  onSubmit,
+}: {
+  dialog: DecisionDialogState | null;
+  isSelfApproval: boolean;
+  isSubmitting: boolean;
+  onChange: (value: string) => void;
+  onClose: () => void;
+  onSubmit: (event: React.FormEvent<HTMLFormElement>) => void;
+}) {
+  if (!dialog) return null;
+
+  const details =
+    dialog.action === 'approve'
+      ? {
+          title: 'Approve Task Request',
+          description: 'Record the rationale for accepting this execution candidate.',
+          label: isSelfApproval ? 'Self-approval reason' : 'Approval reason',
+          submitLabel: 'Approve Task Request',
+          required: isSelfApproval,
+        }
+      : dialog.action === 'request-more-evidence'
+        ? {
+            title: 'Request more evidence',
+            description: 'Record the evidence needed before this request can be reviewed.',
+            label: 'Evidence note',
+            submitLabel: 'Request evidence',
+            required: true,
+          }
+        : {
+            title: 'Reject Task Request',
+            description: 'Record why this execution candidate cannot be accepted.',
+            label: 'Reject reason',
+            submitLabel: 'Reject Task Request',
+            required: true,
+          };
+  const inputId = `task-request-${dialog.action}-reason`;
+
+  return (
+    <Dialog open onOpenChange={(open) => !open && !isSubmitting && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{details.title}</DialogTitle>
+          <DialogDescription>{details.description}</DialogDescription>
+        </DialogHeader>
+        <form onSubmit={onSubmit} className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor={inputId}>{details.label}</Label>
+            <Textarea
+              id={inputId}
+              rows={3}
+              value={dialog.value}
+              onChange={(event) => onChange(event.target.value)}
+              disabled={isSubmitting}
+              aria-invalid={dialog.error !== null}
+            />
+            {details.required && <span className="text-xs text-text-muted">Required.</span>}
+          </div>
+          {dialog.error && (
+            <p className="text-sm text-accent-danger" role="alert">
+              {dialog.error}
+            </p>
+          )}
+          <DialogFooter className="gap-2 sm:gap-2">
+            <Button
+              type="button"
+              variant="secondary"
+              disabled={isSubmitting}
+              onClick={onClose}
+              data-testid="task-request-decision-cancel"
+            >
+              Cancel
+            </Button>
+            <Button type="submit" loading={isSubmitting} disabled={isSubmitting}>
+              {details.submitLabel}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
   );
 }
 
@@ -245,6 +348,9 @@ function TaskRequestPanel({
   const [convertDueDate, setConvertDueDate] = React.useState('');
   const [convertMilestoneId, setConvertMilestoneId] = React.useState('');
   const [convertAnalyticsAreaId, setConvertAnalyticsAreaId] = React.useState('');
+  const [decisionDialog, setDecisionDialog] = React.useState<DecisionDialogState | null>(null);
+  const [isDecisionSubmitting, setIsDecisionSubmitting] = React.useState(false);
+  const decisionSubmittingRef = React.useRef(false);
 
   React.useEffect(() => {
     setConvertTitle(defaultConvertTitle(item.requested_outcome));
@@ -256,6 +362,9 @@ function TaskRequestPanel({
     setConvertAnalyticsAreaId('');
     setConvertOpen(false);
     setLinkOpen(false);
+    setDecisionDialog(null);
+    setIsDecisionSubmitting(false);
+    decisionSubmittingRef.current = false;
   }, [item]);
 
   const selfApprovalCheck = useQuery({
@@ -322,11 +431,20 @@ function TaskRequestPanel({
       return requestMoreEvidenceForTaskRequest(item.id, { note: vars.note ?? '' }, key);
     },
     onSuccess: () => {
+      decisionSubmittingRef.current = false;
+      setIsDecisionSubmitting(false);
+      setDecisionDialog(null);
       void queryClient.invalidateQueries({ queryKey: ['task-requests'] });
       toast('Task Request updated.');
     },
     onError: (err) => {
-      toast.error(err.envelope.message);
+      decisionSubmittingRef.current = false;
+      setIsDecisionSubmitting(false);
+      setDecisionDialog((current) => {
+        if (current) return { ...current, error: err.envelope.message };
+        toast.error(err.envelope.message);
+        return current;
+      });
     },
   });
 
@@ -373,40 +491,48 @@ function TaskRequestPanel({
   });
 
   function approve(): void {
-    const reason = window.prompt(isSelfApproval ? 'Self-approval reason' : 'Approval reason');
-    if (reason === null) return;
-    if (isSelfApproval && reason.trim().length === 0) {
-      toast.error('Self-approval requires a reason.');
-      return;
-    }
     if (isSelfApproval && !canSelfApprove) {
       toast.error('Self-approval requires scoped capability.');
       return;
     }
-    const trimmed = reason.trim();
-    decisionMutation.mutate(
-      trimmed.length > 0 ? { action: 'approve', reason: trimmed } : { action: 'approve' },
-    );
+    setDecisionDialog({ action: 'approve', value: '', error: null });
   }
 
   function requestEvidence(): void {
-    const note = window.prompt('Evidence note');
-    if (note === null) return;
-    if (note.trim().length === 0) {
-      toast.error('Note is required.');
-      return;
-    }
-    decisionMutation.mutate({ action: 'request-more-evidence', note: note.trim() });
+    setDecisionDialog({ action: 'request-more-evidence', value: '', error: null });
   }
 
   function reject(): void {
-    const reason = window.prompt('Reject reason');
-    if (reason === null) return;
-    if (reason.trim().length === 0) {
-      toast.error('Reason is required.');
+    setDecisionDialog({ action: 'reject', value: '', error: null });
+  }
+
+  function submitDecision(event: React.FormEvent<HTMLFormElement>): void {
+    event.preventDefault();
+    if (!decisionDialog || decisionSubmittingRef.current) return;
+    const value = decisionDialog.value.trim();
+    const error =
+      decisionDialog.action === 'approve' && isSelfApproval && value.length === 0
+        ? 'Self-approval requires a reason.'
+        : decisionDialog.action === 'request-more-evidence' && value.length === 0
+          ? 'Note is required.'
+          : decisionDialog.action === 'reject' && value.length === 0
+            ? 'Reason is required.'
+            : null;
+    if (error) {
+      setDecisionDialog((current) => (current ? { ...current, error } : current));
       return;
     }
-    decisionMutation.mutate({ action: 'reject', reason: reason.trim() });
+    decisionSubmittingRef.current = true;
+    setIsDecisionSubmitting(true);
+    if (decisionDialog.action === 'approve') {
+      decisionMutation.mutate(value ? { action: 'approve', reason: value } : { action: 'approve' });
+      return;
+    }
+    decisionMutation.mutate(
+      decisionDialog.action === 'reject'
+        ? { action: 'reject', reason: value }
+        : { action: 'request-more-evidence', note: value },
+    );
   }
 
   const sections: PanelSection[] = [
@@ -765,6 +891,18 @@ function TaskRequestPanel({
           </div>
         </section>
       </div>
+      <TaskRequestDecisionDialog
+        dialog={decisionDialog}
+        isSelfApproval={isSelfApproval}
+        isSubmitting={isDecisionSubmitting}
+        onChange={(value) =>
+          setDecisionDialog((current) => (current ? { ...current, value, error: null } : current))
+        }
+        onClose={() => {
+          if (!decisionSubmittingRef.current) setDecisionDialog(null);
+        }}
+        onSubmit={submitDecision}
+      />
     </aside>
   );
 }

--- a/apps/frontend/src/features/voc/__tests__/integration/voc-composer-flow.integration.test.tsx
+++ b/apps/frontend/src/features/voc/__tests__/integration/voc-composer-flow.integration.test.tsx
@@ -14,7 +14,7 @@
 import type { MeResponse } from '@/lib/api/auth';
 import type { VocDetailEnvelope } from '@fops/shared';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import type * as React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -30,6 +30,8 @@ vi.mock('sonner', () => ({
   },
   Toaster: () => null,
 }));
+
+vi.mock('@/lib/api/attachments', () => ({ uploadAttachment: vi.fn() }));
 
 // ── @fops/ui RichEditor mock ─────────────────────────────────────────────────
 // Replace heavy TipTap editor with a simple textarea so RTL can interact with it.
@@ -65,6 +67,7 @@ vi.mock('@fops/ui', async (importOriginal) => {
   };
 });
 
+import { uploadAttachment } from '@/lib/api/attachments';
 import { toast } from 'sonner';
 import { ComposerSection } from '../../components/detail/ComposerSection';
 
@@ -140,6 +143,20 @@ const VOC_REPORTER_VIEW: VocDetailEnvelope = {
   reporter_id: REPORTER_ID,
 };
 
+const VOC_GATE_BLOCKED: VocDetailEnvelope = {
+  ...VOC_ADMIN_VIEW,
+  reporter_status_gate: { blocking_for: ['progress'], reason: '연결된 Task가 아직 진행 중입니다.' },
+};
+
+const ATTACHMENT = {
+  id: '00000000-0000-0000-0000-000000000200',
+  name: 'preview.png',
+  size_bytes: 1,
+  mime_type: 'image/png',
+  uploaded_by_actor_id: ME_ADMIN.actor.id,
+  created_at: '2026-05-01T00:00:00.000Z',
+} as Awaited<ReturnType<typeof uploadAttachment>>;
+
 function makeWrapper() {
   const qc = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
@@ -156,6 +173,35 @@ function jsonResponse(body: unknown, status = 200): Response {
   });
 }
 
+function fillPublicUpdate(value: string): void {
+  fireEvent.change(screen.getByTestId('rich-editor-public-update'), { target: { value } });
+}
+
+function previewDialog() {
+  return screen.findByRole('dialog', { name: 'Public update — Reporter preview' });
+}
+
+/**
+ * Installs a fetch double that records only POSTs. Reads (e.g. /actors) still
+ * resolve, so a "no mutation happened" assertion counts publish attempts rather
+ * than every request the screen makes.
+ */
+function recordPosts(): Array<{ input: RequestInfo | URL; init?: RequestInit }> {
+  const posts: Array<{ input: RequestInfo | URL; init?: RequestInit }> = [];
+  globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    if (init?.method === 'POST') posts.push({ input, init });
+    return jsonResponse({});
+  }) as typeof globalThis.fetch;
+  return posts;
+}
+
+/** Lets any mutation scheduled by a click actually reach fetch before we count. */
+async function flushMutations(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe('Composer flow — integration (C6.3)', () => {
@@ -163,6 +209,7 @@ describe('Composer flow — integration (C6.3)', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(uploadAttachment).mockResolvedValue(ATTACHMENT);
   });
 
   afterEach(() => {
@@ -349,6 +396,220 @@ describe('Composer flow — integration (C6.3)', () => {
       expect(invalidateSpy).toHaveBeenCalledWith(
         expect.objectContaining({ queryKey: ['voc', VOC_ADMIN_VIEW.id] }),
       );
+    });
+  });
+
+  it('publishes once from preview with the VOC id, If-Match value, and public-update body', async () => {
+    const requests: Array<{ input: RequestInfo | URL; init?: RequestInit }> = [];
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === 'POST') requests.push({ input, init });
+      return jsonResponse({ id: 'pub-update-preview-001' });
+    }) as typeof globalThis.fetch;
+
+    const Wrapper = makeWrapper();
+    render(
+      <Wrapper>
+        <ComposerSection voc={VOC_ADMIN_VIEW} me={ME_ADMIN} />
+      </Wrapper>,
+    );
+
+    fillPublicUpdate('미리보기에서 게시합니다.');
+    fireEvent.click(screen.getByRole('button', { name: 'Preview' }));
+    const preview = await previewDialog();
+
+    await act(async () => {
+      fireEvent.click(within(preview).getByRole('button', { name: 'Publish update' }));
+    });
+
+    await waitFor(() => expect(requests).toHaveLength(1));
+    expect(
+      screen.queryByRole('dialog', { name: 'Public update — Reporter preview' }),
+    ).not.toBeInTheDocument();
+
+    const request = requests[0];
+    if (!request) throw new Error('expected a public-update request');
+    expect(String(request.input)).toContain(`/vocs/${VOC_ADMIN_VIEW.id}/public-updates`);
+    expect(new Headers(request.init?.headers).get('if-match')).toBe(VOC_ADMIN_VIEW.updated_at);
+    expect(JSON.parse(request.init?.body as string)).toEqual({
+      skip_public_update: false,
+      body_rich_content: {
+        type: 'doc',
+        content: [
+          { type: 'paragraph', content: [{ type: 'text', text: '미리보기에서 게시합니다.' }] },
+        ],
+      },
+      next_reporter_facing_status: 'progress',
+      attachment_ids: [],
+    });
+  });
+
+  it('continues editing from preview without mutating', async () => {
+    const posts = recordPosts();
+    const Wrapper = makeWrapper();
+    render(
+      <Wrapper>
+        <ComposerSection voc={VOC_ADMIN_VIEW} me={ME_ADMIN} />
+      </Wrapper>,
+    );
+
+    fillPublicUpdate('계속 편집합니다.');
+    fireEvent.click(screen.getByRole('button', { name: 'Preview' }));
+    const preview = await previewDialog();
+    fireEvent.click(within(preview).getByRole('button', { name: 'Continue editing' }));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('dialog', { name: 'Public update — Reporter preview' }),
+      ).not.toBeInTheDocument();
+    });
+    // The draft survives: this closed the preview, it did not discard the update.
+    expect(screen.getByTestId('rich-editor-public-update')).toHaveValue('계속 편집합니다.');
+    await flushMutations();
+    expect(posts).toHaveLength(0);
+  });
+
+  it('disables preview publish for an empty public update without mutating', async () => {
+    const posts = recordPosts();
+    const Wrapper = makeWrapper();
+    render(
+      <Wrapper>
+        <ComposerSection voc={VOC_ADMIN_VIEW} me={ME_ADMIN} />
+      </Wrapper>,
+    );
+
+    await screen.findByTestId('rich-editor-public-update');
+    fireEvent.click(screen.getByRole('button', { name: 'Preview' }));
+    const preview = await previewDialog();
+    const publish = within(preview).getByRole('button', { name: 'Publish update' });
+    expect(publish).toBeDisabled();
+    fireEvent.click(publish);
+    await flushMutations();
+    expect(posts).toHaveLength(0);
+  });
+
+  it('disables preview publish when the reporter-status gate blocks it', async () => {
+    const posts = recordPosts();
+    const Wrapper = makeWrapper();
+    render(
+      <Wrapper>
+        <ComposerSection voc={VOC_GATE_BLOCKED} me={ME_ADMIN} />
+      </Wrapper>,
+    );
+
+    fillPublicUpdate('게이트가 막은 업데이트');
+    fireEvent.click(screen.getByRole('button', { name: 'Preview' }));
+    const preview = await previewDialog();
+    const publish = within(preview).getByRole('button', { name: 'Publish update' });
+    expect(publish).toBeDisabled();
+    fireEvent.click(publish);
+    await flushMutations();
+    expect(posts).toHaveLength(0);
+  });
+
+  it('disables preview publish while an attachment upload is in progress', async () => {
+    let resolveUpload: ((attachment: typeof ATTACHMENT) => void) | undefined;
+    vi.mocked(uploadAttachment).mockReturnValue(
+      new Promise((resolve) => {
+        resolveUpload = resolve;
+      }),
+    );
+    const posts = recordPosts();
+    const Wrapper = makeWrapper();
+    render(
+      <Wrapper>
+        <ComposerSection voc={VOC_ADMIN_VIEW} me={ME_ADMIN} />
+      </Wrapper>,
+    );
+
+    fillPublicUpdate('첨부를 기다리는 업데이트');
+    fireEvent.change(screen.getByTestId('public-update-attachment-dropzone-input'), {
+      target: { files: [new File(['x'], 'preview.png', { type: 'image/png' })] },
+    });
+    await screen.findByText(/업로드 중/);
+    fireEvent.click(screen.getByRole('button', { name: 'Preview' }));
+    const preview = await previewDialog();
+    const publish = within(preview).getByRole('button', { name: 'Publish update' });
+    expect(publish).toBeDisabled();
+    fireEvent.click(publish);
+    await flushMutations();
+    expect(posts).toHaveLength(0);
+
+    await act(async () => {
+      resolveUpload?.(ATTACHMENT);
+    });
+    // Once the upload settles the same control becomes publishable — proving the
+    // assertion above was blocked by the upload, not by a permanently dead button.
+    await waitFor(() =>
+      expect(within(preview).getByRole('button', { name: 'Publish update' })).toBeEnabled(),
+    );
+  });
+
+  it('sends one preview publish request when activated twice before the first response', async () => {
+    let resolvePost: ((response: Response) => void) | undefined;
+    let postCount = 0;
+    let request: { input: RequestInfo | URL; init?: RequestInit } | undefined;
+    globalThis.fetch = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method !== 'POST') return Promise.resolve(jsonResponse({}));
+      postCount += 1;
+      request = { input, init };
+      return new Promise<Response>((resolve) => {
+        resolvePost = resolve;
+      });
+    }) as typeof globalThis.fetch;
+    const Wrapper = makeWrapper();
+    render(
+      <Wrapper>
+        <ComposerSection voc={VOC_ADMIN_VIEW} me={ME_ADMIN} />
+      </Wrapper>,
+    );
+
+    fillPublicUpdate('프리뷰 연타 방지');
+    fireEvent.click(screen.getByRole('button', { name: 'Preview' }));
+    const preview = await previewDialog();
+    const publish = within(preview).getByRole('button', { name: 'Publish update' });
+    await act(async () => {
+      fireEvent.click(publish);
+      fireEvent.click(publish);
+    });
+
+    expect(postCount).toBe(1);
+    expect(String(request?.input)).toContain(`/vocs/${VOC_ADMIN_VIEW.id}/public-updates`);
+    expect(JSON.parse(request?.init?.body as string)).toMatchObject({
+      body_rich_content: { content: [{ content: [{ text: '프리뷰 연타 방지' }] }] },
+    });
+    await act(async () => {
+      resolvePost?.(jsonResponse({ id: 'pub-update-preview-rapid-001' }));
+    });
+  });
+
+  it('still publishes through the composer footer', async () => {
+    let capturedBody: unknown;
+    let capturedRequest: { input: RequestInfo | URL; init: RequestInit | undefined } | undefined;
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      capturedRequest = { input, init };
+      if (init?.method === 'POST') capturedBody = JSON.parse(init.body as string);
+      return jsonResponse({ id: 'pub-update-footer-001' });
+    }) as typeof globalThis.fetch;
+    const Wrapper = makeWrapper();
+    render(
+      <Wrapper>
+        <ComposerSection voc={VOC_ADMIN_VIEW} me={ME_ADMIN} />
+      </Wrapper>,
+    );
+
+    fillPublicUpdate('푸터 발행 회귀 방지');
+    fireEvent.click(screen.getByRole('button', { name: 'Publish update' }));
+
+    await waitFor(() => expect(capturedBody).toBeTruthy());
+    expect(String(capturedRequest?.input)).toContain(`/vocs/${VOC_ADMIN_VIEW.id}/public-updates`);
+    expect(new Headers(capturedRequest?.init?.headers).get('if-match')).toBe(
+      VOC_ADMIN_VIEW.updated_at,
+    );
+    expect(capturedBody).toMatchObject({
+      body_rich_content: {
+        content: [{ content: [{ text: '푸터 발행 회귀 방지' }] }],
+      },
+      next_reporter_facing_status: 'progress',
     });
   });
 });

--- a/apps/frontend/src/features/voc/components/detail/PublicUpdateComposer.tsx
+++ b/apps/frontend/src/features/voc/components/detail/PublicUpdateComposer.tsx
@@ -67,7 +67,7 @@ import { uploadAttachment } from '@/lib/api/attachments';
 import type { MeResponse } from '@/lib/auth/useMe';
 import { REPORTER_STATUS_LABELS } from '@/lib/copy/reporter-status-labels';
 import type { ReporterFacingStatusEnum, VocDetailEnvelope } from '@fops/shared';
-import { Callout, PreviewModal, RichEditor } from '@fops/ui';
+import { Button, Callout, PreviewModal, RichEditor } from '@fops/ui';
 import type { TipTapDoc } from '@fops/ui';
 import { useQueryClient } from '@tanstack/react-query';
 import { AlertCircle, Megaphone } from 'lucide-react';
@@ -143,6 +143,7 @@ export function PublicUpdateComposer({
     voc.reporter_facing_status,
   );
   const [previewOpen, setPreviewOpen] = useState(false);
+  const submitInFlightRef = useRef(false);
 
   // PLAN-22 C7a: composer-level attachment dropzone state.
   const [attachmentIds, setAttachmentIds] = useState<string[]>([]);
@@ -166,6 +167,7 @@ export function PublicUpdateComposer({
 
   const mutation = useVocPublicUpdateMutation({
     onSuccess: () => {
+      submitInFlightRef.current = false;
       queryClient.invalidateQueries({ queryKey: ['voc', voc.id] });
       // clear draft (calls onDraftChange?.(null) when controlled)
       setDraftDoc(null);
@@ -173,14 +175,22 @@ export function PublicUpdateComposer({
       toast.success('공개 업데이트가 게시되었습니다.');
     },
     onError: (error) => {
+      submitInFlightRef.current = false;
       if (getComposerErrorTone(error.code) == null) {
         toast.error(`${error.code}: ${error.message}`);
       }
     },
   });
 
+  const mutationError = mutation.error as ApiError | null;
+  const isIdempotencyLocked =
+    mutationError != null && mutationError.code === 'conflict.idempotency_key_reuse';
+  const isSubmitBlocked =
+    isEmpty || mutation.isPending || isGateBlocked || isIdempotencyLocked || attachmentsUploading;
+
   function handleSubmit() {
-    if (!draftDoc) return;
+    if (!draftDoc || isSubmitBlocked || submitInFlightRef.current) return;
+    submitInFlightRef.current = true;
     mutation.mutate({
       vocId: voc.id,
       ifMatch: voc.updated_at,
@@ -191,6 +201,12 @@ export function PublicUpdateComposer({
         attachment_ids: attachmentIds,
       },
     });
+  }
+
+  function handlePreviewPublish() {
+    if (isSubmitBlocked) return;
+    setPreviewOpen(false);
+    handleSubmit();
   }
 
   // Owner for the ReporterStatusChangeBlock preview card + ComposerPublicPreview.
@@ -219,10 +235,6 @@ export function PublicUpdateComposer({
   // ── Error matrix ─────────────────────────────────────────────────────────────
   // Inline Callout copy comes from backend detail.reason per D-5.6 in PLAN-21.
   // conflict.idempotency_key_reuse → lock both Submit + Preview until VOC switch.
-
-  const mutationError = mutation.error as ApiError | null;
-  const isIdempotencyLocked =
-    mutationError != null && mutationError.code === 'conflict.idempotency_key_reuse';
 
   const inlineCalloutTone = mutationError != null ? getComposerErrorTone(mutationError.code) : null;
   const inlineCalloutReason =
@@ -300,7 +312,7 @@ export function PublicUpdateComposer({
         onSubmit={handleSubmit}
         isEmpty={isEmpty}
         isSubmitting={mutation.isPending}
-        isSubmitDisabled={isGateBlocked || isIdempotencyLocked || attachmentsUploading}
+        isSubmitDisabled={isSubmitBlocked}
         isPreviewDisabled={isIdempotencyLocked}
         statusHint={statusHint}
       />
@@ -317,6 +329,20 @@ export function PublicUpdateComposer({
           nextStatus={nextStatus}
           draftDoc={draftDoc}
         />
+        <div className="flex justify-end gap-2 border-t border-border-subtle pt-3">
+          <Button type="button" variant="secondary" size="sm" onClick={() => setPreviewOpen(false)}>
+            Continue editing
+          </Button>
+          <Button
+            type="button"
+            variant="primary"
+            size="sm"
+            disabled={isSubmitBlocked}
+            onClick={handlePreviewPublish}
+          >
+            Publish update
+          </Button>
+        </div>
       </PreviewModal>
     </div>
   );


### PR DESCRIPTION
블랙박스 Slice 19의 C5(#335)·C7(#336). 둘 다 FE 전용이고 파일이 겹치지 않아 한 게이트 실행으로 함께 검증했다.

## #335 — Task Request 결정 3종을 인앱 다이얼로그로

`window.prompt` 3곳(승인 사유 / 반려 사유 / 증빙 노트)을 로컬 `TaskRequestDecisionDialog` 하나로 교체했다. action에 따라 제목·라벨·필수 여부만 달라진다.

**규칙은 옮긴 것이지 재설계하지 않았다:** 자가승인 사유 필수, 반려 사유 필수, 증빙 노트 필수, 값 trim, 스코프 권한 없는 자가승인은 다이얼로그를 열기 전에 거절. 실패는 다이얼로그를 닫고 토스트로 날리는 대신 `role="alert"`로 그 안에 남는다.

> 이슈가 지목한 것은 승인 1곳이었지만, 반려·증빙이 바로 다음 줄에서 같은 벽을 만든다. 최소 단위는 3곳이다.
> 리치 텍스트 툴바 3곳의 링크 URL prompt는 다른 화면·다른 상호작용이라 이 PR에 넣지 않았다.

## #336 — 프리뷰 모달에서 공개 업데이트를 발행할 수 있게

**뿌리(실측):** 프리뷰가 모달 오버레이로 열리는데 유일한 `Publish update` 버튼은 그 뒤 컴포저 푸터에 남는다. 프리뷰를 연 리뷰어에게는 발행에 닿을 방법이 없었다. "발행했는데 아무 일도 안 일어남"의 정체다.

프리뷰 안에 `Publish update` / `Continue editing`을 넣었다. 발행 조건은 푸터와 **같은 `isSubmitBlocked` 파생값 하나**를 공유해서(빈 초안 / pending / 상태 게이트 / 멱등성 잠금 / 첨부 업로드 중) 두 진입점이 갈라질 수 없게 했다. `handleSubmit`에는 동기 `useRef` 잠금을 넣었다 — `mutation.isPending`은 같은 배치의 두 번째 클릭 전에 리렌더되지 않는다.

## 뮤테이션 매트릭스 — 어느 단언이 발화했는가

| 뮤테이션 | 결과 | 발화한 단언 |
|---|---|---|
| 승인에 `window.prompt` 부활 | ☠️ | `opens approval without invoking window.prompt` |
| 자가승인 사유 필수 검증 제거 | ☠️ | `keeps a self-approval dialog open when its reason is blank` |
| 입력값 `.trim()` 제거 | ☠️ | 4건 (승인 trim / 자가승인 공백 / 반려 / 증빙) |
| 결정 다이얼로그 중복 제출 잠금 제거 | ☠️ | `locks duplicate submissions while a decision is pending` |
| 프리뷰 발행 버튼 `disabled` 제거 | ☠️ | 3건 (빈 초안 / 게이트 차단 / 업로드 중) |
| 공개 업데이트 제출 잠금 제거 | ☠️ | `sends one preview publish request when activated twice` |
| `Continue editing`이 발행도 하게 | ☠️ | `continues editing from preview without mutating` |
| `handlePreviewPublish`의 조기 반환 제거 | **생존** | — |

**생존자 1건은 알고 남겼다.** `handlePreviewPublish`의 `if (isSubmitBlocked) return;`은 버튼이 이미 `disabled`이고 `handleSubmit`이 같은 조건을 다시 막으므로 UI로 도달할 수 없다. 이중 방어이고, 죽이려면 인위적인 테스트가 필요해서 제거도 우회도 하지 않고 기록만 남긴다.

**첫 실행에서 잡힌 것 (워커는 무엇도 실행할 수 없다):**
- 부재 단언 4건이 POST가 아니라 **모든 fetch**를 세고 있어 무관한 `/actors` GET에 걸렸다 → POST만 세는 오라클로 교체.
- 연타 방지 단언 2건이 `mutate`가 fetch에 닿기 전에 동기로 실행됐다 → 두 클릭을 한 `act`로 묶었다. **이 수정 전에는 잠금을 제거해도 테스트가 통과했다** (상태가 flush돼 `disabled`가 먼저 막았기 때문).
- 타입 에러 3건. 그중 하나는 구현 결함이다: `handleSubmit`의 `if (!draftDoc) return;` 가드가 `isSubmitBlocked`로 대체되면서 null 좁히기가 사라졌다 → 가드 복원.

## 기각한 선택지

- **`ee56ec6` 통째 체리픽.** 그 커밋은 #335와 함께 #334("승인이 조용히 아무것도 안 한다")도 고치려고 낙관적 `setQueriesData`, `currentActorName` 리뷰어 폴백, `key={selected.id}`, effect 의존성 축소를 얹었다. **#334는 NOT_PLANNED로 닫혔다** — 제품 결함이 아니라 자동화 하네스가 JS prompt를 처리하다 생긴 착시였다. 다이얼로그 골격만 참고하고 그 기계장치는 전부 뺐다.
- **참고 커밋의 raw `<button>` + 수동 Tailwind.** `@fops/ui`의 `Button`으로 교체했다.

## 게이트 (feature 브랜치)

```
frontend vitest      812 passed / 150 files   ← 796/149에서
frontend typecheck   0 errors
frontend biome       0 unexpected, 112 allowlisted
frontend visual      58 passed                ← 베이스라인 무변동
```

Closes #335
Closes #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BfiR55zJ7n8uYpr1s3X6q