### PR TITLE
fix(#354): 대화 컴포저 3종이 게시 성공 후 링크된 첨부를 비우도록

### DIFF
--- a/apps/frontend/src/features/voc/components/detail/ComposerAttachmentDropzone.tsx
+++ b/apps/frontend/src/features/voc/components/detail/ComposerAttachmentDropzone.tsx
@@ -23,10 +23,10 @@ import { Check, Paperclip, X } from 'lucide-react';
 import * as React from 'react';
 import { toast } from 'sonner';
 
+import { formatFileSize } from '@/features/voc/lib/format-file-size';
 import { uploadAttachment } from '@/lib/api/attachments';
 import { errorMapper } from '@/lib/api/errorMapper';
 import type { ApiError } from '@/lib/api/types';
-import { formatFileSize } from '@/features/voc/lib/format-file-size';
 
 const MAX_SIZE_BYTES = 25 * 1024 * 1024;
 
@@ -86,6 +86,15 @@ function mintIdempotencyKey(): string {
 
 // formatFileSize moved to lib/format-file-size.ts (PLAN-22 §Bug-1, 2026-05-22).
 
+// Module scope: it reads nothing from the component, and defining it inside
+// made addFiles' empty dependency list a lint error (useExhaustiveDependencies).
+function clientSideRejection(file: File): { code: string; message: string } | null {
+  if (file.size > MAX_SIZE_BYTES) {
+    return { code: 'attachment.too_large', message: COPY.oversize };
+  }
+  return null;
+}
+
 export function ComposerAttachmentDropzone({
   testId,
   onChange,
@@ -137,13 +146,6 @@ export function ComposerAttachmentDropzone({
         : cur,
     );
   }, [resetToken]);
-
-  function clientSideRejection(file: File): { code: string; message: string } | null {
-    if (file.size > MAX_SIZE_BYTES) {
-      return { code: 'attachment.too_large', message: COPY.oversize };
-    }
-    return null;
-  }
 
   const addFiles = React.useCallback((fileList: FileList | File[] | null): void => {
     if (!fileList) return;
@@ -247,10 +249,7 @@ export function ComposerAttachmentDropzone({
   const inputId = `${testId}-input-control`;
 
   return (
-    <div
-      data-testid={testId}
-      className="flex flex-col gap-1.5 px-3 pb-2"
-    >
+    <div data-testid={testId} className="flex flex-col gap-1.5 px-3 pb-2">
       {/* Compact dropzone — no FieldLabel; composer context implies "첨부" */}
       {/* biome-ignore lint/a11y/noLabelWithoutControl: htmlFor wires to hidden input */}
       <label
@@ -279,10 +278,7 @@ export function ComposerAttachmentDropzone({
       </label>
 
       {rows.length > 0 && (
-        <ul
-          className="mt-1 flex flex-col gap-1"
-          data-testid={`${testId}-rows`}
-        >
+        <ul className="mt-1 flex flex-col gap-1" data-testid={`${testId}-rows`}>
           {rows.map((row) => (
             <AttachmentRow key={row.rowId} row={row} onRemove={() => removeRow(row.rowId)} />
           ))}

--- a/apps/frontend/src/features/voc/components/detail/ComposerAttachmentDropzone.tsx
+++ b/apps/frontend/src/features/voc/components/detail/ComposerAttachmentDropzone.tsx
@@ -59,6 +59,13 @@ export interface ComposerAttachmentDropzoneProps {
   testId: string;
   onChange?: (serverAttachmentIds: string[]) => void;
   onUploadingChange?: (uploading: boolean) => void;
+  /**
+   * #354: bump this after a successful post to drop the rows whose attachments
+   * the server has now linked to the published item. Only `uploaded` rows are
+   * dropped — a row still uploading (the user may add files while the post is
+   * in flight) and a row that failed both stay, so nothing is silently lost.
+   */
+  resetToken?: number;
 }
 
 function mintRowId(): string {
@@ -83,6 +90,7 @@ export function ComposerAttachmentDropzone({
   testId,
   onChange,
   onUploadingChange,
+  resetToken,
 }: ComposerAttachmentDropzoneProps): React.ReactElement {
   const [rows, setRows] = React.useState<Row[]>([]);
   const [dragOver, setDragOver] = React.useState(false);
@@ -116,6 +124,19 @@ export function ComposerAttachmentDropzone({
       onUploadingChange?.(anyUploading);
     }
   }, [anyUploading, onUploadingChange]);
+
+  // #354: the parent bumps resetToken after a successful post. Rows that are
+  // still uploading or that errored are kept — only the linked ones go away.
+  // Dropping them re-runs the uploadedIds effect above, so the parent's
+  // attachment id list clears through the same onChange path as any other edit.
+  React.useEffect(() => {
+    if (resetToken === undefined) return;
+    setRows((cur) =>
+      cur.some((r) => r.state.kind === 'uploaded')
+        ? cur.filter((r) => r.state.kind !== 'uploaded')
+        : cur,
+    );
+  }, [resetToken]);
 
   function clientSideRejection(file: File): { code: string; message: string } | null {
     if (file.size > MAX_SIZE_BYTES) {

--- a/apps/frontend/src/features/voc/components/detail/InternalCommentComposer.tsx
+++ b/apps/frontend/src/features/voc/components/detail/InternalCommentComposer.tsx
@@ -93,6 +93,9 @@ export function InternalCommentComposer({
   // PLAN-22 C7a: composer-level attachment dropzone state.
   const [attachmentIds, setAttachmentIds] = React.useState<string[]>([]);
   const [attachmentsUploading, setAttachmentsUploading] = React.useState(false);
+  // #354: bumped on submit success so the dropzone drops the rows the server
+  // has now linked to the added comment.
+  const [attachmentResetToken, setAttachmentResetToken] = React.useState(0);
 
   const isEmpty = isTipTapDocBlank(draftDoc);
 
@@ -100,6 +103,9 @@ export function InternalCommentComposer({
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['voc', voc.id] });
       setDraftDoc(null); // calls onDraftChange?.(null) when controlled
+      // #354: linked to the added comment now — re-sending would be already_linked.
+      // attachmentIds clears through the dropzone's onChange, not from here.
+      setAttachmentResetToken((n) => n + 1);
       toast.success('내부 코멘트가 추가되었습니다.');
     },
     onError: (error) => {
@@ -187,6 +193,7 @@ export function InternalCommentComposer({
         testId="internal-comment-attachment-dropzone"
         onChange={setAttachmentIds}
         onUploadingChange={setAttachmentsUploading}
+        resetToken={attachmentResetToken}
       />
 
       {/* ComposerFooter — Preview disabled per D-5.4 */}

--- a/apps/frontend/src/features/voc/components/detail/PublicUpdateComposer.tsx
+++ b/apps/frontend/src/features/voc/components/detail/PublicUpdateComposer.tsx
@@ -138,6 +138,9 @@ export function PublicUpdateComposer({
   // PLAN-22 C7a: composer-level attachment dropzone state.
   const [attachmentIds, setAttachmentIds] = useState<string[]>([]);
   const [attachmentsUploading, setAttachmentsUploading] = useState(false);
+  // #354: bumped on publish success so the dropzone drops the rows the server
+  // has now linked to the published update.
+  const [attachmentResetToken, setAttachmentResetToken] = useState(0);
 
   // Reset state when VOC changes (status + preview; draft reset handled by parent for controlled).
   const prevVocIdRef = useRef(voc.id);
@@ -163,6 +166,12 @@ export function PublicUpdateComposer({
       // clear draft (calls onDraftChange?.(null) when controlled)
       setDraftDoc(null);
       setNextStatus(data.voc.reporter_facing_status);
+      // #354: these attachments belong to the published update now. Keeping
+      // them would re-send already-linked ids on the next publish (422).
+      // The dropzone drops the linked rows and reports the shrunk list back
+      // through onChange, so attachmentIds clears along the one path it always
+      // travels — clearing it here as well would be a second, silent writer.
+      setAttachmentResetToken((n) => n + 1);
       toast.success('공개 업데이트가 게시되었습니다.');
     },
     onError: (error) => {
@@ -270,6 +279,7 @@ export function PublicUpdateComposer({
         testId="public-update-attachment-dropzone"
         onChange={setAttachmentIds}
         onUploadingChange={setAttachmentsUploading}
+        resetToken={attachmentResetToken}
       />
 
       {/* ReporterStatusChangeBlock — always shown in the public-update composer */}

--- a/apps/frontend/src/features/voc/components/detail/ReporterReplyComposer.tsx
+++ b/apps/frontend/src/features/voc/components/detail/ReporterReplyComposer.tsx
@@ -100,6 +100,9 @@ export function ReporterReplyComposer({
   // PLAN-22 C7a: composer-level attachment dropzone state.
   const [attachmentIds, setAttachmentIds] = useState<string[]>([]);
   const [attachmentsUploading, setAttachmentsUploading] = useState(false);
+  // #354: bumped on send success so the dropzone drops the rows the server
+  // has now linked to the sent reply.
+  const [attachmentResetToken, setAttachmentResetToken] = useState(0);
 
   // Reset state when VOC changes (preview; draft reset handled by parent for controlled).
   const prevVocIdRef = useRef(voc.id);
@@ -117,6 +120,9 @@ export function ReporterReplyComposer({
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['voc', voc.id] });
       setDraftDoc(null); // calls onDraftChange?.(null) when controlled
+      // #354: linked to the sent reply now — re-sending would be already_linked.
+      // attachmentIds clears through the dropzone's onChange, not from here.
+      setAttachmentResetToken((n) => n + 1);
       toast.success('리포터에게 답장이 전송되었습니다.');
     },
     onError: (error) => {
@@ -198,6 +204,7 @@ export function ReporterReplyComposer({
         testId="reporter-reply-attachment-dropzone"
         onChange={setAttachmentIds}
         onUploadingChange={setAttachmentsUploading}
+        resetToken={attachmentResetToken}
       />
 
       {/* Inline error Callout — reporter_facing_status.gate_blocked (amber)

--- a/apps/frontend/src/features/voc/components/detail/__tests__/InternalCommentComposer.attachments.test.tsx
+++ b/apps/frontend/src/features/voc/components/detail/__tests__/InternalCommentComposer.attachments.test.tsx
@@ -1,9 +1,9 @@
 // InternalCommentComposer — attachment dropzone wiring tests (PLAN-22 C7a).
 
-import * as React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import * as React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@fops/ui', async (importOriginal) => {
@@ -41,11 +41,11 @@ import {
   type InternalCommentSuccess,
   useVocInternalCommentMutation,
 } from '@/features/voc/hooks/useVocInternalCommentMutation';
-import { InternalCommentComposer } from '../InternalCommentComposer';
 import * as attachmentsApi from '@/lib/api/attachments';
 import { ApiError } from '@/lib/api/types';
-import type { VocDetailEnvelope } from '@fops/shared';
 import type { MeResponse } from '@/lib/auth/useMe';
+import type { VocDetailEnvelope } from '@fops/shared';
+import { InternalCommentComposer } from '../InternalCommentComposer';
 
 const ADMIN_ID = '00000000-0000-0000-0000-000000000002';
 
@@ -148,11 +148,10 @@ describe('<InternalCommentComposer> attachments (PLAN-22 C7a)', () => {
   it('upload → submit body includes attachment_ids[]', async () => {
     vi.spyOn(attachmentsApi, 'uploadAttachment').mockResolvedValue(ATTACHMENT);
     const mutateMock = vi.fn();
-    vi.mocked(useVocInternalCommentMutation).mockReturnValue(
-      { ...DEFAULT_MUTATION, mutate: mutateMock } as unknown as ReturnType<
-        typeof useVocInternalCommentMutation
-      >,
-    );
+    vi.mocked(useVocInternalCommentMutation).mockReturnValue({
+      ...DEFAULT_MUTATION,
+      mutate: mutateMock,
+    } as unknown as ReturnType<typeof useVocInternalCommentMutation>);
 
     render(<InternalCommentComposer voc={BASE_VOC} me={ME_ADMIN} />, { wrapper: wrap() });
 
@@ -172,7 +171,9 @@ describe('<InternalCommentComposer> attachments (PLAN-22 C7a)', () => {
     await waitFor(() => {
       expect(mutateMock).toHaveBeenCalled();
     });
-    const calledVars = mutateMock.mock.calls[0]![0] as {
+    const firstCall = mutateMock.mock.calls[0];
+    if (!firstCall) throw new Error('expected the internal-comment mutation to have been called');
+    const calledVars = firstCall[0] as {
       body: { attachment_ids: string[] };
     };
     expect(calledVars.body.attachment_ids).toEqual([ATTACHMENT.id]);
@@ -232,11 +233,10 @@ describe('<InternalCommentComposer> attachments (PLAN-22 C7a)', () => {
       new ApiError(422, { code: 'attachment.unsupported_type', message: 'nope' }),
     );
     const mutateMock = vi.fn();
-    vi.mocked(useVocInternalCommentMutation).mockReturnValue(
-      { ...DEFAULT_MUTATION, mutate: mutateMock } as unknown as ReturnType<
-        typeof useVocInternalCommentMutation
-      >,
-    );
+    vi.mocked(useVocInternalCommentMutation).mockReturnValue({
+      ...DEFAULT_MUTATION,
+      mutate: mutateMock,
+    } as unknown as ReturnType<typeof useVocInternalCommentMutation>);
 
     render(<InternalCommentComposer voc={BASE_VOC} me={ME_ADMIN} />, { wrapper: wrap() });
 
@@ -256,7 +256,9 @@ describe('<InternalCommentComposer> attachments (PLAN-22 C7a)', () => {
     await waitFor(() => {
       expect(mutateMock).toHaveBeenCalled();
     });
-    const calledVars = mutateMock.mock.calls[0]![0] as {
+    const firstCall = mutateMock.mock.calls[0];
+    if (!firstCall) throw new Error('expected the internal-comment mutation to have been called');
+    const calledVars = firstCall[0] as {
       body: { attachment_ids: string[] };
     };
     expect(calledVars.body.attachment_ids).toEqual([]);

--- a/apps/frontend/src/features/voc/components/detail/__tests__/InternalCommentComposer.attachments.test.tsx
+++ b/apps/frontend/src/features/voc/components/detail/__tests__/InternalCommentComposer.attachments.test.tsx
@@ -37,7 +37,10 @@ vi.mock('@/features/voc/hooks/useVocInternalCommentMutation', () => ({
   useVocInternalCommentMutation: vi.fn(),
 }));
 
-import { useVocInternalCommentMutation } from '@/features/voc/hooks/useVocInternalCommentMutation';
+import {
+  type InternalCommentSuccess,
+  useVocInternalCommentMutation,
+} from '@/features/voc/hooks/useVocInternalCommentMutation';
 import { InternalCommentComposer } from '../InternalCommentComposer';
 import * as attachmentsApi from '@/lib/api/attachments';
 import { ApiError } from '@/lib/api/types';
@@ -173,6 +176,55 @@ describe('<InternalCommentComposer> attachments (PLAN-22 C7a)', () => {
       body: { attachment_ids: string[] };
     };
     expect(calledVars.body.attachment_ids).toEqual([ATTACHMENT.id]);
+  });
+
+  it('#354 clears linked attachments on submit success so the next submit sends none', async () => {
+    vi.spyOn(attachmentsApi, 'uploadAttachment').mockResolvedValue(ATTACHMENT);
+    const mutateMock = vi.fn();
+    let capturedOnSuccess: ((data: InternalCommentSuccess) => void) | undefined;
+    vi.mocked(useVocInternalCommentMutation).mockImplementation((args) => {
+      capturedOnSuccess = args?.onSuccess as ((data: InternalCommentSuccess) => void) | undefined;
+      return { ...DEFAULT_MUTATION, mutate: mutateMock } as unknown as ReturnType<
+        typeof useVocInternalCommentMutation
+      >;
+    });
+
+    render(<InternalCommentComposer voc={BASE_VOC} me={ME_ADMIN} />, { wrapper: wrap() });
+    const user = userEvent.setup();
+
+    await user.click(screen.getByTestId('rich-editor-internal-comment'));
+    await act(async () => {
+      pickFile(makeFile());
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('attachment-row').getAttribute('data-state')).toBe('uploaded');
+    });
+    await user.click(screen.getByRole('button', { name: 'Add note' }));
+    await waitFor(() => expect(mutateMock).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      capturedOnSuccess?.({
+        internal_comment: {
+          id: 'ic-1',
+          voc_id: BASE_VOC.id,
+          actor_id: ADMIN_ID,
+          body_rich_content: null,
+          created_at: '2026-05-01T00:01:00Z',
+        },
+        voc: BASE_VOC,
+      });
+    });
+
+    expect(screen.queryByTestId('attachment-row')).not.toBeInTheDocument();
+
+    await user.click(screen.getByTestId('rich-editor-internal-comment'));
+    await user.click(screen.getByRole('button', { name: 'Add note' }));
+    await waitFor(() => expect(mutateMock).toHaveBeenCalledTimes(2));
+
+    const secondCall = mutateMock.mock.calls[1];
+    if (!secondCall) throw new Error('expected a second internal-comment mutation call');
+    const secondVars = secondCall[0] as { body: { attachment_ids: string[] } };
+    expect(secondVars.body.attachment_ids).toEqual([]);
   });
 
   it('failed upload not included in POST body', async () => {

--- a/apps/frontend/src/features/voc/components/detail/__tests__/PublicUpdateComposer.attachments.test.tsx
+++ b/apps/frontend/src/features/voc/components/detail/__tests__/PublicUpdateComposer.attachments.test.tsx
@@ -43,7 +43,10 @@ vi.mock('@/features/voc/hooks/useVocPublicUpdateMutation', () => ({
   useVocPublicUpdateMutation: vi.fn(),
 }));
 
-import { useVocPublicUpdateMutation } from '@/features/voc/hooks/useVocPublicUpdateMutation';
+import {
+  type PublicUpdateSuccess,
+  useVocPublicUpdateMutation,
+} from '@/features/voc/hooks/useVocPublicUpdateMutation';
 import * as attachmentsApi from '@/lib/api/attachments';
 import { ApiError } from '@/lib/api/types';
 import type { MeResponse } from '@/lib/auth/useMe';
@@ -228,6 +231,204 @@ describe('<PublicUpdateComposer> attachments (PLAN-22 C7a)', () => {
       body: { attachment_ids: string[] };
     };
     expect(calledVars.body.attachment_ids).toEqual([]);
+  });
+
+  it('#354 clears linked attachments on publish success so the next submit sends none', async () => {
+    vi.spyOn(attachmentsApi, 'uploadAttachment').mockResolvedValue(ATTACHMENT);
+    const mutateMock = vi.fn();
+    let capturedOnSuccess: ((data: PublicUpdateSuccess) => void) | undefined;
+    vi.mocked(useVocPublicUpdateMutation).mockImplementation((args) => {
+      capturedOnSuccess = args?.onSuccess as ((data: PublicUpdateSuccess) => void) | undefined;
+      return {
+        ...DEFAULT_MUTATION,
+        mutate: mutateMock,
+      } as unknown as ReturnType<typeof useVocPublicUpdateMutation>;
+    });
+
+    render(<PublicUpdateComposer voc={BASE_VOC} me={ME_ADMIN} />, { wrapper: wrap() });
+    const user = userEvent.setup();
+
+    await user.click(screen.getByTestId('rich-editor-public-update'));
+    await act(async () => {
+      pickFile(makeFile());
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('attachment-row').getAttribute('data-state')).toBe('uploaded');
+    });
+    await user.click(screen.getByRole('button', { name: 'Publish update' }));
+    await waitFor(() => expect(mutateMock).toHaveBeenCalledTimes(1));
+
+    // Server accepted the publish and linked the attachment.
+    await act(async () => {
+      capturedOnSuccess?.({
+        public_update: {
+          id: 'pu-1',
+          voc_id: BASE_VOC.id,
+          body_rich_content: null,
+          reporter_facing_status_before: 'received',
+          reporter_facing_status_after: 'received',
+          skip_public_update: false,
+          skip_reason: null,
+          created_at: '2026-05-01T00:01:00Z',
+        },
+        voc: BASE_VOC,
+      });
+    });
+
+    // The chip must be gone — the attachment now belongs to the published item.
+    expect(screen.queryByTestId('attachment-row')).not.toBeInTheDocument();
+
+    // Compose a second update and publish again.
+    await user.click(screen.getByTestId('rich-editor-public-update'));
+    await user.click(screen.getByRole('button', { name: 'Publish update' }));
+    await waitFor(() => expect(mutateMock).toHaveBeenCalledTimes(2));
+
+    const secondCall = mutateMock.mock.calls[1];
+    if (!secondCall) throw new Error('expected a second public-update mutation call');
+    const secondVars = secondCall[0] as { body: { attachment_ids: string[] } };
+    expect(secondVars.body.attachment_ids).toEqual([]);
+  });
+
+  it('#354 reset keeps a still-uploading row — a file added while the post was in flight survives', async () => {
+    // First file resolves immediately; the second is left pending so it is
+    // mid-upload at the moment the publish succeeds.
+    let resolveSecond!: (v: typeof ATTACHMENT) => void;
+    const SECOND = { ...ATTACHMENT, id: 'aaaa1111-0000-4000-8000-000000000002' };
+    vi.spyOn(attachmentsApi, 'uploadAttachment')
+      .mockResolvedValueOnce(ATTACHMENT)
+      .mockReturnValueOnce(
+        new Promise((res) => {
+          resolveSecond = res;
+        }),
+      );
+
+    const mutateMock = vi.fn();
+    let capturedOnSuccess: ((data: PublicUpdateSuccess) => void) | undefined;
+    vi.mocked(useVocPublicUpdateMutation).mockImplementation((args) => {
+      capturedOnSuccess = args?.onSuccess as ((data: PublicUpdateSuccess) => void) | undefined;
+      return {
+        ...DEFAULT_MUTATION,
+        mutate: mutateMock,
+      } as unknown as ReturnType<typeof useVocPublicUpdateMutation>;
+    });
+
+    render(<PublicUpdateComposer voc={BASE_VOC} me={ME_ADMIN} />, { wrapper: wrap() });
+    const user = userEvent.setup();
+
+    await user.click(screen.getByTestId('rich-editor-public-update'));
+    await act(async () => {
+      pickFile(makeFile('first.png'));
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('attachment-row').getAttribute('data-state')).toBe('uploaded');
+    });
+    await user.click(screen.getByRole('button', { name: 'Publish update' }));
+    await waitFor(() => expect(mutateMock).toHaveBeenCalledTimes(1));
+
+    // User attaches another file while the publish request is still in flight.
+    await act(async () => {
+      pickFile(makeFile('second.png'));
+    });
+    await waitFor(() => {
+      expect(
+        screen.getAllByTestId('attachment-row').map((r) => r.getAttribute('data-state')),
+      ).toEqual(['uploaded', 'uploading']);
+    });
+
+    await act(async () => {
+      capturedOnSuccess?.({
+        public_update: {
+          id: 'pu-1',
+          voc_id: BASE_VOC.id,
+          body_rich_content: null,
+          reporter_facing_status_before: 'received',
+          reporter_facing_status_after: 'received',
+          skip_public_update: false,
+          skip_reason: null,
+          created_at: '2026-05-01T00:01:00Z',
+        },
+        voc: BASE_VOC,
+      });
+    });
+
+    // The linked row is gone; the in-flight one is untouched.
+    const rowsAfterReset = screen.getAllByTestId('attachment-row');
+    expect(rowsAfterReset).toHaveLength(1);
+    expect(rowsAfterReset[0]?.getAttribute('data-state')).toBe('uploading');
+
+    // It finishes normally and is carried by the next submit.
+    await act(async () => {
+      resolveSecond(SECOND);
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('attachment-row').getAttribute('data-state')).toBe('uploaded');
+    });
+
+    await user.click(screen.getByTestId('rich-editor-public-update'));
+    await user.click(screen.getByRole('button', { name: 'Publish update' }));
+    await waitFor(() => expect(mutateMock).toHaveBeenCalledTimes(2));
+    const secondCall = mutateMock.mock.calls[1];
+    if (!secondCall) throw new Error('expected a second public-update mutation call');
+    expect((secondCall[0] as { body: { attachment_ids: string[] } }).body.attachment_ids).toEqual([
+      SECOND.id,
+    ]);
+  });
+
+  it('#354 reset keeps a failed row so the user can still see and remove it', async () => {
+    vi.spyOn(attachmentsApi, 'uploadAttachment')
+      .mockResolvedValueOnce(ATTACHMENT)
+      .mockRejectedValueOnce(
+        new ApiError(422, { code: 'attachment.unsupported_type', message: 'nope' }),
+      );
+
+    const mutateMock = vi.fn();
+    let capturedOnSuccess: ((data: PublicUpdateSuccess) => void) | undefined;
+    vi.mocked(useVocPublicUpdateMutation).mockImplementation((args) => {
+      capturedOnSuccess = args?.onSuccess as ((data: PublicUpdateSuccess) => void) | undefined;
+      return {
+        ...DEFAULT_MUTATION,
+        mutate: mutateMock,
+      } as unknown as ReturnType<typeof useVocPublicUpdateMutation>;
+    });
+
+    render(<PublicUpdateComposer voc={BASE_VOC} me={ME_ADMIN} />, { wrapper: wrap() });
+    const user = userEvent.setup();
+
+    await user.click(screen.getByTestId('rich-editor-public-update'));
+    await act(async () => {
+      pickFile(makeFile('ok.png'));
+    });
+    await act(async () => {
+      pickFile(makeFile('bad.zip', 'application/zip'));
+    });
+    await waitFor(() => {
+      expect(
+        screen.getAllByTestId('attachment-row').map((r) => r.getAttribute('data-state')),
+      ).toEqual(['uploaded', 'error']);
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Publish update' }));
+    await waitFor(() => expect(mutateMock).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      capturedOnSuccess?.({
+        public_update: {
+          id: 'pu-1',
+          voc_id: BASE_VOC.id,
+          body_rich_content: null,
+          reporter_facing_status_before: 'received',
+          reporter_facing_status_after: 'received',
+          skip_public_update: false,
+          skip_reason: null,
+          created_at: '2026-05-01T00:01:00Z',
+        },
+        voc: BASE_VOC,
+      });
+    });
+
+    const rowsAfterReset = screen.getAllByTestId('attachment-row');
+    expect(rowsAfterReset).toHaveLength(1);
+    expect(rowsAfterReset[0]?.getAttribute('data-state')).toBe('error');
   });
 
   it('Publish disabled while any attachment is mid-upload', async () => {

--- a/apps/frontend/src/features/voc/components/detail/__tests__/ReporterReplyComposer.attachments.test.tsx
+++ b/apps/frontend/src/features/voc/components/detail/__tests__/ReporterReplyComposer.attachments.test.tsx
@@ -37,7 +37,10 @@ vi.mock('@/features/voc/hooks/useVocReporterReplyMutation', () => ({
   useVocReporterReplyMutation: vi.fn(),
 }));
 
-import { useVocReporterReplyMutation } from '@/features/voc/hooks/useVocReporterReplyMutation';
+import {
+  type ReporterReplySuccess,
+  useVocReporterReplyMutation,
+} from '@/features/voc/hooks/useVocReporterReplyMutation';
 import * as attachmentsApi from '@/lib/api/attachments';
 import { ApiError } from '@/lib/api/types';
 import type { MeResponse } from '@/lib/auth/useMe';
@@ -182,6 +185,56 @@ describe('<ReporterReplyComposer> attachments (PLAN-22 C7a)', () => {
     });
     expect(calledVars.body).not.toHaveProperty('attachments');
     expect(reporterReplyRequestSchema.safeParse(calledVars.body).success).toBe(true);
+  });
+
+  it('#354 clears linked attachments on send success so the next submit sends none', async () => {
+    vi.spyOn(attachmentsApi, 'uploadAttachment').mockResolvedValue(ATTACHMENT);
+    const mutateMock = vi.fn();
+    let capturedOnSuccess: ((data: ReporterReplySuccess) => void) | undefined;
+    vi.mocked(useVocReporterReplyMutation).mockImplementation((args) => {
+      capturedOnSuccess = args?.onSuccess as ((data: ReporterReplySuccess) => void) | undefined;
+      return {
+        ...DEFAULT_MUTATION,
+        mutate: mutateMock,
+      } as unknown as ReturnType<typeof useVocReporterReplyMutation>;
+    });
+
+    render(<ReporterReplyComposer voc={BASE_VOC} me={ME_ADMIN} />, { wrapper: wrap() });
+    const user = userEvent.setup();
+
+    await user.click(screen.getByTestId('rich-editor-reporter-reply'));
+    await act(async () => {
+      pickFile(makeFile());
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('attachment-row').getAttribute('data-state')).toBe('uploaded');
+    });
+    await user.click(screen.getByRole('button', { name: 'Send reply' }));
+    await waitFor(() => expect(mutateMock).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      capturedOnSuccess?.({
+        reporter_reply: {
+          id: 'rr-1',
+          voc_id: BASE_VOC.id,
+          actor_id: ADMIN_ID,
+          body_rich_content: null,
+          created_at: '2026-05-01T00:01:00Z',
+        },
+        voc: BASE_VOC,
+      });
+    });
+
+    expect(screen.queryByTestId('attachment-row')).not.toBeInTheDocument();
+
+    await user.click(screen.getByTestId('rich-editor-reporter-reply'));
+    await user.click(screen.getByRole('button', { name: 'Send reply' }));
+    await waitFor(() => expect(mutateMock).toHaveBeenCalledTimes(2));
+
+    const secondCall = mutateMock.mock.calls[1];
+    if (!secondCall) throw new Error('expected a second reporter-reply mutation call');
+    const secondVars = secondCall[0] as { body: { attachment_ids: string[] } };
+    expect(secondVars.body.attachment_ids).toEqual([]);
   });
 
   it('failed upload not included in POST body', async () => {


### PR DESCRIPTION
Closes #354.

## 재현부터 했다

이슈 본문이 "코드 실측이고 재현 스크립트로 확인한 것은 아니다"라고 못박아 뒀으므로, 손대기 전에 실패하는 테스트로 먼저 재현했다. 예측은 사실이었다:

- 성공 직후에도 첨부 칩이 화면에 남는다 (`chipPresent = true`)
- 두 번째 제출이 같은 id를 다시 싣는다 (`["aaaa1111-…0001"]`)

BE는 `conversation-service.ts:330-336`에서 `already_linked`를 `validation.failed`로 던지고, 이 코드는 `getComposerErrorTone`에 없어 인라인 Callout이 아니라 정체불명 토스트로 빠진다.

## 무엇을 고쳤나

`ComposerAttachmentDropzone`는 완전히 uncontrolled였고 리셋 경로가 아예 없었다. optional `resetToken`을 받아, 값이 바뀌면 **업로드가 끝난 행만** 지운다.

진행 중인 행과 실패한 행은 남긴다. 제출은 `attachmentsUploading`으로 막혀 있지만 **요청이 떠 있는 동안 파일을 새로 붙이는 것은 막지 않는다** — 그때 응답이 오면 통짜 리마운트나 전체 비우기는 그 업로드를 조용히 삼킨다. 실패한 행도 남겨야 사용자가 보고 지울 수 있다.

행이 지워지면 기존 `uploadedIds` 이펙트가 다시 돌아 `onChange([])`가 나가고, 부모의 `attachmentIds`는 **평소 편집과 똑같은 경로로** 비워진다. 그래서 컴포저 쪽에서 `setAttachmentIds([])`를 따로 쓰지 않는다 — 아래 매트릭스에서 그게 죽은 코드임이 드러났다.

## 기각한 선택지

- **`key` 리마운트** — 최소 변경이지만 응답 대기 중 추가한 업로드가 잘린다.
- **완전 controlled** — rows·abort·에러 상태까지 부모로 올라가 컴포저 3개가 같은 로직을 중복한다. 이 버그가 요구하는 범위보다 크다.
- **`validation.failed`를 `getComposerErrorTone`에 추가** — 이번 수정으로 `already_linked` 경로 자체가 사라져 급하지 않다. `validation.failed`는 넓은 상위 코드라 전부 인라인으로 보내는 게 옳은지는 별개 판정이다. 후속 이슈로 분리.

## 뮤테이션 매트릭스 — 7/7 사망, 생존자 0

| 뮤테이션 | 발화한 단언 |
|---|---|
| PublicUpdate `resetToken` 증가 제거 | 칩 `not.toBeInTheDocument` + 잔존 행 수 2건 |
| ReporterReply `resetToken` 증가 제거 | 칩 `not.toBeInTheDocument` |
| InternalComment `resetToken` 증가 제거 | 칩 `not.toBeInTheDocument` |
| 리셋이 모든 행을 지움 | `attachment-row` 미발견 (진행 중·에러 보존 테스트 2건) |
| 리셋 이펙트 무력화 | 칩 단언 3건 + 잔존 행 수 2건 |
| `resetToken`을 이펙트 deps에서 제거 | 위와 동일 5건 |
| `onChange`가 빈 목록일 때 통지 생략 | **`attachment_ids` `toEqual([])` 3건** |

마지막 것은 일부러 넣었다. `attachment_ids` 단언은 항상 칩 단언보다 뒤에 있어 다른 뮤테이션에서는 한 번도 발화하지 않는다 — 공허하지 않은지 확인하려면 칩은 지워지되 부모 목록만 낡는 뮤테이션이 필요했다.

**첫 라운드에서 생존한 것 1건:** 컴포저의 `setAttachmentIds([])`를 지워도 14/14가 통과했다. dropzone의 `onChange`가 이미 하는 일이라 두 번째 조용한 writer였고, 그래서 지웠다.

## 두 번째 커밋 — biome 부채

biome 게이트가 변경-파일 스코프라, 이 두 파일을 건드리는 순간 그 파일들의 기존 진단이 이 브랜치 것이 됐다 (import 순서, 포맷, `mock.calls[0]!` 2건, `addFiles` 의존성 목록). 전부 브랜치 이전 부채다.

`clientSideRejection`을 모듈 스코프로 올렸다 — 컴포넌트에서 아무것도 읽지 않는데 안에 있어서 `addFiles`의 빈 의존성 목록이 lint 에러였다. 동작 변경 없음.

`noLabelWithoutControl` 억제에 대한 `suppressions/unused` 경고는 그대로 뒀다. 경고라 게이트가 막지 않고, 억제를 걷어내는 것은 이 브랜치가 판정할 a11y 문제가 아니다.

## 게이트 실측

```
frontend vitest      835 passed / 150 files   ← 830에서 (+5 회귀 테스트)
frontend typecheck   0 errors
frontend biome       0 unexpected, 128 allowlisted, warning 1 (기존)
frontend visual      58 passed
shared               449 passed / 31 files
check:boundaries     OK
backend voc          70 passed / 366 skipped (WORKSPACE_ID 게이트)
```

diff는 프론트엔드 7파일뿐이다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BfiR55zJ7n8uYpr1s3X6q