### PR TITLE
fix(#368): reject whitespace-only Finding title and summary

### DIFF
--- a/apps/backend/src/modules/findings/__tests__/create-finding-blank-fields.integration.test.ts
+++ b/apps/backend/src/modules/findings/__tests__/create-finding-blank-fields.integration.test.ts
@@ -27,131 +27,134 @@ const runIntegration = Boolean(APP_URL && MIGRATE_URL && WORKSPACE_ID);
 
 const SLUG_PREFIX = 'it-findings-blank-fields';
 
-describe.skipIf(!runIntegration)('POST /vocs/:id/create-finding blank required fields (#368)', () => {
-  let dbHandle: DbHandle;
-  let migrateHandle: DbHandle;
-  let app: FastifyInstance;
-  let adminCookie: string;
-  let reporterActorId: string;
+describe.skipIf(!runIntegration)(
+  'POST /vocs/:id/create-finding blank required fields (#368)',
+  () => {
+    let dbHandle: DbHandle;
+    let migrateHandle: DbHandle;
+    let app: FastifyInstance;
+    let adminCookie: string;
+    let reporterActorId: string;
 
-  beforeAll(async () => {
-    process.env.NODE_ENV = 'test';
-    dbHandle = createDb(APP_URL);
-    migrateHandle = createDb(MIGRATE_URL);
-    app = await buildServer({ config: loadConfig(), dbHandle });
-    await app.ready();
+    beforeAll(async () => {
+      process.env.NODE_ENV = 'test';
+      dbHandle = createDb(APP_URL);
+      migrateHandle = createDb(MIGRATE_URL);
+      app = await buildServer({ config: loadConfig(), dbHandle });
+      await app.ready();
 
-    adminCookie = await loginAs(app, 'mock-admin-1');
-    const actors = await dbHandle.pool.query<{ id: string }>(
-      `select id from core.actors where workspace_id = $1 and external_id = 'mock-user-1'`,
-      [WORKSPACE_ID],
-    );
-    reporterActorId = actors.rows[0]?.id ?? '';
-    if (!reporterActorId) throw new Error('seed reporter actor not found');
-  });
+      adminCookie = await loginAs(app, 'mock-admin-1');
+      const actors = await dbHandle.pool.query<{ id: string }>(
+        `select id from core.actors where workspace_id = $1 and external_id = 'mock-user-1'`,
+        [WORKSPACE_ID],
+      );
+      reporterActorId = actors.rows[0]?.id ?? '';
+      if (!reporterActorId) throw new Error('seed reporter actor not found');
+    });
 
-  beforeEach(async () => {
-    await cleanupFixtures();
-  });
+    beforeEach(async () => {
+      await cleanupFixtures();
+    });
 
-  afterAll(async () => {
-    await cleanupFixtures();
-    await app?.close();
-    await dbHandle?.close();
-    await migrateHandle?.close();
-  });
+    afterAll(async () => {
+      await cleanupFixtures();
+      await app?.close();
+      await dbHandle?.close();
+      await migrateHandle?.close();
+    });
 
-  async function cleanupFixtures(): Promise<void> {
-    if (!migrateHandle) return;
-    await migrateHandle.pool.query(
-      `delete from core.entity_links
+    async function cleanupFixtures(): Promise<void> {
+      if (!migrateHandle) return;
+      await migrateHandle.pool.query(
+        `delete from core.entity_links
         where workspace_id = $1
           and relation_type = 'created_finding'
           and managed_system_id in (
             select id from core.managed_systems where workspace_id = $1 and slug like $2
           )`,
-      [WORKSPACE_ID, `${SLUG_PREFIX}%`],
-    );
-    await migrateHandle.pool.query(
-      `delete from core.audit_log
+        [WORKSPACE_ID, `${SLUG_PREFIX}%`],
+      );
+      await migrateHandle.pool.query(
+        `delete from core.audit_log
         where workspace_id = $1
           and event_type in ('finding_created_from_voc', 'entity_link.created')`,
-      [WORKSPACE_ID],
-    );
-    await migrateHandle.pool.query(
-      `delete from finding.findings
+        [WORKSPACE_ID],
+      );
+      await migrateHandle.pool.query(
+        `delete from finding.findings
         where workspace_id = $1
           and primary_managed_system_id in (
             select id from core.managed_systems where workspace_id = $1 and slug like $2
           )`,
-      [WORKSPACE_ID, `${SLUG_PREFIX}%`],
-    );
-    await migrateHandle.pool.query('delete from core.idempotency_keys');
-    await migrateHandle.pool.query("delete from core.rate_limits where key like '127.0.0.%'");
-    await cleanupReadTestTables(dbHandle, WORKSPACE_ID, SLUG_PREFIX);
-  }
+        [WORKSPACE_ID, `${SLUG_PREFIX}%`],
+      );
+      await migrateHandle.pool.query('delete from core.idempotency_keys');
+      await migrateHandle.pool.query("delete from core.rate_limits where key like '127.0.0.%'");
+      await cleanupReadTestTables(dbHandle, WORKSPACE_ID, SLUG_PREFIX);
+    }
 
-  async function seedSource(): Promise<string> {
-    const managedSystemId = await insertMsDirectly(
-      dbHandle,
-      WORKSPACE_ID,
-      uid(SLUG_PREFIX),
-      'Finding blank fields',
-    );
-    const voc = await insertVocDirectly(
-      dbHandle,
-      WORKSPACE_ID,
-      managedSystemId,
-      reporterActorId,
-      'VOC with synthesis need',
-    );
-    return voc.id;
-  }
+    async function seedSource(): Promise<string> {
+      const managedSystemId = await insertMsDirectly(
+        dbHandle,
+        WORKSPACE_ID,
+        uid(SLUG_PREFIX),
+        'Finding blank fields',
+      );
+      const voc = await insertVocDirectly(
+        dbHandle,
+        WORKSPACE_ID,
+        managedSystemId,
+        reporterActorId,
+        'VOC with synthesis need',
+      );
+      return voc.id;
+    }
 
-  function postFinding(vocId: string, body: Record<string, unknown>) {
-    return app.inject({
-      method: 'POST',
-      url: `/vocs/${vocId}/create-finding`,
-      headers: {
-        cookie: `${SESSION_COOKIE_NAME}=${adminCookie}`,
-        'content-type': 'application/json',
-        'idempotency-key': randomUUID(),
-      },
-      payload: body,
-    });
-  }
+    function postFinding(vocId: string, body: Record<string, unknown>) {
+      return app.inject({
+        method: 'POST',
+        url: `/vocs/${vocId}/create-finding`,
+        headers: {
+          cookie: `${SESSION_COOKIE_NAME}=${adminCookie}`,
+          'content-type': 'application/json',
+          'idempotency-key': randomUUID(),
+        },
+        payload: body,
+      });
+    }
 
-  it.each([
-    ['title', { title: '   ', summary: 'Valid summary' }],
-    ['summary', { title: 'Blank field finding', summary: '   ' }],
-  ])('rejects a whitespace-only %s with no matching Finding row', async (field, body) => {
-    const vocId = await seedSource();
-    const res = await postFinding(vocId, { ...body, severity: 'medium' });
+    it.each([
+      ['title', { title: '   ', summary: 'Valid summary' }],
+      ['summary', { title: 'Blank field finding', summary: '   ' }],
+    ])('rejects a whitespace-only %s with no matching Finding row', async (field, body) => {
+      const vocId = await seedSource();
+      const res = await postFinding(vocId, { ...body, severity: 'medium' });
 
-    expect(res.statusCode).toBe(422);
-    expect(res.json().code).toBe('validation.failed');
-    expect(res.json().detail?.fields?.[0]?.path).toEqual([field]);
-    const rows = await dbHandle.pool.query(
-      'select id from finding.findings where workspace_id = $1 and title = $2',
-      [WORKSPACE_ID, body.title],
-    );
-    expect(rows.rowCount).toBe(0);
-  });
-
-  it('creates a Finding with trimmed title and summary', async () => {
-    const vocId = await seedSource();
-    const res = await postFinding(vocId, {
-      title: '  유효한 제목  ',
-      summary: '  유효한 요약  ',
-      severity: 'medium',
+      expect(res.statusCode).toBe(422);
+      expect(res.json().code).toBe('validation.failed');
+      expect(res.json().detail?.fields?.[0]?.path).toEqual([field]);
+      const rows = await dbHandle.pool.query(
+        'select id from finding.findings where workspace_id = $1 and title = $2',
+        [WORKSPACE_ID, body.title],
+      );
+      expect(rows.rowCount).toBe(0);
     });
 
-    expect(res.statusCode).toBe(201);
-    const finding = res.json<{ id: string }>();
-    const rows = await dbHandle.pool.query<{ title: string; summary: string }>(
-      'select title, summary from finding.findings where id = $1',
-      [finding.id],
-    );
-    expect(rows.rows[0]).toMatchObject({ title: '유효한 제목', summary: '유효한 요약' });
-  });
-});
+    it('creates a Finding with trimmed title and summary', async () => {
+      const vocId = await seedSource();
+      const res = await postFinding(vocId, {
+        title: '  유효한 제목  ',
+        summary: '  유효한 요약  ',
+        severity: 'medium',
+      });
+
+      expect(res.statusCode).toBe(201);
+      const finding = res.json<{ id: string }>();
+      const rows = await dbHandle.pool.query<{ title: string; summary: string }>(
+        'select title, summary from finding.findings where id = $1',
+        [finding.id],
+      );
+      expect(rows.rows[0]).toMatchObject({ title: '유효한 제목', summary: '유효한 요약' });
+    });
+  },
+);

--- a/apps/backend/src/modules/findings/__tests__/create-finding-blank-fields.integration.test.ts
+++ b/apps/backend/src/modules/findings/__tests__/create-finding-blank-fields.integration.test.ts
@@ -1,0 +1,157 @@
+// POST /vocs/:id/create-finding blank required-field contract (#368).
+//
+// Gate: DATABASE_URL + DATABASE_URL_MIGRATE + WORKSPACE_ID. The migrate role is
+// required for cleanup of append-only core.entity_links and core.audit_log rows.
+
+import { randomUUID } from 'node:crypto';
+
+import type { FastifyInstance } from 'fastify';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import { loadConfig } from '../../../config.js';
+import { type DbHandle, createDb } from '../../../db/client.js';
+import { buildServer } from '../../../server.js';
+import {
+  SESSION_COOKIE_NAME,
+  cleanupReadTestTables,
+  insertMsDirectly,
+  insertVocDirectly,
+  loginAs,
+  uid,
+} from '../../voc/__tests__/_seed-helpers.js';
+
+const APP_URL = process.env.DATABASE_URL ?? '';
+const MIGRATE_URL = process.env.DATABASE_URL_MIGRATE ?? '';
+const WORKSPACE_ID = process.env.WORKSPACE_ID ?? '';
+const runIntegration = Boolean(APP_URL && MIGRATE_URL && WORKSPACE_ID);
+
+const SLUG_PREFIX = 'it-findings-blank-fields';
+
+describe.skipIf(!runIntegration)('POST /vocs/:id/create-finding blank required fields (#368)', () => {
+  let dbHandle: DbHandle;
+  let migrateHandle: DbHandle;
+  let app: FastifyInstance;
+  let adminCookie: string;
+  let reporterActorId: string;
+
+  beforeAll(async () => {
+    process.env.NODE_ENV = 'test';
+    dbHandle = createDb(APP_URL);
+    migrateHandle = createDb(MIGRATE_URL);
+    app = await buildServer({ config: loadConfig(), dbHandle });
+    await app.ready();
+
+    adminCookie = await loginAs(app, 'mock-admin-1');
+    const actors = await dbHandle.pool.query<{ id: string }>(
+      `select id from core.actors where workspace_id = $1 and external_id = 'mock-user-1'`,
+      [WORKSPACE_ID],
+    );
+    reporterActorId = actors.rows[0]?.id ?? '';
+    if (!reporterActorId) throw new Error('seed reporter actor not found');
+  });
+
+  beforeEach(async () => {
+    await cleanupFixtures();
+  });
+
+  afterAll(async () => {
+    await cleanupFixtures();
+    await app?.close();
+    await dbHandle?.close();
+    await migrateHandle?.close();
+  });
+
+  async function cleanupFixtures(): Promise<void> {
+    if (!migrateHandle) return;
+    await migrateHandle.pool.query(
+      `delete from core.entity_links
+        where workspace_id = $1
+          and relation_type = 'created_finding'
+          and managed_system_id in (
+            select id from core.managed_systems where workspace_id = $1 and slug like $2
+          )`,
+      [WORKSPACE_ID, `${SLUG_PREFIX}%`],
+    );
+    await migrateHandle.pool.query(
+      `delete from core.audit_log
+        where workspace_id = $1
+          and event_type in ('finding_created_from_voc', 'entity_link.created')`,
+      [WORKSPACE_ID],
+    );
+    await migrateHandle.pool.query(
+      `delete from finding.findings
+        where workspace_id = $1
+          and primary_managed_system_id in (
+            select id from core.managed_systems where workspace_id = $1 and slug like $2
+          )`,
+      [WORKSPACE_ID, `${SLUG_PREFIX}%`],
+    );
+    await migrateHandle.pool.query('delete from core.idempotency_keys');
+    await migrateHandle.pool.query("delete from core.rate_limits where key like '127.0.0.%'");
+    await cleanupReadTestTables(dbHandle, WORKSPACE_ID, SLUG_PREFIX);
+  }
+
+  async function seedSource(): Promise<string> {
+    const managedSystemId = await insertMsDirectly(
+      dbHandle,
+      WORKSPACE_ID,
+      uid(SLUG_PREFIX),
+      'Finding blank fields',
+    );
+    const voc = await insertVocDirectly(
+      dbHandle,
+      WORKSPACE_ID,
+      managedSystemId,
+      reporterActorId,
+      'VOC with synthesis need',
+    );
+    return voc.id;
+  }
+
+  function postFinding(vocId: string, body: Record<string, unknown>) {
+    return app.inject({
+      method: 'POST',
+      url: `/vocs/${vocId}/create-finding`,
+      headers: {
+        cookie: `${SESSION_COOKIE_NAME}=${adminCookie}`,
+        'content-type': 'application/json',
+        'idempotency-key': randomUUID(),
+      },
+      payload: body,
+    });
+  }
+
+  it.each([
+    ['title', { title: '   ', summary: 'Valid summary' }],
+    ['summary', { title: 'Blank field finding', summary: '   ' }],
+  ])('rejects a whitespace-only %s with no matching Finding row', async (field, body) => {
+    const vocId = await seedSource();
+    const res = await postFinding(vocId, { ...body, severity: 'medium' });
+
+    expect(res.statusCode).toBe(422);
+    expect(res.json().code).toBe('validation.failed');
+    expect(res.json().detail?.fields?.[0]?.path).toEqual([field]);
+    const rows = await dbHandle.pool.query(
+      'select id from finding.findings where workspace_id = $1 and title = $2',
+      [WORKSPACE_ID, body.title],
+    );
+    expect(rows.rowCount).toBe(0);
+  });
+
+  it('creates a Finding with trimmed title and summary', async () => {
+    const vocId = await seedSource();
+    const res = await postFinding(vocId, {
+      title: '  유효한 제목  ',
+      summary: '  유효한 요약  ',
+      severity: 'medium',
+    });
+
+    expect(res.statusCode).toBe(201);
+    const finding = res.json<{ id: string }>();
+    const rows = await dbHandle.pool.query<{ title: string; summary: string }>(
+      'select title, summary from finding.findings where id = $1',
+      [finding.id],
+    );
+    expect(rows.rows[0]).toMatchObject({ title: '유효한 제목', summary: '유효한 요약' });
+  });
+});

--- a/apps/frontend/src/features/integration/components/FindingDetail/__tests__/CreateFindingModal.test.tsx
+++ b/apps/frontend/src/features/integration/components/FindingDetail/__tests__/CreateFindingModal.test.tsx
@@ -132,4 +132,33 @@ describe('CreateFindingModal Analytics Area inheritance', () => {
     });
     expect(body).not.toHaveProperty('analytics_area_id');
   });
+
+  it.each([
+    ['제목', 'title', '   ', '유효한 요약'],
+    ['요약', 'summary', '   ', '유효한 제목'],
+  ])(
+    'does not submit a whitespace-only %s and shows its validation error',
+    async (label, field, whitespace, validValue) => {
+      renderModal(null);
+      const input = screen.getByLabelText(new RegExp(label));
+      fireEvent.change(input, { target: { value: whitespace } });
+      fireEvent.change(screen.getByLabelText(new RegExp(field === 'title' ? '요약' : '제목')), {
+        target: { value: validValue },
+      });
+      fireEvent.click(screen.getByRole('button', { name: 'Finding 생성' }));
+
+      await waitFor(() => expect(input).toHaveAttribute('aria-invalid', 'true'));
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+    },
+  );
+
+  it('submits trimmed title and summary exactly once', async () => {
+    renderModal(null);
+    fireEvent.change(screen.getByLabelText(/제목/), { target: { value: '  유효한 제목  ' } });
+    fireEvent.change(screen.getByLabelText(/요약/), { target: { value: '  유효한 요약  ' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Finding 생성' }));
+
+    expect(await submittedBody()).toMatchObject({ title: '유효한 제목', summary: '유효한 요약' });
+  });
 });

--- a/packages/shared/src/findings/__tests__/findings.test.ts
+++ b/packages/shared/src/findings/__tests__/findings.test.ts
@@ -9,6 +9,7 @@ import {
   findingSourceSchema,
   findingStatusSchema,
   linkTaskRequestSchema,
+  patchFindingRequestSchema,
   surveyResponseExcerptCandidateDtoSchema,
 } from '../index.js';
 
@@ -39,6 +40,50 @@ describe('createFindingRequestSchema', () => {
         severity: 'high',
         source_id: U1,
       }),
+    ).toThrow();
+  });
+
+  it.each([
+    ['title', { title: '   ', summary: 'VOC evidence needs synthesis.' }],
+    ['summary', { title: 'Export failures', summary: '   ' }],
+  ])('rejects a whitespace-only %s', (_field, body) => {
+    expect(() =>
+      createFindingRequestSchema.parse({
+        ...body,
+        severity: 'high',
+      }),
+    ).toThrow();
+  });
+
+  it('trims a valid title and preserves the 200-character title boundary', () => {
+    expect(
+      createFindingRequestSchema.parse({
+        title: '  유효한 제목  ',
+        summary: 'VOC evidence needs synthesis.',
+        severity: 'high',
+      }).title,
+    ).toBe('유효한 제목');
+    expect(
+      createFindingRequestSchema.safeParse({
+        title: 'a'.repeat(200),
+        summary: 'VOC evidence needs synthesis.',
+        severity: 'high',
+      }).success,
+    ).toBe(true);
+    expect(
+      createFindingRequestSchema.safeParse({
+        title: 'a'.repeat(201),
+        summary: 'VOC evidence needs synthesis.',
+        severity: 'high',
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe('patchFindingRequestSchema', () => {
+  it('rejects a whitespace-only reason', () => {
+    expect(() =>
+      patchFindingRequestSchema.parse({ status: 'not_actionable', reason: '   ' }),
     ).toThrow();
   });
 });

--- a/packages/shared/src/findings/index.ts
+++ b/packages/shared/src/findings/index.ts
@@ -26,8 +26,8 @@ export type EvidenceHighlightImportance = z.infer<typeof evidenceHighlightImport
 
 export const createFindingRequestSchema = z
   .object({
-    title: z.string().min(1).max(200),
-    summary: z.string().min(1),
+    title: z.string().trim().min(1).max(200),
+    summary: z.string().trim().min(1),
     severity: findingSeveritySchema,
     confidence: findingConfidenceSchema.optional(),
     analytics_area_id: z.string().uuid().optional(),
@@ -91,7 +91,7 @@ export type ListSurveyResponseExcerptCandidatesResponse = z.infer<
 export const patchFindingRequestSchema = z
   .object({
     status: findingStatusSchema,
-    reason: z.string().min(1).max(1000).optional(),
+    reason: z.string().trim().min(1).max(1000).optional(),
   })
   .strict();
 export type PatchFindingRequest = z.infer<typeof patchFindingRequestSchema>;


### PR DESCRIPTION
## 무엇이 잘못됐나

2026-08-10 블랙박스 라운드(BBX-20260810)가 **정상 UI로** 요약에 공백 3칸만 넣은 Finding을 만들었다. DB 실측:

```
title   = BBX-20260810 월말 보정 중복 집계
summary = [   ]   length=3   length(trim)=0   status=draft
```

근본 원인은 `packages/shared/src/findings/index.ts` 의 `z.string().min(1)` 에 `.trim()` 이 없다는 것.

**선례가 두 번 있다.** VOC는 같은 결함을 `#327`(PR #343)과 `#344`(PR #349)로 고쳤고 `vocs/create-request.ts:61` 이 `z.string().trim().min(1).max(200)` 으로 정착했다. **Finding 생성만 그 교정에 동행하지 않았다.**

## 한 곳만 고치면 두 층이 닫힌다

`CreateFindingModal` 이 `zodResolver(createFindingRequestSchema)` 를 쓰고(`CreateFindingModal.tsx:70-71`) 라우트도 같은 스키마로 검증한다. 그래서 **FE에 별도 검증을 새로 만들지 않았다.**

`patchFindingRequestSchema.reason` 도 같은 파일의 같은 형태라 함께 고쳤다.

## 의도적으로 범위 밖

- `createFindingFromSurveyResponseRequestSchema` — 호출자가 title/summary를 주지 않는다. 백엔드가 문안을 생성하며 그 이유(개인 응답 텍스트 세탁 방지)가 파일 주석에 있다.
- `redacted_excerpt`, `question_label` — 설문 응답 경로. 이번 라운드에서 `survey.manage` 권한 부재로 도달 불가라 실측되지 않았다(#365 참조).

## `.trim()` 은 변환이다

허용된 값은 이제 trim되어 저장된다. VOC 선례와 같은 동작이며, **이 변환을 고정하는 단언**을 넣었다 — `.trim()` 을 비변환 `.refine()` 으로 바꾸면 테스트가 깨진다.

## 뮤테이션 매트릭스 — 6/6 사망, 생존자 0

| 뮤턴트 | 발화한 단언 |
|---|---|
| M1 `summary` `.trim()` 제거 | shared `rejects a whitespace-only summary` |
| M2 `title` `.trim()` 제거 | shared `rejects a whitespace-only title` + `trims a valid title…` |
| M3 `reason` `.trim()` 제거 | shared `rejects a whitespace-only reason` |
| M4 `.trim()` → 비변환 `.refine()` | **`trims a valid title…` 단독** — 변환 고정 단언만이 잡는다 |
| M5 `summary` `.trim()` 제거 (라우트) | 통합 `expected 201 to be 422` + `creates a Finding with trimmed…` |
| M6 `summary` `.trim()` 제거 (FE) | 모달 `does not submit a whitespace-only 요약…` + `submits trimmed…` |

## 게이트 실측

```
shared vitest        453 passed / 31 files
frontend vitest      843 passed / 150 files   (develop 840 → +3)
backend integration  3 passed (WORKSPACE_ID 켜고 실측, skip 아님)
frontend typecheck   0 errors
shared/backend tsc   1 / 3 errors — develop과 동일 (기존 부채, 이 브랜치 기여 0)
frontend biome       0 unexpected, 128 allowlisted, 0 warnings
check:boundaries     OK
```

## 참고

`FIN-1004`(공백 요약 행)는 통합 테스트의 global-setup이 37개 테이블을 리셋하며 함께 사라졌다. 별도 데이터 정리는 필요 없다.

Closes #368

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BfiR55zJ7n8uYpr1s3X6q