### PR TITLE
docs(#347): ADR-0031 peer 규칙의 리포터 소유 arm 복구

### DIFF
--- a/docs/adr/0031-similar-voc-same-managed-system-heuristic.md
+++ b/docs/adr/0031-similar-voc-same-managed-system-heuristic.md
@@ -46,14 +46,23 @@ statuses and all ages are eligible. This is deliberately a weak heuristic, not
 > because the provider is disabled or the source has not yet been embedded, the
 > heuristic remains the only related-VOC signal.
 
-> **Amended 2026-08-05 (#337).** Reporter ownership does not grant peer read
-> access. A reporter arm without `voc.read` or `voc.triage` receives a full
-> detail envelope without peer-derived or internal-triage fields.
+> **Amended 2026-08-05 (#337).** A reporter arm — an actor who reported the
+> source VOC but holds neither `voc.read` nor `voc.triage` on its Managed
+> System — receives a full detail envelope with the peer-derived and
+> internal-triage fields omitted entirely, not zeroed.
+>
+> **Corrected 2026-08-05 (#347).** The #337 amendment first restated the peer
+> rule below as `voc.read` scope alone, dropping the reporter-ownership arm.
+> That was wrong and did not match `similarVocVisibilityPredicate`: the arm
+> admits only VOCs the actor themself reported, so it never reveals that
+> another reporter submitted a peer. The rule below is restored; #337 narrows
+> which *envelope* carries peer fields, not which *peers* are visible.
 
 A peer is visible only when its Managed System is in the actor's `voc.read`
-scope. A triage-only summary envelope and a reporter arm without `voc.read` or
-`voc.triage` expose neither `similar_count` nor `similar.items`: a full
-envelope for an actor's own VOC does not grant peer read access.
+scope or the actor reported that peer. A triage-only summary envelope and a
+reporter arm without `voc.read` or `voc.triage` expose neither `similar_count`
+nor `similar.items`: a full envelope for an actor's own VOC does not grant
+peer read access.
 
 `similar_count` is the sole authorized-peer total. Detail adds
 `similar.items`, ordered by `created_at DESC, id DESC` and capped at three,


### PR DESCRIPTION
#347을 실측한 결과다. **코드가 아니라 문서가 틀렸고, 그 문서를 틀리게 만든 것은 #337(PR #346)의 내 개정 문구다.**

## 측정

`similarVocVisibilityPredicate`(`repo-read.ts:939`)는 여전히:

```sql
(p.primary_managed_system_id = ANY(:readScope) OR p.reporter_id = :actorId)
```

그 `OR` arm이 admit하는 것은 **액터 자신이 신고한 VOC뿐**이다. 다른 리포터가 peer를 제출했는지는 절대 드러나지 않는다 — predicate 주석이 존재 이유로 명시한 성질 그대로다:

> "a reporter can read their own source VOC without voc.read, but must not learn whether other reporters submitted peers."

**목록·사전제출 표면에 유출은 없다.** #347이 의심한 결함은 존재하지 않는다.

## 그래서 진짜 결함

#337에서 내가 ADR-0031의 peer 규칙을 "`voc.read` 스코프에서만"으로 다시 썼다. 그건 과했다. #337이 좁힌 것은 **어느 봉투가 peer 필드를 싣는가**지 **어느 peer가 보이는가**가 아니다. 그 결과 ADR이 코드와 모순된 채 남았고, **아무것도 실패하지 않았다** — 문서 드리프트의 전형이다.

원래 문장을 복구하고 §Corrected 2026-08-05 (#347)로 경위를 남겼다. #337 amendment도 "omitted entirely, not zeroed"로 의도를 더 정확히 적었다.

## 검증

`voc-visibility-predicate.integration.test.ts`의 verdict matrix 2건이 **변경 없이** 통과한다 — 코드를 건드리지 않았다는 증거다.

Closes #347

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BfiR55zJ7n8uYpr1s3X6q