### PR TITLE
fix(#324): 보관된 Managed System에 재등록 경로를 드러낸다

### DIFF
--- a/apps/frontend/src/routes/_authed/admin/__tests__/admin-archive-actions.test.tsx
+++ b/apps/frontend/src/routes/_authed/admin/__tests__/admin-archive-actions.test.tsx
@@ -133,4 +133,39 @@ describe('admin archive actions', () => {
     expect(screen.getByText('이미 보관됨')).toBeInTheDocument();
     expect(screen.queryByTestId(`archive-${ARCHIVED_MS_SLUG}`)).not.toBeInTheDocument();
   });
+
+  test('#324 an archived Managed System offers re-registration instead of a Save that must 409', async () => {
+    installFetch();
+    renderPage('/admin/managed-systems', ManagedSystemsAdminPage);
+    await waitFor(() =>
+      expect(screen.getByTestId(`managed-system-row-${ACTIVE_MS_SLUG}`)).toBeInTheDocument(),
+    );
+
+    // Active row first: it keeps Save. Without this the archived assertion below
+    // would also pass against a build that simply never renders Save.
+    fireEvent.click(screen.getByTestId(`ms-configure-${ACTIVE_MS_SLUG}`));
+    expect(await screen.findByTestId(`save-${ACTIVE_MS_SLUG}`)).toBeInTheDocument();
+    expect(screen.queryByTestId(`reregister-${ACTIVE_MS_SLUG}`)).not.toBeInTheDocument();
+    fireEvent.keyDown(document.body, { key: 'Escape' });
+
+    fireEvent.click(screen.getByTestId('ms-filter-button'));
+    fireEvent.click(await screen.findByTestId('ms-filter-include-archived'));
+    await waitFor(() =>
+      expect(screen.getByTestId(`managed-system-row-${ARCHIVED_MS_SLUG}`)).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByTestId(`ms-configure-${ARCHIVED_MS_SLUG}`));
+
+    // PATCH against an archived row is 409 conflict.record_archived by contract,
+    // so Save must be gone rather than merely disabled.
+    expect(
+      await screen.findByTestId(`archived-immutable-note-${ARCHIVED_MS_SLUG}`),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId(`save-${ARCHIVED_MS_SLUG}`)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId(`reregister-${ARCHIVED_MS_SLUG}`));
+
+    const register = await screen.findByTestId('ms-register-dialog');
+    expect(register).toBeInTheDocument();
+    expect(screen.getByTestId('create-slug')).toHaveValue(ARCHIVED_MS_SLUG);
+  });
 });

