### PR TITLE
release: develop → main (#372 advisory/enforcement 정합 + 타입 부채 청산, 5 commits)

### DIFF
--- a/apps/backend/src/lib/storage/factory.ts
+++ b/apps/backend/src/lib/storage/factory.ts
@@ -14,8 +14,8 @@
 // `toString()` on the config object — see `redact()` and the
 // `Symbol.for('nodejs.util.inspect.custom')` hook below.
 
-import { S3CompatStorageBackend, type S3CompatConfig } from './s3-compat.js';
 import type { StorageBackend } from './index.js';
+import { type S3CompatConfig, S3CompatStorageBackend } from './s3-compat.js';
 
 const REDACTED = '***REDACTED***';
 

--- a/apps/backend/src/lib/storage/factory.ts
+++ b/apps/backend/src/lib/storage/factory.ts
@@ -20,12 +20,17 @@ import type { StorageBackend } from './index.js';
 const REDACTED = '***REDACTED***';
 
 export interface StorageEnv {
-  STORAGE_S3_ENDPOINT?: string;
-  STORAGE_S3_REGION?: string;
-  STORAGE_S3_BUCKET?: string;
-  STORAGE_S3_ACCESS_KEY_ID?: string;
-  STORAGE_S3_SECRET_ACCESS_KEY?: string;
-  STORAGE_S3_FORCE_PATH_STYLE?: string;
+  STORAGE_S3_ENDPOINT?: string | undefined;
+  STORAGE_S3_REGION?: string | undefined;
+  STORAGE_S3_BUCKET?: string | undefined;
+  STORAGE_S3_ACCESS_KEY_ID?: string | undefined;
+  STORAGE_S3_SECRET_ACCESS_KEY?: string | undefined;
+  STORAGE_S3_FORCE_PATH_STYLE?: string | undefined;
+  // An environment bag carries arbitrary other keys. Without this, every
+  // property is optional and TypeScript's weak-type check rejects
+  // `process.env` outright (TS2559) for sharing no declared property with
+  // this interface — which is exactly what `cli/storage-bootstrap.ts` passes.
+  [key: string]: string | undefined;
 }
 
 /** Pure env → config parser. Throws on missing required fields. Exported for tests. */

--- a/apps/backend/src/modules/findings/__tests__/authorization-boundary.contract.test.ts
+++ b/apps/backend/src/modules/findings/__tests__/authorization-boundary.contract.test.ts
@@ -251,7 +251,7 @@ describe.skipIf(!runIntegration)(
           actorIds.reporterWithGrant,
           "voc.read",
           ids.activeMs,
-          actorIds.admin,
+          actorIds.admin!,
         ),
       );
       grantIds.push(
@@ -261,7 +261,7 @@ describe.skipIf(!runIntegration)(
           actorIds.reporterWithGrant,
           "finding.read",
           ids.activeMs,
-          actorIds.admin,
+          actorIds.admin!,
         ),
       );
       await grant(

--- a/apps/backend/src/modules/findings/__tests__/authorization-boundary.contract.test.ts
+++ b/apps/backend/src/modules/findings/__tests__/authorization-boundary.contract.test.ts
@@ -244,6 +244,8 @@ describe.skipIf(!runIntegration)(
         await grant(actorIds.userWithGrant!, "finding.read", managedSystemId);
         await grant(actorIds.userWithGrant!, "finding.manage", managedSystemId);
       }
+      const grantedBy = actorIds.admin;
+      if (!grantedBy) throw new Error("admin actor was not seeded");
       grantIds.push(
         await grantCapability(
           dbHandle,
@@ -251,7 +253,7 @@ describe.skipIf(!runIntegration)(
           actorIds.reporterWithGrant,
           "voc.read",
           ids.activeMs,
-          actorIds.admin!,
+          grantedBy,
         ),
       );
       grantIds.push(
@@ -261,7 +263,7 @@ describe.skipIf(!runIntegration)(
           actorIds.reporterWithGrant,
           "finding.read",
           ids.activeMs,
-          actorIds.admin!,
+          grantedBy,
         ),
       );
       await grant(

--- a/apps/backend/src/modules/findings/authorization.ts
+++ b/apps/backend/src/modules/findings/authorization.ts
@@ -54,6 +54,7 @@ export async function checkFindingRead(
   policy: FindingPointAuthorizationPolicy,
   options?: Parameters<CheckService['checkCapability']>[3],
 ): Promise<Decision> {
+  // Declared as `adminModuleBypass: 'always'` in `CAPABILITY_META` (issue #372).
   if (actor.role_level === 'admin') return { allow: true, via: 'role' };
   if (policy.requireElevatedRole && actor.role_level !== 'developer') return findingRoleDenied;
   return checkService.checkCapability(
@@ -73,6 +74,8 @@ export async function checkFindingManage(
 ): Promise<Decision> {
   // Preserve the workspace-admin bypass before delegating scoped decisions to
   // Permission. This mirrors the Finding policy and avoids needless DB reads.
+  // Declared as `adminModuleBypass: 'always'` in `CAPABILITY_META` — change
+  // both together or the advisory check route drifts from here (issue #372).
   if (actor.role_level === 'admin') return { allow: true, via: 'role' };
   if (policy.requireElevatedRole && actor.role_level !== 'developer') return findingRoleDenied;
   return checkService.checkCapability(

--- a/apps/backend/src/modules/permissions/AGENTS.md
+++ b/apps/backend/src/modules/permissions/AGENTS.md
@@ -11,6 +11,11 @@ Permission is not a generic shared utility package.
 - Permission errors must include requestable permission information only when safe.
 - Permission-limited content should expose approved summary contracts, not raw restricted data.
 - Frontend permission states are display hints only; backend decisions are authoritative.
+- A display hint must still agree with the route that enforces it. `checkCapability` answers for the
+  generic role layer only (`roleSatisfies`); domain modules that layer an admin-role bypass on top
+  declare it once in `CAPABILITY_META.adminModuleBypass` (`packages/shared/src/enums/capabilities.ts`),
+  and `GET /me/permissions/check` re-applies that declaration via `applyAdminModuleBypass`. Adding or
+  moving a module-level bypass without updating that declaration is the issue #372 defect.
 
 ## Cross-System Rules
 

--- a/apps/backend/src/modules/permissions/__tests__/admin-module-bypass.test.ts
+++ b/apps/backend/src/modules/permissions/__tests__/admin-module-bypass.test.ts
@@ -1,0 +1,87 @@
+// Unit tests for `applyAdminModuleBypass` (issue #372).
+//
+// No database: the function is pure, and the whole point of it is that the
+// advisory `GET /me/permissions/check` decision matches what the *enforcing*
+// domain module would answer. These tests pin the per-capability rule table
+// declared in `CAPABILITY_META.adminModuleBypass`.
+
+import { CAPABILITIES, type Capability } from '@fops/shared';
+import { describe, expect, it } from 'vitest';
+
+import { type Decision, applyAdminModuleBypass } from '../check-service.js';
+
+const noGrant: Decision = { allow: false, reason: 'no_grant', requestable: null };
+const explicitDeny: Decision = { allow: false, reason: 'explicit_deny', requestable: null };
+const workspaceMismatch: Decision = {
+  allow: false,
+  reason: 'workspace_mismatch',
+  requestable: null,
+};
+
+/** Capabilities a module lets the admin role through on, and how. */
+const ALWAYS: Capability[] = ['finding.read', 'finding.manage', 'task_request.self_approve'];
+const UNLESS_DENIED: Capability[] = ['survey.read', 'survey.manage'];
+const NONE: Capability[] = [
+  'workspace.read',
+  'workspace.admin',
+  'voc.triage',
+  'voc.read',
+  'survey.read_personal_responses',
+  'survey.export',
+];
+
+describe('applyAdminModuleBypass', () => {
+  it('covers every capability exactly once across the three rule buckets', () => {
+    // Guards the table below: a new capability must be classified, not
+    // silently inherit `none` and re-open the #372 divergence.
+    const classified = [...ALWAYS, ...UNLESS_DENIED, ...NONE].sort();
+    expect(classified).toEqual([...CAPABILITIES].sort());
+  });
+
+  it.each(ALWAYS)('%s — admin is allowed even over an explicit deny', (capability) => {
+    // `findings/authorization.ts` and `task-requests/service.ts` short-circuit
+    // on role BEFORE consulting Permission, so a deny row never gets read.
+    expect(applyAdminModuleBypass('admin', capability, noGrant)).toEqual({
+      allow: true,
+      via: 'role',
+    });
+    expect(applyAdminModuleBypass('admin', capability, explicitDeny)).toEqual({
+      allow: true,
+      via: 'role',
+    });
+  });
+
+  it.each(UNLESS_DENIED)('%s — admin is allowed, but an explicit deny still wins', (capability) => {
+    // `surveys/authorization.ts` runs the scoped check first and returns it
+    // verbatim when the reason is `explicit_deny` (ADR-0033 §C).
+    expect(applyAdminModuleBypass('admin', capability, noGrant)).toEqual({
+      allow: true,
+      via: 'role',
+    });
+    expect(applyAdminModuleBypass('admin', capability, explicitDeny)).toBe(explicitDeny);
+  });
+
+  it.each(NONE)('%s — admin gets nothing beyond roleSatisfies', (capability) => {
+    expect(applyAdminModuleBypass('admin', capability, noGrant)).toBe(noGrant);
+    expect(applyAdminModuleBypass('admin', capability, explicitDeny)).toBe(explicitDeny);
+  });
+
+  it.each(['developer', 'user'])('%s role is never bypassed', (roleLevel) => {
+    for (const capability of CAPABILITIES) {
+      expect(applyAdminModuleBypass(roleLevel, capability, noGrant)).toBe(noGrant);
+    }
+  });
+
+  it('never bypasses workspace_mismatch — a foreign actor is not this workspace admin', () => {
+    for (const capability of CAPABILITIES) {
+      expect(applyAdminModuleBypass('admin', capability, workspaceMismatch)).toBe(
+        workspaceMismatch,
+      );
+    }
+  });
+
+  it('leaves an already-allowed decision untouched, preserving its attribution', () => {
+    const granted: Decision = { allow: true, via: 'direct_grant', grant_id: 'g-1' };
+    expect(applyAdminModuleBypass('admin', 'survey.manage', granted)).toBe(granted);
+  });
+});

--- a/apps/backend/src/modules/permissions/__tests__/check-route.integration.test.ts
+++ b/apps/backend/src/modules/permissions/__tests__/check-route.integration.test.ts
@@ -9,6 +9,8 @@ import { loadConfig } from '../../../config.js';
 import { type DbHandle, createDb } from '../../../db/client.js';
 import { SESSION_COOKIE_NAME } from '../../../middleware/require-session.js';
 import { buildServer } from '../../../server.js';
+import { checkSurveyManage } from '../../surveys/authorization.js';
+import { createCheckService } from '../check-service.js';
 
 const APP_URL = process.env.DATABASE_URL ?? '';
 const WORKSPACE_ID = process.env.WORKSPACE_ID ?? '';
@@ -149,6 +151,108 @@ describe.skipIf(!runIntegration)('GET /me/permissions/check', () => {
     });
     expect(res2.statusCode).toBe(200);
     expect(res2.json().state).toBe('pending_request');
+  });
+
+  // ── issue #372: advisory answer must match the enforcing module ─────────
+  //
+  // `checkCapability` alone only knows `roleSatisfies`, which gives the admin
+  // role neither survey.* nor finding.*. The Survey/Finding modules layer
+  // their own admin bypass on top before enforcing, so before the fix this
+  // route told an Admin they needed `survey.manage` while `POST /surveys`
+  // would have accepted them.
+
+  async function checkAs(externalId: string, query: string): Promise<Record<string, unknown>> {
+    const cookie = await loginAs(app, externalId);
+    const res = await app.inject({
+      method: 'GET',
+      url: `/me/permissions/check?${query}`,
+      headers: { cookie: `${SESSION_COOKIE_NAME}=${cookie}` },
+    });
+    expect(res.statusCode).toBe(200);
+    return res.json();
+  }
+
+  async function adminActorId(): Promise<string> {
+    const rows = await dbHandle.pool.query<{ id: string }>(
+      `select id from core.actors where external_id = 'mock-admin-1' and workspace_id = $1`,
+      [WORKSPACE_ID],
+    );
+    const id = rows.rows[0]?.id;
+    if (!id) throw new Error('mock-admin-1 missing');
+    return id;
+  }
+
+  async function anyManagedSystemId(): Promise<string> {
+    const rows = await dbHandle.pool.query<{ id: string }>(
+      `select id from core.managed_systems where workspace_id = $1 and archived_at is null limit 1`,
+      [WORKSPACE_ID],
+    );
+    const id = rows.rows[0]?.id;
+    if (!id) throw new Error('no active managed system in seeded workspace');
+    return id;
+  }
+
+  it('admin + survey.manage → approved, matching what checkSurveyManage enforces', async () => {
+    const managedSystemId = await anyManagedSystemId();
+    const body = await checkAs(
+      'mock-admin-1',
+      `capability=survey.manage&managed_system_id=${managedSystemId}`,
+    );
+    expect(body.state).toBe('approved');
+    expect(body.decision).toEqual({ allow: true, via: 'role' });
+
+    // Parity oracle: the enforcing helper `POST /surveys` calls must agree.
+    const enforced = await checkSurveyManage(
+      createCheckService({ db: dbHandle.db }),
+      {
+        actor_id: await adminActorId(),
+        workspace_id: WORKSPACE_ID,
+        role_level: 'admin',
+      },
+      managedSystemId,
+    );
+    expect(enforced).toEqual(body.decision);
+  });
+
+  it('admin + finding.manage → approved (module short-circuits on role)', async () => {
+    const body = await checkAs(
+      'mock-admin-1',
+      `capability=finding.manage&managed_system_id=${await anyManagedSystemId()}`,
+    );
+    expect(body.state).toBe('approved');
+    expect(body.decision).toEqual({ allow: true, via: 'role' });
+  });
+
+  it('admin + survey.read_personal_responses → NOT approved (no role bypass, ADR-0033 §C)', async () => {
+    const body = await checkAs(
+      'mock-admin-1',
+      `capability=survey.read_personal_responses&managed_system_id=${await anyManagedSystemId()}`,
+    );
+    expect(body.state).not.toBe('approved');
+    expect((body.decision as { allow: boolean }).allow).toBe(false);
+  });
+
+  it('admin + explicit deny on survey.manage → blocked, deny still dominates', async () => {
+    const managedSystemId = await anyManagedSystemId();
+    const actorId = await adminActorId();
+    await dbHandle.pool.query(
+      `insert into permission.permission_denies
+         (workspace_id, actor_id, capability, managed_system_id, reason, created_by_actor_id)
+       values ($1, $2, 'survey.manage', $3, 'issue #372 test', $2)`,
+      [WORKSPACE_ID, actorId, managedSystemId],
+    );
+    try {
+      const body = await checkAs(
+        'mock-admin-1',
+        `capability=survey.manage&managed_system_id=${managedSystemId}`,
+      );
+      expect(body.state).toBe('blocked_non_requestable');
+      expect(body.decision).toMatchObject({ allow: false, reason: 'explicit_deny' });
+    } finally {
+      await dbHandle.pool.query(
+        `delete from permission.permission_denies where reason = 'issue #372 test'`,
+      );
+    }
   });
 
   it('unknown capability → validation.unknown_capability envelope', async () => {

--- a/apps/backend/src/modules/permissions/__tests__/check-route.integration.test.ts
+++ b/apps/backend/src/modules/permissions/__tests__/check-route.integration.test.ts
@@ -58,10 +58,10 @@ describe.skipIf(!runIntegration)('GET /me/permissions/check', () => {
     await dbHandle.pool.query(
       `delete from core.sessions where created_user_agent_summary = 'integration-test'`,
     );
-    await dbHandle.pool.query(`delete from core.rate_limits`);
+    await dbHandle.pool.query('delete from core.rate_limits');
     // Earlier suites may have left pending permission_requests rows that
     // flip this suite's `request_access` expectation to `pending_request`.
-    await dbHandle.pool.query(`delete from permission.permission_requests`);
+    await dbHandle.pool.query('delete from permission.permission_requests');
   });
 
   it('admin + workspace.admin → state=approved', async () => {
@@ -184,7 +184,7 @@ describe.skipIf(!runIntegration)('GET /me/permissions/check', () => {
 
   async function anyManagedSystemId(): Promise<string> {
     const rows = await dbHandle.pool.query<{ id: string }>(
-      `select id from core.managed_systems where workspace_id = $1 and archived_at is null limit 1`,
+      'select id from core.managed_systems where workspace_id = $1 and archived_at is null limit 1',
       [WORKSPACE_ID],
     );
     const id = rows.rows[0]?.id;

--- a/apps/backend/src/modules/permissions/check-service.ts
+++ b/apps/backend/src/modules/permissions/check-service.ts
@@ -28,7 +28,7 @@
 
 import { and, eq, isNull } from 'drizzle-orm';
 
-import type { Capability } from '@fops/shared';
+import { type Capability, adminModuleBypassFor } from '@fops/shared';
 import type { Db } from '../../db/client.js';
 import { permissionDenies, permissionGrants } from '../../db/schema/permission.js';
 import type { Tx } from '../../db/tx.js';
@@ -276,6 +276,43 @@ export function createCheckService(deps: CheckServiceDeps) {
   }
 
   return { checkCapability, capabilityScope };
+}
+
+/**
+ * Mirror a domain module's admin-role bypass onto an advisory decision.
+ *
+ * `checkCapability` answers for the generic layer only: `roleSatisfies` covers
+ * the four role-derived Slice 1 capabilities and nothing else. Several domain
+ * modules layer their own admin bypass on top of it before enforcing — Finding
+ * point authorization, Task Request self-approval, and Survey read/manage. A
+ * caller that asks the generic service *about* one of those capabilities
+ * therefore gets a stricter answer than the enforcing route would give.
+ *
+ * That divergence is safe in the deny direction but wrong as a display hint:
+ * `GET /me/permissions/check` is what the frontend gates on, so an Admin was
+ * told they needed `survey.manage` while `POST /surveys` would have let them
+ * through (issue #372). This function re-applies the module's rule from the
+ * single declaration in `CAPABILITY_META.adminModuleBypass`.
+ *
+ * It is deliberately advisory-only: enforcement still happens in the domain
+ * modules, so this widens no permission wall. `workspace_mismatch` is never
+ * bypassed — a cross-workspace actor is not this workspace's Admin.
+ */
+export function applyAdminModuleBypass(
+  roleLevel: string,
+  capability: Capability,
+  decision: Decision,
+): Decision {
+  if (decision.allow || roleLevel !== 'admin') return decision;
+  if (decision.reason === 'workspace_mismatch') return decision;
+  switch (adminModuleBypassFor(capability)) {
+    case 'always':
+      return { allow: true, via: 'role' };
+    case 'unless_denied':
+      return decision.reason === 'explicit_deny' ? decision : { allow: true, via: 'role' };
+    case 'none':
+      return decision;
+  }
 }
 
 function roleSatisfies(roleLevel: string, capability: Capability): boolean {

--- a/apps/backend/src/modules/permissions/routes.ts
+++ b/apps/backend/src/modules/permissions/routes.ts
@@ -18,6 +18,7 @@ import { HttpError, sendError } from '../../lib/errors.js';
 import { requireSession } from '../../middleware/require-session.js';
 import { requireWorkspace } from '../../middleware/require-workspace.js';
 import type { SessionService } from '../auth/session-service.js';
+import { applyAdminModuleBypass } from './check-service.js';
 import type { ActorContext, CheckService, Decision } from './check-service.js';
 import type { RequestService } from './request-service.js';
 import type { DecisionService } from './decision-service.js';
@@ -103,10 +104,18 @@ export const permissionsRoutes: FastifyPluginAsync<PermissionsRoutesOptions> = a
         role_level: sess.role_level,
       };
 
-      const decision: Decision = await checkService.checkCapability(actor, capability, {
-        workspace_id: sess.workspace_id,
-        ...(q.managed_system_id !== undefined ? { managed_system_id: q.managed_system_id } : {}),
-      });
+      // The generic check answers for `roleSatisfies` only. Domain modules that
+      // layer their own admin bypass (Finding, Task Request, Survey) would let
+      // this actor through, so mirror that rule here — otherwise the frontend
+      // gate hides an action the enforcing route allows (issue #372).
+      const decision: Decision = applyAdminModuleBypass(
+        sess.role_level,
+        capability,
+        await checkService.checkCapability(actor, capability, {
+          workspace_id: sess.workspace_id,
+          ...(q.managed_system_id !== undefined ? { managed_system_id: q.managed_system_id } : {}),
+        }),
+      );
 
       // Look up the actor's currently-open request (pending|needs_more_info)
       // for this capability AND the same managed-system scope so the state

--- a/apps/backend/src/modules/permissions/routes.ts
+++ b/apps/backend/src/modules/permissions/routes.ts
@@ -7,12 +7,12 @@ import type { FastifyPluginAsync } from 'fastify';
 import { z } from 'zod';
 
 import {
+  type Capability,
   approvePermissionRequestSchema,
   denyPermissionRequestSchema,
+  isCapability,
   needMoreInfoPermissionRequestSchema,
   rejectPermissionRequestSchema,
-  type Capability,
-  isCapability,
 } from '@fops/shared';
 import { HttpError, sendError } from '../../lib/errors.js';
 import { requireSession } from '../../middleware/require-session.js';
@@ -20,8 +20,8 @@ import { requireWorkspace } from '../../middleware/require-workspace.js';
 import type { SessionService } from '../auth/session-service.js';
 import { applyAdminModuleBypass } from './check-service.js';
 import type { ActorContext, CheckService, Decision } from './check-service.js';
-import type { RequestService } from './request-service.js';
 import type { DecisionService } from './decision-service.js';
+import type { RequestService } from './request-service.js';
 import { type FrontendState, toFrontendState } from './state-mapper.js';
 
 // Export the exact parser used by the approve route so its shared-contract
@@ -144,19 +144,12 @@ export const permissionsRoutes: FastifyPluginAsync<PermissionsRoutesOptions> = a
     schema: { querystring: z.object({ capability: z.string().min(1) }) },
     handler: async (req, reply) => {
       const sess = req.session;
-      if (!sess)
-        throw new HttpError(
-          'internal.unexpected',
-          'session missing after middleware',
-        );
+      if (!sess) throw new HttpError('internal.unexpected', 'session missing after middleware');
       const q = req.query as { capability: string };
       if (!isCapability(q.capability)) {
-        return sendError(
-          reply,
-          'validation.unknown_capability',
-          'unknown capability',
-          { capability: q.capability },
-        );
+        return sendError(reply, 'validation.unknown_capability', 'unknown capability', {
+          capability: q.capability,
+        });
       }
       const scope = await checkService.capabilityScope(
         {
@@ -230,7 +223,7 @@ export const permissionsRoutes: FastifyPluginAsync<PermissionsRoutesOptions> = a
     method: 'GET',
     url: '/permission-requests/mine',
     preHandler: [requireSession(sessionService), requireWorkspace(workspaceId)],
-    handler: async (req, reply) => {
+    handler: async (req) => {
       const sess = req.session;
       if (!sess) throw new HttpError('internal.unexpected', 'session missing after middleware');
 

--- a/apps/backend/src/modules/surveys/authorization.ts
+++ b/apps/backend/src/modules/surveys/authorization.ts
@@ -51,6 +51,9 @@ export async function checkSurveyRead(
     },
     options,
   );
+  // ADR-0033 §C. Declared as `adminModuleBypass: 'unless_denied'` in
+  // `CAPABILITY_META` — change both together or the advisory
+  // `GET /me/permissions/check` drifts from this route (issue #372).
   if (!decision.allow && decision.reason === 'explicit_deny') return decision;
   if (actor.role_level === 'admin') return { allow: true, via: 'role' };
   return decision;
@@ -71,6 +74,8 @@ export async function checkSurveyManage(
     },
     options,
   );
+  // ADR-0033 §C. Declared as `adminModuleBypass: 'unless_denied'` in
+  // `CAPABILITY_META` — change both together (issue #372).
   if (!decision.allow && decision.reason === 'explicit_deny') return decision;
   if (actor.role_level === 'admin') return { allow: true, via: 'role' };
   return decision;

--- a/apps/backend/src/modules/task-requests/service.ts
+++ b/apps/backend/src/modules/task-requests/service.ts
@@ -360,9 +360,15 @@ export function createTaskRequestsService(deps: TaskRequestsServiceDeps) {
           }
 
           const canManage = (
-            await checkFindingManage(deps.checkService, args.actor, voc.primaryManagedSystemId, { requireElevatedRole: true }, {
-              tx,
-            })
+            await checkFindingManage(
+              deps.checkService,
+              args.actor,
+              voc.primaryManagedSystemId,
+              { requireElevatedRole: true },
+              {
+                tx,
+              },
+            )
           ).allow;
           if (!canManage) {
             throw new HttpError('permission.denied', 'finding.manage capability required');
@@ -459,7 +465,9 @@ export function createTaskRequestsService(deps: TaskRequestsServiceDeps) {
     const items: TaskRequestDto[] = [];
     for (const row of rows) {
       const canManage = (
-        await checkFindingManage(deps.checkService, args.actor, row.primary_managed_system_id, { requireElevatedRole: true })
+        await checkFindingManage(deps.checkService, args.actor, row.primary_managed_system_id, {
+          requireElevatedRole: true,
+        })
       ).allow;
       if (!canManage) continue;
       items.push(taskRequestToDto(row, await sourceLinkForTaskRequest(row)));

--- a/apps/backend/src/modules/task-requests/service.ts
+++ b/apps/backend/src/modules/task-requests/service.ts
@@ -128,6 +128,8 @@ async function hasSelfApprovalCapability(
   managedSystemId: string,
   options: Parameters<TaskRequestsServiceDeps['checkService']['checkCapability']>[3],
 ): Promise<boolean> {
+  // Declared as `adminModuleBypass: 'always'` in `CAPABILITY_META` — change
+  // both together or the advisory check route drifts from here (issue #372).
   if (actor.role_level === 'admin') return true;
   const decision = await deps.checkService.checkCapability(
     actor,

--- a/packages/shared/src/enums/capabilities.ts
+++ b/packages/shared/src/enums/capabilities.ts
@@ -26,9 +26,32 @@ export const CAPABILITIES = [
 
 export type Capability = (typeof CAPABILITIES)[number];
 
+/**
+ * How the workspace-admin role is satisfied *above* the generic
+ * `roleSatisfies` layer in `modules/permissions/check-service.ts`.
+ *
+ * `roleSatisfies` only covers the Slice 1 role-derived set (`workspace.read`,
+ * `workspace.admin`, `voc.triage`, `voc.read`). Several domain modules layer an
+ * additional admin bypass on top of it, and those bypasses are part of the
+ * access contract — not local shortcuts. This field is the single declaration
+ * of that layering so the advisory `GET /me/permissions/check` decision cannot
+ * drift from what the enforcing route will actually do (issue #372).
+ *
+ * - `none` — admin gets nothing beyond `roleSatisfies` for this capability.
+ * - `unless_denied` — admin is allowed unless an explicit deny applies; the
+ *   module runs the scoped check first and returns it when the reason is
+ *   `explicit_deny`. See `modules/surveys/authorization.ts`.
+ * - `always` — the module short-circuits on `role_level === 'admin'` before
+ *   consulting Permission at all. See `modules/findings/authorization.ts` and
+ *   `modules/task-requests/service.ts`.
+ */
+export type AdminModuleBypass = 'none' | 'unless_denied' | 'always';
+
 export interface CapabilityMeta {
   /** When true, permission_requests must include a non-empty reason. */
   sensitive: boolean;
+  /** Admin-role satisfaction layered above `roleSatisfies`. */
+  adminModuleBypass: AdminModuleBypass;
 }
 
 /**
@@ -38,26 +61,33 @@ export interface CapabilityMeta {
  * another rename.
  */
 export const CAPABILITY_META: Readonly<Record<Capability, CapabilityMeta>> = {
-  'workspace.read': { sensitive: false },
-  'workspace.admin': { sensitive: true },
+  // The four role-derived Slice 1 capabilities are satisfied by `roleSatisfies`
+  // itself, so no module layers anything on top: `adminModuleBypass: 'none'`.
+  'workspace.read': { sensitive: false, adminModuleBypass: 'none' },
+  'workspace.admin': { sensitive: true, adminModuleBypass: 'none' },
   // voc.triage: NOT sensitive — Developers may request it for a specific MS.
-  'voc.triage': { sensitive: false },
+  'voc.triage': { sensitive: false, adminModuleBypass: 'none' },
   // voc.read: NOT sensitive — Developers may request it for a specific MS to view VOCs.
-  'voc.read': { sensitive: false },
-  'finding.read': { sensitive: false },
-  'finding.manage': { sensitive: false },
+  'voc.read': { sensitive: false, adminModuleBypass: 'none' },
+  // Finding point authorization short-circuits on the admin role before
+  // consulting Permission (`modules/findings/authorization.ts`).
+  'finding.read': { sensitive: false, adminModuleBypass: 'always' },
+  'finding.manage': { sensitive: false, adminModuleBypass: 'always' },
   // Self-approval is sensitive because it bypasses normal reviewer separation.
-  'task_request.self_approve': { sensitive: true },
+  // `hasSelfApprovalCapability` still short-circuits on the admin role.
+  'task_request.self_approve': { sensitive: true, adminModuleBypass: 'always' },
   // survey.read: NOT sensitive — Developers may request scoped read access for a Managed System.
-  'survey.read': { sensitive: false },
+  // ADR-0033 §C: Admin may bypass, but an explicit deny still wins.
+  'survey.read': { sensitive: false, adminModuleBypass: 'unless_denied' },
   // Survey creation and management are sensitive actions for a Managed System.
-  'survey.manage': { sensitive: true },
+  // ADR-0033 §C: same Admin bypass as survey.read, explicit deny dominant.
+  'survey.manage': { sensitive: true, adminModuleBypass: 'unless_denied' },
   // Workspace Admin does not bypass this by role alone; explicit permission is required.
-  // See docs/design/07-survey-system.md:230-232.
-  'survey.read_personal_responses': { sensitive: true },
+  // See docs/design/07-survey-system.md and ADR-0033 §C ("no role bypass, including Admin").
+  'survey.read_personal_responses': { sensitive: true, adminModuleBypass: 'none' },
   // Workspace Admin does not bypass this by role alone; explicit permission is required.
-  // See docs/design/07-survey-system.md:230-232.
-  'survey.export': { sensitive: true },
+  // See docs/design/07-survey-system.md and ADR-0033 §C ("no role bypass, including Admin").
+  'survey.export': { sensitive: true, adminModuleBypass: 'none' },
 };
 
 export function isCapability(value: string): value is Capability {
@@ -66,4 +96,8 @@ export function isCapability(value: string): value is Capability {
 
 export function isSensitiveCapability(cap: Capability): boolean {
   return CAPABILITY_META[cap].sensitive;
+}
+
+export function adminModuleBypassFor(cap: Capability): AdminModuleBypass {
+  return CAPABILITY_META[cap].adminModuleBypass;
 }

--- a/packages/shared/src/vocs/__tests__/detail.test.ts
+++ b/packages/shared/src/vocs/__tests__/detail.test.ts
@@ -50,13 +50,15 @@ describe('vocDetailEnvelopeSchema', () => {
     const result = vocDetailEnvelopeSchema.parse({
       ...validDetail,
       similar: {
-        items: [{
-          id: U2,
-          display_id: 'VOC-002',
-          title: 'Peer VOC',
-          reporter_facing_status: 'received',
-          severity: 'high',
-        }],
+        items: [
+          {
+            id: U2,
+            display_id: 'VOC-002',
+            title: 'Peer VOC',
+            reporter_facing_status: 'received',
+            severity: 'high',
+          },
+        ],
       },
     });
     // `similar` is optional on the envelope, so narrow it before indexing —
@@ -74,17 +76,19 @@ describe('vocDetailEnvelopeSchema', () => {
       severity: 'high' as const,
     };
 
-    expect(() => vocDetailEnvelopeSchema.parse({
-      ...validDetail,
-      similar: {
-        items: [
-          peer,
-          { ...peer, id: '01919b8c-0000-7000-8000-000000000003' },
-          { ...peer, id: '01919b8c-0000-7000-8000-000000000004' },
-          { ...peer, id: '01919b8c-0000-7000-8000-000000000005' },
-        ],
-      },
-    })).toThrow();
+    expect(() =>
+      vocDetailEnvelopeSchema.parse({
+        ...validDetail,
+        similar: {
+          items: [
+            peer,
+            { ...peer, id: '01919b8c-0000-7000-8000-000000000003' },
+            { ...peer, id: '01919b8c-0000-7000-8000-000000000004' },
+            { ...peer, id: '01919b8c-0000-7000-8000-000000000005' },
+          ],
+        },
+      }),
+    ).toThrow();
   });
 
   it('accepts description_rich_content as any shape (opaque)', () => {
@@ -175,9 +179,7 @@ describe('vocSummaryEnvelopeSchema', () => {
   });
 
   it('rejects invalid id (not uuid)', () => {
-    expect(() =>
-      vocSummaryEnvelopeSchema.parse({ ...validSummary, id: 'not-a-uuid' }),
-    ).toThrow();
+    expect(() => vocSummaryEnvelopeSchema.parse({ ...validSummary, id: 'not-a-uuid' })).toThrow();
   });
 
   it('rejects missing display_id', () => {

--- a/packages/shared/src/vocs/__tests__/detail.test.ts
+++ b/packages/shared/src/vocs/__tests__/detail.test.ts
@@ -59,7 +59,10 @@ describe('vocDetailEnvelopeSchema', () => {
         }],
       },
     });
-    expect(result.similar.items[0]?.display_id).toBe('VOC-002');
+    // `similar` is optional on the envelope, so narrow it before indexing —
+    // an absent block must fail this assertion, not crash the type checker.
+    expect(result.similar).toBeDefined();
+    expect(result.similar?.items[0]?.display_id).toBe('VOC-002');
   });
 
   it('rejects a similar peer preview with more than three items', () => {

--- a/scripts/gates/frontend-biome-allowlist.txt
+++ b/scripts/gates/frontend-biome-allowlist.txt
@@ -138,3 +138,6 @@ apps/frontend/src/features/voc/components/detail/__tests__/PublicUpdateComposer.
 packages/shared/src/vocs/edit-description-request.ts format -- pre-existing on develop (1x, unchanged)
 packages/shared/src/vocs/__tests__/internal-comment-request.test.ts format -- pre-existing on develop (1x, unchanged)
 packages/shared/src/vocs/__tests__/edit-description-request.test.ts format -- pre-existing on develop (1x, unchanged)
+apps/backend/src/modules/findings/__tests__/authorization-boundary.contract.test.ts lint/style/noNonNullAssertion -- pre-existing on develop; the suite reads seeded ids out of a Record<string, string> and asserts non-null at 13 call sites, none of which this branch added
+apps/backend/src/modules/findings/__tests__/authorization-boundary.contract.test.ts format -- pre-existing on develop; the file predates biome formatting and reformatting it would rewrite lines this branch never touched
+apps/backend/src/modules/findings/__tests__/authorization-boundary.contract.test.ts organizeImports -- pre-existing on develop; import order predates biome


### PR DESCRIPTION
develop → main. 세션 32 릴리스(#373) 이후 5 커밋.

## 내용

| 커밋 | 내용 |
|---|---|
| `dc2401d` | **fix(#372)** — `GET /me/permissions/check` 가 모듈 층의 admin 바이패스를 반영한다. 강제 경로는 손대지 않았으므로 권한 벽은 이동하지 않는다 |
| `361dd55` | chore(#372) — 위 수정이 스코프로 끌어들인 biome 진단 정리 |
| `b59df3d` | **chore** — 모노레포 `pnpm typecheck` 부채 청산. 여러 세션 동안 red 였다 |
| `e3738d5` | chore — 타입 수정이 스코프로 끌어들인 biome 진단 정리 + allowlist 3건 |
| `62689d6` | PR #374 머지 |

`origin/develop..origin/main` 의 3 커밋은 과거 릴리스 PR(#373·#193·#183)의 머지 커밋뿐이고, **main 고유 내용 변경은 0건**이다.

## #372 — 이슈 전제가 틀렸다

ADR-0033 §C 와 구현 사이에 충돌은 없다. `roleSatisfies` 는 제네릭 하위 층이고, `surveys/authorization.ts:55,75` 가 그 위에 Survey admin 바이패스를 얹는다 — ADR 이 적은 그대로다. 진짜 결함은 조언 엔드포인트가 그 층을 못 보고 답해서, 프론트가 **Admin 에게 백엔드는 허용하는 동작을 금지된 것처럼 안내**한 것이었다. 방향은 안전한 쪽(허용된 것을 숨김)이라 보안 영향은 없다. 자세한 근거는 #374 와 #372 코멘트에 있다.

## 게이트 실측 (develop `62689d6`)

```
pnpm typecheck (전체)   6/6 successful   ← 세션 32 핸드오프 §5 의 🔴 부채 해소
backend integration     1238 passed / 137 files   (세션 32 베이스라인 1218/136, +20)
frontend vitest          850 passed / 151 files
frontend typecheck         0 errors
frontend biome             0 unexpected, 131 allowlisted, 0 warnings
frontend visual           59 passed (하네스 전수)
check-boundaries          OK
```

## 남은 것

- 열린 이슈는 #340(2026-08-07 "지금은 안 산다" 판정) 하나. 열린 마일스톤 0개.
- 블랙박스 M06~M08 은 이 수정으로 Mock Admin 재실행이 가능해졌다. M11~M16 은 여전히 미실행.
- 미머지 브랜치 `chore/wiki-phase-a`·`feat/mvp-foundation` — 내용 미확인, 세 세션째.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BfiR55zJ7n8uYpr1s3X6q