### PR TITLE
fix(#338,#325): 스코프 밖 VOC 상세 패널 정리 + 로그아웃 세션 경계

### DIFF
--- a/apps/frontend/src/features/voc/components/detail/VocDetailPanel.tsx
+++ b/apps/frontend/src/features/voc/components/detail/VocDetailPanel.tsx
@@ -41,6 +41,8 @@ import { TriageBlock } from './TriageBlock';
 
 export interface VocDetailPanelProps {
   vocId: string;
+  /** Current Managed System URL scope; an out-of-scope cached selection closes. */
+  managedSystemId?: string;
   /** Called when user closes the panel via X button or 404 selection clear. */
   onClose: () => void;
   /** Optional fullscreen toggle handler from useFullscreenPanel (#18). */
@@ -86,11 +88,24 @@ function DetailPanelSkeleton(): React.ReactElement {
 
 export function VocDetailPanel({
   vocId,
+  managedSystemId,
   onClose,
   onExpandToggle,
-}: VocDetailPanelProps): React.ReactElement {
+  // `null` while the scope-exit effect clears `selected`: rendering the old
+  // record for that tick is the bug this panel is closing over.
+}: VocDetailPanelProps): React.ReactElement | null {
   const { data, isLoading, isError, error } = useVocDetail(vocId);
   const { data: me } = useMe();
+  const selectedScopeExcludesVoc =
+    managedSystemId !== undefined &&
+    !isLoading &&
+    !isError &&
+    data !== undefined &&
+    data.primary_managed_system_id !== managedSystemId;
+
+  React.useEffect(() => {
+    if (selectedScopeExcludesVoc) onClose();
+  }, [onClose, selectedScopeExcludesVoc]);
 
   // 1. Loading
   if (isLoading) {
@@ -119,6 +134,10 @@ export function VocDetailPanel({
 
   if (!data) {
     return <DetailPanelNotFound onClearSelection={onClose} />;
+  }
+
+  if (selectedScopeExcludesVoc) {
+    return null;
   }
 
   // 3. Summary envelope — permission blocked

--- a/apps/frontend/src/features/voc/components/detail/__tests__/VocDetailPanel.test.tsx
+++ b/apps/frontend/src/features/voc/components/detail/__tests__/VocDetailPanel.test.tsx
@@ -1,6 +1,6 @@
+import type { TaskDetailDto } from '@fops/shared';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import type { TaskDetailDto } from '@fops/shared';
 import type * as React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -265,6 +265,90 @@ describe('<VocDetailPanel>', () => {
     vi.mocked(useVocDetail).mockReturnValue(makeDetailQuery());
     renderWithClient(<VocDetailPanel vocId="voc-uuid-1111" onClose={vi.fn()} />);
     expect(screen.getByText('테스트 VOC 제목')).toBeInTheDocument();
+  });
+
+  it('closes a mounted detail when the Managed System scope changes outside its envelope', async () => {
+    vi.mocked(useVocDetail).mockReturnValue(makeDetailQuery());
+    const onClose = vi.fn();
+    const { rerender } = renderWithClient(
+      <VocDetailPanel
+        vocId={DETAIL_ENVELOPE.id}
+        managedSystemId={DETAIL_ENVELOPE.primary_managed_system_id}
+        onClose={onClose}
+      />,
+    );
+
+    await screen.findByText('테스트 VOC 제목');
+    rerender(
+      <QueryClientProvider client={createQueryClient()}>
+        <VocDetailPanel
+          vocId={DETAIL_ENVELOPE.id}
+          managedSystemId="another-managed-system"
+          onClose={onClose}
+        />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => expect(onClose).toHaveBeenCalledOnce());
+    expect(screen.queryByText('테스트 VOC 제목')).not.toBeInTheDocument();
+    expect(screen.queryByText('VOC를 찾을 수 없습니다.')).not.toBeInTheDocument();
+  });
+
+  it('keeps a selected detail open for all Managed Systems', async () => {
+    vi.mocked(useVocDetail).mockReturnValue(makeDetailQuery());
+    const onClose = vi.fn();
+    renderWithClient(<VocDetailPanel vocId={DETAIL_ENVELOPE.id} onClose={onClose} />);
+
+    await screen.findByText('테스트 VOC 제목');
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('does not close while detail data is loading', async () => {
+    vi.mocked(useVocDetail).mockReturnValue(
+      makeDetailQuery({
+        isLoading: true,
+        isPending: true,
+        isSuccess: false,
+        status: 'pending',
+      }),
+    );
+    const onClose = vi.fn();
+    renderWithClient(
+      <VocDetailPanel
+        vocId={DETAIL_ENVELOPE.id}
+        managedSystemId="another-managed-system"
+        onClose={onClose}
+      />,
+    );
+
+    await screen.findByLabelText('VOC 상세 불러오는 중');
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('keeps a selected detail open when its Managed System scope remains the same', async () => {
+    vi.mocked(useVocDetail).mockReturnValue(makeDetailQuery());
+    const onClose = vi.fn();
+    const { rerender } = renderWithClient(
+      <VocDetailPanel
+        vocId={DETAIL_ENVELOPE.id}
+        managedSystemId={DETAIL_ENVELOPE.primary_managed_system_id}
+        onClose={onClose}
+      />,
+    );
+
+    await screen.findByText('테스트 VOC 제목');
+    rerender(
+      <QueryClientProvider client={createQueryClient()}>
+        <VocDetailPanel
+          vocId={DETAIL_ENVELOPE.id}
+          managedSystemId={DETAIL_ENVELOPE.primary_managed_system_id}
+          onClose={onClose}
+        />
+      </QueryClientProvider>,
+    );
+
+    expect(screen.getByText('테스트 VOC 제목')).toBeInTheDocument();
+    expect(onClose).not.toHaveBeenCalled();
   });
 
   it('loading state: renders skeletons instead of content', () => {

--- a/apps/frontend/src/features/voc/routes/InboxRoute.tsx
+++ b/apps/frontend/src/features/voc/routes/InboxRoute.tsx
@@ -154,7 +154,7 @@ export interface InboxRouteSlots {
 
 export function useInboxRoute(view: 'inbox' | 'my'): InboxRouteSlots {
   const search = useSearch({ strict: false }) as InboxSearch;
-  const navigate = useNavigate();
+  const navigate = useNavigate({ from: '/vocs' });
 
   // ── Derived URL state ─────────────────────────────────────────────────────
 
@@ -185,53 +185,51 @@ export function useInboxRoute(view: 'inbox' | 'my'): InboxRouteSlots {
 
   // ── Handlers ──────────────────────────────────────────────────────────────
 
-  // Navigate helpers use `as` casts on individual changed values to avoid
-  // fighting exactOptionalPropertyTypes against TanStack Router's internal
-  // ParamsReducerFn signature (where `prev` is optional-keyed but our return
-  // must be schema-exact). The router validates the output through the route's
-  // validateSearch at runtime, so the casts are safe.
-
   function handleTabChange(next: string): void {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     void navigate({
       to: '/vocs',
-      search: (prev: any) => ({ ...prev, tab: next as InboxTab }) as any,
+      search: (prev) => ({ ...prev, tab: next as InboxTab }),
     });
   }
 
   function handleFiltersChange(next: Record<string, string[]>): void {
     void navigate({
       to: '/vocs',
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      search: (prev: any) =>
-        ({
-          ...prev,
-          'filter.severity': serialiseCommaList(next['filter.severity'] ?? []),
-          'filter.reporterStatus': serialiseCommaList(next['filter.reporterStatus'] ?? []),
-          'filter.owner': serialiseCommaList(next['filter.owner'] ?? []),
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        }) as any,
+      search: (prev) => {
+        const {
+          'filter.severity': _severity,
+          'filter.reporterStatus': _reporterStatus,
+          'filter.owner': _owner,
+          ...rest
+        } = prev;
+        const severity = serialiseCommaList(next['filter.severity'] ?? []);
+        const reporterStatus = serialiseCommaList(next['filter.reporterStatus'] ?? []);
+        const owner = serialiseCommaList(next['filter.owner'] ?? []);
+        return {
+          ...rest,
+          ...(severity !== undefined ? { 'filter.severity': severity } : {}),
+          ...(reporterStatus !== undefined ? { 'filter.reporterStatus': reporterStatus } : {}),
+          ...(owner !== undefined ? { 'filter.owner': owner } : {}),
+        };
+      },
     });
   }
 
   function handleSortChange(next: string): void {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     void navigate({
       to: '/vocs',
-      search: (prev: any) => ({ ...prev, sort: next as InboxSort }) as any,
+      search: (prev) => ({ ...prev, sort: next as InboxSort }),
     });
   }
 
   function handleRowSelect(id: string): void {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    void navigate({ to: '/vocs', search: (prev: any) => ({ ...prev, selected: id }) as any });
+    void navigate({ to: '/vocs', search: (prev) => ({ ...prev, selected: id }) });
   }
 
   function handlePanelClose(): void {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     void navigate({
       to: '/vocs',
-      search: (prev: any) => ({ ...prev, selected: undefined }) as any,
+      search: ({ selected: _selected, ...rest }) => rest,
     });
   }
 
@@ -340,7 +338,11 @@ export function useInboxRoute(view: 'inbox' | 'my'): InboxRouteSlots {
 
   const detailPanel =
     search.selected !== undefined ? (
-      <VocDetailPanel vocId={search.selected} onClose={handlePanelClose} />
+      <VocDetailPanel
+        vocId={search.selected}
+        {...(search.managedSystem !== undefined ? { managedSystemId: search.managedSystem } : {})}
+        onClose={handlePanelClose}
+      />
     ) : undefined;
 
   return { list, detailPanel };

--- a/apps/frontend/src/features/voc/routes/__tests__/InboxRoute.test.tsx
+++ b/apps/frontend/src/features/voc/routes/__tests__/InboxRoute.test.tsx
@@ -9,6 +9,7 @@
 
 import { ApiError } from '@/lib/api/types';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useEffect } from 'react';
 import type * as React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -121,17 +122,29 @@ vi.mock('../../hooks/useVocList', () => ({
 vi.mock('../../components/detail/VocDetailPanel', () => ({
   VocDetailPanel: ({
     vocId,
+    managedSystemId,
     onClose,
   }: {
     vocId: string;
+    managedSystemId?: string;
     onClose: () => void;
-  }) => (
-    <div data-testid="voc-detail-panel-stub" data-voc-id={vocId}>
-      <button type="button" onClick={onClose}>
-        닫기
-      </button>
-    </div>
-  ),
+  }) => {
+    useEffect(() => {
+      if (managedSystemId !== undefined && managedSystemId !== 'ms-1') onClose();
+    }, [managedSystemId, onClose]);
+
+    return (
+      <div
+        data-testid="voc-detail-panel-stub"
+        data-managed-system-id={managedSystemId}
+        data-voc-id={vocId}
+      >
+        <button type="button" onClick={onClose}>
+          닫기
+        </button>
+      </div>
+    );
+  },
 }));
 
 // ── Stub VocList to use real component but mock managed-systems query ─────────
@@ -231,6 +244,41 @@ describe('useInboxRoute', () => {
     });
     expect(screen.getByTestId('voc-detail-panel-stub').getAttribute('data-voc-id')).toBe(
       '00000000-0000-0000-0000-000000000001',
+    );
+  });
+
+  it('clears selected after the URL Managed System changes outside the open VOC scope', async () => {
+    const selected = '00000000-0000-0000-0000-000000000001';
+    searchState = { view: 'inbox', managedSystem: 'ms-1', selected };
+    const { rerender } = render(<InboxTestHarness view="inbox" />);
+
+    await screen.findByTestId('voc-detail-panel-stub');
+
+    searchState = { view: 'inbox', managedSystem: 'ms-2', selected };
+    rerender(<InboxTestHarness view="inbox" />);
+
+    await waitFor(() => expect(navigateMock).toHaveBeenCalled());
+    const navigation = navigateMock.mock.calls.at(-1)?.[0] as {
+      search: (previous: Record<string, unknown>) => Record<string, unknown>;
+    };
+    expect(navigation.search(searchState)).toEqual({ view: 'inbox', managedSystem: 'ms-2' });
+
+    searchState = navigation.search(searchState);
+    rerender(<InboxTestHarness view="inbox" />);
+    expect(screen.queryByTestId('voc-detail-panel-stub')).not.toBeInTheDocument();
+  });
+
+  it('passes the selected Managed System to the open detail panel', async () => {
+    searchState = {
+      view: 'my',
+      managedSystem: 'ms-1',
+      selected: '00000000-0000-0000-0000-000000000001',
+    };
+    render(<InboxTestHarness view="my" />);
+
+    expect(await screen.findByTestId('voc-detail-panel-stub')).toHaveAttribute(
+      'data-managed-system-id',
+      'ms-1',
     );
   });
 

--- a/apps/frontend/src/lib/layout/AppRail.tsx
+++ b/apps/frontend/src/lib/layout/AppRail.tsx
@@ -73,7 +73,16 @@ export function AppRail({ activeDomain = 'voc', className }: AppRailProps) {
       // Navigation still ends the local session when the revoke request cannot finish.
     } finally {
       queryClient.clear();
-      navigate({ to: '/login' });
+      // `replace` so Back cannot return to the previous actor's app shell. The
+      // revoked session would not serve it data, but a stale render of another
+      // actor's screen is exactly the boundary a logout is meant to draw.
+      // Wrapped rather than chained directly: navigate's return value is not
+      // part of the contract we rely on here.
+      void Promise.resolve(navigate({ to: '/login', replace: true })).catch(() => {
+        // Only on failure: the success path unmounts this rail. Without this the
+        // menu item stays disabled forever and the user cannot retry.
+        setIsLoggingOut(false);
+      });
     }
   }
 

--- a/apps/frontend/src/lib/layout/__tests__/AppRail.test.tsx
+++ b/apps/frontend/src/lib/layout/__tests__/AppRail.test.tsx
@@ -104,7 +104,7 @@ describe('AppRail account menu', () => {
     openAccountMenu();
     fireEvent.click(screen.getByRole('menuitem', { name: '로그아웃' }));
 
-    await waitFor(() => expect(navigate).toHaveBeenCalledWith({ to: '/login' }));
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith({ to: '/login', replace: true }));
     expect(logout).toHaveBeenCalledOnce();
     expect(queryClient.clear).toHaveBeenCalledOnce();
     expect(calls).toEqual(['logout', 'clear', 'navigate']);
@@ -118,8 +118,28 @@ describe('AppRail account menu', () => {
     openAccountMenu();
     fireEvent.click(screen.getByRole('menuitem', { name: '로그아웃' }));
 
-    await waitFor(() => expect(navigate).toHaveBeenCalledWith({ to: '/login' }));
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith({ to: '/login', replace: true }));
     expect(clear).toHaveBeenCalledOnce();
+  });
+
+  it('re-enables logout when the route change itself fails', async () => {
+    // Without this the item stays disabled for the rest of the session and the
+    // user is stranded on a screen whose session has already been revoked.
+    logout.mockResolvedValue(undefined);
+    navigate.mockRejectedValue(new Error('route failed'));
+    renderRail();
+
+    openAccountMenu();
+    fireEvent.click(screen.getByRole('menuitem', { name: '로그아웃' }));
+
+    await waitFor(() => expect(navigate).toHaveBeenCalledOnce());
+    openAccountMenu();
+    await waitFor(() =>
+      expect(screen.getByRole('menuitem', { name: '로그아웃' })).not.toHaveAttribute(
+        'aria-disabled',
+        'true',
+      ),
+    );
   });
 
   it('shows the Actor display name and Role Level in the account menu', () => {


### PR DESCRIPTION
블랙박스 Slice 19의 C4(#338)와 C1 잔여(#325). 둘 다 "경계를 바꿨는데 이전 상태가 남는다"는 같은 모양이고 파일이 겹치지 않아 함께 검증했다.

## #338 — Managed System을 바꿔도 이전 스코프의 상세가 남는다

**뿌리:** `InboxRoute.tsx`의 상세 슬롯이 `search.selected`만 봤다. `search.managedSystem`이 바뀌면 목록은 새 스코프로 갈아엎어지는데 상세는 이전 스코프의 레코드를 계속 그렸다.

패널이 봉투의 `primary_managed_system_id`를 URL 스코프와 대조해 닫고 `selected`를 비운다.

**`DetailPanelNotFound`로 렌더하지 않는다.** 레코드는 존재하고 액터는 읽을 권한도 있다 — 필터를 바꿨을 뿐이다. 그걸 "찾을 수 없음"이라 하는 것은 거짓말이고, 백엔드의 `out_of_scope_summary` 어휘는 **권한** 경계지 필터가 아니다. (참고 커밋 `ff894e5`는 not-found를 렌더한다 — 이 지점에서 갈라섰다.)

로딩·에러 중에는 판정하지 않고, 필터가 없는 "전체" 상태에서는 아무것도 스코프 밖이 아니다. 안 그러면 정상 선택이 깜빡이며 사라진다.

**곁가지:** 이 라우트의 `(prev: any)` search 리듀서 3곳을 걷어냈다. `useNavigate({ from: '/vocs' })`로 라우터가 형태를 추론하게 했고, #341이 `LinksRoute`에 한 것과 같은 처방이다. **애초에 이 캐스트들 때문에 이 종류의 회귀를 컴파일러가 못 잡았다.**

## #325 — 로그아웃 후 Back이 이전 액터의 앱 셸로 돌아간다

로그아웃은 세션을 revoke하고 캐시를 비웠지만 `/login`을 **push**했다. revoke된 세션이 데이터를 주지는 않지만, 다른 액터 화면의 낡은 렌더가 남는 것 자체가 로그아웃이 그으려는 경계다. `replace`로 바꿨다.

`isLoggingOut`에 리셋이 없던 것도 고쳤다. 성공 시에는 레일이 언마운트되므로 리셋이 필요 없지만, **라우트 전환이 실패하면 메뉴 항목이 세션 내내 비활성으로 남아** 이미 죽은 세션의 화면에 사용자가 갇힌다. 실패 경로에서만 리셋한다.

## 뮤테이션 매트릭스 — 어느 단언이 발화했는가

| 뮤테이션 | 결과 | 발화한 단언 |
|---|---|---|
| 스코프 판정 무력화 | ☠️ | `closes a mounted detail when the Managed System scope changes outside its envelope` |
| 전체 범위(`undefined`)에서도 닫음 | ☠️ | 11건 — `keeps a selected detail open for all Managed Systems` 외 기존 패널 테스트 전부 |
| 로딩 중에도 스코프 판정 | ☠️ | `does not close while detail data is loading` |
| 로그아웃에서 `replace` 제거 | ☠️ | `revokes once, then clears cached data and routes to login` + 실패 경로 1건 |
| 실패 시 `isLoggingOut` 리셋 제거 | ☠️ | `re-enables logout when the route change itself fails` |

**첫 실행에서 잡힌 것:** `VocDetailPanel`이 `null`을 반환하게 되면서 반환 타입이 `React.ReactElement`와 어긋났다 (typecheck 1건). 워커는 타입체크를 돌릴 수 없다.

**직접 확인한 전제:** 요약(권한 차단) 봉투에도 `primary_managed_system_id`가 있다(`detail.ts:83`). 그래서 스코프 비교가 두 봉투 모두에서 유효하고, 참고 커밋이 쓰던 `'primary_managed_system_id' in data` 가드는 필요 없다.

## 게이트

```
frontend vitest      822 passed / 150 files   ← 815에서
frontend typecheck   0 errors
frontend biome       0 unexpected, 120 allowlisted
frontend visual      58 passed                ← 베이스라인 무변동
```

Closes #338
Closes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BfiR55zJ7n8uYpr1s3X6q