### PR TITLE
fix(#363): VOC 상세 트리아지 패널에서 트리아지 콘솔로 가는 경로를 안내한다

### DIFF
--- a/apps/frontend/src/features/voc/components/detail/TriageBlock.tsx
+++ b/apps/frontend/src/features/voc/components/detail/TriageBlock.tsx
@@ -1,28 +1,39 @@
-// TriageBlock — read-only triage fields (Slice 3, no edit affordances).
+// TriageBlock — read-only triage fields; edits happen in the triage console (#363).
 
 import * as React from 'react';
 import type { VocDetailEnvelope } from '@fops/shared';
-import {
-  PanelSectionTitle,
-  FieldRow,
-  SeverityBadge,
-  UserChip,
-} from '@fops/ui';
+import { PanelSectionTitle, FieldRow, SeverityBadge, UserChip, Button } from '@fops/ui';
 
 export interface TriageBlockProps {
   voc: VocDetailEnvelope;
   ownerDisplayName?: string | null | undefined;
   analyticsAreaName?: string | null | undefined;
+  canTriage: boolean;
+  onOpenTriage: () => void;
 }
 
 export function TriageBlock({
   voc,
   ownerDisplayName,
   analyticsAreaName,
+  canTriage,
+  onOpenTriage,
 }: TriageBlockProps): React.ReactElement {
   return (
     <div>
-      <PanelSectionTitle>트리아지 (Read only)</PanelSectionTitle>
+      <div className="flex items-center justify-between">
+        <PanelSectionTitle>트리아지 (Read only)</PanelSectionTitle>
+        {canTriage && (
+          <Button
+            variant="ghost"
+            size="sm"
+            data-testid="triage-open-console"
+            onClick={onOpenTriage}
+          >
+            트리아지에서 변경
+          </Button>
+        )}
+      </div>
 
       {/* 심각도 */}
       <FieldRow label="심각도">

--- a/apps/frontend/src/features/voc/components/detail/TriageBlock.tsx
+++ b/apps/frontend/src/features/voc/components/detail/TriageBlock.tsx
@@ -1,8 +1,8 @@
 // TriageBlock — read-only triage fields; edits happen in the triage console (#363).
 
-import * as React from 'react';
 import type { VocDetailEnvelope } from '@fops/shared';
-import { PanelSectionTitle, FieldRow, SeverityBadge, UserChip, Button } from '@fops/ui';
+import { Button, FieldRow, PanelSectionTitle, SeverityBadge, UserChip } from '@fops/ui';
+import type * as React from 'react';
 
 export interface TriageBlockProps {
   voc: VocDetailEnvelope;

--- a/apps/frontend/src/features/voc/components/detail/VocDetailPanel.tsx
+++ b/apps/frontend/src/features/voc/components/detail/VocDetailPanel.tsx
@@ -2,6 +2,7 @@
 // REV-1 #6: dirty composer close now intercepted — DirtyConfirmation shown before panel close.
 
 import { usePermissionDecision } from '@/features/voc/hooks/usePermissionDecision';
+import { usePermissionCheck } from '@/features/admin/permissions/use-permission-check';
 import { usePublicUpdateReviewCandidates } from '@/features/voc/hooks/usePublicUpdateReviewCandidates';
 import { useRequestTaskFromVoc } from '@/features/voc/hooks/useRequestTaskFromVoc';
 import { useVocDetail } from '@/features/voc/hooks/useVocDetail';
@@ -165,6 +166,7 @@ export function VocDetailPanel({
       voc={voc}
       vocId={vocId}
       onClose={onClose}
+      {...(managedSystemId !== undefined ? { managedSystemId } : {})}
       {...(onExpandToggle !== undefined ? { onExpandToggle } : {})}
       isReporterOnOwnVoc={isReporterOnOwnVoc}
       canRenderAllowedTask={canRenderAllowedTask}
@@ -178,6 +180,7 @@ export function VocDetailPanel({
 interface FullDetailViewProps {
   voc: VocDetailEnvelope;
   vocId: string;
+  managedSystemId?: string;
   onClose: () => void;
   onExpandToggle?: () => void;
   isReporterOnOwnVoc: boolean;
@@ -202,6 +205,7 @@ const STATIC_DETAIL_SECTIONS = [
 function FullDetailView({
   voc,
   vocId,
+  managedSystemId,
   onClose,
   onExpandToggle,
   isReporterOnOwnVoc,
@@ -215,6 +219,11 @@ function FullDetailView({
   const [requestTaskOpen, setRequestTaskOpen] = React.useState(false);
   const [reviewOpen, setReviewOpen] = React.useState(false);
   const navigate = useNavigate();
+  const capCheck = usePermissionCheck({
+    capability: 'voc.triage',
+    ...(managedSystemId !== undefined ? { managedSystemId } : {}),
+  });
+  const canTriage = capCheck.data?.state === 'approved';
   const { key: requestTaskIdempotencyKey, markConsumed: markRequestTaskConsumed } =
     useIdempotencyKey();
   // Scroll container ref for section nav anchor tracking
@@ -312,6 +321,14 @@ function FullDetailView({
     });
   }
 
+  function handleOpenTriage(): void {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    void navigate({
+      to: '/vocs',
+      search: (prev: any) => ({ ...prev, view: 'triage', selected: vocId }) as any,
+    });
+  }
+
   return (
     <>
       <div className="flex flex-col h-full" data-testid="voc-detail-panel">
@@ -347,6 +364,8 @@ function FullDetailView({
                     ? (analyticsAreasById.get(voc.analytics_area_id) ?? null)
                     : null
                 }
+                canTriage={canTriage}
+                onOpenTriage={handleOpenTriage}
               />
             </div>
           )}

--- a/apps/frontend/src/features/voc/components/detail/VocDetailPanel.tsx
+++ b/apps/frontend/src/features/voc/components/detail/VocDetailPanel.tsx
@@ -1,8 +1,8 @@
 // VocDetailPanel — orchestrator for the read-only VOC detail panel (Slice 3 #20 C8).
 // REV-1 #6: dirty composer close now intercepted — DirtyConfirmation shown before panel close.
 
-import { usePermissionDecision } from '@/features/voc/hooks/usePermissionDecision';
 import { usePermissionCheck } from '@/features/admin/permissions/use-permission-check';
+import { usePermissionDecision } from '@/features/voc/hooks/usePermissionDecision';
 import { usePublicUpdateReviewCandidates } from '@/features/voc/hooks/usePublicUpdateReviewCandidates';
 import { useRequestTaskFromVoc } from '@/features/voc/hooks/useRequestTaskFromVoc';
 import { useVocDetail } from '@/features/voc/hooks/useVocDetail';
@@ -325,6 +325,7 @@ function FullDetailView({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     void navigate({
       to: '/vocs',
+      // biome-ignore lint/suspicious/noExplicitAny: TanStack search updater is untyped at this call site (same idiom as TriageRoute.tsx:73)
       search: (prev: any) => ({ ...prev, view: 'triage', selected: vocId }) as any,
     });
   }

--- a/apps/frontend/src/features/voc/components/detail/__tests__/TriageBlock.test.tsx
+++ b/apps/frontend/src/features/voc/components/detail/__tests__/TriageBlock.test.tsx
@@ -1,28 +1,46 @@
-import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
 
 import { TriageBlock } from '../TriageBlock';
 import { DETAIL_ENVELOPE } from './_fixtures';
 
 describe('<TriageBlock>', () => {
   it('renders section title', () => {
-    render(<TriageBlock voc={DETAIL_ENVELOPE} />);
+    render(<TriageBlock voc={DETAIL_ENVELOPE} canTriage={false} onOpenTriage={vi.fn()} />);
     expect(screen.getByText('트리아지 (Read only)')).toBeInTheDocument();
   });
 
   it('shows SeverityBadge when severity is non-null', () => {
-    render(<TriageBlock voc={{ ...DETAIL_ENVELOPE, severity: 'critical' }} />);
+    render(
+      <TriageBlock
+        voc={{ ...DETAIL_ENVELOPE, severity: 'critical' }}
+        canTriage={false}
+        onOpenTriage={vi.fn()}
+      />,
+    );
     // SeverityBadge renders Korean label '심각' for 'critical'
     expect(screen.getByText('심각')).toBeInTheDocument();
   });
 
   it('shows "미설정" when severity is null', () => {
-    render(<TriageBlock voc={{ ...DETAIL_ENVELOPE, severity: null }} />);
+    render(
+      <TriageBlock
+        voc={{ ...DETAIL_ENVELOPE, severity: null }}
+        canTriage={false}
+        onOpenTriage={vi.fn()}
+      />,
+    );
     expect(screen.getByText('미설정')).toBeInTheDocument();
   });
 
   it('shows "Owner 없음" when owner_user_id and owner_team_id are both null', () => {
-    render(<TriageBlock voc={{ ...DETAIL_ENVELOPE, owner_user_id: null, owner_team_id: null }} />);
+    render(
+      <TriageBlock
+        voc={{ ...DETAIL_ENVELOPE, owner_user_id: null, owner_team_id: null }}
+        canTriage={false}
+        onOpenTriage={vi.fn()}
+      />,
+    );
     expect(screen.getByText('Owner 없음')).toBeInTheDocument();
   });
 
@@ -32,6 +50,8 @@ describe('<TriageBlock>', () => {
       <TriageBlock
         voc={{ ...DETAIL_ENVELOPE, owner_user_id: ownerId, owner_team_id: null }}
         ownerDisplayName="정담당"
+        canTriage={false}
+        onOpenTriage={vi.fn()}
       />,
     );
     expect(screen.getByText('정담당')).toBeInTheDocument();
@@ -39,7 +59,13 @@ describe('<TriageBlock>', () => {
   });
 
   it('shows "미지정" in amber text when analytics_area_id is null', () => {
-    render(<TriageBlock voc={{ ...DETAIL_ENVELOPE, analytics_area_id: null }} />);
+    render(
+      <TriageBlock
+        voc={{ ...DETAIL_ENVELOPE, analytics_area_id: null }}
+        canTriage={false}
+        onOpenTriage={vi.fn()}
+      />,
+    );
     expect(screen.getByText('미지정')).toBeInTheDocument();
   });
 
@@ -49,6 +75,8 @@ describe('<TriageBlock>', () => {
       <TriageBlock
         voc={{ ...DETAIL_ENVELOPE, analytics_area_id: areaId }}
         analyticsAreaName="결제 경험"
+        canTriage={false}
+        onOpenTriage={vi.fn()}
       />,
     );
     expect(screen.getByText('결제 경험')).toBeInTheDocument();
@@ -56,7 +84,36 @@ describe('<TriageBlock>', () => {
   });
 
   it('renders triage_state value', () => {
-    render(<TriageBlock voc={{ ...DETAIL_ENVELOPE, triage_state: 'triaged' }} />);
+    render(
+      <TriageBlock
+        voc={{ ...DETAIL_ENVELOPE, triage_state: 'triaged' }}
+        canTriage={false}
+        onOpenTriage={vi.fn()}
+      />,
+    );
     expect(screen.getByText('triaged')).toBeInTheDocument();
+  });
+
+  it('opens the triage console once when authorized', () => {
+    const onOpenTriage = vi.fn();
+    render(<TriageBlock voc={DETAIL_ENVELOPE} canTriage onOpenTriage={onOpenTriage} />);
+
+    fireEvent.click(screen.getByTestId('triage-open-console'));
+    expect(onOpenTriage).toHaveBeenCalledTimes(1);
+  });
+
+  it('omits the triage-console button when unauthorized', () => {
+    render(<TriageBlock voc={DETAIL_ENVELOPE} canTriage={false} onOpenTriage={vi.fn()} />);
+
+    expect(screen.getByText('트리아지 (Read only)')).toBeInTheDocument();
+    expect(screen.queryByTestId('triage-open-console')).toBeNull();
+  });
+
+  it('renders all four read-only triage fields regardless of capability', () => {
+    render(<TriageBlock voc={DETAIL_ENVELOPE} canTriage={false} onOpenTriage={vi.fn()} />);
+
+    for (const label of ['심각도', '담당자', '분석 영역', '트리아지 상태']) {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
   });
 });


### PR DESCRIPTION
Closes #363

## 무엇이 문제였나

VOC 상세 패널의 `TriageBlock` 은 `트리아지 (Read only)` 로만 표시되고 편집 어포던스가 하나도 없었다.
상세 패널에서 업무를 시작한 사용자는 "이미 트리아지된 VOC는 재판단할 수 없다"고 결론짓는다.

**그 결론은 사실이 아니다.** 백엔드는 재판단을 막지 않고(`apps/backend/src/modules/voc/service.ts:505-535`
에 가드 없음, 빈 diff일 때만 쓰기를 생략), 편집 가능한 표면은 트리아지 콘솔(`/vocs?view=triage`)에 이미 있다.
발견성 결함이지 기능 결함이 아니다.

## 무엇을 바꿨나

- `TriageBlock` 제목 행 우측에 `트리아지에서 변경` 버튼을 추가했다. 클릭하면
  `/vocs?view=triage&selected=<voc id>` 로 이동한다.
- 노출은 `voc.triage` **서버 판정**(`usePermissionCheck`)이 `approved` 일 때만이다.
  `role_level` 로 파생하지 않는다 — `docs/design/09-permission-access.md` 의
  "frontend must not derive authorization from display labels".
- 제목의 `(Read only)` 는 유지했다. 패널 자체는 여전히 읽기 전용이므로 정확한 표기다.
- 버튼 위치·무게는 프로토타입 `docs/design-prototype/screen-voc.jsx:207-215` 의 Triage 섹션
  우측 어포던스(`변경`)를 따랐다. 인라인 편집은 슬라이스 범위 밖이라 이동 링크로 구현했다.

## 뮤테이션 매트릭스

| 뮤턴트 | 결과 | 발화한 단언 |
|---|---|---|
| `{canTriage && (` → `{true && (` | ☠️ | `TriageBlock.test.tsx:109` `queryByTestId('triage-open-console')` 가 null이 아님 |
| `onClick={onOpenTriage}` 제거 | ☠️ | `TriageBlock.test.tsx:102` spy 호출 0회 |

부정 단언(`canTriage=false` 에서 버튼 부재)은 같은 렌더에서 `트리아지 (Read only)` 제목 존재를
함께 단언해 공허하지 않다.

## 게이트 실측

```
frontend vitest      846 passed / 150 files   ← develop 843에서 (+3)
frontend typecheck   0 errors
frontend biome       3 changed files, 0 unexpected errors, 128 allowlisted, 0 warnings
check-boundaries     OK
```

## 범위 밖으로 남긴 것

- **인라인 편집**(담당자 변경 드롭다운, 심각도 셀렉트)은 구현하지 않았다. 프로토타입은 인라인 편집을
  보여주지만 슬라이스 범위 밖이고, #363이 보고한 것은 "경로 미안내"다.
- `VocDetailPanel` 의 `canTriage` 판정 자체는 단위 테스트가 없다. 이 패널은 렌더 비용이 커
  기존 테스트도 `TriageBlock` 을 모킹한다. 판정 로직은 `TriageRoute.tsx:52-57` 과 동일한 관용구이고,
  잘못돼도 최악의 결과는 목적지에서 다시 차단되는 죽은 링크(권한 상승 아님)라 수용했다.
- VOC 상세 패널은 비주얼 하네스 커버리지가 없다(`tests/visual` 에 해당 스펙 없음). 이번 변경은
  기존 flex 행에 버튼 하나를 더한 것이라 새 하네스를 세우지 않았다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BfiR55zJ7n8uYpr1s3X6q