### PR TITLE
fix(#337): 리포터 arm에 내부 트리아지·유사 VOC 필드를 보내지 않는다

### DIFF
--- a/apps/backend/src/modules/voc/__tests__/get-voc.integration.test.ts
+++ b/apps/backend/src/modules/voc/__tests__/get-voc.integration.test.ts
@@ -155,7 +155,7 @@ describe.skipIf(!runIntegration)('GET /vocs/:id (#15 C4)', () => {
     expect(body.similar.items.map((item) => item.id)).toEqual([peer4.id, peer3.id, peer2.id]);
   });
 
-  it('does not leak unscoped peers from a reporter-owned source VOC', async () => {
+  it('omits peer fields from an unscoped reporter-owned source VOC', async () => {
     const msAId = await insertMsDirectly(dbHandle, WORKSPACE_ID, `${uid(SLUG_PREFIX)}-scope-a`, 'Scope A');
     const msBId = await insertMsDirectly(dbHandle, WORKSPACE_ID, `${uid(SLUG_PREFIX)}-scope-b`, 'Scope B');
     const { id: actorId, externalId } = await insertDevActor(dbHandle, WORKSPACE_ID, uid('similar-scope'));
@@ -169,9 +169,9 @@ describe.skipIf(!runIntegration)('GET /vocs/:id (#15 C4)', () => {
       headers: { cookie: `${SESSION_COOKIE_NAME}=${cookie}` },
     });
     expect(res.statusCode).toBe(200);
-    const body = res.json<{ similar_count: number; similar: { items: unknown[] } }>();
-    expect(body.similar_count).toBe(0);
-    expect(body.similar.items).toEqual([]);
+    const body = res.json<Record<string, unknown>>();
+    expect(Object.keys(body)).not.toContain('similar_count');
+    expect(Object.keys(body)).not.toContain('similar');
   });
 
   // ── AC2: next_reporter_states derived from transitions ───────────────────
@@ -388,6 +388,93 @@ describe.skipIf(!runIntegration)('GET /vocs/:id (#15 C4)', () => {
     const replies = body.conversation_timeline.filter((e) => e.kind === 'reporter_reply');
     for (const reply of replies) {
       expect(reply.actor_id).toBe(reporterId);
+    }
+  });
+
+  it('#337: reporter without voc.read or voc.triage receives no internal triage or peer fields', async () => {
+    const msId = await insertMsDirectly(dbHandle, WORKSPACE_ID, `${uid(SLUG_PREFIX)}-337-reporter`, 'Reporter Arm MS');
+    const { id: reporterActorId, externalId } = await insertDevActor(dbHandle, WORKSPACE_ID, uid('337-reporter'));
+    const cookie = await loginAs(app, externalId);
+    const voc = await insertVocDirectly(dbHandle, WORKSPACE_ID, msId, reporterActorId, 'Reporter arm VOC');
+    await insertVocDirectly(dbHandle, WORKSPACE_ID, msId, reporterActorId, 'Reporter arm peer');
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/vocs/${voc.id}`,
+      headers: { cookie: `${SESSION_COOKIE_NAME}=${cookie}` },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<Record<string, unknown>>();
+    for (const field of [
+      'similar_count',
+      'similar',
+      'analytics_area_id',
+      'owner_user_id',
+      'owner_team_id',
+    ]) {
+      expect(Object.keys(body)).not.toContain(field);
+    }
+    for (const field of [
+      'triage_state',
+      'severity',
+      'reporter_facing_status',
+      'display_id',
+      'conversation_timeline',
+    ]) {
+      expect(Object.keys(body)).toContain(field);
+    }
+  });
+
+  it('#337: voc.read actor retains every internal triage and peer field', async () => {
+    const msId = await insertMsDirectly(dbHandle, WORKSPACE_ID, `${uid(SLUG_PREFIX)}-337-read`, 'Read Scope MS');
+    const { id: readerId, externalId } = await insertDevActor(dbHandle, WORKSPACE_ID, uid('337-reader'));
+    await grantCapability(dbHandle, WORKSPACE_ID, readerId, 'voc.read', msId, adminActorId);
+    const cookie = await loginAs(app, externalId);
+    const voc = await insertVoc(msId, 'Read scope VOC');
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/vocs/${voc.id}`,
+      headers: { cookie: `${SESSION_COOKIE_NAME}=${cookie}` },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<Record<string, unknown>>();
+    for (const field of [
+      'similar_count',
+      'similar',
+      'analytics_area_id',
+      'owner_user_id',
+      'owner_team_id',
+    ]) {
+      expect(Object.keys(body)).toContain(field);
+    }
+  });
+
+  it('#337: reporter with voc.read retains the full envelope', async () => {
+    const msId = await insertMsDirectly(dbHandle, WORKSPACE_ID, `${uid(SLUG_PREFIX)}-337-reporter-read`, 'Reporter Read MS');
+    const { id: reporterActorId, externalId } = await insertDevActor(dbHandle, WORKSPACE_ID, uid('337-reporter-read'));
+    await grantCapability(dbHandle, WORKSPACE_ID, reporterActorId, 'voc.read', msId, adminActorId);
+    const cookie = await loginAs(app, externalId);
+    const voc = await insertVocDirectly(dbHandle, WORKSPACE_ID, msId, reporterActorId, 'Reporter read VOC');
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/vocs/${voc.id}`,
+      headers: { cookie: `${SESSION_COOKIE_NAME}=${cookie}` },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<Record<string, unknown>>();
+    for (const field of [
+      'similar_count',
+      'similar',
+      'analytics_area_id',
+      'owner_user_id',
+      'owner_team_id',
+    ]) {
+      expect(Object.keys(body)).toContain(field);
     }
   });
 

--- a/apps/backend/src/modules/voc/read-service.ts
+++ b/apps/backend/src/modules/voc/read-service.ts
@@ -484,6 +484,7 @@ export function createVocReadService(deps: VocReadServiceDeps) {
     const msInReadScope = msInScope(readScope, primaryMs);
     const msInEffectiveScope = msInScope(effectiveScope, primaryMs);
     const canTriage = msInScope(triageScope, primaryMs);
+    const isReporterArm = isReporter && !msInReadScope && !canTriage;
 
     // ── 4. Access matrix ─────────────────────────────────────────────────────
     const etag = `W/"${row.updatedAt.toISOString()}"`;
@@ -602,18 +603,22 @@ export function createVocReadService(deps: VocReadServiceDeps) {
       display_id: row.displayId,
       title: row.title,
       primary_managed_system_id: primaryMs,
-      analytics_area_id: row.analyticsAreaId,
       reporter_id: row.reporterId,
-      owner_user_id: row.ownerUserId,
-      owner_team_id: row.ownerTeamId,
       severity: row.severity,
       reporter_facing_status: row.reporterFacingStatus as VocDetailEnvelope['reporter_facing_status'],
       triage_state: row.triageState as VocDetailEnvelope['triage_state'],
       source_context: row.sourceContext as VocDetailEnvelope['source_context'],
       created_at: row.createdAt.toISOString(),
       updated_at: row.updatedAt.toISOString(),
-      similar_count: similarCount,
-      similar: mapSimilarItems(similarItems),
+      ...(!isReporterArm
+        ? {
+            analytics_area_id: row.analyticsAreaId,
+            owner_user_id: row.ownerUserId,
+            owner_team_id: row.ownerTeamId,
+            similar_count: similarCount,
+            similar: mapSimilarItems(similarItems),
+          }
+        : {}),
       // PLAN-22 §Bug-1: detail row also carries attachment_count (matches the
       // shared schema which extends vocListItemSchema).
       attachment_count: vocAttRows.length,
@@ -751,6 +756,7 @@ export function createVocReadService(deps: VocReadServiceDeps) {
       repoRead.actorReadScope(tx, actor),
     ]);
     const canTriage = msInScope(triageScope, primaryMs);
+    const isReporterArm = isReporter && !msInScope(readScope, primaryMs) && !canTriage;
 
     // Inline conversation (first 50 entries).
     const convResult = await repoRead.selectConversationPage(tx, {
@@ -816,18 +822,22 @@ export function createVocReadService(deps: VocReadServiceDeps) {
       display_id: row.displayId,
       title: row.title,
       primary_managed_system_id: primaryMs,
-      analytics_area_id: row.analyticsAreaId,
       reporter_id: row.reporterId,
-      owner_user_id: row.ownerUserId,
-      owner_team_id: row.ownerTeamId,
       severity: row.severity,
       reporter_facing_status: row.reporterFacingStatus as VocDetailEnvelope['reporter_facing_status'],
       triage_state: row.triageState as VocDetailEnvelope['triage_state'],
       source_context: row.sourceContext as VocDetailEnvelope['source_context'],
       created_at: row.createdAt.toISOString(),
       updated_at: row.updatedAt.toISOString(),
-      similar_count: similarCount,
-      similar: mapSimilarItems(similarItems),
+      ...(!isReporterArm
+        ? {
+            analytics_area_id: row.analyticsAreaId,
+            owner_user_id: row.ownerUserId,
+            owner_team_id: row.ownerTeamId,
+            similar_count: similarCount,
+            similar: mapSimilarItems(similarItems),
+          }
+        : {}),
       attachment_count: vocAttRows.length,
       description_rich_content: row.descriptionRichContent,
       next_actions: [],

--- a/apps/frontend/src/features/voc/components/detail/IdentitySection.tsx
+++ b/apps/frontend/src/features/voc/components/detail/IdentitySection.tsx
@@ -84,7 +84,9 @@ export function IdentityMetadataStrip({
   const sourceContextLabel = SOURCE_CONTEXT_LABELS[voc.source_context] ?? voc.source_context;
 
   const hasSeverity = voc.severity !== null;
-  const hasAnalyticsArea = voc.analytics_area_id !== null;
+  // `undefined` means the reporter arm redacted the field (#337), not "no area".
+  // `!== null` alone would let a redacted envelope render an empty chip.
+  const hasAnalyticsArea = voc.analytics_area_id != null;
   const hasManagedSystem = managedSystem !== null;
   const severity = voc.severity;
   const analyticsAreaId = voc.analytics_area_id;

--- a/apps/frontend/src/features/voc/components/detail/SimilarVocSection.tsx
+++ b/apps/frontend/src/features/voc/components/detail/SimilarVocSection.tsx
@@ -5,16 +5,21 @@ import type * as React from 'react';
 
 export interface SimilarVocSectionProps {
   similar: VocDetailEnvelope['similar'] | undefined;
-  similarCount: number;
+  similarCount: number | undefined;
   onSelect: (vocId: string) => void;
 }
 
 /** Keep the section, its anchor, and its navigation entry in lockstep. */
 export function hasSimilarVocSection(
   similar: VocDetailEnvelope['similar'] | undefined,
-  similarCount: number,
-): similar is VocDetailEnvelope['similar'] {
-  return similar !== undefined && similarCount > 0 && similar.items.length > 0;
+  similarCount: number | undefined,
+): similar is NonNullable<VocDetailEnvelope['similar']> {
+  return (
+    similar !== undefined &&
+    similarCount !== undefined &&
+    similarCount > 0 &&
+    similar.items.length > 0
+  );
 }
 
 /**
@@ -26,7 +31,9 @@ export function SimilarVocSection({
   similarCount,
   onSelect,
 }: SimilarVocSectionProps): React.ReactElement | null {
-  if (!hasSimilarVocSection(similar, similarCount)) {
+  // The count is checked here as well as inside the guard: a type predicate can
+  // narrow only one parameter, and the badge below prints the count itself.
+  if (similarCount === undefined || !hasSimilarVocSection(similar, similarCount)) {
     return null;
   }
 

--- a/apps/frontend/src/features/voc/components/detail/VocDetailPanel.tsx
+++ b/apps/frontend/src/features/voc/components/detail/VocDetailPanel.tsx
@@ -243,13 +243,16 @@ function FullDetailView({
   const pendingReviewCount = reviewCandidates.data?.items.length ?? 0;
   const canRequestTask = canCreateFinding;
   const showsSimilarVocSection = hasSimilarVocSection(voc.similar, voc.similar_count);
-  const detailSections = showsSimilarVocSection
-    ? [
-        ...STATIC_DETAIL_SECTIONS.slice(0, 4),
-        { id: 'similar', label: 'Similar' },
-        ...STATIC_DETAIL_SECTIONS.slice(4),
-      ]
-    : STATIC_DETAIL_SECTIONS;
+  const isReporterArm = voc.similar === undefined || voc.similar_count === undefined;
+  const detailSections = isReporterArm
+    ? STATIC_DETAIL_SECTIONS.filter((section) => section.id !== 'triage')
+    : showsSimilarVocSection
+      ? [
+          ...STATIC_DETAIL_SECTIONS.slice(0, 4),
+          { id: 'similar', label: 'Similar' },
+          ...STATIC_DETAIL_SECTIONS.slice(4),
+        ]
+      : STATIC_DETAIL_SECTIONS;
 
   const requestTaskMutation = useRequestTaskFromVoc({
     vocId,
@@ -313,19 +316,21 @@ function FullDetailView({
               reporterDisplayName={actorNamesById.get(voc.reporter_id) ?? me?.actor.display_name}
             />
           </div>
-          <div data-anchor="triage">
-            <TriageBlock
-              voc={voc}
-              ownerDisplayName={
-                voc.owner_user_id !== null ? (actorNamesById.get(voc.owner_user_id) ?? null) : null
-              }
-              analyticsAreaName={
-                voc.analytics_area_id !== null
-                  ? (analyticsAreasById.get(voc.analytics_area_id) ?? null)
-                  : null
-              }
-            />
-          </div>
+          {!isReporterArm && (
+            <div data-anchor="triage">
+              <TriageBlock
+                voc={voc}
+                ownerDisplayName={
+                  voc.owner_user_id != null ? (actorNamesById.get(voc.owner_user_id) ?? null) : null
+                }
+                analyticsAreaName={
+                  voc.analytics_area_id != null
+                    ? (analyticsAreasById.get(voc.analytics_area_id) ?? null)
+                    : null
+                }
+              />
+            </div>
+          )}
           <div data-anchor="description">
             <DescriptionSection voc={voc} isReporterOnOwnVoc={isReporterOnOwnVoc} />
             {/* Relocated metadata strip — severity/managed-system/AA/source-context
@@ -333,7 +338,7 @@ function FullDetailView({
             <IdentityMetadataStrip
               voc={voc}
               analyticsAreaName={
-                voc.analytics_area_id !== null
+                voc.analytics_area_id != null
                   ? (analyticsAreasById.get(voc.analytics_area_id) ?? null)
                   : null
               }
@@ -419,7 +424,7 @@ function FullDetailView({
       <CreateFindingModal
         vocId={vocId}
         managedSystemId={voc.primary_managed_system_id}
-        sourceAnalyticsAreaId={voc.analytics_area_id}
+        sourceAnalyticsAreaId={voc.analytics_area_id ?? null}
         open={createFindingOpen}
         onClose={() => setCreateFindingOpen(false)}
       />

--- a/apps/frontend/src/features/voc/components/detail/__tests__/VocDetailPanel.test.tsx
+++ b/apps/frontend/src/features/voc/components/detail/__tests__/VocDetailPanel.test.tsx
@@ -388,6 +388,70 @@ describe('<VocDetailPanel>', () => {
     expect(container.querySelector('[data-anchor="similar"]')).not.toBeNull();
   });
 
+  it('#337: reporter-arm envelope omits Triage, Similar, and their navigation entries', async () => {
+    const {
+      analytics_area_id: _analyticsAreaId,
+      owner_user_id: _ownerUserId,
+      owner_team_id: _ownerTeamId,
+      similar_count: _similarCount,
+      similar: _similar,
+      ...reporterArmEnvelope
+    } = DETAIL_ENVELOPE;
+    vi.mocked(useVocDetail).mockReturnValue(makeDetailQuery({ data: reporterArmEnvelope }));
+
+    renderWithClient(<VocDetailPanel vocId={DETAIL_ENVELOPE.id} onClose={vi.fn()} />);
+
+    await screen.findByText('테스트 VOC 제목');
+    expect(screen.queryByText('트리아지 (Read only)')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('유사 VOC')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Triage' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Similar' })).not.toBeInTheDocument();
+  });
+
+  it('#337: treats a half-redacted envelope as the reporter arm', async () => {
+    // The backend drops the peer fields together, so a partial envelope means a
+    // contract has drifted. Fail closed rather than rendering internal triage
+    // because one of the two keys happened to survive.
+    const { similar_count: _similarCount, ...halfRedacted } = DETAIL_ENVELOPE;
+    vi.mocked(useVocDetail).mockReturnValue(makeDetailQuery({ data: halfRedacted }));
+
+    renderWithClient(<VocDetailPanel vocId={DETAIL_ENVELOPE.id} onClose={vi.fn()} />);
+
+    await screen.findByText('테스트 VOC 제목');
+    expect(screen.queryByText('트리아지 (Read only)')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Triage' })).not.toBeInTheDocument();
+  });
+
+  it('#337: scoped envelope renders Triage and Similar with their navigation entries', async () => {
+    vi.mocked(useVocDetail).mockReturnValue(
+      makeDetailQuery({
+        data: {
+          ...DETAIL_ENVELOPE,
+          similar_count: 1,
+          similar: {
+            items: [
+              {
+                id: '00000000-0000-0000-0000-000000000002',
+                display_id: 'VOC-0002',
+                title: '유사 VOC 제목',
+                reporter_facing_status: 'reviewing',
+                severity: 'medium',
+              },
+            ],
+          },
+        },
+      }),
+    );
+
+    renderWithClient(<VocDetailPanel vocId={DETAIL_ENVELOPE.id} onClose={vi.fn()} />);
+
+    await screen.findByText('테스트 VOC 제목');
+    expect(screen.getByText('트리아지 (Read only)')).toBeInTheDocument();
+    expect(screen.getByLabelText('유사 VOC')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Triage' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Similar' })).toBeInTheDocument();
+  });
+
   it('renders me.display_name when me matches reporter', () => {
     vi.mocked(useVocDetail).mockReturnValue(
       makeDetailQuery({ data: { ...DETAIL_ENVELOPE, reporter_id: ME_RESPONSE.actor.id } }),

--- a/docs/adr/0031-similar-voc-same-managed-system-heuristic.md
+++ b/docs/adr/0031-similar-voc-same-managed-system-heuristic.md
@@ -46,10 +46,14 @@ statuses and all ages are eligible. This is deliberately a weak heuristic, not
 > because the provider is disabled or the source has not yet been embedded, the
 > heuristic remains the only related-VOC signal.
 
+> **Amended 2026-08-05 (#337).** Reporter ownership does not grant peer read
+> access. A reporter arm without `voc.read` or `voc.triage` receives a full
+> detail envelope without peer-derived or internal-triage fields.
+
 A peer is visible only when its Managed System is in the actor's `voc.read`
-scope or the actor reported that peer. A triage-only summary envelope exposes
-neither `similar_count` nor `similar.items`: a full envelope for an actor's own
-VOC does not grant peer read access.
+scope. A triage-only summary envelope and a reporter arm without `voc.read` or
+`voc.triage` expose neither `similar_count` nor `similar.items`: a full
+envelope for an actor's own VOC does not grant peer read access.
 
 `similar_count` is the sole authorized-peer total. Detail adds
 `similar.items`, ordered by `created_at DESC, id DESC` and capped at three,

--- a/packages/shared/src/vocs/detail.ts
+++ b/packages/shared/src/vocs/detail.ts
@@ -8,15 +8,27 @@ import { reporterFacingStatusEnumSchema, vocListItemSchema } from './list-item.j
 export const vocDetailEnvelopeSchema = vocListItemSchema.extend({
   // The capped peer preview uses the same authorized peer set as similar_count.
   // similar_count remains the sole total; this array is intentionally not paginated.
-  similar: z.object({
-    items: z.array(z.object({
-      id: z.string().uuid(),
-      display_id: z.string(),
-      title: z.string(),
-      reporter_facing_status: reporterFacingStatusEnumSchema,
-      severity: z.enum(['low', 'medium', 'high', 'critical']).nullable(),
-    })).max(3),
-  }),
+  similar: z
+    .object({
+      items: z
+        .array(
+          z.object({
+            id: z.string().uuid(),
+            display_id: z.string(),
+            title: z.string(),
+            reporter_facing_status: reporterFacingStatusEnumSchema,
+            severity: z.enum(['low', 'medium', 'high', 'critical']).nullable(),
+          }),
+        )
+        .max(3),
+    })
+    .optional(),
+  // Reporter-arm envelopes omit peer-derived and internal-triage fields rather
+  // than claiming zero peers or an unassigned owner.
+  analytics_area_id: z.string().uuid().nullable().optional(),
+  owner_user_id: z.string().uuid().nullable().optional(),
+  owner_team_id: z.string().uuid().nullable().optional(),
+  similar_count: z.number().int().min(0).optional(),
   // TipTap doc — opaque jsonb; backend validates structure.
   description_rich_content: z.unknown(),
   // No action items in Slice 3; kept as opaque array for future shape.

--- a/scripts/gates/frontend-biome-allowlist.txt
+++ b/scripts/gates/frontend-biome-allowlist.txt
@@ -122,3 +122,11 @@ apps/frontend/src/features/voc/components/detail/ReporterStatusChangeBlock.tsx l
 packages/shared/src/vocs/create-request.ts format -- pre-existing on develop (1x, unchanged)
 packages/shared/src/vocs/__tests__/create-request.test.ts format -- pre-existing on develop (1x, unchanged)
 packages/shared/src/vocs/__tests__/create-request.test.ts organizeImports -- pre-existing on develop; import order predates biome
+apps/backend/src/modules/voc/read-service.ts format -- pre-existing on develop (1x, unchanged; measured against `git show develop:` of the same file)
+apps/backend/src/modules/voc/read-service.ts lint/style/noNonNullAssertion -- pre-existing on develop (1x, unchanged)
+apps/backend/src/modules/voc/read-service.ts lint/correctness/noUnusedVariables -- pre-existing on develop (1x, unchanged)
+apps/backend/src/modules/voc/__tests__/get-voc.integration.test.ts format -- pre-existing on develop (1x, unchanged)
+apps/backend/src/modules/voc/__tests__/get-voc.integration.test.ts lint/style/noUnusedTemplateLiteral -- pre-existing on develop (4x, unchanged)
+apps/backend/src/modules/voc/__tests__/get-voc.integration.test.ts lint/complexity/useLiteralKeys -- pre-existing on develop (5x, unchanged)
+apps/frontend/src/features/voc/components/detail/IdentitySection.tsx format -- pre-existing on develop (2x, unchanged)
+apps/frontend/src/features/voc/components/detail/__tests__/VocDetailPanel.test.tsx organizeImports -- pre-existing on develop; import order predates biome


### PR DESCRIPTION
블랙박스 Slice 19의 C3.

## 뿌리 (코드 실측)

`read-service.ts:537`의 분기가 그대로 원인이다:

```
msInReadScope || isReporter                          → FULL envelope
!msInReadScope && !isReporter && msInEffectiveScope   → SUMMARY envelope
!msInReadScope && !isReporter && !msInEffectiveScope  → 404
```

**리포터는 `voc.read`도 `voc.triage`도 없이 FULL 봉투를 받는다.** 그래서 `analytics_area_id`, `owner_user_id`, `owner_team_id`, `similar_count`, `similar.items`가 리포터에게 그대로 나갔다. 이슈가 본 "run-key 모양 식별자"는 `TriageBlock`이 raw로 찍은 UUID고, "유사 VOC ID 참조"는 `SimilarVocSection`이다.

## 고친 방식

**프론트에서 숨기지 않고 백엔드에서 뺐다.** 패널에서만 감추면 응답 본문에 남아 개발자 도구 한 탭 거리다.

리포터 arm = `isReporter && !msInReadScope && !canTriage`. 이 arm에서만 위 5개 키를 조립하지 않는다. **GET 상세와 post-write compose 경로 둘 다** 적용했다 — 읽기만 막으면 대화·수정 mutation 응답에서 같은 식별자가 재노출된다.

**0으로 채우지 않고 키를 생략한다.** `similar_count: 0`은 "이 VOC에 유사 건이 없다"는 **다른, 그리고 거짓인 주장**이다. shared 스키마에서 해당 필드를 옵셔널로 바꿔 부재를 유효한 계약으로 만들었다.

**리포터라는 사실이 권한을 빼앗지는 않는다.** `voc.read`가 있는 리포터는 지금과 똑같이 FULL을 받는다. SUMMARY 봉투와 404 분기는 건드리지 않았다.

프론트는 **액터 role이 아니라 백엔드가 보낸 키의 부재로** arm을 판정한다. API가 유일한 신뢰 경계이고, 한쪽 키만 빠진 malformed 봉투도 fail-closed로 처리한다.

## 곁가지로 잡은 것

`IdentitySection`의 `voc.analytics_area_id !== null`은 **`undefined`일 때 참**이 되어 리포터에게 빈 분석영역 칩을 렌더했을 것이다. null-ish 검사로 바꿨다.

## 뮤테이션 매트릭스 — 어느 단언이 발화했는가

| 뮤테이션 | 결과 | 발화한 단언 |
|---|---|---|
| 리포터 arm 판정 무력화 (`isReporterArm = false`) | ☠️ | BE 2건 (기존 unscoped-reporter + `#337: reporter without voc.read or voc.triage...`) |
| 생략 대신 `0`/`null`/빈 배열로 채움 | ☠️ | 같은 BE 2건 — **부재 계약이 실제로 검증된다** |
| `analytics_area_id` 한 필드만 되돌림 | ☠️ | `#337: reporter without voc.read or voc.triage...` |
| FE `TriageBlock` 게이팅 제거 | ☠️ | `#337: reporter-arm envelope omits Triage, Similar, and their navigation entries` |
| FE가 `similar` 한 키만 보고 판정 | ☠️ | `#337: treats a half-redacted envelope as the reporter arm` |

마지막 뮤테이션은 **처음엔 생존했다.** 두 키가 항상 함께 빠지므로 fail-closed OR의 두 번째 항을 아무도 검증하지 않았다. half-redacted 봉투 테스트를 추가해 죽였다.

**첫 실행에서 잡힌 타입 에러 3건** (워커는 타입체크를 돌릴 수 없다): `hasSimilarVocSection`의 타입 술어가 옵셔널 전환 후 `undefined`를 포함하는 타입으로 좁히고 있었다 → `NonNullable`로 교체.

## ADR-0031

peer 가시성 규칙이 "`voc.read` 스코프 **또는** 액터가 그 peer를 신고했으면"이었다. **그 두 번째 절이 구멍이다.** 해당 문단만 고치고 §Amended 2026-08-05 (#337)을 추가했다. 나머지 줄은 verbatim이다.

## 남은 것 — 후속 이슈로 낸다

`repo-read.ts`의 peer 가시성 SQL predicate는 여전히 리포터 소유를 허용한다. 상세 응답은 이 PR이 막았지만 **목록/사전제출(#293) 표면은 그 predicate를 그대로 쓴다.** 소유 파일 밖이라 이 청크에 넣지 않았다.

## 게이트

```
backend voc          432 passed / 42 files    ← 429에서
shared               437 passed / 31 files
frontend vitest      815 passed / 150 files
frontend typecheck   0 errors
frontend biome       0 unexpected, 120 allowlisted (8건 추가 — 전부 develop 대비 동일 개수로 실측)
frontend visual      58 passed                ← 베이스라인 무변동
check:boundaries     OK
```

Closes #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BfiR55zJ7n8uYpr1s3X6q