--- a/apps/frontend/src/routes/_authed/admin/managed-systems.tsx
+++ b/apps/frontend/src/routes/_authed/admin/managed-systems.tsx
@@ -219,6 +219,10 @@ export function ManagedSystemsBody({
 }) {
   const qc = useQueryClient();
   const [editTarget, setEditTarget] = useState<ManagedSystemDto | null>(null);
+  // Archived rows cannot be restored (ADR-0019 §A: archived rows are immutable).
+  // The designed remedy for "archived by mistake" is re-registering the same
+  // slug (ADR-0017), so Configure hands the archived row's fields to Register.
+  const [reregisterFrom, setReregisterFrom] = useState<ManagedSystemDto | null>(null);
 
   const listQuery = useQuery({
     queryKey: [...MANAGED_SYSTEMS_KEY, { includeArchived }] as const,
@@ -349,10 +353,16 @@ export function ManagedSystemsBody({
       </div>
 
       <RegisterDialog
+        key={reregisterFrom?.id ?? 'blank'}
         open={registerOpen}
-        onOpenChange={setRegisterOpen}
+        prefill={reregisterFrom}
+        onOpenChange={(open) => {
+          setRegisterOpen(open);
+          if (!open) setReregisterFrom(null);
+        }}
         onSaved={async () => {
           setRegisterOpen(false);
+          setReregisterFrom(null);
           await invalidate();
         }}
       />
@@ -360,6 +370,11 @@ export function ManagedSystemsBody({
         target={editTarget}
         onOpenChange={(open) => {
           if (!open) setEditTarget(null);
+        }}
+        onReregister={(target) => {
+          setEditTarget(null);
+          setReregisterFrom(target);
+          setRegisterOpen(true);
         }}
         onSaved={async () => {
           setEditTarget(null);
@@ -485,16 +500,19 @@ function RegistryRow({
 
 function RegisterDialog({
   open,
+  prefill,
   onOpenChange,
   onSaved,
 }: {
   open: boolean;
+  /** Archived row being re-registered under the same slug, if any. */
+  prefill?: ManagedSystemDto | null;
   onOpenChange: (v: boolean) => void;
   onSaved: () => Promise<void>;
 }) {
-  const [slug, setSlug] = useState('');
-  const [name, setName] = useState('');
-  const [externalKey, setExternalKey] = useState('');
+  const [slug, setSlug] = useState(prefill?.slug ?? '');
+  const [name, setName] = useState(prefill?.name ?? '');
+  const [externalKey, setExternalKey] = useState(prefill?.external_key ?? '');
   const [owner, setOwner] = useState<OwnerSelection>({ kind: 'none' });
   const [error, setError] = useState<string | null>(null);
   const [fieldErrors, setFieldErrors] = useState<Partial<Record<'slug' | 'name', string>>>({});
@@ -518,8 +536,12 @@ function RegisterDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent data-testid="ms-register-dialog">
         <DialogHeader>
-          <DialogTitle>Register system</DialogTitle>
-          <DialogDescription>새 Managed System 을 레지스트리에 추가합니다.</DialogDescription>
+          <DialogTitle>{prefill ? '보관된 시스템 재등록' : 'Register system'}</DialogTitle>
+          <DialogDescription>
+            {prefill
+              ? `보관된 "${prefill.slug}" 를 같은 slug로 다시 등록합니다. 보관 해제가 아니라 새 레코드가 만들어지며, 기존 VOC·Finding·Task 등 과거 참조는 보관된 시스템에 그대로 남습니다.`
+              : '새 Managed System 을 레지스트리에 추가합니다.'}
+          </DialogDescription>
         </DialogHeader>
         <form
           data-testid="create-managed-system-form"
@@ -623,16 +645,25 @@ function RegisterDialog({
 function EditDialog({
   target,
   onOpenChange,
+  onReregister,
   onSaved,
 }: {
   target: ManagedSystemDto | null;
   onOpenChange: (v: boolean) => void;
+  onReregister: (target: ManagedSystemDto) => void;
   onSaved: () => Promise<void>;
 }) {
   return (
     <Dialog open={target !== null} onOpenChange={onOpenChange}>
       <DialogContent data-testid="ms-edit-dialog">
-        {target && <EditForm key={target.id} target={target} onSaved={onSaved} />}
+        {target && (
+          <EditForm
+            key={target.id}
+            target={target}
+            onReregister={onReregister}
+            onSaved={onSaved}
+          />
+        )}
       </DialogContent>
     </Dialog>
   );
@@ -640,11 +671,14 @@ function EditDialog({
 
 function EditForm({
   target,
+  onReregister,
   onSaved,
 }: {
   target: ManagedSystemDto;
+  onReregister: (target: ManagedSystemDto) => void;
   onSaved: () => Promise<void>;
 }) {
+  const isArchived = target.archived_at !== null;
   const [name, setName] = useState(target.name);
   const [externalKey, setExternalKey] = useState(target.external_key ?? '');
   const [owner, setOwner] = useState<OwnerSelection>(() => ownerSelection(target));
@@ -703,6 +737,7 @@ function EditForm({
             id={`ms-edit-name-${target.slug}`}
             value={name}
             onChange={(e) => setName(e.target.value)}
+            readOnly={isArchived}
             data-testid={`name-input-${target.slug}`}
           />
         </div>
@@ -720,6 +755,7 @@ function EditForm({
             id={`ms-edit-key-${target.slug}`}
             value={externalKey}
             onChange={(e) => setExternalKey(e.target.value)}
+            readOnly={isArchived}
             data-testid={`external-key-input-${target.slug}`}
           />
         </div>
@@ -728,8 +764,20 @@ function EditForm({
             {error}
           </p>
         )}
+        {isArchived && (
+          <p
+            className="text-sm text-text-muted"
+            data-testid={`archived-immutable-note-${target.slug}`}
+          >
+            보관된 시스템은 수정할 수 없고 보관 해제도 지원하지 않습니다. 실수로 보관했다면 같은
+            slug로 다시 등록하세요 — 새 레코드가 만들어지고, 과거 참조는 이 보관된 시스템에 그대로
+            남습니다.
+          </p>
+        )}
         <DialogFooter className="justify-between">
-          {target.archived_at === null ? (
+          {isArchived ? (
+            <span className="text-sm text-text-muted">이미 보관됨</span>
+          ) : (
             <Button
               type="button"
               variant="destructive"
@@ -739,16 +787,26 @@ function EditForm({
             >
               Archive
             </Button>
-          ) : (
-            <span className="text-sm text-text-muted">이미 보관됨</span>
           )}
-          <Button
-            type="submit"
-            disabled={updateMutation.isPending}
-            data-testid={`save-${target.slug}`}
-          >
-            Save
-          </Button>
+          {isArchived ? (
+            // No Save: PATCH against an archived row is 409 conflict.record_archived
+            // by contract (ADR-0019 §A), so offering it can only fail.
+            <Button
+              type="button"
+              onClick={() => onReregister(target)}
+              data-testid={`reregister-${target.slug}`}
+            >
+              같은 slug로 재등록
+            </Button>
+          ) : (
+            <Button
+              type="submit"
+              disabled={updateMutation.isPending}
+              data-testid={`save-${target.slug}`}
+            >
+              Save
+            </Button>
+          )}
         </DialogFooter>
       </form>
     </>


### PR DESCRIPTION
## 이슈의 전제가 틀렸다 — 복원은 누락이 아니라 설계다

이슈와 이전 라운드의 뿌리 진단은 둘 다 "복원 API 자체가 없다 → BE 선행 청크"였다. **문서를 읽으면 다르다.**

**ADR-0019 §A (Locked):**
> "Archived rows are immutable. PATCH against a row whose `archived_at IS NOT NULL` returns `409 conflict.record_archived`... **Re-registering the same slug via the partial-unique-after-archive pattern (ADR-0017:63) is the only path to 'edit a retired registry entry.'**"

**ADR-0017:**
> "Slug reuse after archive is permitted by the partial unique indexes (`WHERE archived_at IS NULL`). **An operator who archived `tableau` by mistake may re-register it with the same slug**; the historical FK rows continue to point at the archived row's UUID and are unaffected."

unarchive 엔드포인트를 만드는 것은 Locked ADR 두 개를 뒤집는 일이다. 실제 결함은 **UX**다.

## 관측된 화면의 진짜 문제

블랙박스 보고 그대로 — 보관된 시스템의 Configure에는 "이미 보관됨"과 **Save 버튼**만 있었다. 그 Save는 계약상 **반드시 409**다. 즉 운영자에게 **실패가 보장된 액션 하나와 동작하는 액션 0개**가 제시돼 있었다.

## 고친 것

보관된 시스템의 Configure는 이제:
- **Save를 없앤다** (비활성이 아니라 제거 — 계약상 성공할 수 없는 액션이다)
- 입력 필드를 읽기 전용으로 만든다
- 보관은 되돌릴 수 없다고 설명한다
- **"같은 slug로 재등록"** 을 제공한다 → 보관된 행의 slug·이름·external key로 **prefill된 Register 다이얼로그**가 열린다

재등록 다이얼로그의 문구는 **새 레코드가 만들어지고 과거 참조는 보관된 시스템에 남는다**는 것을 명시한다. 둘은 UUID가 다르므로, 복원을 기대한 운영자는 어느 VOC가 따라오는지에서 놀라게 된다.

## 뮤테이션 매트릭스

| 뮤테이션 | 결과 | 발화한 단언 |
|---|---|---|
| 보관 행에도 Save를 되살림 | ☠️ | `#324 an archived Managed System offers re-registration instead of a Save that must 409` |
| Register의 prefill 무시 | ☠️ | 같은 테스트의 `create-slug` 값 단언 |

테스트는 **활성 행을 먼저 검사한다** — 활성 행은 Save를 유지하고 재등록 버튼이 없다. 이 대조가 없으면 보관 행 단언이 "Save를 아예 안 그리는 빌드"와 구별되지 않는다.

## 게이트

```
frontend vitest      829 passed / 150 files   ← 828에서
frontend typecheck   0 errors
frontend biome       0 unexpected, 128 allowlisted
frontend visual      58 passed                ← 베이스라인 무변동
```

Closes #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BfiR55zJ7n8uYpr1s3X6q