### PR TITLE
release: develop → main (사용자 테스트 4건 수정, 8 commits)

### DIFF
--- a/apps/frontend/src/features/tasks/routes/TaskListRoute.test.tsx
+++ b/apps/frontend/src/features/tasks/routes/TaskListRoute.test.tsx
@@ -1,7 +1,8 @@
 import { getTask, listTasks } from '@/lib/api';
 import { ApiError } from '@/lib/api/types';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import type * as React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { TaskDetailPanel, TaskListRoute } from './TaskListRoute';
@@ -25,8 +26,10 @@ vi.mock('@fops/ui', async () => {
   };
 });
 
+// Shared across renders so a test can assert where a trail node sends the actor.
+const navigateMock = vi.hoisted(() => vi.fn());
 vi.mock('@tanstack/react-router', () => ({
-  useNavigate: () => vi.fn(),
+  useNavigate: () => navigateMock,
 }));
 
 vi.mock('@/features/voc/hooks/useWorkspaceActors', () => ({
@@ -96,6 +99,36 @@ describe('TaskListRoute display ids', () => {
     });
     expect(await screen.findByText('FIN-179')).toBeInTheDocument();
     expect(screen.queryByText(/10000000/)).not.toBeInTheDocument();
+  });
+
+  it('opens the source Finding from the linked-context trail', async () => {
+    navigateMock.mockClear();
+    renderWithClient(<TaskListRoute />);
+
+    // The trail names the Finding twice over (Source evidence block and the
+    // trail node); the navigable one is the button the trail renders.
+    const findingNode = await screen.findByRole('button', { name: /리포트 속도 저하/ });
+    await userEvent.click(findingNode);
+
+    expect(navigateMock).toHaveBeenCalledWith({
+      to: '/findings/$findingId',
+      params: { findingId: '40000000-0000-0000-0000-000000000004' },
+    });
+  });
+
+  it('leaves the viewed Task itself unnavigable in the trail', async () => {
+    renderWithClient(<TaskListRoute />);
+
+    await screen.findByText('FIN-179');
+    // Scoped to the Linked context section — the list row on the other side of
+    // the shell is a button carrying the same title, and it is not the subject.
+    const trail = document.querySelector('[data-anchor="context"]');
+    expect(trail).not.toBeNull();
+    const context = within(trail as HTMLElement);
+    expect(context.getByRole('button', { name: /리포트 속도 저하/ })).toBeInTheDocument();
+    expect(
+      context.queryByRole('button', { name: /매출 리포트 쿼리 플랜 개선/ }),
+    ).not.toBeInTheDocument();
   });
 
   it('renders permission denied instead of the list unavailable copy for a 403', async () => {

--- a/apps/frontend/src/features/tasks/routes/TaskListRoute.tsx
+++ b/apps/frontend/src/features/tasks/routes/TaskListRoute.tsx
@@ -1,7 +1,7 @@
+import { useWorkspaceActors } from '@/features/voc/hooks/useWorkspaceActors';
 import { getTask, listTasks } from '@/lib/api';
 import { fetchManagedSystems } from '@/lib/api/managed-systems';
 import { ApiError } from '@/lib/api/types';
-import { useWorkspaceActors } from '@/features/voc/hooks/useWorkspaceActors';
 import type { TaskDetailDto, TaskDto } from '@fops/shared';
 import {
   Button,
@@ -14,16 +14,16 @@ import {
   ListShell,
   ManagedSystemPill,
   ObjectRow,
+  type ObjectRowSeverity,
   OutlineBadge,
+  type PanelSection,
   PanelSectionTitle,
   PanelTitleBlock,
   PermissionBlockedPanel,
   SeverityBadge,
-  type ObjectRowSeverity,
-  type PanelSection,
 } from '@fops/ui';
-import { useNavigate } from '@tanstack/react-router';
 import { useQuery } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
 import { ArrowRight } from 'lucide-react';
 import * as React from 'react';
 
@@ -89,7 +89,14 @@ export function TaskDetailPanel({
     return <div className="p-4 text-sm text-text-muted">Loading Task...</div>;
   }
   if (isPermissionDenied(taskQuery.error)) {
-    return <PermissionBlockedPanel state="denied" category="Task detail" reason={taskQuery.error.message} className="m-4" />;
+    return (
+      <PermissionBlockedPanel
+        state="denied"
+        category="Task detail"
+        reason={taskQuery.error.message}
+        className="m-4"
+      />
+    );
   }
   if (taskQuery.error || !taskQuery.data) {
     return <div className="p-4 text-sm text-accent-danger">Task detail unavailable.</div>;
@@ -145,7 +152,9 @@ export function TaskDetailPanel({
               <span className="text-accent-danger">Unassigned</span>
             )}
           </FieldRow>
-          <FieldRow label="Due">{task.due_date ?? <span className="text-text-muted">-</span>}</FieldRow>
+          <FieldRow label="Due">
+            {task.due_date ?? <span className="text-text-muted">-</span>}
+          </FieldRow>
           <FieldRow label="Managed System">
             <ManagedSystemPill
               name={managedSystemNamesById.get(task.primary_managed_system_id) ?? 'Managed System'}
@@ -202,7 +211,12 @@ export function TaskDetailPanel({
                   : []),
                 // The last node is the task being viewed — deliberately not
                 // navigable, it is the "you are here" marker.
-                { type: 'task' as const, id: task.id, display_id: task.display_id, title: task.title },
+                {
+                  type: 'task' as const,
+                  id: task.id,
+                  display_id: task.display_id,
+                  title: task.title,
+                },
               ]}
             />
           </div>
@@ -210,8 +224,14 @@ export function TaskDetailPanel({
       </div>
       {view === 'board' && task.status !== 'released' && onMoveToNextStatus && (
         <div className="border-t border-border-subtle p-3">
-          <Button type="button" variant="primary" className="w-full" onClick={() => onMoveToNextStatus(task.id)}>
-            <ArrowRight className="h-4 w-4" />Move to next status
+          <Button
+            type="button"
+            variant="primary"
+            className="w-full"
+            onClick={() => onMoveToNextStatus(task.id)}
+          >
+            <ArrowRight className="h-4 w-4" />
+            Move to next status
           </Button>
         </div>
       )}
@@ -262,7 +282,14 @@ export function TaskListRoute({ selectedParam }: { selectedParam?: string | unde
     return <div className="p-4 text-sm text-text-muted">Loading Tasks...</div>;
   }
   if (isPermissionDenied(tasksQuery.error)) {
-    return <PermissionBlockedPanel state="denied" category="Task list" reason={tasksQuery.error.message} className="m-4" />;
+    return (
+      <PermissionBlockedPanel
+        state="denied"
+        category="Task list"
+        reason={tasksQuery.error.message}
+        className="m-4"
+      />
+    );
   }
   if (tasksQuery.error) {
     return <div className="p-4 text-sm text-accent-danger">Task list unavailable.</div>;
@@ -293,8 +320,7 @@ export function TaskListRoute({ selectedParam }: { selectedParam?: string | unde
                   </span>
                   {dot()}
                   <span>
-                    {managedSystemNamesById.get(task.primary_managed_system_id) ??
-                      'Managed System'}
+                    {managedSystemNamesById.get(task.primary_managed_system_id) ?? 'Managed System'}
                   </span>
                   {dot()}
                   <span>{formatDate(task.updated_at)}</span>

--- a/apps/frontend/src/features/tasks/routes/TaskListRoute.tsx
+++ b/apps/frontend/src/features/tasks/routes/TaskListRoute.tsx
@@ -78,6 +78,7 @@ export function TaskDetailPanel({
   onMoveToNextStatus?: (taskId: string) => void;
 }) {
   const scrollRef = React.useRef<HTMLDivElement>(null);
+  const navigate = useNavigate();
   const taskQuery = useQuery({
     queryKey: ['task', taskId] as const,
     queryFn: ({ signal }) => getTask(taskId, signal),
@@ -188,9 +189,19 @@ export function TaskDetailPanel({
                         id: sourceFinding.id,
                         display_id: optionalDisplayId(sourceFinding),
                         title: sourceFinding.title,
+                        // The trail is the only place this panel names the source
+                        // Finding, so it has to be the way there too.
+                        onNavigate: () => {
+                          void navigate({
+                            to: '/findings/$findingId',
+                            params: { findingId: sourceFinding.id },
+                          });
+                        },
                       },
                     ]
                   : []),
+                // The last node is the task being viewed — deliberately not
+                // navigable, it is the "you are here" marker.
                 { type: 'task' as const, id: task.id, display_id: task.display_id, title: task.title },
               ]}
             />

--- a/apps/frontend/src/features/voc/components/detail/LinkedEntityTrailSection.tsx
+++ b/apps/frontend/src/features/voc/components/detail/LinkedEntityTrailSection.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import type { EntityLinkDto, TaskReporterSummary } from '@fops/shared';
 import {
   LinkedEntityTrail,
@@ -6,6 +5,7 @@ import {
   PanelSectionTitle,
   PermissionBlockedPanel,
 } from '@fops/ui';
+import type * as React from 'react';
 
 export interface LinkedEntityTrailSectionProps {
   /** Backend-decided link DTOs included with the VOC detail read model. */

--- a/apps/frontend/src/features/voc/components/detail/LinkedEntityTrailSection.tsx
+++ b/apps/frontend/src/features/voc/components/detail/LinkedEntityTrailSection.tsx
@@ -12,6 +12,13 @@ export interface LinkedEntityTrailSectionProps {
   links?: EntityLinkDto[];
   /** A Reporter may consume only summary_visible.summary, never an allowed Task DTO. */
   isReporterContext: boolean;
+  /**
+   * Opens the linked Task. Injected rather than taken from `useNavigate` so this
+   * stays a presentational component its tests can render without a router.
+   * Omitted means the trail renders as plain text, which is the correct
+   * fallback for any surface with nowhere to send the actor.
+   */
+  onOpenTask?: ((taskId: string) => void) | undefined;
 }
 
 function isTaskLink(link: EntityLinkDto): boolean {
@@ -75,15 +82,18 @@ function SafeTaskLink({
 function AllowedTaskLink({
   link,
   isReporterContext,
+  onOpenTask,
 }: {
   link: Extract<EntityLinkDto, { visibility_state: 'allowed' }>;
   isReporterContext: boolean;
+  onOpenTask?: ((taskId: string) => void) | undefined;
 }): React.ReactElement | null {
   if (isReporterContext) return null;
 
   const task = link.target_summary?.type === 'task' ? link.target_summary : null;
   if (task === null) return null;
 
+  const openTask = onOpenTask;
   return (
     <div data-testid="linked-task-allowed">
       <LinkedEntityTrail
@@ -94,6 +104,12 @@ function AllowedTaskLink({
             display_id: task.display_id,
             title: task.title,
             meta: task.status,
+            // `allowed` already means the backend decided this actor may read
+            // the Task, so naming it without a way there is a dead end. Only
+            // this state gets a destination — summary_visible and denied must
+            // stay unnavigable (ADR-0023 §A/§E), and Reporter context returned
+            // above before reaching here.
+            ...(openTask ? { onNavigate: () => openTask(task.id) } : {}),
           },
         ]}
       />
@@ -104,9 +120,11 @@ function AllowedTaskLink({
 function TaskLink({
   link,
   isReporterContext,
+  onOpenTask,
 }: {
   link: EntityLinkDto;
   isReporterContext: boolean;
+  onOpenTask?: ((taskId: string) => void) | undefined;
 }): React.ReactElement | null {
   switch (link.visibility_state) {
     case 'summary_visible':
@@ -119,7 +137,13 @@ function TaskLink({
         />
       );
     case 'allowed':
-      return <AllowedTaskLink link={link} isReporterContext={isReporterContext} />;
+      return (
+        <AllowedTaskLink
+          link={link}
+          isReporterContext={isReporterContext}
+          onOpenTask={onOpenTask}
+        />
+      );
     case 'hidden':
       // ADR-0023 §A: do not acknowledge that this link exists.
       return null;
@@ -131,6 +155,7 @@ function TaskLink({
 export function LinkedEntityTrailSection({
   links = [],
   isReporterContext,
+  onOpenTask,
 }: LinkedEntityTrailSectionProps): React.ReactElement {
   const taskLinks = links.filter(
     (link) =>
@@ -145,7 +170,12 @@ export function LinkedEntityTrailSection({
     <div>
       <PanelSectionTitle>관련 엔티티</PanelSectionTitle>
       {taskLinks.map((link) => (
-        <TaskLink key={link.id} link={link} isReporterContext={isReporterContext} />
+        <TaskLink
+          key={link.id}
+          link={link}
+          isReporterContext={isReporterContext}
+          onOpenTask={onOpenTask}
+        />
       ))}
     </div>
   );

--- a/apps/frontend/src/features/voc/components/detail/VocDetailPanel.tsx
+++ b/apps/frontend/src/features/voc/components/detail/VocDetailPanel.tsx
@@ -398,6 +398,9 @@ function FullDetailView({
             <LinkedEntityTrailSection
               links={voc.links ?? []}
               isReporterContext={!canRenderAllowedTask}
+              onOpenTask={(taskId) => {
+                void navigate({ to: '/tasks', search: { param: taskId } });
+              }}
             />
           </div>
           {showsSimilarVocSection && (

--- a/apps/frontend/src/features/voc/components/detail/__tests__/LinkedEntityTrailSection.test.tsx
+++ b/apps/frontend/src/features/voc/components/detail/__tests__/LinkedEntityTrailSection.test.tsx
@@ -1,7 +1,7 @@
+import type { EntityLinkDto } from '@fops/shared';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
-import type { EntityLinkDto } from '@fops/shared';
 
 import { LinkedEntityTrailSection } from '../LinkedEntityTrailSection';
 

--- a/apps/frontend/src/features/voc/components/detail/__tests__/LinkedEntityTrailSection.test.tsx
+++ b/apps/frontend/src/features/voc/components/detail/__tests__/LinkedEntityTrailSection.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
 import type { EntityLinkDto } from '@fops/shared';
 
 import { LinkedEntityTrailSection } from '../LinkedEntityTrailSection';
@@ -35,6 +36,27 @@ const summaryVisibleTask: EntityLinkDto = {
     reporter_facing_status: '진행 중',
   },
 };
+
+function allowedTaskLink(): EntityLinkDto {
+  return {
+    ...baseLink(),
+    source_id: IDS.voc,
+    target_id: IDS.task,
+    visibility: 'internal_only',
+    visibility_state: 'allowed',
+    target_summary: {
+      type: 'task',
+      id: IDS.task,
+      display_id: 'TASK-42',
+      title: '운영자 전용 Task',
+      status: 'in_progress',
+      priority: 'high',
+      primary_managed_system_id: IDS.system,
+      assignee_actor_id: null,
+      due_date: null,
+    },
+  };
+}
 
 describe('<LinkedEntityTrailSection>', () => {
   it('renders only the reporter summary title and projected status', () => {
@@ -82,27 +104,45 @@ describe('<LinkedEntityTrailSection>', () => {
   });
 
   it('renders an allowed Task only for an operator view', () => {
-    const allowedTask: EntityLinkDto = {
-      ...baseLink(),
-      source_id: IDS.voc,
-      target_id: IDS.task,
-      visibility: 'internal_only',
-      visibility_state: 'allowed',
-      target_summary: {
-        type: 'task',
-        id: IDS.task,
-        display_id: 'TASK-42',
-        title: '운영자 전용 Task',
-        status: 'in_progress',
-        priority: 'high',
-        primary_managed_system_id: IDS.system,
-        assignee_actor_id: null,
-        due_date: null,
-      },
-    };
-
-    render(<LinkedEntityTrailSection links={[allowedTask]} isReporterContext={false} />);
+    render(<LinkedEntityTrailSection links={[allowedTaskLink()]} isReporterContext={false} />);
     expect(screen.getByTestId('linked-task-allowed')).toHaveTextContent('운영자 전용 Task');
+  });
+
+  it('opens the linked Task from an allowed trail node', async () => {
+    const onOpenTask = vi.fn();
+    render(
+      <LinkedEntityTrailSection
+        links={[allowedTaskLink()]}
+        isReporterContext={false}
+        onOpenTask={onOpenTask}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /운영자 전용 Task/ }));
+    expect(onOpenTask).toHaveBeenCalledWith(IDS.task);
+  });
+
+  it('renders the allowed node as plain text when no destination is supplied', () => {
+    render(<LinkedEntityTrailSection links={[allowedTaskLink()]} isReporterContext={false} />);
+
+    expect(screen.getByTestId('linked-task-allowed')).toHaveTextContent('운영자 전용 Task');
+    expect(screen.queryByRole('button', { name: /운영자 전용 Task/ })).not.toBeInTheDocument();
+  });
+
+  it('never offers a destination for a summary_visible Task, even when one is supplied', () => {
+    // ADR-0023 §E: a Reporter sees the projected summary and nothing more —
+    // handing this surface a navigation callback must not create a way in.
+    const onOpenTask = vi.fn();
+    render(
+      <LinkedEntityTrailSection
+        links={[summaryVisibleTask]}
+        isReporterContext
+        onOpenTask={onOpenTask}
+      />,
+    );
+
+    expect(screen.queryByRole('button', { name: /공개 가능한 개선 작업/ })).not.toBeInTheDocument();
+    expect(onOpenTask).not.toHaveBeenCalled();
   });
 
   it('conceals hidden Task links completely', () => {

--- a/apps/frontend/src/lib/api/__tests__/idempotency.test.ts
+++ b/apps/frontend/src/lib/api/__tests__/idempotency.test.ts
@@ -24,7 +24,9 @@ describe('mintIdempotencyKey', () => {
     // `crypto.randomUUID` is secure-context only, so any non-https origin that
     // is not localhost — a LAN IP during device testing — takes this path on
     // every mutation.
-    vi.stubGlobal('crypto', { getRandomValues: globalThis.crypto.getRandomValues.bind(globalThis.crypto) });
+    vi.stubGlobal('crypto', {
+      getRandomValues: globalThis.crypto.getRandomValues.bind(globalThis.crypto),
+    });
 
     for (let i = 0; i < 200; i++) {
       expect(mintIdempotencyKey()).toMatch(BACKEND_IDEMPOTENCY_KEY_REGEX);
@@ -74,7 +76,9 @@ describe('apiClient auto-minted Idempotency-Key', () => {
     // `Math.random().toString(36) + Date.now().toString(36)`, which is not a
     // UUID, so every mutation that did not pass its own key failed with
     // validation.malformed_idempotency_key on such an origin.
-    vi.stubGlobal('crypto', { getRandomValues: globalThis.crypto.getRandomValues.bind(globalThis.crypto) });
+    vi.stubGlobal('crypto', {
+      getRandomValues: globalThis.crypto.getRandomValues.bind(globalThis.crypto),
+    });
     const fetchMock = stubFetch();
 
     await apiClient('POST', '/vocs/abc/reporter-replies', { body: {} });

--- a/apps/frontend/src/lib/api/__tests__/idempotency.test.ts
+++ b/apps/frontend/src/lib/api/__tests__/idempotency.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { apiClient } from '../client';
+import { mintIdempotencyKey } from '../idempotency';
+
+// Copied verbatim from the backend guard every mutation route applies
+// (e.g. apps/backend/src/modules/permissions/routes.ts). A key this rejects is
+// answered with `validation.malformed_idempotency_key`, so this regex — not a
+// looser "looks like a uuid" shape — is the oracle.
+const BACKEND_IDEMPOTENCY_KEY_REGEX =
+  /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$/;
+
+describe('mintIdempotencyKey', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('produces a key the backend accepts when crypto.randomUUID exists', () => {
+    expect(mintIdempotencyKey()).toMatch(BACKEND_IDEMPOTENCY_KEY_REGEX);
+  });
+
+  it('produces a key the backend accepts without crypto.randomUUID', () => {
+    // `crypto.randomUUID` is secure-context only, so any non-https origin that
+    // is not localhost — a LAN IP during device testing — takes this path on
+    // every mutation.
+    vi.stubGlobal('crypto', { getRandomValues: globalThis.crypto.getRandomValues.bind(globalThis.crypto) });
+
+    for (let i = 0; i < 200; i++) {
+      expect(mintIdempotencyKey()).toMatch(BACKEND_IDEMPOTENCY_KEY_REGEX);
+    }
+  });
+
+  it('produces a key the backend accepts with no Web Crypto at all', () => {
+    vi.stubGlobal('crypto', undefined);
+
+    for (let i = 0; i < 200; i++) {
+      expect(mintIdempotencyKey()).toMatch(BACKEND_IDEMPOTENCY_KEY_REGEX);
+    }
+  });
+
+  it('does not repeat itself', () => {
+    const keys = new Set(Array.from({ length: 500 }, () => mintIdempotencyKey()));
+    expect(keys.size).toBe(500);
+  });
+});
+
+describe('apiClient auto-minted Idempotency-Key', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  function stubFetch(): ReturnType<typeof vi.fn> {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    return fetchMock;
+  }
+
+  function sentKey(fetchMock: ReturnType<typeof vi.fn>): string {
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
+    const headers = init?.headers as Record<string, string> | undefined;
+    return headers?.['Idempotency-Key'] ?? '';
+  }
+
+  it('sends a backend-valid key on a POST outside a secure context', async () => {
+    // The regression this pins: the auto-mint fallback used to emit
+    // `Math.random().toString(36) + Date.now().toString(36)`, which is not a
+    // UUID, so every mutation that did not pass its own key failed with
+    // validation.malformed_idempotency_key on such an origin.
+    vi.stubGlobal('crypto', { getRandomValues: globalThis.crypto.getRandomValues.bind(globalThis.crypto) });
+    const fetchMock = stubFetch();
+
+    await apiClient('POST', '/vocs/abc/reporter-replies', { body: {} });
+
+    expect(sentKey(fetchMock)).toMatch(BACKEND_IDEMPOTENCY_KEY_REGEX);
+  });
+
+  it('prefers an explicitly supplied key over minting one', async () => {
+    const fetchMock = stubFetch();
+    const explicit = '11111111-1111-4111-8111-111111111111';
+
+    await apiClient('POST', '/vocs', { body: {}, idempotencyKey: explicit });
+
+    expect(sentKey(fetchMock)).toBe(explicit);
+  });
+
+  it('sends no Idempotency-Key on a GET', async () => {
+    const fetchMock = stubFetch();
+
+    await apiClient('GET', '/vocs');
+
+    expect(sentKey(fetchMock)).toBe('');
+  });
+});

--- a/apps/frontend/src/lib/api/client.ts
+++ b/apps/frontend/src/lib/api/client.ts
@@ -1,3 +1,4 @@
+import { mintIdempotencyKey } from './idempotency';
 import { ApiError, type ApiErrorEnvelope, type RateLimitInfo } from './types';
 
 export interface ApiClientOptions {
@@ -43,7 +44,7 @@ export async function apiClient<T = unknown>(
   }
 
   if (MUTATION_METHODS.has(upper)) {
-    headers['Idempotency-Key'] = opts.idempotencyKey ?? mintInlineKey();
+    headers['Idempotency-Key'] = opts.idempotencyKey ?? mintIdempotencyKey();
   }
   if (opts.ifMatch) headers['If-Match'] = opts.ifMatch;
   if (opts.ifNoneMatch) headers['If-None-Match'] = opts.ifNoneMatch;
@@ -89,10 +90,6 @@ export async function apiClient<T = unknown>(
   return base;
 }
 
-function mintInlineKey(): string {
-  if (typeof crypto !== 'undefined' && crypto.randomUUID) return crypto.randomUUID();
-  return Math.random().toString(36).slice(2) + Date.now().toString(36);
-}
 
 // Parses fastify @fastify/rate-limit response headers.
 // `x-ratelimit-reset` is unix epoch seconds; `retry-after` is delta-seconds.

--- a/apps/frontend/src/lib/api/client.ts
+++ b/apps/frontend/src/lib/api/client.ts
@@ -90,14 +90,14 @@ export async function apiClient<T = unknown>(
   return base;
 }
 
-
 // Parses fastify @fastify/rate-limit response headers.
 // `x-ratelimit-reset` is unix epoch seconds; `retry-after` is delta-seconds.
 // All four headers must be present and integer-parseable for rateLimit to be populated;
 // otherwise the field is omitted (callers fall back to generic copy).
-function parseRateLimitHeaders(
-  headers: Headers,
-): { rateLimit?: RateLimitInfo; retryAfterSeconds?: number } {
+function parseRateLimitHeaders(headers: Headers): {
+  rateLimit?: RateLimitInfo;
+  retryAfterSeconds?: number;
+} {
   const limit = parseIntHeader(headers.get('x-ratelimit-limit'));
   const remaining = parseIntHeader(headers.get('x-ratelimit-remaining'));
   const reset = parseIntHeader(headers.get('x-ratelimit-reset'));

--- a/apps/frontend/src/lib/api/idempotency.ts
+++ b/apps/frontend/src/lib/api/idempotency.ts
@@ -1,0 +1,37 @@
+// Single source of Idempotency-Key minting.
+//
+// ADR-0015:72 locks the header to a client-generated UUIDv4, and every mutation
+// route rejects anything else with `validation.malformed_idempotency_key`. That
+// makes the *fallback* path load-bearing rather than cosmetic: `crypto.randomUUID`
+// exists only in a secure context, so any origin that is not https and not
+// localhost — a LAN IP during device testing, for instance — falls through to it
+// on every POST/PATCH/DELETE.
+//
+// This module exists because there used to be two fallbacks. `client.ts` minted
+// `Math.random().toString(36) + Date.now().toString(36)`, which is not a UUID at
+// all, so every mutation that let the client auto-mint failed outright in exactly
+// those environments while the ones passing a key from `useIdempotencyKey` (which
+// had a correct fallback) kept working.
+
+/** A UUIDv4 suitable for the `Idempotency-Key` header, in any browser context. */
+export function mintIdempotencyKey(): string {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) return crypto.randomUUID();
+
+  // RFC4122 §4.4 — random bits with the version and variant nibbles pinned.
+  const bytes = new Uint8Array(16);
+  if (typeof crypto !== 'undefined' && crypto.getRandomValues) {
+    crypto.getRandomValues(bytes);
+  } else {
+    for (let i = 0; i < 16; i++) bytes[i] = Math.floor(Math.random() * 256);
+  }
+  bytes[6] = ((bytes[6] ?? 0) & 0x0f) | 0x40;
+  bytes[8] = ((bytes[8] ?? 0) & 0x3f) | 0x80;
+  const hex = Array.from(bytes, (b) => (b ?? 0).toString(16).padStart(2, '0'));
+  return [
+    hex.slice(0, 4).join(''),
+    hex.slice(4, 6).join(''),
+    hex.slice(6, 8).join(''),
+    hex.slice(8, 10).join(''),
+    hex.slice(10, 16).join(''),
+  ].join('-');
+}

--- a/apps/frontend/src/lib/api/useIdempotencyKey.ts
+++ b/apps/frontend/src/lib/api/useIdempotencyKey.ts
@@ -1,19 +1,5 @@
 import { useCallback, useRef, useState } from 'react';
-
-function mintKey(): string {
-  if (typeof crypto !== 'undefined' && crypto.randomUUID) return crypto.randomUUID();
-  // RFC4122 v4 fallback for older test envs
-  const bytes = new Uint8Array(16);
-  if (typeof crypto !== 'undefined' && crypto.getRandomValues) {
-    crypto.getRandomValues(bytes);
-  } else {
-    for (let i = 0; i < 16; i++) bytes[i] = Math.floor(Math.random() * 256);
-  }
-  bytes[6] = ((bytes[6] ?? 0) & 0x0f) | 0x40;
-  bytes[8] = ((bytes[8] ?? 0) & 0x3f) | 0x80;
-  const hex = Array.from(bytes, (b) => (b ?? 0).toString(16).padStart(2, '0'));
-  return `${hex.slice(0, 4).join('')}-${hex.slice(4, 6).join('')}-${hex.slice(6, 8).join('')}-${hex.slice(8, 10).join('')}-${hex.slice(10, 16).join('')}`;
-}
+import { mintIdempotencyKey as mintKey } from './idempotency';
 
 /**
  * Stable Idempotency-Key per call site. Re-mints automatically when `ifMatchEtag` changes

--- a/apps/frontend/tests/visual/rich-editor-click-target.spec.ts
+++ b/apps/frontend/tests/visual/rich-editor-click-target.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from './support/visual-test';
+
+// Behavioural, not pixel: `minHeight` sizes the RichEditor wrapper, but the
+// element TipTap actually makes editable (`.ProseMirror`) is only as tall as
+// its content. When those two came apart, every composer in the app took focus
+// only on its first line and the rest of the box was dead space. jsdom cannot
+// see this — ProseMirror needs real layout — so the oracle lives here.
+//
+// `/dev-rich-editor` renders a RichEditor at minHeight 140 outside the authed
+// tree, so no session or mock API is needed.
+
+test.describe('RichEditor click target', () => {
+  test('takes focus when the bottom of the box is clicked, not just the first line', async ({
+    page,
+  }) => {
+    await page.goto('/dev-rich-editor');
+
+    const editable = page.locator('.ProseMirror').first();
+    await expect(editable).toBeVisible();
+    await expect(editable).not.toBeFocused();
+
+    const wrapper = page.locator('.rich-editor').first();
+    const box = await wrapper.boundingBox();
+    if (!box) throw new Error('rich editor wrapper has no layout box');
+    expect(box.height).toBeGreaterThan(100);
+
+    // Click low in the box — well past the first line, where the old dead zone
+    // was. A few pixels above the bottom edge to stay clear of the border.
+    await page.mouse.click(box.x + box.width / 2, box.y + box.height - 8);
+
+    await expect(editable).toBeFocused();
+
+    // And it is genuinely editable from there, not merely focused.
+    await page.keyboard.type('bottom click reaches the editor');
+    await expect(editable).toContainText('bottom click reaches the editor');
+  });
+
+  test('the editable element fills the wrapper rather than one line of it', async ({ page }) => {
+    await page.goto('/dev-rich-editor');
+
+    const wrapper = page.locator('.rich-editor').first();
+    const editable = page.locator('.ProseMirror').first();
+    await expect(editable).toBeVisible();
+
+    const wrapperBox = await wrapper.boundingBox();
+    const editableBox = await editable.boundingBox();
+    if (!wrapperBox || !editableBox) throw new Error('missing layout box');
+
+    // The editable area reaches the bottom of the wrapper, leaving only the
+    // border. Padding belongs to `.ProseMirror` itself, so it must not show up
+    // here as an inset that clicks fall into.
+    const slack = wrapperBox.y + wrapperBox.height - (editableBox.y + editableBox.height);
+    expect(slack).toBeLessThanOrEqual(4);
+  });
+});

--- a/packages/ui/src/panel/DetailPanelHeaderActions.tsx
+++ b/packages/ui/src/panel/DetailPanelHeaderActions.tsx
@@ -25,6 +25,46 @@ const DEFERRED_ITEMS: Array<{ label: string; disabledReason: string }> = [
   { label: '보관',       disabledReason: 'Slice 3+에 출시 예정' },
 ];
 
+/**
+ * Copies `text`, returning whether it actually landed on the clipboard.
+ *
+ * `navigator.clipboard` is secure-context only, so it is absent whenever the
+ * app is served over http from anything but localhost — which is exactly how
+ * the dev server is reached when it binds 0.0.0.0 and someone else on the
+ * network opens it by IP. `document.execCommand('copy')` still works there.
+ */
+async function writeToClipboard(text: string): Promise<boolean> {
+  if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // Permission denied or a detached document — fall through to the range copy.
+    }
+  }
+  if (typeof document === 'undefined' || !document.body) return false;
+
+  const scratch = document.createElement('textarea');
+  scratch.value = text;
+  scratch.setAttribute('readonly', '');
+  // Kept in the viewport but invisible: `display:none` is not selectable, and
+  // an off-screen position makes some browsers scroll on focus.
+  scratch.style.position = 'fixed';
+  scratch.style.top = '0';
+  scratch.style.opacity = '0';
+  scratch.style.pointerEvents = 'none';
+  document.body.appendChild(scratch);
+  scratch.select();
+  let copied = false;
+  try {
+    copied = document.execCommand('copy');
+  } catch {
+    copied = false;
+  }
+  scratch.remove();
+  return copied;
+}
+
 const iconButtonCls = cn(
   'flex items-center justify-center rounded p-1',
   'text-text-muted hover:text-text-primary hover:bg-surface-canvas',
@@ -38,11 +78,19 @@ export function DetailPanelHeaderActions({
   onExpandToggle,
   extraMore,
 }: DetailPanelHeaderActionsProps) {
-  function handleCopyLink() {
-    if (typeof navigator !== 'undefined' && navigator.clipboard) {
-      void navigator.clipboard.writeText(copyUrl);
+  async function handleCopyLink() {
+    // Callers pass either an absolute URL or a route path; resolving against
+    // the current document makes both produce something pasteable.
+    const absolute =
+      typeof window !== 'undefined' ? new URL(copyUrl, window.location.href).href : copyUrl;
+
+    if (await writeToClipboard(absolute)) {
+      toast('링크가 복사되었습니다.');
+    } else {
+      // Saying "복사되었습니다" after copying nothing is worse than failing:
+      // the actor pastes stale content and never learns why.
+      toast.error('링크를 복사하지 못했습니다. 주소창의 URL을 직접 복사해 주세요.');
     }
-    toast('링크가 복사되었습니다.');
   }
 
   return (
@@ -53,7 +101,9 @@ export function DetailPanelHeaderActions({
         aria-label="링크 복사"
         title="링크 복사"
         className={iconButtonCls}
-        onClick={handleCopyLink}
+        onClick={() => {
+          void handleCopyLink();
+        }}
       >
         <Link2 size={16} />
       </button>

--- a/packages/ui/src/panel/DetailPanelHeaderActions.tsx
+++ b/packages/ui/src/panel/DetailPanelHeaderActions.tsx
@@ -1,14 +1,14 @@
-import * as React from 'react';
 import { Link2, Maximize2, MoreVertical } from 'lucide-react';
+import type * as React from 'react';
 import { toast } from 'sonner';
-import { cn } from '../utils/cn.js';
-import type { DetailPanelKind } from './DetailPanelHeader.js';
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '../components/shadcn/dropdown-menu.js';
+import { cn } from '../utils/cn.js';
+import type { DetailPanelKind } from './DetailPanelHeader.js';
 
 export interface DetailPanelHeaderActionsProps {
   entityKind: DetailPanelKind;
@@ -19,10 +19,10 @@ export interface DetailPanelHeaderActionsProps {
 }
 
 const DEFERRED_ITEMS: Array<{ label: string; disabledReason: string }> = [
-  { label: '읽음 표시',  disabledReason: 'Slice 3+에 출시 예정' },
-  { label: '스누즈',     disabledReason: 'Slice 3+에 출시 예정' },
-  { label: '구독',       disabledReason: 'Slice 3+에 출시 예정' },
-  { label: '보관',       disabledReason: 'Slice 3+에 출시 예정' },
+  { label: '읽음 표시', disabledReason: 'Slice 3+에 출시 예정' },
+  { label: '스누즈', disabledReason: 'Slice 3+에 출시 예정' },
+  { label: '구독', disabledReason: 'Slice 3+에 출시 예정' },
+  { label: '보관', disabledReason: 'Slice 3+에 출시 예정' },
 ];
 
 /**
@@ -124,23 +124,14 @@ export function DetailPanelHeaderActions({
       {/* Kebab dropdown */}
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <button
-            type="button"
-            aria-label="더 보기"
-            title="더 보기"
-            className={iconButtonCls}
-          >
+          <button type="button" aria-label="더 보기" title="더 보기" className={iconButtonCls}>
             <MoreVertical size={16} />
           </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
           {extraMore}
           {DEFERRED_ITEMS.map((item) => (
-            <DropdownMenuItem
-              key={item.label}
-              disabled
-              title={item.disabledReason}
-            >
+            <DropdownMenuItem key={item.label} disabled title={item.disabledReason}>
               {item.label}
             </DropdownMenuItem>
           ))}

--- a/packages/ui/src/panel/__tests__/DetailPanelHeaderActions.test.tsx
+++ b/packages/ui/src/panel/__tests__/DetailPanelHeaderActions.test.tsx
@@ -1,5 +1,3 @@
-/// <reference types="@testing-library/jest-dom" />
-import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { DetailPanelHeaderActions } from '../DetailPanelHeaderActions.js';
@@ -182,7 +180,9 @@ describe('DetailPanelHeaderActions — kebab dropdown', () => {
     await user.click(screen.getByRole('button', { name: '더 보기' }));
     const item = screen.getByText('읽음 표시');
     // Radix DropdownMenuItem with disabled prop sets aria-disabled
-    expect(item.closest('[aria-disabled="true"]') ?? item.closest('[data-disabled]')).not.toBeNull();
+    expect(
+      item.closest('[aria-disabled="true"]') ?? item.closest('[data-disabled]'),
+    ).not.toBeNull();
   });
 
   it('renders extraMore slot inside dropdown', async () => {

--- a/packages/ui/src/panel/__tests__/DetailPanelHeaderActions.test.tsx
+++ b/packages/ui/src/panel/__tests__/DetailPanelHeaderActions.test.tsx
@@ -4,17 +4,14 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { DetailPanelHeaderActions } from '../DetailPanelHeaderActions.js';
 
-// Mock sonner
+// Mock sonner. `toast` is callable and carries `.error`, matching the real API.
 vi.mock('sonner', () => ({
-  toast: vi.fn(),
+  toast: Object.assign(vi.fn(), { error: vi.fn() }),
 }));
 
 afterEach(() => {
   vi.clearAllMocks();
-});
-
-afterEach(() => {
-  vi.clearAllMocks();
+  vi.unstubAllGlobals();
 });
 
 const defaultProps = {
@@ -23,17 +20,122 @@ const defaultProps = {
   copyUrl: 'https://app.example.com/vocs/V-1024',
 };
 
+// `vi.stubGlobal('navigator', ...)` does not take in jsdom — the component keeps
+// seeing the real navigator — so shadow the single property under test with an
+// own property and drop it again afterwards.
+function setClipboard(value: unknown): void {
+  Object.defineProperty(navigator, 'clipboard', {
+    value,
+    configurable: true,
+    writable: true,
+  });
+}
+
+afterEach(() => {
+  // biome-ignore lint/performance/noDelete: removing the shadow restores the real descriptor
+  delete (navigator as { clipboard?: unknown }).clipboard;
+  // biome-ignore lint/performance/noDelete: same, for the execCommand shim
+  delete (document as { execCommand?: unknown }).execCommand;
+});
+
+/** Installs exactly the copy mechanisms a case wants available. */
+function stubClipboard(options: { writeText?: () => Promise<void>; execCommand?: boolean }) {
+  setClipboard(options.writeText ? { writeText: vi.fn(options.writeText) } : undefined);
+  if (options.execCommand !== undefined) {
+    document.execCommand = vi.fn(() => options.execCommand as boolean);
+  }
+}
+
 describe('DetailPanelHeaderActions — copy link', () => {
   it('renders copy link button', () => {
     render(<DetailPanelHeaderActions {...defaultProps} />);
     expect(screen.getByRole('button', { name: '링크 복사' })).toBeInTheDocument();
   });
 
-  it('fires toast with Korean message when copy button clicked', async () => {
-    const { toast } = await import('sonner');
+  it('copies via the Clipboard API and confirms it', async () => {
+    // userEvent.setup() installs its own navigator.clipboard stub, so it has to
+    // run before this test decides what the clipboard should be.
     const user = userEvent.setup();
+    stubClipboard({ writeText: async () => {} });
+    const { toast } = await import('sonner');
     render(<DetailPanelHeaderActions {...defaultProps} />);
+
     await user.click(screen.getByRole('button', { name: '링크 복사' }));
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      'https://app.example.com/vocs/V-1024',
+    );
+    expect(toast).toHaveBeenCalledWith('링크가 복사되었습니다.');
+  });
+
+  it('resolves a route path into a pasteable absolute URL', async () => {
+    // The Task panels pass `/tasks?...`; a bare path is not a link anyone can
+    // paste anywhere.
+    const user = userEvent.setup();
+    stubClipboard({ writeText: async () => {} });
+    render(<DetailPanelHeaderActions {...defaultProps} copyUrl="/tasks?view=board&param=abc" />);
+
+    await user.click(screen.getByRole('button', { name: '링크 복사' }));
+
+    const copied = vi.mocked(navigator.clipboard.writeText).mock.calls[0]?.[0] as string;
+    expect(copied).toBe(new URL('/tasks?view=board&param=abc', window.location.href).href);
+    expect(copied.startsWith('http')).toBe(true);
+  });
+
+  it('falls back to execCommand when the Clipboard API is absent', async () => {
+    // `navigator.clipboard` is secure-context only, so it is missing whenever
+    // the app is served over http from a LAN IP.
+    const user = userEvent.setup();
+    stubClipboard({ execCommand: true });
+    const { toast } = await import('sonner');
+    render(<DetailPanelHeaderActions {...defaultProps} />);
+
+    await user.click(screen.getByRole('button', { name: '링크 복사' }));
+
+    expect(document.execCommand).toHaveBeenCalledWith('copy');
+    expect(toast).toHaveBeenCalledWith('링크가 복사되었습니다.');
+  });
+
+  it('reports failure instead of claiming a copy that never happened', async () => {
+    const user = userEvent.setup();
+    stubClipboard({ execCommand: false });
+    const { toast } = await import('sonner');
+    render(<DetailPanelHeaderActions {...defaultProps} />);
+
+    await user.click(screen.getByRole('button', { name: '링크 복사' }));
+
+    expect(toast).not.toHaveBeenCalledWith('링크가 복사되었습니다.');
+    expect(toast.error).toHaveBeenCalledWith(
+      '링크를 복사하지 못했습니다. 주소창의 URL을 직접 복사해 주세요.',
+    );
+  });
+
+  it('reports failure when nothing can copy at all', async () => {
+    const user = userEvent.setup();
+    stubClipboard({});
+    const { toast } = await import('sonner');
+    render(<DetailPanelHeaderActions {...defaultProps} />);
+
+    await user.click(screen.getByRole('button', { name: '링크 복사' }));
+
+    expect(toast).not.toHaveBeenCalledWith('링크가 복사되었습니다.');
+    expect(toast.error).toHaveBeenCalled();
+  });
+
+  it('falls back when the Clipboard API rejects', async () => {
+    const user = userEvent.setup();
+    stubClipboard({
+      writeText: async () => {
+        throw new Error('permission denied');
+      },
+    });
+    document.execCommand = vi.fn(() => true);
+    const { toast } = await import('sonner');
+    render(<DetailPanelHeaderActions {...defaultProps} />);
+
+    await user.click(screen.getByRole('button', { name: '링크 복사' }));
+
+    expect(document.execCommand).toHaveBeenCalledWith('copy');
     expect(toast).toHaveBeenCalledWith('링크가 복사되었습니다.');
   });
 });

--- a/packages/ui/src/rich-content/RichEditor.tsx
+++ b/packages/ui/src/rich-content/RichEditor.tsx
@@ -6,10 +6,7 @@ import { type Editor, EditorContent, useEditor } from '@tiptap/react';
 import StarterKit, { type StarterKitOptions } from '@tiptap/starter-kit';
 import * as React from 'react';
 import { cn } from '../utils/cn';
-import {
-  getExtensionsForSurface,
-  type UIRichContentExtensionCapability,
-} from './allowlist-local';
+import { type UIRichContentExtensionCapability, getExtensionsForSurface } from './allowlist-local';
 import { AttachmentRef } from './extensions/attachmentRef';
 import { Mention } from './extensions/mention';
 
@@ -102,7 +99,8 @@ export function RichEditor({
   const editor = useEditor({
     extensions,
     // value can be null (explicit clear); fall through to defaultValue / empty doc.
-    content: (value ?? defaultValue ?? { type: 'doc', content: [{ type: 'paragraph' }] }) as TipTapDoc,
+    content: (value ??
+      defaultValue ?? { type: 'doc', content: [{ type: 'paragraph' }] }) as TipTapDoc,
     editable: !disabled,
     onUpdate({ editor }) {
       const doc = editor.getJSON() as TipTapDoc;

--- a/packages/ui/src/rich-content/RichEditor.tsx
+++ b/packages/ui/src/rich-content/RichEditor.tsx
@@ -191,9 +191,20 @@ export function RichEditor({
       data-surface={surface}
     >
       {toolbar?.(editor, toolbarApi)}
+      {/*
+        `minHeight` sizes this wrapper, but the editable element TipTap renders
+        inside it (`.ProseMirror`) is only as tall as its content. Everything
+        below the first line was therefore dead space: clicking it hit the
+        wrapper, not the editor, so an 84px composer only took focus on its top
+        line. Laying the wrapper out as a column, letting `.ProseMirror` grow
+        into it, and moving the padding onto `.ProseMirror` itself makes the
+        whole box the click target. Geometry is unchanged: the padding renders
+        at the same offsets, it just belongs to the editable element now, so
+        the inset that used to swallow clicks no longer does.
+      */}
       <EditorContent
         editor={editor}
-        className="prose prose-sm max-w-none px-3 py-2 focus:outline-none"
+        className="prose prose-sm flex max-w-none flex-col focus:outline-none [&_.ProseMirror]:flex-1 [&_.ProseMirror]:px-3 [&_.ProseMirror]:py-2"
         style={
           minHeight
             ? { minHeight: typeof minHeight === 'number' ? `${minHeight}px` : minHeight }


### PR DESCRIPTION
develop → main. 릴리스 #375 이후 8 커밋. main 고유 비머지 커밋은 과거 릴리스 PR의 머지 커밋뿐이고 **내용 변경은 0건**이다.

## 내용 — PR #376 하나

사용자가 직접 테스트하며 보고한 네 건이다.

| 건 | 원인 | 영향 범위 |
|---|---|---|
| 컨텍스트에 링크가 없다 | `LinkedEntityTrail`의 `onNavigate`를 넘기는 호출부가 앱 전체에 하나도 없었다 | Task 상세, VOC 상세 |
| `validation.malformed_idempotency_key` | `client.ts`의 폴백이 UUID가 아니었다 | secure context가 아닌 곳의 **모든** 자동발급 뮤테이션 |
| 에디터가 첫째 줄에서만 활성화 | `minHeight`는 래퍼에, 편집 대상 `.ProseMirror`는 내용 높이만 | 컴포저 4개 전부 |
| 복사 안 됐는데 "복사되었습니다" | `navigator.clipboard`가 secure context 전용 | 모든 상세 패널 |

가운데 둘은 **같은 뿌리**다: dev 서버를 `0.0.0.0`에 바인드하고 사내에서 IP로 접속하면 http + non-localhost라 **secure context가 아니고**, `crypto.randomUUID`와 `navigator.clipboard`가 둘 다 사라진다. 로컬 게이트가 전부 green이어도 100% 통과하는 경로라 사내 테스터 보고가 유일한 발견 수단이었다.

**이 릴리스가 급한 이유가 그것이다** — 사내 테스터는 현재 리포터 노트를 아예 쓸 수 없다.

상세 근거·뮤테이션 매트릭스는 PR #376 본문에 있다.

## 게이트 실측 (develop `ffb1c95`)

```
frontend vitest        862 passed / 152 files   (직전 릴리스 850)
@fops/ui vitest        505 passed               (직전 500)
frontend visual         61 passed               (기존 59 + 신규 2, 베이스라인 변경 0장)
frontend typecheck       0 errors
frontend biome           0 unexpected, 131 allowlisted
pnpm typecheck (전체)   6/6 successful
check-boundaries        OK
backend integration     1238 passed / 137 files  ← 이 브랜치는 백엔드를 건드리지 않았다 (#375에서 측정)
```

비주얼 베이스라인이 한 장도 바뀌지 않은 것이 에디터·복사 수정에서 기하가 변하지 않았다는 증거다.

## 남은 것

- 열린 이슈 3건: #340(안 산다 판정), #377(Finding·Task 조치 기록 — 설계 필요), #378(Task 상세 소스 VOC 노드 — 백엔드 envelope 필요)
- 열린 마일스톤 0개
- 블랙박스 라운드 BBX-20260810은 M11~M16이 미실행. 다음 세션 1번 안건이다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BfiR55zJ7n8uYpr1s3X6q