### PR TITLE
fix(#344): 나머지 4개 표면에서도 공백만 있는 rich content를 거부한다

### DIFF
--- a/apps/backend/src/modules/voc/__tests__/blank-rich-content-surfaces.integration.test.ts
+++ b/apps/backend/src/modules/voc/__tests__/blank-rich-content-surfaces.integration.test.ts
@@ -1,0 +1,250 @@
+// Remaining blank rich-content route contracts (#344).
+
+import { randomUUID } from 'node:crypto';
+
+import type { FastifyInstance } from 'fastify';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { loadConfig } from '../../../config.js';
+import { type DbHandle, createDb } from '../../../db/client.js';
+import { SESSION_COOKIE_NAME } from '../../../middleware/require-session.js';
+import { buildServer } from '../../../server.js';
+import {
+  grantCapability,
+  insertDevActor,
+  insertMsDirectly,
+  insertVocDirectly,
+  loginAs,
+  paragraphDoc,
+  uid,
+} from './_seed-helpers.js';
+
+const APP_URL = process.env.DATABASE_URL ?? '';
+const MIGRATE_URL = process.env.DATABASE_URL_MIGRATE ?? '';
+const WORKSPACE_ID = process.env.WORKSPACE_ID ?? '';
+const runIntegration = Boolean(APP_URL && WORKSPACE_ID);
+const SLUG_PREFIX = 'it-blank-rich';
+
+const blankDoc = paragraphDoc('   ');
+
+async function insertReporterActor(
+  dbHandle: DbHandle,
+  suffix: string,
+): Promise<{ id: string; externalId: string }> {
+  const externalId = `mock-user-blank-rich-${suffix}`;
+  const result = await dbHandle.pool.query<{ id: string }>(
+    `insert into core.actors (workspace_id, external_id, email, display_name, role_level, actor_type)
+       values ($1, $2, $3, $4, 'user', 'internal_member') returning id`,
+    [WORKSPACE_ID, externalId, `${suffix}@local`, `Blank rich ${suffix}`],
+  );
+  const id = result.rows[0]?.id;
+  if (!id) throw new Error('failed to insert reporter');
+  return { id, externalId };
+}
+
+describe.skipIf(!runIntegration)(
+  'remaining rich-content surfaces reject blank bodies (#344)',
+  () => {
+    let app: FastifyInstance;
+    let dbHandle: DbHandle;
+    let adminActorId: string;
+
+    function request(
+      cookie: string,
+      method: 'POST' | 'PATCH',
+      url: string,
+      payload: Record<string, unknown>,
+      ifMatch?: string,
+    ) {
+      return app.inject({
+        method,
+        url,
+        headers: {
+          cookie: `${SESSION_COOKIE_NAME}=${cookie}`,
+          'content-type': 'application/json',
+          'idempotency-key': randomUUID(),
+          ...(ifMatch ? { 'if-match': ifMatch } : {}),
+        },
+        payload,
+      });
+    }
+
+    async function setupReporter(suffix: string) {
+      const reporter = await insertReporterActor(dbHandle, suffix);
+      const cookie = await loginAs(app, reporter.externalId);
+      const msId = await insertMsDirectly(
+        dbHandle,
+        WORKSPACE_ID,
+        `${uid(SLUG_PREFIX)}-${suffix}`,
+        suffix,
+      );
+      const voc = await insertVocDirectly(dbHandle, WORKSPACE_ID, msId, reporter.id, suffix);
+      return { cookie, voc };
+    }
+
+    async function setupDeveloper(suffix: string) {
+      const developer = await insertDevActor(dbHandle, WORKSPACE_ID, `blank-rich-${suffix}`);
+      const cookie = await loginAs(app, developer.externalId);
+      const reporter = await insertReporterActor(dbHandle, `${suffix}-reporter`);
+      const msId = await insertMsDirectly(
+        dbHandle,
+        WORKSPACE_ID,
+        `${uid(SLUG_PREFIX)}-${suffix}`,
+        suffix,
+      );
+      await grantCapability(dbHandle, WORKSPACE_ID, developer.id, 'voc.triage', msId, adminActorId);
+      const voc = await insertVocDirectly(dbHandle, WORKSPACE_ID, msId, reporter.id, suffix);
+      return { cookie, voc };
+    }
+
+    beforeAll(async () => {
+      process.env.NODE_ENV = 'test';
+      dbHandle = createDb(APP_URL);
+      app = await buildServer({ config: loadConfig(), dbHandle });
+      await app.ready();
+      const admin = await dbHandle.pool.query<{ id: string }>(
+        `select id from core.actors where workspace_id = $1 and external_id = 'mock-admin-1'`,
+        [WORKSPACE_ID],
+      );
+      adminActorId = admin.rows[0]?.id ?? '';
+      if (!adminActorId) throw new Error('mock-admin-1 not found');
+    });
+
+    afterAll(async () => {
+      if (MIGRATE_URL) {
+        const ops = createDb(MIGRATE_URL);
+        try {
+          await ops.pool.query(
+            `delete from core.audit_log where subject_id in (
+             select v.id from voc.vocs v join core.managed_systems ms on ms.id = v.primary_managed_system_id
+             where ms.slug like $1
+           )`,
+            [`${SLUG_PREFIX}%`],
+          );
+        } finally {
+          await ops.close();
+        }
+      }
+      await dbHandle.pool.query(
+        'delete from voc.vocs where primary_managed_system_id in (select id from core.managed_systems where slug like $1)',
+        [`${SLUG_PREFIX}%`],
+      );
+      await dbHandle.pool.query(
+        `delete from permission.permission_grants where actor_id in (select id from core.actors where external_id like 'mock-%blank-rich%')`,
+      );
+      await dbHandle.pool.query(
+        `delete from core.sessions where actor_id in (select id from core.actors where external_id like 'mock-%blank-rich%')`,
+      );
+      // Every request in this suite sends an Idempotency-Key, and those rows FK
+      // to the actor. They must go before the actors do.
+      await dbHandle.pool.query(
+        `delete from core.idempotency_keys where actor_id in (select id from core.actors where external_id like 'mock-%blank-rich%')`,
+      );
+      await dbHandle.pool.query(
+        `delete from core.actors where external_id like 'mock-%blank-rich%'`,
+      );
+      await dbHandle.pool.query('delete from core.managed_systems where slug like $1', [
+        `${SLUG_PREFIX}%`,
+      ]);
+      await app?.close();
+      await dbHandle?.close();
+    });
+
+    it('reporter reply rejects blank content and stores a normal reply', async () => {
+      const { cookie, voc } = await setupReporter('reply');
+      const blank = await request(cookie, 'POST', `/vocs/${voc.id}/reporter-replies`, {
+        body_rich_content: blankDoc,
+      });
+      expect(blank.statusCode).toBe(422);
+      expect(blank.json<{ code: string }>().code).toBe('validation.failed');
+      const normal = await request(cookie, 'POST', `/vocs/${voc.id}/reporter-replies`, {
+        body_rich_content: paragraphDoc('reply'),
+      });
+      expect(normal.statusCode).toBe(201);
+      const stored = await dbHandle.pool.query(
+        'select id from voc.voc_reporter_replies where id = $1',
+        [normal.json<{ reporter_reply: { id: string } }>().reporter_reply.id],
+      );
+      expect(stored.rowCount).toBe(1);
+    });
+
+    it('public update rejects blank content and stores a normal update', async () => {
+      const { cookie, voc } = await setupDeveloper('update');
+      const body = {
+        skip_public_update: false as const,
+        next_reporter_facing_status: 'received' as const,
+      };
+      const blank = await request(cookie, 'POST', `/vocs/${voc.id}/public-updates`, {
+        ...body,
+        body_rich_content: blankDoc,
+      });
+      expect(blank.statusCode).toBe(422);
+      expect(blank.json<{ code: string }>().code).toBe('validation.failed');
+      const normal = await request(cookie, 'POST', `/vocs/${voc.id}/public-updates`, {
+        ...body,
+        body_rich_content: paragraphDoc('update'),
+      });
+      expect(normal.statusCode).toBe(201);
+      const stored = await dbHandle.pool.query(
+        'select id from voc.voc_public_updates where id = $1',
+        [normal.json<{ public_update: { id: string } }>().public_update.id],
+      );
+      expect(stored.rowCount).toBe(1);
+    });
+
+    it('internal comment rejects blank content and stores a normal comment', async () => {
+      const { cookie, voc } = await setupDeveloper('comment');
+      const blank = await request(cookie, 'POST', `/vocs/${voc.id}/internal-comments`, {
+        body_rich_content: blankDoc,
+      });
+      expect(blank.statusCode).toBe(422);
+      expect(blank.json<{ code: string }>().code).toBe('validation.failed');
+      const normal = await request(cookie, 'POST', `/vocs/${voc.id}/internal-comments`, {
+        body_rich_content: paragraphDoc('comment'),
+      });
+      expect(normal.statusCode).toBe(201);
+      const stored = await dbHandle.pool.query(
+        'select id from voc.voc_internal_comments where id = $1',
+        [normal.json<{ internal_comment: { id: string } }>().internal_comment.id],
+      );
+      expect(stored.rowCount).toBe(1);
+    });
+
+    it('description edit rejects blank content and stores a normal description', async () => {
+      const { cookie, voc } = await setupReporter('description');
+      // If-Match must come from the API, not from the SQL seed: `updated_at::text`
+      // is postgres text ("2026-08-05 03:20:00+00"), not the ISO string the route
+      // compares against, and every request would 409 stale_write.
+      const seeded = await app.inject({
+        method: 'GET',
+        url: `/vocs/${voc.id}`,
+        headers: { cookie: `${SESSION_COOKIE_NAME}=${cookie}` },
+      });
+      expect(seeded.statusCode).toBe(200);
+      const etag = seeded.json<{ updated_at: string }>().updated_at;
+
+      const blank = await request(
+        cookie,
+        'PATCH',
+        `/vocs/${voc.id}/description`,
+        { description_rich_content: blankDoc },
+        etag,
+      );
+      expect(blank.statusCode).toBe(422);
+      expect(blank.json<{ code: string }>().code).toBe('validation.failed');
+      const normal = await request(
+        cookie,
+        'PATCH',
+        `/vocs/${voc.id}/description`,
+        { description_rich_content: paragraphDoc('description') },
+        etag,
+      );
+      expect(normal.statusCode).toBe(200);
+      const stored = await dbHandle.pool.query<{ description_rich_content: unknown }>(
+        'select description_rich_content from voc.vocs where id = $1',
+        [voc.id],
+      );
+      expect(stored.rows[0]?.description_rich_content).toEqual(paragraphDoc('description'));
+    });
+  },
+);

--- a/apps/frontend/src/features/voc/components/detail/InternalCommentComposer.tsx
+++ b/apps/frontend/src/features/voc/components/detail/InternalCommentComposer.tsx
@@ -30,7 +30,7 @@ import { useVocInternalCommentMutation } from '@/features/voc/hooks/useVocIntern
 import { extractMentions } from '@/features/voc/lib/extractMentions';
 import { uploadAttachment } from '@/lib/api/attachments';
 import type { MeResponse } from '@/lib/auth/useMe';
-import type { VocDetailEnvelope } from '@fops/shared';
+import { type VocDetailEnvelope, isTipTapDocBlank } from '@fops/shared';
 import type { TipTapDoc, TipTapEditor } from '@fops/ui';
 import { RichEditor } from '@fops/ui';
 import { useQueryClient } from '@tanstack/react-query';
@@ -50,20 +50,6 @@ export interface InternalCommentComposerProps {
   draftDoc?: TipTapDoc | null;
   /** REV-1 #7: called when the editor content changes. */
   onDraftChange?: (doc: TipTapDoc | null) => void;
-}
-
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
-function isDocEmpty(doc: TipTapDoc | null): boolean {
-  if (doc == null) return true;
-  const content = doc.content;
-  if (!Array.isArray(content) || content.length === 0) return true;
-  return content.every((node) => {
-    if (node == null || typeof node !== 'object') return true;
-    const n = node as { type?: string; content?: unknown[] };
-    if (n.type !== 'paragraph') return false;
-    return !Array.isArray(n.content) || n.content.length === 0;
-  });
 }
 
 // ── Component ─────────────────────────────────────────────────────────────────
@@ -108,7 +94,7 @@ export function InternalCommentComposer({
   const [attachmentIds, setAttachmentIds] = React.useState<string[]>([]);
   const [attachmentsUploading, setAttachmentsUploading] = React.useState(false);
 
-  const isEmpty = isDocEmpty(draftDoc);
+  const isEmpty = isTipTapDocBlank(draftDoc);
 
   const mutation = useVocInternalCommentMutation({
     onSuccess: () => {

--- a/apps/frontend/src/features/voc/components/detail/PublicUpdateComposer.tsx
+++ b/apps/frontend/src/features/voc/components/detail/PublicUpdateComposer.tsx
@@ -66,7 +66,11 @@ import type { ApiError } from '@/lib/api';
 import { uploadAttachment } from '@/lib/api/attachments';
 import type { MeResponse } from '@/lib/auth/useMe';
 import { REPORTER_STATUS_LABELS } from '@/lib/copy/reporter-status-labels';
-import type { ReporterFacingStatusEnum, VocDetailEnvelope } from '@fops/shared';
+import {
+  type ReporterFacingStatusEnum,
+  type VocDetailEnvelope,
+  isTipTapDocBlank,
+} from '@fops/shared';
 import { Button, Callout, PreviewModal, RichEditor } from '@fops/ui';
 import type { TipTapDoc } from '@fops/ui';
 import { useQueryClient } from '@tanstack/react-query';
@@ -92,20 +96,6 @@ export interface PublicUpdateComposerProps {
   draftDoc?: TipTapDoc | null;
   /** REV-1 #7: called when the editor content changes. */
   onDraftChange?: (doc: TipTapDoc | null) => void;
-}
-
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
-function isDocEmpty(doc: TipTapDoc | null): boolean {
-  if (doc == null) return true;
-  const content = doc.content;
-  if (!Array.isArray(content) || content.length === 0) return true;
-  return content.every((node) => {
-    if (node == null || typeof node !== 'object') return true;
-    const n = node as { type?: string; content?: unknown[] };
-    if (n.type !== 'paragraph') return false;
-    return !Array.isArray(n.content) || n.content.length === 0;
-  });
 }
 
 // Maps ApiError code to Callout tone for the inline error surface.
@@ -163,7 +153,7 @@ export function PublicUpdateComposer({
   // Gate check: Publish is disabled when reporter_status_gate.blocking_for includes nextStatus.
   const isGateBlocked = voc.reporter_status_gate?.blocking_for.includes(nextStatus) ?? false;
 
-  const isEmpty = isDocEmpty(draftDoc);
+  const isEmpty = isTipTapDocBlank(draftDoc);
 
   const mutation = useVocPublicUpdateMutation({
     onSuccess: () => {

--- a/apps/frontend/src/features/voc/components/detail/ReporterReplyComposer.tsx
+++ b/apps/frontend/src/features/voc/components/detail/ReporterReplyComposer.tsx
@@ -41,7 +41,7 @@ import { useVocReporterReplyMutation } from '@/features/voc/hooks/useVocReporter
 import type { ApiError } from '@/lib/api';
 import { uploadAttachment } from '@/lib/api/attachments';
 import type { MeResponse } from '@/lib/auth/useMe';
-import { type VocDetailEnvelope, isTipTapDocStructurallyEmpty } from '@fops/shared';
+import { type VocDetailEnvelope, isTipTapDocBlank } from '@fops/shared';
 import { Callout, PreviewModal, RichEditor } from '@fops/ui';
 import type { TipTapDoc } from '@fops/ui';
 import { useQueryClient } from '@tanstack/react-query';
@@ -111,7 +111,7 @@ export function ReporterReplyComposer({
     setPreviewOpen(false);
   }
 
-  const isEmpty = isTipTapDocStructurallyEmpty(draftDoc);
+  const isEmpty = isTipTapDocBlank(draftDoc);
 
   const mutation = useVocReporterReplyMutation({
     onSuccess: () => {

--- a/apps/frontend/src/features/voc/components/detail/__tests__/InternalCommentComposer.test.tsx
+++ b/apps/frontend/src/features/voc/components/detail/__tests__/InternalCommentComposer.test.tsx
@@ -185,4 +185,41 @@ describe('<InternalCommentComposer>', () => {
     expect(previewBtn).toBeInTheDocument();
     expect(previewBtn).toBeDisabled();
   });
+
+  it('disables Add note for a whitespace-only draft without calling the mutation', () => {
+    render(
+      <InternalCommentComposer
+        voc={BASE_VOC}
+        me={ME_ADMIN}
+        draftDoc={{
+          type: 'doc',
+          content: [{ type: 'paragraph', content: [{ type: 'text', text: '   ' }] }],
+        }}
+      />,
+      { wrapper: makeWrapper() },
+    );
+
+    expect(screen.getByTestId('internal-comment-composer')).toBeInTheDocument();
+    const add = screen.getByRole('button', { name: /add note/i });
+    expect(add).toBeDisabled();
+    fireEvent.click(add);
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  it('enables Add note for a text draft', () => {
+    render(
+      <InternalCommentComposer
+        voc={BASE_VOC}
+        me={ME_ADMIN}
+        draftDoc={{
+          type: 'doc',
+          content: [{ type: 'paragraph', content: [{ type: 'text', text: 'note' }] }],
+        }}
+      />,
+      { wrapper: makeWrapper() },
+    );
+
+    expect(screen.getByTestId('internal-comment-composer')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /add note/i })).not.toBeDisabled();
+  });
 });

--- a/apps/frontend/src/features/voc/components/detail/__tests__/PublicUpdateComposer.test.tsx
+++ b/apps/frontend/src/features/voc/components/detail/__tests__/PublicUpdateComposer.test.tsx
@@ -15,9 +15,11 @@ import * as React from 'react';
 
 // ── Module mocks ─────────────────────────────────────────────────────────────
 
+const mockMutate = vi.fn();
+
 vi.mock('@/features/voc/hooks/useVocPublicUpdateMutation', () => ({
   useVocPublicUpdateMutation: vi.fn(() => ({
-    mutate: vi.fn(),
+    mutate: mockMutate,
     isPending: false,
     isError: false,
     error: null,
@@ -152,5 +154,42 @@ describe('<PublicUpdateComposer>', () => {
     // The Publish button must be disabled when gate blocks the staged next status.
     const publishBtn = screen.getByRole('button', { name: /publish update/i });
     expect(publishBtn).toBeDisabled();
+  });
+
+  it('disables Publish for a whitespace-only draft without calling the mutation', () => {
+    render(
+      <PublicUpdateComposer
+        voc={BASE_VOC}
+        me={ME_ADMIN}
+        draftDoc={{
+          type: 'doc',
+          content: [{ type: 'paragraph', content: [{ type: 'text', text: '   ' }] }],
+        }}
+      />,
+      { wrapper: makeWrapper() },
+    );
+
+    expect(screen.getByTestId('public-update-composer')).toBeInTheDocument();
+    const publish = screen.getByRole('button', { name: /^publish update$/i });
+    expect(publish).toBeDisabled();
+    publish.click();
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  it('enables Publish for a text draft', () => {
+    render(
+      <PublicUpdateComposer
+        voc={BASE_VOC}
+        me={ME_ADMIN}
+        draftDoc={{
+          type: 'doc',
+          content: [{ type: 'paragraph', content: [{ type: 'text', text: 'update' }] }],
+        }}
+      />,
+      { wrapper: makeWrapper() },
+    );
+
+    expect(screen.getByTestId('public-update-composer')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^publish update$/i })).not.toBeDisabled();
   });
 });

--- a/apps/frontend/src/features/voc/components/detail/__tests__/ReporterReplyComposer.test.tsx
+++ b/apps/frontend/src/features/voc/components/detail/__tests__/ReporterReplyComposer.test.tsx
@@ -186,4 +186,41 @@ describe('<ReporterReplyComposer>', () => {
     const composers = screen.getAllByTestId('reporter-reply-composer');
     expect(composers.length).toBeGreaterThanOrEqual(1);
   });
+
+  it('disables Send reply for a whitespace-only draft without calling the mutation', () => {
+    render(
+      <ReporterReplyComposer
+        voc={BASE_VOC}
+        me={ME_REPORTER}
+        draftDoc={{
+          type: 'doc',
+          content: [{ type: 'paragraph', content: [{ type: 'text', text: '   ' }] }],
+        }}
+      />,
+      { wrapper: makeWrapper() },
+    );
+
+    expect(screen.getByTestId('reporter-reply-composer')).toBeInTheDocument();
+    const send = screen.getByRole('button', { name: /send reply/i });
+    expect(send).toBeDisabled();
+    fireEvent.click(send);
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  it('enables Send reply for a text draft', () => {
+    render(
+      <ReporterReplyComposer
+        voc={BASE_VOC}
+        me={ME_REPORTER}
+        draftDoc={{
+          type: 'doc',
+          content: [{ type: 'paragraph', content: [{ type: 'text', text: 'reply' }] }],
+        }}
+      />,
+      { wrapper: makeWrapper() },
+    );
+
+    expect(screen.getByTestId('reporter-reply-composer')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /send reply/i })).not.toBeDisabled();
+  });
 });

--- a/apps/frontend/src/features/voc/hooks/__tests__/useVocInternalCommentMutation.test.ts
+++ b/apps/frontend/src/features/voc/hooks/__tests__/useVocInternalCommentMutation.test.ts
@@ -49,7 +49,10 @@ const BASE_VARS: InternalCommentVars = {
   vocId: VOC_ID,
   ifMatch: UPDATED_AT,
   body: {
-    body_rich_content: { type: 'doc', content: [{ type: 'paragraph' }] },
+    body_rich_content: {
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'body' }] }],
+    },
     mentions: MENTION_IDS,
     attachment_ids: ['30000000-0000-4000-8000-000000000005'],
   },

--- a/apps/frontend/src/features/voc/hooks/__tests__/useVocPublicUpdateMutation.test.ts
+++ b/apps/frontend/src/features/voc/hooks/__tests__/useVocPublicUpdateMutation.test.ts
@@ -45,7 +45,10 @@ const BODY_ONLY_VARS: PublicUpdateVars = {
   ifMatch: UPDATED_AT,
   body: {
     skip_public_update: false,
-    body_rich_content: { type: 'doc', content: [{ type: 'paragraph' }] },
+    body_rich_content: {
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'body' }] }],
+    },
     next_reporter_facing_status: 'received',
     attachment_ids: ['20000000-0000-4000-8000-000000000002'],
   },

--- a/apps/frontend/src/features/voc/hooks/__tests__/useVocReporterReplyMutation.test.ts
+++ b/apps/frontend/src/features/voc/hooks/__tests__/useVocReporterReplyMutation.test.ts
@@ -47,7 +47,10 @@ const REPLY_VARS: ReporterReplyVars = {
   vocId: VOC_ID,
   ifMatch: UPDATED_AT,
   body: {
-    body_rich_content: { type: 'doc', content: [{ type: 'paragraph' }] },
+    body_rich_content: {
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'body' }] }],
+    },
     attachment_ids: ['10000000-0000-4000-8000-000000000001'],
   },
 };

--- a/packages/shared/src/vocs/__tests__/edit-description-request.test.ts
+++ b/packages/shared/src/vocs/__tests__/edit-description-request.test.ts
@@ -7,6 +7,12 @@ const validDoc = {
   type: 'doc' as const,
   content: [{ type: 'paragraph', content: [{ type: 'text', text: 'hello' }] }],
 };
+const blankDoc = {
+  type: 'doc' as const,
+  content: [{ type: 'paragraph', content: [{ type: 'text', text: '   ' }] }],
+};
+const emptyDoc = { type: 'doc' as const, content: [] };
+const mentionDoc = { type: 'doc' as const, content: [{ type: 'mention' }] };
 
 describe('editDescriptionRequestSchema', () => {
   it('accepts all 3 fields', () => {
@@ -28,6 +34,19 @@ describe('editDescriptionRequestSchema', () => {
       description_rich_content: validDoc,
     });
     expect(result.description_rich_content).toEqual(validDoc);
+  });
+
+  it.each([
+    ['whitespace-only paragraph', blankDoc],
+    ['structurally empty document', emptyDoc],
+  ])('rejects %s description_rich_content', (_name, description_rich_content) => {
+    expect(() => editDescriptionRequestSchema.parse({ description_rich_content })).toThrow();
+  });
+
+  it('accepts a mention-only description_rich_content as content', () => {
+    expect(
+      editDescriptionRequestSchema.safeParse({ description_rich_content: mentionDoc }).success,
+    ).toBe(true);
   });
 
   it('accepts attachment_ids only (PLAN-22 C7b)', () => {

--- a/packages/shared/src/vocs/__tests__/internal-comment-request.test.ts
+++ b/packages/shared/src/vocs/__tests__/internal-comment-request.test.ts
@@ -1,7 +1,16 @@
 import { describe, expect, it } from 'vitest';
 import { internalCommentRequestSchema } from '../internal-comment-request.js';
 
-const VALID_DOC = { type: 'doc' as const, content: [] };
+const VALID_DOC = {
+  type: 'doc' as const,
+  content: [{ type: 'paragraph', content: [{ type: 'text', text: 'normal comment' }] }],
+};
+const BLANK_DOC = {
+  type: 'doc' as const,
+  content: [{ type: 'paragraph', content: [{ type: 'text', text: '   ' }] }],
+};
+const EMPTY_DOC = { type: 'doc' as const, content: [] };
+const MENTION_DOC = { type: 'doc' as const, content: [{ type: 'mention' }] };
 const UUID = '00000000-0000-4000-8000-000000000001';
 const UUID2 = '00000000-0000-4000-8000-000000000002';
 
@@ -57,5 +66,16 @@ describe('internalCommentRequestSchema', () => {
 
   it('rejects missing body_rich_content', () => {
     expect(() => internalCommentRequestSchema.parse({})).toThrow();
+  });
+
+  it.each([
+    ['whitespace-only paragraph', BLANK_DOC],
+    ['structurally empty document', EMPTY_DOC],
+  ])('rejects %s', (_name, body_rich_content) => {
+    expect(() => internalCommentRequestSchema.parse({ body_rich_content })).toThrow();
+  });
+
+  it('accepts a mention-only document as content', () => {
+    expect(internalCommentRequestSchema.safeParse({ body_rich_content: MENTION_DOC }).success).toBe(true);
   });
 });

--- a/packages/shared/src/vocs/__tests__/public-update-request.test.ts
+++ b/packages/shared/src/vocs/__tests__/public-update-request.test.ts
@@ -1,7 +1,16 @@
 import { describe, expect, it } from 'vitest';
 import { publicUpdateRequestSchema } from '../public-update-request.js';
 
-const VALID_DOC = { type: 'doc' as const, content: [] };
+const VALID_DOC = {
+  type: 'doc' as const,
+  content: [{ type: 'paragraph', content: [{ type: 'text', text: 'normal update' }] }],
+};
+const BLANK_DOC = {
+  type: 'doc' as const,
+  content: [{ type: 'paragraph', content: [{ type: 'text', text: '   ' }] }],
+};
+const EMPTY_DOC = { type: 'doc' as const, content: [] };
+const MENTION_DOC = { type: 'doc' as const, content: [{ type: 'mention' }] };
 const STATUS = 'reviewing' as const;
 
 describe('publicUpdateRequestSchema — shape A/B (skip_public_update=false)', () => {
@@ -44,6 +53,29 @@ describe('publicUpdateRequestSchema — shape A/B (skip_public_update=false)', (
         next_reporter_facing_status: 'bogus',
       }),
     ).toThrow();
+  });
+
+  it.each([
+    ['whitespace-only paragraph', BLANK_DOC],
+    ['structurally empty document', EMPTY_DOC],
+  ])('rejects %s', (_name, body_rich_content) => {
+    expect(() =>
+      publicUpdateRequestSchema.parse({
+        skip_public_update: false,
+        body_rich_content,
+        next_reporter_facing_status: STATUS,
+      }),
+    ).toThrow();
+  });
+
+  it('accepts a mention-only document as content', () => {
+    expect(
+      publicUpdateRequestSchema.safeParse({
+        skip_public_update: false,
+        body_rich_content: MENTION_DOC,
+        next_reporter_facing_status: STATUS,
+      }).success,
+    ).toBe(true);
   });
 });
 

--- a/packages/shared/src/vocs/__tests__/reporter-reply-request.test.ts
+++ b/packages/shared/src/vocs/__tests__/reporter-reply-request.test.ts
@@ -1,7 +1,16 @@
 import { describe, expect, it } from 'vitest';
 import { reporterReplyRequestSchema } from '../reporter-reply-request.js';
 
-const VALID_DOC = { type: 'doc' as const, content: [] };
+const VALID_DOC = {
+  type: 'doc' as const,
+  content: [{ type: 'paragraph', content: [{ type: 'text', text: 'normal reply' }] }],
+};
+const BLANK_DOC = {
+  type: 'doc' as const,
+  content: [{ type: 'paragraph', content: [{ type: 'text', text: '   ' }] }],
+};
+const EMPTY_DOC = { type: 'doc' as const, content: [] };
+const MENTION_DOC = { type: 'doc' as const, content: [{ type: 'mention' }] };
 const UUID = '00000000-0000-4000-8000-000000000001';
 
 describe('reporterReplyRequestSchema', () => {
@@ -53,5 +62,18 @@ describe('reporterReplyRequestSchema', () => {
     expect(() =>
       reporterReplyRequestSchema.parse({ body_rich_content: { type: 'paragraph' } }),
     ).toThrow();
+  });
+
+  it.each([
+    ['whitespace-only paragraph', BLANK_DOC],
+    ['structurally empty document', EMPTY_DOC],
+  ])('rejects %s', (_name, body_rich_content) => {
+    expect(() => reporterReplyRequestSchema.parse({ body_rich_content })).toThrow();
+  });
+
+  it('accepts a mention-only document as content', () => {
+    expect(reporterReplyRequestSchema.safeParse({ body_rich_content: MENTION_DOC }).success).toBe(
+      true,
+    );
   });
 });

--- a/packages/shared/src/vocs/edit-description-request.ts
+++ b/packages/shared/src/vocs/edit-description-request.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 import type { ErrorCode } from '../errors/codes.js';
 import { attachmentIdsSchema, tipTapDocSchema } from './create-request.js';
+import { isTipTapDocBlank } from './rich-content.js';
 
 // ── editDescriptionRequestSchema ───────────────────────────────────────────
 // Used by PATCH /vocs/:id/description (Slice 3 #17). Strict so that any
@@ -18,7 +19,11 @@ import { attachmentIdsSchema, tipTapDocSchema } from './create-request.js';
 export const editDescriptionRequestSchema = z
   .object({
     title: z.string().min(1).max(200).optional(),
-    description_rich_content: tipTapDocSchema.optional(),
+    description_rich_content: tipTapDocSchema
+      .refine((doc) => !isTipTapDocBlank(doc), {
+        message: '상세 설명을 입력해 주세요.',
+      })
+      .optional(),
     attachment_ids: attachmentIdsSchema.optional(),
   })
   .strict()

--- a/packages/shared/src/vocs/internal-comment-request.ts
+++ b/packages/shared/src/vocs/internal-comment-request.ts
@@ -1,12 +1,15 @@
 import { z } from 'zod';
 
 import { attachmentIdsSchema, tipTapDocSchema } from './create-request.js';
+import { isTipTapDocBlank } from './rich-content.js';
 
 // PLAN-22 C7b: wire shape carries `attachment_ids: string[]` referencing
 // pre-uploaded voc_attachments rows linked to the new internal comment.
 export const internalCommentRequestSchema = z
   .object({
-    body_rich_content: tipTapDocSchema,
+    body_rich_content: tipTapDocSchema.refine((doc) => !isTipTapDocBlank(doc), {
+      message: '상세 설명을 입력해 주세요.',
+    }),
     mentions: z.array(z.string().uuid()).max(50).optional(),
     attachment_ids: attachmentIdsSchema.optional(),
   })

--- a/packages/shared/src/vocs/public-update-request.ts
+++ b/packages/shared/src/vocs/public-update-request.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 import { attachmentIdsSchema, tipTapDocSchema } from './create-request.js';
 import { reporterFacingStatusEnumSchema } from './list-item.js';
+import { isTipTapDocBlank } from './rich-content.js';
 
 // shape A / B — body present, skip_public_update=false.
 // shape A = status change (next !== current, validated server-side).
@@ -13,7 +14,9 @@ import { reporterFacingStatusEnumSchema } from './list-item.js';
 const publicUpdateBodyShape = z
   .object({
     skip_public_update: z.literal(false),
-    body_rich_content: tipTapDocSchema,
+    body_rich_content: tipTapDocSchema.refine((doc) => !isTipTapDocBlank(doc), {
+      message: '상세 설명을 입력해 주세요.',
+    }),
     next_reporter_facing_status: reporterFacingStatusEnumSchema,
     attachment_ids: attachmentIdsSchema.optional(),
   })

--- a/packages/shared/src/vocs/reporter-reply-request.ts
+++ b/packages/shared/src/vocs/reporter-reply-request.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 import { attachmentIdsSchema, tipTapDocSchema } from './create-request.js';
+import { isTipTapDocBlank } from './rich-content.js';
 
 // PLAN-22 C7b: wire shape is `attachment_ids: string[]` (UUIDs referencing
 // pre-uploaded voc.voc_attachments rows linked to the new reporter reply).
@@ -8,7 +9,9 @@ import { attachmentIdsSchema, tipTapDocSchema } from './create-request.js';
 // has been retired now that the storage slice (PLAN-22 C3a/C3b) ships.
 export const reporterReplyRequestSchema = z
   .object({
-    body_rich_content: tipTapDocSchema,
+    body_rich_content: tipTapDocSchema.refine((doc) => !isTipTapDocBlank(doc), {
+      message: '상세 설명을 입력해 주세요.',
+    }),
     attachment_ids: attachmentIdsSchema.optional(),
   })
   .strict();

--- a/scripts/gates/frontend-biome-allowlist.txt
+++ b/scripts/gates/frontend-biome-allowlist.txt
@@ -130,3 +130,11 @@ apps/backend/src/modules/voc/__tests__/get-voc.integration.test.ts lint/style/no
 apps/backend/src/modules/voc/__tests__/get-voc.integration.test.ts lint/complexity/useLiteralKeys -- pre-existing on develop (5x, unchanged)
 apps/frontend/src/features/voc/components/detail/IdentitySection.tsx format -- pre-existing on develop (2x, unchanged)
 apps/frontend/src/features/voc/components/detail/__tests__/VocDetailPanel.test.tsx organizeImports -- pre-existing on develop; import order predates biome
+apps/frontend/src/features/voc/components/detail/__tests__/ReporterReplyComposer.test.tsx format -- pre-existing on develop (1x, unchanged)
+apps/frontend/src/features/voc/components/detail/__tests__/ReporterReplyComposer.test.tsx organizeImports -- pre-existing on develop; import order predates biome
+apps/frontend/src/features/voc/components/detail/__tests__/ReporterReplyComposer.test.tsx lint/suspicious/noExplicitAny -- pre-existing on develop (2x, unchanged)
+apps/frontend/src/features/voc/components/detail/__tests__/PublicUpdateComposer.test.tsx format -- pre-existing on develop (1x, unchanged)
+apps/frontend/src/features/voc/components/detail/__tests__/PublicUpdateComposer.test.tsx organizeImports -- pre-existing on develop; import order predates biome
+packages/shared/src/vocs/edit-description-request.ts format -- pre-existing on develop (1x, unchanged)
+packages/shared/src/vocs/__tests__/internal-comment-request.test.ts format -- pre-existing on develop (1x, unchanged)
+packages/shared/src/vocs/__tests__/edit-description-request.test.ts format -- pre-existing on develop (1x, unchanged)


### PR DESCRIPTION
#327이 막은 것은 **VOC 생성 하나**였다. 답글·공개 업데이트·내부 코멘트·설명 수정은 여전히 공백만 있는 문서를 받아들였다 — 리포터에게 빈 메시지가 게시되거나 빈 설명이 정본으로 기록될 수 있었다.

네 스키마 전부 `create-request.ts`와 **같은** `isTipTapDocBlank` refine을 단다.

## 표면별 판정

**첨부가 빈 본문을 구제하지 않는다.** 이건 새 규칙이 아니다 — 세 컴포저가 이미 `isEmpty`를 본문만으로 판정하고 `attachment_ids`를 보지 않는다. 서버 계약이 제품을 따라간 것이다.

```
InternalCommentComposer.tsx:111   isDocEmpty(draftDoc)
PublicUpdateComposer.tsx:166      isDocEmpty(draftDoc)
ReporterReplyComposer.tsx:114     isTipTapDocStructurallyEmpty(draftDoc)
```

- **edit-description**: 필드는 optional 유지(patch 의미론), **제공됐을 때만** 거부. 설명을 공백으로 지우는 것은 #327이 생성 시점에 금지한 상태를 사후에 다시 만드는 것이다.
- **public-update `skip_public_update: true`**: 건드리지 않았다. 본문 없는 전이는 `skip_reason`의 non-whitespace 8자 규칙이 이미 관장한다.

## 컴포저도 같은 술어로 맞췄다

구조적 empty 헬퍼들은 `"   "`를 "비어있지 않다"고 본다 — **그게 공백이 서버까지 새어 들어간 경로다.** 이제 사용자는 422 대신 비활성 버튼을 본다.

`rich-content.ts`는 **건드리지 않았다.** 구조적 노드 목록을 반전시켜 둔 그 계약이, mention만 있거나 모르는 노드만 있는 문서가 "blank"로 삼켜져 `rich_content.disallowed_node`를 잃는 것을 막는다.

## 뮤테이션 매트릭스 — 어느 단언이 발화했는가

| 뮤테이션 | 결과 | 발화한 단언 |
|---|---|---|
| `reporter-reply`의 refine 제거 | ☠️ | `rejects whitespace-only paragraph` + `rejects structurally empty document` |
| `public-update`의 refine 제거 | ☠️ | 같은 2건 (shape A) |
| `internal-comment`의 refine 제거 | ☠️ | 같은 2건 |
| `edit-description`의 refine 제거 | ☠️ | 같은 2건 |
| **`isTipTapDocBlank`를 content-allowlist로 되돌림** (mention을 blank로 취급) | ☠️ | **6건** — 네 스키마의 `accepts a mention-only document` + `blank: textless mention node` + `blank: entirely unknown node type` |
| 컴포저를 구조적 empty 헬퍼로 되돌림 | ☠️ | `disables Send reply for a whitespace-only draft` 외 3건 |

다섯 번째가 이 청크의 핵심 보호막이다. **과거에 정확히 그 형태로 `disallowed_node` 계약이 삼켜진 적이 있다.**

## 첫 실행에서 잡힌 것 (워커는 무엇도 실행할 수 없다)

1. **`PATCH /vocs/:id/description` 해피패스가 409.** If-Match를 SQL 시드의 `updated_at::text`에서 가져왔는데, 그건 postgres 텍스트(`"2026-08-05 03:20:00+00"`)라 라우트가 비교하는 ISO 문자열과 다르다. API GET에서 ETag를 받도록 고쳤다.
2. **스위트 전체 실패 — 테어다운 순서.** 모든 요청이 Idempotency-Key를 보내는데 그 행이 actor를 FK로 잡는다. actors보다 먼저 지우게 했다.
3. **FE 뮤테이션 훅 3건 실패.** 픽스처가 `{type:'doc',content:[{type:'paragraph'}]}` — 전송 형태 검사용 채움 문서였고 새 스키마가 **맞게** 거부했다. 픽스처에 실제 텍스트를 넣었다. 그 테스트의 `schema.safeParse(...).success` 단언은 이제 다시 의미를 갖는다.

## 게이트

```
backend voc          436 passed / 43 files    ← 432/42에서
shared               449 passed / 31 files    ← 437에서
frontend vitest      828 passed / 150 files   ← 822에서
frontend typecheck   0 errors
frontend biome       0 unexpected, 128 allowlisted (8건 추가 — 전부 develop 대비 동일 개수로 실측, 신규 1건은 포맷 수정)
frontend visual      58 passed
check:boundaries     OK
```

Closes #344

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BfiR55zJ7n8uYpr1s3X6q