### PR TITLE
fix(#352): consume the refreshed VOC envelope returned by conversation POSTs

### DIFF
--- a/apps/frontend/src/features/voc/__tests__/integration/voc-composer-flow.integration.test.tsx
+++ b/apps/frontend/src/features/voc/__tests__/integration/voc-composer-flow.integration.test.tsx
@@ -11,6 +11,7 @@
 // C6.3 of slice3 #21.
 // Test framework: Vitest + @testing-library/react (O-6 in PLAN-21).
 
+import type { PublicUpdateSuccess } from '@/features/voc/hooks/useVocPublicUpdateMutation';
 import type { MeResponse } from '@/lib/api/auth';
 import type { VocDetailEnvelope } from '@fops/shared';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -147,6 +148,35 @@ const VOC_GATE_BLOCKED: VocDetailEnvelope = {
   ...VOC_ADMIN_VIEW,
   reporter_status_gate: { blocking_for: ['progress'], reason: '연결된 Task가 아직 진행 중입니다.' },
 };
+
+const VOC_AFTER_PUBLIC_UPDATE: VocDetailEnvelope = {
+  ...VOC_ADMIN_VIEW,
+  reporter_facing_status: 'resolved',
+  updated_at: '2026-05-01T12:00:00.000Z',
+  next_reporter_states: { allowed: ['closed', 'reopened'], forbidden: {} },
+};
+
+function publicUpdateEnvelope(
+  id: string,
+  voc: VocDetailEnvelope = VOC_ADMIN_VIEW,
+): PublicUpdateSuccess {
+  return {
+    public_update: {
+      id,
+      voc_id: VOC_ADMIN_VIEW.id,
+      body_rich_content: {
+        type: 'doc',
+        content: [{ type: 'paragraph', content: [{ type: 'text', text: '공개 업데이트' }] }],
+      },
+      reporter_facing_status_before: VOC_ADMIN_VIEW.reporter_facing_status,
+      reporter_facing_status_after: voc.reporter_facing_status,
+      skip_public_update: false,
+      skip_reason: null,
+      created_at: '2026-05-01T12:00:00.000Z',
+    },
+    voc,
+  };
+}
 
 const ATTACHMENT = {
   id: '00000000-0000-0000-0000-000000000200',
@@ -285,11 +315,7 @@ describe('Composer flow — integration (C6.3)', () => {
       capturedUrl = typeof input === 'string' ? input : input.toString();
       capturedMethod = init?.method ?? 'GET';
       if (init?.body) capturedBody = JSON.parse(init.body as string);
-      return jsonResponse({
-        id: 'pub-update-001',
-        voc_id: VOC_ADMIN_VIEW.id,
-        created_at: '2026-05-01T12:00:00.000Z',
-      });
+      return jsonResponse(publicUpdateEnvelope('pub-update-001', VOC_AFTER_PUBLIC_UPDATE), 201);
     }) as typeof globalThis.fetch;
 
     const Wrapper = makeWrapper();
@@ -303,6 +329,9 @@ describe('Composer flow — integration (C6.3)', () => {
     // Type into the public-update rich editor (mocked as textarea)
     const editor = screen.getByTestId('rich-editor-public-update');
     fireEvent.change(editor, { target: { value: '공개 업데이트 내용입니다.' } });
+    fireEvent.change(screen.getByRole('combobox', { name: '다음 reporter-facing status 선택' }), {
+      target: { value: 'resolved' },
+    });
 
     // Find the Publish button on the ComposerFooter and click it
     const publishBtn = screen.getByRole('button', { name: /publish update/i });
@@ -321,7 +350,7 @@ describe('Composer flow — integration (C6.3)', () => {
     const body = capturedBody as Record<string, unknown>;
     // Must have body_rich_content and next_reporter_facing_status
     expect(body.body_rich_content).toBeTruthy();
-    expect(body.next_reporter_facing_status).toBeTruthy();
+    expect(body.next_reporter_facing_status).toBe('resolved');
 
     // Success toast fired
     await waitFor(() => {
@@ -371,11 +400,7 @@ describe('Composer flow — integration (C6.3)', () => {
     const invalidateSpy = vi.spyOn(qc, 'invalidateQueries');
 
     globalThis.fetch = vi.fn(async () =>
-      jsonResponse({
-        id: 'pub-update-002',
-        voc_id: VOC_ADMIN_VIEW.id,
-        created_at: '2026-05-01T12:00:00.000Z',
-      }),
+      jsonResponse(publicUpdateEnvelope('pub-update-002'), 201),
     ) as typeof globalThis.fetch;
 
     render(
@@ -403,7 +428,7 @@ describe('Composer flow — integration (C6.3)', () => {
     const requests: Array<{ input: RequestInfo | URL; init?: RequestInit }> = [];
     globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       if (init?.method === 'POST') requests.push({ input, init });
-      return jsonResponse({ id: 'pub-update-preview-001' });
+      return jsonResponse(publicUpdateEnvelope('pub-update-preview-001'), 201);
     }) as typeof globalThis.fetch;
 
     const Wrapper = makeWrapper();
@@ -578,7 +603,7 @@ describe('Composer flow — integration (C6.3)', () => {
       body_rich_content: { content: [{ content: [{ text: '프리뷰 연타 방지' }] }] },
     });
     await act(async () => {
-      resolvePost?.(jsonResponse({ id: 'pub-update-preview-rapid-001' }));
+      resolvePost?.(jsonResponse(publicUpdateEnvelope('pub-update-preview-rapid-001'), 201));
     });
   });
 
@@ -588,7 +613,7 @@ describe('Composer flow — integration (C6.3)', () => {
     globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       capturedRequest = { input, init };
       if (init?.method === 'POST') capturedBody = JSON.parse(init.body as string);
-      return jsonResponse({ id: 'pub-update-footer-001' });
+      return jsonResponse(publicUpdateEnvelope('pub-update-footer-001'), 201);
     }) as typeof globalThis.fetch;
     const Wrapper = makeWrapper();
     render(

--- a/apps/frontend/src/features/voc/components/detail/PublicUpdateComposer.tsx
+++ b/apps/frontend/src/features/voc/components/detail/PublicUpdateComposer.tsx
@@ -156,12 +156,13 @@ export function PublicUpdateComposer({
   const isEmpty = isTipTapDocBlank(draftDoc);
 
   const mutation = useVocPublicUpdateMutation({
-    onSuccess: () => {
+    onSuccess: (data) => {
       submitInFlightRef.current = false;
+      queryClient.setQueryData(['voc', voc.id], data.voc);
       queryClient.invalidateQueries({ queryKey: ['voc', voc.id] });
       // clear draft (calls onDraftChange?.(null) when controlled)
       setDraftDoc(null);
-      setNextStatus(voc.reporter_facing_status);
+      setNextStatus(data.voc.reporter_facing_status);
       toast.success('공개 업데이트가 게시되었습니다.');
     },
     onError: (error) => {

--- a/apps/frontend/src/features/voc/components/detail/__tests__/PublicUpdateComposer.test.tsx
+++ b/apps/frontend/src/features/voc/components/detail/__tests__/PublicUpdateComposer.test.tsx
@@ -8,22 +8,29 @@
 // C5.2 of slice3 #21.
 // Prototype ref: docs/design-prototype/screen-voc.jsx:415-468
 
-import { render, screen } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { PublicUpdateSuccess } from '@/features/voc/hooks/useVocPublicUpdateMutation';
+import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import * as React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // ── Module mocks ─────────────────────────────────────────────────────────────
 
-const mockMutate = vi.fn();
+const mutationMock = vi.hoisted(() => ({
+  mutate: vi.fn(),
+  onSuccess: undefined as ((data: PublicUpdateSuccess) => void) | undefined,
+}));
 
 vi.mock('@/features/voc/hooks/useVocPublicUpdateMutation', () => ({
-  useVocPublicUpdateMutation: vi.fn(() => ({
-    mutate: mockMutate,
-    isPending: false,
-    isError: false,
-    error: null,
-  })),
+  useVocPublicUpdateMutation: vi.fn((args: { onSuccess?: (data: PublicUpdateSuccess) => void }) => {
+    mutationMock.onSuccess = args.onSuccess;
+    return {
+      mutate: mutationMock.mutate,
+      isPending: false,
+      isError: false,
+      error: null,
+    };
+  }),
 }));
 
 // Mock RichEditor to avoid TipTap JSDOM issues.
@@ -50,9 +57,9 @@ vi.mock('@fops/ui', async (importActual) => {
   };
 });
 
-import { PublicUpdateComposer } from '../PublicUpdateComposer';
-import type { VocDetailEnvelope } from '@fops/shared';
 import type { MeResponse } from '@/lib/auth/useMe';
+import type { VocDetailEnvelope } from '@fops/shared';
+import { PublicUpdateComposer } from '../PublicUpdateComposer';
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
 
@@ -60,10 +67,10 @@ const REPORTER_ID = '00000000-0000-0000-0000-000000000001';
 const ADMIN_ID = '00000000-0000-0000-0000-000000000002';
 
 const BASE_VOC: VocDetailEnvelope = {
-  id: 'voc-uuid-1111',
+  id: '00000000-0000-0000-0000-000000000111',
   display_id: 'VOC-0001',
   title: '테스트 VOC 제목',
-  primary_managed_system_id: 'ms-uuid-1111',
+  primary_managed_system_id: '00000000-0000-0000-0000-000000000222',
   analytics_area_id: null,
   reporter_id: REPORTER_ID,
   owner_user_id: ADMIN_ID,
@@ -75,6 +82,9 @@ const BASE_VOC: VocDetailEnvelope = {
   created_at: '2026-05-01T00:00:00Z',
   updated_at: '2026-05-01T00:00:00Z',
   similar_count: 0,
+  similar: { items: [] },
+  attachments: [],
+  attachment_count: 0,
   description_rich_content: { type: 'doc', content: [] },
   next_actions: [],
   next_reporter_states: { allowed: ['reviewing'], forbidden: {} },
@@ -82,7 +92,31 @@ const BASE_VOC: VocDetailEnvelope = {
   conversation_timeline: [],
   conversation_page: { has_more: false },
   permission_decisions: {},
-} as unknown as VocDetailEnvelope;
+};
+
+const UPDATED_VOC: VocDetailEnvelope = {
+  ...BASE_VOC,
+  reporter_facing_status: 'reviewing',
+  updated_at: '2026-05-01T00:01:00Z',
+  next_reporter_states: { allowed: ['assigned'], forbidden: {} },
+};
+
+const PUBLIC_UPDATE_ENVELOPE: PublicUpdateSuccess = {
+  public_update: {
+    id: '00000000-0000-0000-0000-000000000333',
+    voc_id: BASE_VOC.id,
+    body_rich_content: {
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'hello' }] }],
+    },
+    reporter_facing_status_before: 'received',
+    reporter_facing_status_after: 'reviewing',
+    skip_public_update: false,
+    skip_reason: null,
+    created_at: '2026-05-01T00:01:00Z',
+  },
+  voc: UPDATED_VOC,
+};
 
 const ME_ADMIN: MeResponse = {
   actor: {
@@ -108,17 +142,13 @@ function makeWrapper() {
 describe('<PublicUpdateComposer>', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mutationMock.onSuccess = undefined;
   });
 
   it('renders ReporterStatusChangeBlock for body+status path (status change)', () => {
-    render(
-      <PublicUpdateComposer voc={BASE_VOC} me={ME_ADMIN} />,
-      { wrapper: makeWrapper() },
-    );
+    render(<PublicUpdateComposer voc={BASE_VOC} me={ME_ADMIN} />, { wrapper: makeWrapper() });
     // ReporterStatusChangeBlock should always be visible in the public composer.
-    expect(
-      screen.getByTestId('reporter-status-change-block'),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId('reporter-status-change-block')).toBeInTheDocument();
   });
 
   it('renders ReporterStatusChangeBlock for body-only path (status unchanged)', () => {
@@ -128,13 +158,10 @@ describe('<PublicUpdateComposer>', () => {
       next_reporter_states: { allowed: [], forbidden: {} },
     } as unknown as VocDetailEnvelope;
 
-    render(
-      <PublicUpdateComposer voc={vocNoTransitions} me={ME_ADMIN} />,
-      { wrapper: makeWrapper() },
-    );
-    expect(
-      screen.getByTestId('reporter-status-change-block'),
-    ).toBeInTheDocument();
+    render(<PublicUpdateComposer voc={vocNoTransitions} me={ME_ADMIN} />, {
+      wrapper: makeWrapper(),
+    });
+    expect(screen.getByTestId('reporter-status-change-block')).toBeInTheDocument();
   });
 
   it('disables Publish when reporter_status_gate.blocking_for includes nextStatus', () => {
@@ -146,10 +173,7 @@ describe('<PublicUpdateComposer>', () => {
       },
     } as unknown as VocDetailEnvelope;
 
-    render(
-      <PublicUpdateComposer voc={vocGated} me={ME_ADMIN} />,
-      { wrapper: makeWrapper() },
-    );
+    render(<PublicUpdateComposer voc={vocGated} me={ME_ADMIN} />, { wrapper: makeWrapper() });
 
     // The Publish button must be disabled when gate blocks the staged next status.
     const publishBtn = screen.getByRole('button', { name: /publish update/i });
@@ -173,7 +197,7 @@ describe('<PublicUpdateComposer>', () => {
     const publish = screen.getByRole('button', { name: /^publish update$/i });
     expect(publish).toBeDisabled();
     publish.click();
-    expect(mockMutate).not.toHaveBeenCalled();
+    expect(mutationMock.mutate).not.toHaveBeenCalled();
   });
 
   it('enables Publish for a text draft', () => {
@@ -191,5 +215,65 @@ describe('<PublicUpdateComposer>', () => {
 
     expect(screen.getByTestId('public-update-composer')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /^publish update$/i })).not.toBeDisabled();
+  });
+
+  it('keeps the response status through the delayed detail refetch after publishing', async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    let resolveDetailRefetch: (voc: VocDetailEnvelope) => void = vi.fn();
+    const delayedDetailRefetch = vi.fn(
+      () =>
+        new Promise<VocDetailEnvelope>((resolve) => {
+          resolveDetailRefetch = resolve;
+        }),
+    );
+
+    function CachedComposer() {
+      const { data: voc } = useQuery({
+        queryKey: ['voc', BASE_VOC.id],
+        queryFn: delayedDetailRefetch,
+        initialData: BASE_VOC,
+        staleTime: Number.POSITIVE_INFINITY,
+      });
+      return <PublicUpdateComposer voc={voc} me={ME_ADMIN} />;
+    }
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <CachedComposer />
+      </QueryClientProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('textbox'));
+    fireEvent.change(screen.getByRole('combobox', { name: '다음 reporter-facing status 선택' }), {
+      target: { value: 'reviewing' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^publish update$/i }));
+
+    expect(mutationMock.mutate).toHaveBeenCalledTimes(1);
+    await React.act(async () => {
+      mutationMock.onSuccess?.(PUBLIC_UPDATE_ENVELOPE);
+    });
+
+    await waitFor(() => {
+      expect(delayedDetailRefetch).toHaveBeenCalledTimes(1);
+      expect(
+        screen.getByRole('combobox', { name: '다음 reporter-facing status 선택' }),
+      ).toHaveValue('reviewing');
+      // The "(현재)" marker tracks the response VOC, and that option is the one
+      // selected — i.e. nextStatus was resynced from data.voc, not the stale prop.
+      const currentOption = screen.getByRole('option', {
+        name: '검토 중 (현재)',
+      }) as HTMLOptionElement;
+      expect(currentOption.value).toBe('reviewing');
+      expect(currentOption.selected).toBe(true);
+      expect(screen.getByText('Reporter-facing status는 그대로 유지됩니다.')).toBeInTheDocument();
+    });
+    expect(queryClient.getQueryData(['voc', BASE_VOC.id])).toEqual(UPDATED_VOC);
+
+    await React.act(async () => {
+      resolveDetailRefetch(UPDATED_VOC);
+    });
   });
 });

--- a/apps/frontend/src/features/voc/hooks/__tests__/useVocInternalCommentMutation.test.ts
+++ b/apps/frontend/src/features/voc/hooks/__tests__/useVocInternalCommentMutation.test.ts
@@ -9,8 +9,10 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { internalCommentRequestSchema } from '@fops/shared';
+import { type VocDetailEnvelope, internalCommentRequestSchema } from '@fops/shared';
+import { DETAIL_ENVELOPE } from '../../components/detail/__tests__/_fixtures';
 import {
+  type InternalCommentSuccess,
   type InternalCommentVars,
   useVocInternalCommentMutation,
 } from '../useVocInternalCommentMutation';
@@ -44,6 +46,29 @@ const MENTION_IDS = [
   '30000000-0000-4000-8000-000000000003',
   '30000000-0000-4000-8000-000000000004',
 ];
+
+const UPDATED_VOC: VocDetailEnvelope = {
+  ...DETAIL_ENVELOPE,
+  id: VOC_ID,
+  primary_managed_system_id: '00000000-0000-0000-0000-000000000010',
+  reporter_id: '00000000-0000-0000-0000-000000000011',
+  reporter_facing_status: 'reviewing',
+  updated_at: '2026-05-02T00:00:00.000Z',
+};
+
+const SUCCESS_ENVELOPE: InternalCommentSuccess = {
+  internal_comment: {
+    id: '00000000-0000-0000-0000-000000000014',
+    voc_id: VOC_ID,
+    actor_id: '00000000-0000-0000-0000-000000000011',
+    body_rich_content: {
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'body' }] }],
+    },
+    created_at: '2026-05-02T00:00:00.000Z',
+  },
+  voc: UPDATED_VOC,
+};
 
 const BASE_VARS: InternalCommentVars = {
   vocId: VOC_ID,
@@ -88,7 +113,7 @@ describe('useVocInternalCommentMutation', () => {
       if (init?.body) {
         capturedBody = JSON.parse(init.body as string);
       }
-      return jsonResponse({ id: 'comment-uuid-1', created_at: '2026-05-02T00:00:00.000Z' });
+      return jsonResponse(SUCCESS_ENVELOPE, 201);
     }) as typeof globalThis.fetch;
 
     const onSuccess = vi.fn();
@@ -120,5 +145,6 @@ describe('useVocInternalCommentMutation', () => {
     expect(internalCommentRequestSchema.safeParse(capturedBody).success).toBe(true);
 
     expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(onSuccess.mock.calls[0]?.[0]).toEqual(SUCCESS_ENVELOPE);
   });
 });

--- a/apps/frontend/src/features/voc/hooks/__tests__/useVocPublicUpdateMutation.test.ts
+++ b/apps/frontend/src/features/voc/hooks/__tests__/useVocPublicUpdateMutation.test.ts
@@ -11,8 +11,13 @@ import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { ApiError } from '@/lib/api';
-import { publicUpdateRequestSchema } from '@fops/shared';
-import { type PublicUpdateVars, useVocPublicUpdateMutation } from '../useVocPublicUpdateMutation';
+import { type VocDetailEnvelope, publicUpdateRequestSchema } from '@fops/shared';
+import { DETAIL_ENVELOPE } from '../../components/detail/__tests__/_fixtures';
+import {
+  type PublicUpdateSuccess,
+  type PublicUpdateVars,
+  useVocPublicUpdateMutation,
+} from '../useVocPublicUpdateMutation';
 
 // ── helpers ────────────────────────────────────────────────────────────────
 
@@ -39,6 +44,32 @@ function jsonResponse(body: unknown, status = 200): Response {
 
 const VOC_ID = '00000000-0000-0000-0000-000000000001';
 const UPDATED_AT = '2026-05-01T00:00:00.000Z';
+
+const UPDATED_VOC: VocDetailEnvelope = {
+  ...DETAIL_ENVELOPE,
+  id: VOC_ID,
+  primary_managed_system_id: '00000000-0000-0000-0000-000000000010',
+  reporter_id: '00000000-0000-0000-0000-000000000011',
+  reporter_facing_status: 'reviewing',
+  updated_at: '2026-05-02T00:00:00.000Z',
+};
+
+const SUCCESS_ENVELOPE: PublicUpdateSuccess = {
+  public_update: {
+    id: '00000000-0000-0000-0000-000000000012',
+    voc_id: VOC_ID,
+    body_rich_content: {
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'body' }] }],
+    },
+    reporter_facing_status_before: 'received',
+    reporter_facing_status_after: 'reviewing',
+    skip_public_update: false,
+    skip_reason: null,
+    created_at: '2026-05-02T00:00:00.000Z',
+  },
+  voc: UPDATED_VOC,
+};
 
 const BODY_ONLY_VARS: PublicUpdateVars = {
   vocId: VOC_ID,
@@ -84,7 +115,7 @@ describe('useVocPublicUpdateMutation', () => {
       if (init?.body) {
         capturedBody = JSON.parse(init.body as string);
       }
-      return jsonResponse({ id: VOC_ID, updated_at: '2026-05-02T00:00:00.000Z' });
+      return jsonResponse(SUCCESS_ENVELOPE, 201);
     }) as typeof globalThis.fetch;
 
     const onSuccess = vi.fn();
@@ -116,6 +147,7 @@ describe('useVocPublicUpdateMutation', () => {
     expect(publicUpdateRequestSchema.safeParse(capturedBody).success).toBe(true);
 
     expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(onSuccess.mock.calls[0]?.[0]).toEqual(SUCCESS_ENVELOPE);
   });
 
   // ── 2. Error: gate_blocked ─────────────────────────────────────────────

--- a/apps/frontend/src/features/voc/hooks/__tests__/useVocReporterReplyMutation.test.ts
+++ b/apps/frontend/src/features/voc/hooks/__tests__/useVocReporterReplyMutation.test.ts
@@ -11,8 +11,10 @@ import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { ApiError } from '@/lib/api';
-import { reporterReplyRequestSchema } from '@fops/shared';
+import { type VocDetailEnvelope, reporterReplyRequestSchema } from '@fops/shared';
+import { DETAIL_ENVELOPE } from '../../components/detail/__tests__/_fixtures';
 import {
+  type ReporterReplySuccess,
   type ReporterReplyVars,
   useVocReporterReplyMutation,
 } from '../useVocReporterReplyMutation';
@@ -42,6 +44,29 @@ function jsonResponse(body: unknown, status = 200): Response {
 
 const VOC_ID = '00000000-0000-0000-0000-000000000001';
 const UPDATED_AT = '2026-05-01T00:00:00.000Z';
+
+const UPDATED_VOC: VocDetailEnvelope = {
+  ...DETAIL_ENVELOPE,
+  id: VOC_ID,
+  primary_managed_system_id: '00000000-0000-0000-0000-000000000010',
+  reporter_id: '00000000-0000-0000-0000-000000000011',
+  reporter_facing_status: 'reviewing',
+  updated_at: '2026-05-02T00:00:00.000Z',
+};
+
+const SUCCESS_ENVELOPE: ReporterReplySuccess = {
+  reporter_reply: {
+    id: '00000000-0000-0000-0000-000000000013',
+    voc_id: VOC_ID,
+    actor_id: '00000000-0000-0000-0000-000000000011',
+    body_rich_content: {
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'body' }] }],
+    },
+    created_at: '2026-05-02T00:00:00.000Z',
+  },
+  voc: UPDATED_VOC,
+};
 
 const REPLY_VARS: ReporterReplyVars = {
   vocId: VOC_ID,
@@ -85,7 +110,7 @@ describe('useVocReporterReplyMutation', () => {
       if (init?.body) {
         capturedBody = JSON.parse(init.body as string);
       }
-      return jsonResponse({ id: VOC_ID, updated_at: '2026-05-02T00:00:00.000Z' });
+      return jsonResponse(SUCCESS_ENVELOPE, 201);
     }) as typeof globalThis.fetch;
 
     const onSuccess = vi.fn();
@@ -119,6 +144,7 @@ describe('useVocReporterReplyMutation', () => {
     expect(reporterReplyRequestSchema.safeParse(capturedBody).success).toBe(true);
 
     expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(onSuccess.mock.calls[0]?.[0]).toEqual(SUCCESS_ENVELOPE);
   });
 
   // ── 2. Error: idempotency key reuse ───────────────────────────────────────

--- a/apps/frontend/src/features/voc/hooks/useVocInternalCommentMutation.ts
+++ b/apps/frontend/src/features/voc/hooks/useVocInternalCommentMutation.ts
@@ -7,10 +7,11 @@
 //   Idempotency-Key: auto-minted by apiClient
 //   If-Match: voc.updated_at (optimistic concurrency)
 //
-// On 200: caller should invalidate ['voc', vocId], clear draft, toast.
+// On 201: caller should invalidate ['voc', vocId], clear draft, toast.
 
 import { apiClient } from '@/lib/api/client';
 import type { ApiError } from '@/lib/api/types';
+import type { VocDetailEnvelope } from '@fops/shared';
 import type { TipTapDoc } from '@fops/ui';
 import { type UseMutationResult, useMutation } from '@tanstack/react-query';
 
@@ -35,8 +36,14 @@ export interface InternalCommentVars {
 }
 
 export interface InternalCommentSuccess {
-  id: string;
-  created_at: string;
+  internal_comment: {
+    id: string;
+    voc_id: string;
+    actor_id: string;
+    body_rich_content: unknown;
+    created_at: string;
+  };
+  voc: VocDetailEnvelope;
 }
 
 export interface UseVocInternalCommentMutationArgs {

--- a/apps/frontend/src/features/voc/hooks/useVocPublicUpdateMutation.ts
+++ b/apps/frontend/src/features/voc/hooks/useVocPublicUpdateMutation.ts
@@ -14,11 +14,11 @@
 //   Idempotency-Key: auto-minted by apiClient
 //   If-Match: voc.updated_at (optimistic concurrency)
 //
-// On 200: caller should invalidate ['voc', vocId] and clear draft.
+// On 201: caller should invalidate ['voc', vocId] and clear draft.
 
 import { apiClient } from '@/lib/api/client';
 import type { ApiError } from '@/lib/api/types';
-import type { ReporterFacingStatusEnum } from '@fops/shared';
+import type { ReporterFacingStatusEnum, VocDetailEnvelope } from '@fops/shared';
 import type { TipTapDoc } from '@fops/ui';
 import { type UseMutationResult, useMutation } from '@tanstack/react-query';
 
@@ -43,8 +43,17 @@ export interface PublicUpdateVars {
 }
 
 export interface PublicUpdateSuccess {
-  id: string;
-  updated_at: string;
+  public_update: {
+    id: string;
+    voc_id: string;
+    body_rich_content: unknown | null;
+    reporter_facing_status_before: ReporterFacingStatusEnum;
+    reporter_facing_status_after: ReporterFacingStatusEnum;
+    skip_public_update: boolean;
+    skip_reason: string | null;
+    created_at: string;
+  };
+  voc: VocDetailEnvelope;
 }
 
 export interface UseVocPublicUpdateMutationArgs {

--- a/apps/frontend/src/features/voc/hooks/useVocReporterReplyMutation.ts
+++ b/apps/frontend/src/features/voc/hooks/useVocReporterReplyMutation.ts
@@ -11,11 +11,12 @@
 //   Idempotency-Key: auto-minted by apiClient (POST/PATCH/DELETE)
 //   If-Match: voc.updated_at (optimistic concurrency)
 //
-// On 200: caller should invalidate ['voc', vocId] and clear draft.
+// On 201: caller should invalidate ['voc', vocId] and clear draft.
 // Toast copy: 리포터에게 답장이 전송되었습니다.
 
 import { apiClient } from '@/lib/api/client';
 import type { ApiError } from '@/lib/api/types';
+import type { VocDetailEnvelope } from '@fops/shared';
 import type { TipTapDoc } from '@fops/ui';
 import { type UseMutationResult, useMutation } from '@tanstack/react-query';
 
@@ -37,8 +38,14 @@ export interface ReporterReplyVars {
 }
 
 export interface ReporterReplySuccess {
-  id: string;
-  updated_at: string;
+  reporter_reply: {
+    id: string;
+    voc_id: string;
+    actor_id: string;
+    body_rich_content: unknown;
+    created_at: string;
+  };
+  voc: VocDetailEnvelope;
 }
 
 export interface UseVocReporterReplyMutationArgs {


### PR DESCRIPTION
Closes #352.

## 뿌리

대화 POST 3종(`public-updates`, `reporter-replies`, `internal-comments`)은 모두 같은 트랜잭션 안에서 갱신된 `VocDetailEnvelope`를 조립해 `{ <conversation>, voc }`로 반환한다 (`conversation-service.ts:54-88, 375-393`). 그런데 FE 훅 3개가 응답 타입을 **API가 절대 보내지 않는 평평한 shape**로 선언해 놨다 — 그래서 봉투가 타입상 보이지 않았고, 소비처는 전부 낡은 prop으로 폴백했다.

실제 사용자 영향은 `PublicUpdateComposer` 한 곳이었다. `onSuccess`가 mutation **직전** `voc` prop에서 `nextStatus`를 리셋했고, 리셋 블록은 `voc.id`를 가드로 쓰기 때문에 리페치된 상태가 재동기화되지 않았다. 상태를 바꾸는 발행 직후:

- 셀렉터가 옛 상태에 고착
- "상태가 …(으)로 변경됩니다" 예고가 이미 끝난 변경을 계속 광고
- 다음 발행이 역방향 전이를 전송 → 전이 매트릭스에 역방향 간선이 없어(`docs/design-prototype/data.js:599-608`) `422 validation.failed`. 그 코드는 `getComposerErrorTone`에 없어 인라인 Callout이 아니라 정체불명 토스트로만 뜬다.

## 변경

- 훅 3개의 성공 타입을 실제 봉투 shape로 정정. `voc`는 공유 `VocDetailEnvelope`를 쓴다.
- `PublicUpdateComposer.onSuccess`가 `data.voc`를 `['voc', id]`에 write-through한 뒤 invalidate하고, `nextStatus`를 응답에서 읽는다.
- 리포터 답장·내부 코멘트 훅은 **타입만** 정정. 두 컴포저의 `onSuccess`는 payload를 안 읽으므로 동작 무변화 — 본문 한 줄도 안 건드렸다.

## 왜 테스트가 못 잡았나

픽스처 4개가 백엔드가 절대 안 보내는 평평한 shape를 목킹하고 있었다. 이제 전부 캐스트 없는 진짜 `VocDetailEnvelope`를 싣는다 — **타입체크가 wire 계약을 강제한다.**

## 뮤테이션 매트릭스 (4/4 사망)

| 뮤테이션 | 발화한 단언 |
|---|---|
| `setNextStatus(data.voc…)` → `voc…` | 콤보박스 `toHaveValue('reviewing')` |
| `setQueryData` write-through 제거 | `option '검토 중 (현재)'` 미발견 |
| `invalidateQueries` 제거 | spy 호출 수 + 통합 테스트 무효화 단언 (2건) |
| `PublicUpdateSuccess`를 평평한 shape로 되돌림 | 4개 파일에 타입체크 에러 5건 |

세 번째 뮤테이션이 "write-through가 invalidate를 대체하지 않는다"를, 네 번째가 "타입 정정이 실제로 하중을 받는다"를 각각 증명한다.

## 기각한 선택지

- **`onMutate` 낙관적 업데이트** — 이건 성공 *응답*을 쓰는 것이지 성공을 미리 가정하는 것이 아니다. 롤백 경로 없는 낙관적 쓰기는 범위 밖.
- **`invalidateQueries` 제거** — 봉투에는 상세만 있다. 목록·카운트 쿼리는 여전히 갱신돼야 한다.
- **`voc.id` 리셋 가드 수정** — 그 블록은 "다른 VOC로 이동"을 담당한다. 우리가 고친 것은 "같은 VOC, 발행 성공"이다. 다른 경로다.

## 범위 밖으로 남긴 것

- **`attachmentIds`가 발행 성공 후 비워지지 않는다.** 이 청크에서 판정하지 않았다. 별개로 다뤄야 한다.
- `PublicUpdateComposer.test.tsx`의 **기존** biome format 위반을 함께 정리했다. develop에도 있던 부채인데, 이 파일이 이제서야 게이트의 변경-파일 스코프에 들어왔다. 그 결과 `frontend-biome-allowlist.txt`의 해당 format 항목은 이제 stale이다 — 게이트 설정 변경이라 이 PR에서 건드리지 않았다.

## 유래

`origin/fix/327-whitespace-voc`의 `af35606`이 이 결함을 지목했으나, #330이 "Orca 좌표 클릭 실수, 제품 버그 아님"으로 닫히면서 함께 폐기됐다. 이슈 코멘트 전수 수확에서 그 커밋이 미소화 상태로 남은 것을 발견했고, 진단을 코드로 재확인한 뒤 그 커밋보다 좁은 범위로 다시 구현했다.

## 게이트

```
frontend vitest      830 passed / 150 files   ← 829/150에서 (+1 회귀 테스트)
frontend typecheck   0 errors
frontend biome       0 unexpected, 128 allowlisted
shared               449 passed / 31 files    ← 무변동
check:boundaries     OK
```

백엔드·shared 소스는 한 줄도 바뀌지 않았다(FE 전용 변경). shared 테스트는 확인차 돌렸다.
