### PR TITLE
fix(voc): 재트리아지 딥링크가 가리키는 VOC를 트리아지 대기열에 싣는다 (#383)

### DIFF
--- a/apps/backend/src/modules/voc/__tests__/list-vocs-pin.integration.test.ts
+++ b/apps/backend/src/modules/voc/__tests__/list-vocs-pin.integration.test.ts
@@ -1,0 +1,278 @@
+// GET /vocs?view=triage&pin_voc_id=… integration tests (#383).
+//
+// The triage queue predicate pins triage_state IN ('untriaged',
+// 'needs_more_information'), so an already-triaged VOC can never appear in it —
+// including the one the VOC detail panel's "트리아지에서 변경" deep link points at.
+// pin_voc_id is the only path that carries such a target into the queue, and it
+// must do so WITHOUT widening the scope wall and WITHOUT disturbing pagination.
+//
+// Gate: DATABASE_URL + WORKSPACE_ID. Without these the suite is skipped.
+//
+// Rows are seeded with direct SQL so the mutation rate limit (10/min per actor)
+// never enters the picture.
+
+import type { FastifyInstance } from 'fastify';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import { loadConfig } from '../../../config.js';
+import { type DbHandle, createDb } from '../../../db/client.js';
+import { buildServer } from '../../../server.js';
+import {
+  SESSION_COOKIE_NAME,
+  cleanupReadTestTables,
+  grantCapability,
+  insertDevActor,
+  insertMsDirectly,
+  insertVocDirectly,
+  loginAs,
+  randomUUID,
+  uid,
+} from './_seed-helpers.js';
+
+const APP_URL = process.env.DATABASE_URL ?? '';
+const WORKSPACE_ID = process.env.WORKSPACE_ID ?? '';
+const runIntegration = Boolean(APP_URL && WORKSPACE_ID);
+
+const SLUG_PREFIX = 'it-pin';
+
+interface ListBody {
+  items: { id: string; display_id: string }[];
+  page: { has_more: boolean; cursor?: string };
+}
+
+describe.skipIf(!runIntegration)('GET /vocs?view=triage&pin_voc_id (#383)', () => {
+  let dbHandle: DbHandle;
+  let app: FastifyInstance;
+  let adminCookie: string;
+  let adminActorId: string;
+  let reporterId: string;
+
+  async function listTriage(
+    cookie: string,
+    params: Record<string, string> = {},
+  ): Promise<{ status: number; body: ListBody }> {
+    const qs = new URLSearchParams({ view: 'triage', ...params });
+    const res = await app.inject({
+      method: 'GET',
+      url: `/vocs?${qs.toString()}`,
+      headers: { cookie: `${SESSION_COOKIE_NAME}=${cookie}` },
+    });
+    return { status: res.statusCode, body: res.json() as ListBody };
+  }
+
+  const idsOf = (body: ListBody): Set<string> => new Set(body.items.map((i) => i.id));
+
+  beforeAll(async () => {
+    process.env.NODE_ENV = 'test';
+    dbHandle = createDb(APP_URL);
+    app = await buildServer({ config: loadConfig(), dbHandle });
+    await app.ready();
+
+    adminCookie = await loginAs(app, 'mock-admin-1');
+    const a = await dbHandle.pool.query<{ id: string }>(
+      `select id from core.actors where external_id = 'mock-admin-1' and workspace_id = $1`,
+      [WORKSPACE_ID],
+    );
+    const aid = a.rows[0]?.id;
+    if (!aid) throw new Error('mock-admin-1 not found');
+    adminActorId = aid;
+
+    const r = await dbHandle.pool.query<{ id: string }>(
+      `select id from core.actors where external_id = 'mock-user-1' and workspace_id = $1`,
+      [WORKSPACE_ID],
+    );
+    const rid = r.rows[0]?.id;
+    if (!rid) throw new Error('mock-user-1 not found');
+    reporterId = rid;
+  });
+
+  beforeEach(async () => {
+    await cleanupReadTestTables(dbHandle, WORKSPACE_ID, SLUG_PREFIX);
+  });
+
+  afterAll(async () => {
+    await cleanupReadTestTables(dbHandle, WORKSPACE_ID, SLUG_PREFIX);
+    await app?.close();
+    await dbHandle?.close();
+  });
+
+  // ── The defect this endpoint exists to close ──────────────────────────────
+
+  it('pins a triaged+assigned VOC that no triage tab can show', async () => {
+    const msId = await insertMsDirectly(dbHandle, WORKSPACE_ID, uid(SLUG_PREFIX), 'Pin MS');
+    const queued = await insertVocDirectly(dbHandle, WORKSPACE_ID, msId, reporterId, 'pin-queued');
+    const settled = await insertVocDirectly(
+      dbHandle,
+      WORKSPACE_ID,
+      msId,
+      reporterId,
+      'pin-settled',
+      {
+        triageState: 'triaged',
+        severity: 'medium',
+        ownerUserId: adminActorId,
+      },
+    );
+
+    const without = await listTriage(adminCookie);
+    const withPin = await listTriage(adminCookie, { pin_voc_id: settled.id });
+
+    // Set difference, not counts: names the row that appeared.
+    expect(idsOf(without.body).has(settled.id)).toBe(false);
+    expect(idsOf(withPin.body).has(settled.id)).toBe(true);
+    // The rest of the queue is untouched by pinning.
+    expect(idsOf(without.body).has(queued.id)).toBe(true);
+    expect(idsOf(withPin.body).has(queued.id)).toBe(true);
+  });
+
+  it('places the pinned VOC first so the deep link lands on it', async () => {
+    const msId = await insertMsDirectly(dbHandle, WORKSPACE_ID, uid(SLUG_PREFIX), 'Pin MS first');
+    await insertVocDirectly(dbHandle, WORKSPACE_ID, msId, reporterId, 'pin-first-queued');
+    const settled = await insertVocDirectly(
+      dbHandle,
+      WORKSPACE_ID,
+      msId,
+      reporterId,
+      'pin-first-settled',
+      { triageState: 'triaged', severity: 'medium', ownerUserId: adminActorId },
+    );
+
+    const { body } = await listTriage(adminCookie, { pin_voc_id: settled.id });
+    expect(body.items[0]?.id).toBe(settled.id);
+  });
+
+  it('does not duplicate a VOC the queue already contains', async () => {
+    const msId = await insertMsDirectly(dbHandle, WORKSPACE_ID, uid(SLUG_PREFIX), 'Pin MS dup');
+    const queued = await insertVocDirectly(dbHandle, WORKSPACE_ID, msId, reporterId, 'pin-dup');
+
+    const { body } = await listTriage(adminCookie, { pin_voc_id: queued.id });
+    expect(body.items.filter((i) => i.id === queued.id)).toHaveLength(1);
+  });
+
+  // ── Scope wall — pinning must not widen it ────────────────────────────────
+
+  it('drops a pin outside the actor triage scope, and answers 200 (no existence probe)', async () => {
+    const msMine = await insertMsDirectly(
+      dbHandle,
+      WORKSPACE_ID,
+      `${uid(SLUG_PREFIX)}-mine`,
+      'Pin mine',
+    );
+    const msTheirs = await insertMsDirectly(
+      dbHandle,
+      WORKSPACE_ID,
+      `${uid(SLUG_PREFIX)}-theirs`,
+      'Pin theirs',
+    );
+    const mine = await insertVocDirectly(
+      dbHandle,
+      WORKSPACE_ID,
+      msMine,
+      reporterId,
+      'pin-scope-mine',
+    );
+    const theirs = await insertVocDirectly(
+      dbHandle,
+      WORKSPACE_ID,
+      msTheirs,
+      reporterId,
+      'pin-scope-theirs',
+      { triageState: 'triaged', severity: 'medium', ownerUserId: adminActorId },
+    );
+
+    // Developer scoped to msMine only.
+    const dev = await insertDevActor(dbHandle, WORKSPACE_ID, `pin-${uid('')}`);
+    await grantCapability(dbHandle, WORKSPACE_ID, dev.id, 'workspace.read', null, adminActorId);
+    await grantCapability(dbHandle, WORKSPACE_ID, dev.id, 'voc.read', msMine, adminActorId);
+    await grantCapability(dbHandle, WORKSPACE_ID, dev.id, 'voc.triage', msMine, adminActorId);
+    const devCookie = await loginAs(app, dev.externalId);
+
+    const { status, body } = await listTriage(devCookie, { pin_voc_id: theirs.id });
+
+    expect(status).toBe(200);
+    expect(idsOf(body).has(theirs.id)).toBe(false);
+    expect(idsOf(body).has(mine.id)).toBe(true);
+  });
+
+  it('ignores an unknown pin id and returns the same queue', async () => {
+    const msId = await insertMsDirectly(dbHandle, WORKSPACE_ID, uid(SLUG_PREFIX), 'Pin MS unknown');
+    const queued = await insertVocDirectly(dbHandle, WORKSPACE_ID, msId, reporterId, 'pin-unknown');
+
+    const baseline = await listTriage(adminCookie);
+    const { status, body } = await listTriage(adminCookie, { pin_voc_id: randomUUID() });
+
+    expect(status).toBe(200);
+    expect(idsOf(body)).toEqual(idsOf(baseline.body));
+    expect(idsOf(body).has(queued.id)).toBe(true);
+  });
+
+  it('ignores a pin pointing at an archived VOC', async () => {
+    const msId = await insertMsDirectly(
+      dbHandle,
+      WORKSPACE_ID,
+      uid(SLUG_PREFIX),
+      'Pin MS archived',
+    );
+    const archived = await insertVocDirectly(
+      dbHandle,
+      WORKSPACE_ID,
+      msId,
+      reporterId,
+      'pin-archived',
+      { triageState: 'triaged', severity: 'medium', ownerUserId: adminActorId },
+    );
+    await dbHandle.pool.query('update voc.vocs set archived_at = now() where id = $1', [
+      archived.id,
+    ]);
+
+    const { status, body } = await listTriage(adminCookie, { pin_voc_id: archived.id });
+    expect(status).toBe(200);
+    expect(idsOf(body).has(archived.id)).toBe(false);
+  });
+
+  // ── Cross-view validation ─────────────────────────────────────────────────
+
+  it('rejects pin_voc_id on view=inbox', async () => {
+    const msId = await insertMsDirectly(dbHandle, WORKSPACE_ID, uid(SLUG_PREFIX), 'Pin MS inbox');
+    const voc = await insertVocDirectly(dbHandle, WORKSPACE_ID, msId, reporterId, 'pin-inbox');
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/vocs?view=inbox&pin_voc_id=${voc.id}`,
+      headers: { cookie: `${SESSION_COOKIE_NAME}=${adminCookie}` },
+    });
+
+    expect(res.statusCode).toBe(422);
+    expect((res.json() as { code?: string }).code).toBe('validation.failed');
+  });
+
+  // ── Pagination must not shift ─────────────────────────────────────────────
+
+  it('leaves has_more and cursor computed from the tab query alone', async () => {
+    const msId = await insertMsDirectly(dbHandle, WORKSPACE_ID, uid(SLUG_PREFIX), 'Pin MS page');
+    for (let i = 0; i < 3; i += 1) {
+      await insertVocDirectly(dbHandle, WORKSPACE_ID, msId, reporterId, `pin-page-${i}`);
+    }
+    const settled = await insertVocDirectly(
+      dbHandle,
+      WORKSPACE_ID,
+      msId,
+      reporterId,
+      'pin-page-settled',
+      {
+        triageState: 'triaged',
+        severity: 'medium',
+        ownerUserId: adminActorId,
+      },
+    );
+
+    const without = await listTriage(adminCookie, { limit: '2' });
+    const withPin = await listTriage(adminCookie, { limit: '2', pin_voc_id: settled.id });
+
+    expect(withPin.body.page.has_more).toBe(without.body.page.has_more);
+    expect(withPin.body.page.cursor).toBe(without.body.page.cursor);
+    // The pinned row is extra — it does not consume a page slot.
+    expect(idsOf(withPin.body).has(settled.id)).toBe(true);
+    expect(withPin.body.items).toHaveLength(without.body.items.length + 1);
+  });
+});

--- a/apps/backend/src/modules/voc/read-service.ts
+++ b/apps/backend/src/modules/voc/read-service.ts
@@ -341,6 +341,14 @@ export function createVocReadService(deps: VocReadServiceDeps) {
       });
     }
 
+    // ── 2b. pin_voc_id cross-view validation (#383) ──────────────────────────
+    const pinVocId = query.pin_voc_id;
+    if (pinVocId !== undefined && view !== 'triage') {
+      throw new HttpError('validation.failed', 'pin_voc_id is only valid for view=triage', {
+        fields: [{ path: ['pin_voc_id'], code: 'invalid_for_view' }],
+      });
+    }
+
     // ── 3. Determine sort key and direction ──────────────────────────────────
     // For triage view, use internal 'triage_pinned' sort.
     // For other views, default to 'created_at:desc' if sort not specified.
@@ -408,8 +416,31 @@ export function createVocReadService(deps: VocReadServiceDeps) {
 
     const { rows, hasMore, nextCursor: repoCursor } = await repoRead.listVocsForRead(deps.db, repoArgs);
 
+    // ── 8. Pin the re-triage deep-link target (#383) ─────────────────────────
+    // The triage queue predicate excludes already-triaged VOCs, so a deep link
+    // from the VOC detail panel would otherwise land on a queue that cannot
+    // show its target — and the screen would silently fall back to a different
+    // VOC's commit form. Union the requested row in FIRST, and only when the
+    // caller's own triage scope already covers it.
+    //
+    // Deliberately placed AFTER the repo call and BEFORE the count/mapping
+    // stage so the pinned row gets the same attachment/similar projection as
+    // every other row. `hasMore` / `nextCursor` are computed from the tab query
+    // alone and are NOT touched here — pagination must not shift because a row
+    // was pinned.
+    let pinnedRows = rows;
+    if (pinVocId !== undefined && !rows.some((r) => r.id === pinVocId)) {
+      const pinnedRow = await repoRead.selectPinnedVocListRow(deps.db, {
+        workspaceId: actor.workspace_id,
+        scopeFilter,
+        vocId: pinVocId,
+      });
+      // Out of scope, archived, other workspace, or unknown id → drop silently.
+      if (pinnedRow !== null) pinnedRows = [pinnedRow, ...rows];
+    }
+
     // ── 9. Bulk attachment count per row (PLAN-22 §Bug-1) ────────────────────
-    const sourceVocIds = rows.map((r) => r.id);
+    const sourceVocIds = pinnedRows.map((r) => r.id);
     const [attachmentCounts, similarCounts] = await Promise.all([
       repoRead.selectVocAttachmentCounts(deps.db, sourceVocIds),
       repoRead.selectSimilarVocCounts(deps.db, {
@@ -421,7 +452,7 @@ export function createVocReadService(deps: VocReadServiceDeps) {
     ]);
 
     // ── 9b. Map rows → VocListItem with attachment_count ─────────────────────
-    const items = rows.map((r) => mapRowToListItem(
+    const items = pinnedRows.map((r) => mapRowToListItem(
       r,
       attachmentCounts.get(r.id) ?? 0,
       similarCounts.get(r.id) ?? 0,

--- a/apps/backend/src/modules/voc/repo-read.ts
+++ b/apps/backend/src/modules/voc/repo-read.ts
@@ -518,6 +518,56 @@ export async function selectVocByIdForRead(
   return mapVocRow(row);
 }
 
+// ── selectPinnedVocListRow ───────────────────────────────────────────────────
+
+/**
+ * Fetch ONE VOC in the list-row projection, bypassing the view/tab predicate
+ * but NOT the scope predicate.
+ *
+ * WHY: the triage console's queue predicate pins `triage_state IN
+ * ('untriaged','needs_more_information')` (see buildVocListPredicate), so a VOC
+ * that has already been triaged can never appear in it — including the one the
+ * VOC detail panel's "트리아지에서 변경" deep link points at (#383). This helper
+ * is the ONLY path that re-triage deep links use to put that row back in the
+ * queue.
+ *
+ * The scope contract is unchanged: workspace + `scopeFilter` are applied here
+ * exactly as buildVocListPredicate applies them, and archived rows stay out.
+ * A row outside the caller's scope returns null so the caller can drop it
+ * silently — never 403/404, which would turn this into an existence probe.
+ */
+export async function selectPinnedVocListRow(
+  db: Db | Tx,
+  args: { workspaceId: string; scopeFilter: Scope; vocId: string },
+): Promise<VocReadRow | null> {
+  const { workspaceId, scopeFilter, vocId } = args;
+  if (scopeFilter.kind === 'scoped' && scopeFilter.managedSystemIds.length === 0) return null;
+
+  const wheres: ReturnType<typeof sql>[] = [
+    sql`id = ${vocId}`,
+    sql`workspace_id = ${workspaceId}`,
+    sql`archived_at IS NULL`,
+  ];
+  if (scopeFilter.kind === 'scoped') {
+    wheres.push(sql`primary_managed_system_id = ANY(${sqlUuidArray(scopeFilter.managedSystemIds)})`);
+  }
+
+  const result = await (db as Db).execute<Record<string, unknown>>(sql`
+    SELECT
+      id, display_id, title, workspace_id, primary_managed_system_id,
+      analytics_area_id, reporter_id, owner_user_id, owner_team_id,
+      severity, reporter_facing_status, triage_state,
+      triage_state_review_postponed_at, source_context,
+      NULL::jsonb as description_rich_content,
+      created_at, updated_at
+    FROM ${vocs}
+    WHERE ${sql.join(wheres, sql` AND `)}
+  `);
+  const row = result.rows[0];
+  if (!row) return null;
+  return mapVocRow(row);
+}
+
 // ── selectConversationPage ────────────────────────────────────────────────────
 
 export type ConversationKind = 'public_update' | 'reporter_reply' | 'internal_comment';

--- a/apps/frontend/src/features/voc/components/triage/VocTriageScreen.tsx
+++ b/apps/frontend/src/features/voc/components/triage/VocTriageScreen.tsx
@@ -11,6 +11,7 @@
 import type { VocListItem } from '@fops/shared';
 import { Flag } from 'lucide-react';
 import type * as React from 'react';
+import { useEffect, useRef } from 'react';
 import { useTriageQueue } from '../../hooks/useTriageQueue';
 import { TriagePanel } from './TriagePanel';
 import { TriageQueue } from './TriageQueue';
@@ -57,9 +58,34 @@ export function VocTriageScreen({
   // exists for a per-session processed count.
   const processedCount = queueState.optimisticallyRemoved.size;
 
-  // Derive the selected VOC — when the current selection is optimistically removed,
-  // auto-advance to the next item in the live queue.
-  const selectedVoc = liveQueue.find((v) => v.id === selectedId) ?? liveQueue[0] ?? null;
+  // Derive the selected VOC.
+  //
+  // Two cases must NOT be conflated (#383):
+  //   1. The selection was in this queue at some point during the session and
+  //      has since left it — triaged away optimistically, or dropped by the
+  //      next server refetch. That is the "확정 & 다음 VOC" flow: auto-advance
+  //      to the next item, exactly as before.
+  //   2. The selection was never in this queue — a deep link whose target the
+  //      queue predicate cannot show. Falling back here would silently put a
+  //      DIFFERENT VOC's commit form in front of an operator who asked for a
+  //      specific one, which is a wrong-record write hazard. Render the reason
+  //      instead of a substitute.
+  //
+  // A ref (not derived state) records case 1 because the row is already gone
+  // from `items` by the time the refetch lands — the queue itself can no longer
+  // answer "was this ever mine?".
+  const everInQueueRef = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    for (const v of items) everInQueueRef.current.add(v.id);
+  }, [items]);
+
+  const selectedInQueue = liveQueue.find((v) => v.id === selectedId) ?? null;
+  const deepLinkTargetMissing =
+    selectedId !== null &&
+    selectedInQueue === null &&
+    !items.some((v) => v.id === selectedId) &&
+    !everInQueueRef.current.has(selectedId);
+  const selectedVoc = deepLinkTargetMissing ? null : (selectedInQueue ?? liveQueue[0] ?? null);
 
   return (
     <div className="flex flex-col h-full">
@@ -140,6 +166,23 @@ export function VocTriageScreen({
             {...(outOfScopeSummary !== undefined ? { outOfScopeSummary } : {})}
           />
         </div>
+
+        {/* Deep link target this queue cannot show (#383) — never silently
+            swap in another VOC's commit form. */}
+        {deepLinkTargetMissing && (
+          <div className="w-[440px] shrink-0 border-l border-border-subtle p-6">
+            <p
+              data-testid="triage-deeplink-missing"
+              className="text-sm font-medium text-text-primary"
+            >
+              요청한 VOC를 이 대기열에서 찾을 수 없습니다.
+            </p>
+            <p className="mt-2 text-sm text-text-muted">
+              다른 담당자가 이미 처리했거나, 현재 권한 범위 밖일 수 있습니다. 왼쪽 대기열에서 다른
+              VOC를 선택하세요.
+            </p>
+          </div>
+        )}
 
         {/* Right: detail panel (always rendered when queue non-empty) */}
         {selectedVoc !== null && (

--- a/apps/frontend/src/features/voc/components/triage/__tests__/VocTriageScreen.deepLinkSelection.test.tsx
+++ b/apps/frontend/src/features/voc/components/triage/__tests__/VocTriageScreen.deepLinkSelection.test.tsx
@@ -1,0 +1,142 @@
+// VocTriageScreen.deepLinkSelection.test.tsx — #383
+//
+// The VOC detail panel's "트리아지에서 변경" button deep-links into this screen
+// with ?selected=<id>. Before the fix, a target the queue could not show fell
+// through `?? liveQueue[0]` and put a DIFFERENT VOC's commit form on screen with
+// no indication the target had changed — a wrong-record write hazard.
+//
+// Two behaviours must stay apart:
+//   - selection absent from the server result  → show nothing, say so
+//   - selection present but optimistically removed (just triaged) → auto-advance
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import type * as React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/api/analytics-areas', () => ({
+  fetchAnalyticsAreas: vi.fn(async () => ({ items: [], total: 0 })),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    custom: vi.fn(() => 'toast-deeplink-test'),
+    dismiss: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+    info: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+import type { VocListItem } from '@fops/shared';
+import { VocTriageScreen } from '../VocTriageScreen';
+
+function makeVoc(id: string, displayId: string, title: string): VocListItem {
+  return {
+    id,
+    display_id: displayId,
+    title,
+    reporter_facing_status: 'received',
+    severity: null,
+    owner_user_id: null,
+    owner_team_id: null,
+    analytics_area_id: null,
+    primary_managed_system_id: '00000000-0000-0000-0000-000000000001',
+    reporter_id: '00000000-0000-0000-0000-000000000010',
+    triage_state: 'untriaged',
+    source_context: 'direct_use',
+    created_at: '2026-05-01T00:00:00.000Z',
+    updated_at: '2026-05-01T00:00:00.000Z',
+    similar_count: 0,
+    attachment_count: 0,
+  };
+}
+
+const QUEUED = makeVoc('voc-queued-001', 'VOC-Q-001', '대기열에 있는 다른 VOC');
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+describe('VocTriageScreen — deep-link selection (#383)', () => {
+  it('does not swap in another VOC when the deep-link target is absent', () => {
+    render(
+      <Wrapper>
+        <VocTriageScreen
+          items={[QUEUED]}
+          selectedId="voc-not-in-this-queue"
+          activeTab="unassigned"
+          onSelectVoc={vi.fn()}
+          onTabChange={vi.fn()}
+        />
+      </Wrapper>,
+    );
+
+    // Assert the explanation is on screen FIRST — otherwise the negative
+    // assertion below would also pass on a screen that rendered nothing.
+    expect(screen.getByTestId('triage-deeplink-missing')).toBeInTheDocument();
+
+    // The other VOC's commit form must not have been substituted. Its title
+    // still appears in the left queue, so key off the panel's commit control.
+    expect(screen.queryByRole('button', { name: /Triage 확정/ })).not.toBeInTheDocument();
+  });
+
+  it('still auto-advances after the selected VOC is triaged away', () => {
+    const NEXT = makeVoc('voc-next-002', 'VOC-Q-002', '다음 VOC');
+
+    const { rerender } = render(
+      <Wrapper>
+        <VocTriageScreen
+          items={[QUEUED, NEXT]}
+          selectedId={QUEUED.id}
+          activeTab="unassigned"
+          onSelectVoc={vi.fn()}
+          onTabChange={vi.fn()}
+        />
+      </Wrapper>,
+    );
+
+    // Selected item is in the server result → panel shows it, no missing notice.
+    expect(screen.queryByTestId('triage-deeplink-missing')).not.toBeInTheDocument();
+
+    // Server drops the triaged row on refetch; the selection id lingers in the
+    // URL. That is the auto-advance case, NOT a broken deep link.
+    rerender(
+      <Wrapper>
+        <VocTriageScreen
+          items={[NEXT]}
+          selectedId={QUEUED.id}
+          activeTab="unassigned"
+          onSelectVoc={vi.fn()}
+          onTabChange={vi.fn()}
+        />
+      </Wrapper>,
+    );
+
+    // The row was this screen's selection a moment ago, so this is the
+    // auto-advance case — NOT a broken deep link.
+    expect(screen.queryByTestId('triage-deeplink-missing')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Triage 확정/ })).toBeInTheDocument();
+  });
+
+  it('falls back to the first queue item when no selection is requested', () => {
+    render(
+      <Wrapper>
+        <VocTriageScreen
+          items={[QUEUED]}
+          selectedId={null}
+          activeTab="unassigned"
+          onSelectVoc={vi.fn()}
+          onTabChange={vi.fn()}
+        />
+      </Wrapper>,
+    );
+
+    expect(screen.queryByTestId('triage-deeplink-missing')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Triage 확정/ })).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/features/voc/hooks/useVocList.ts
+++ b/apps/frontend/src/features/voc/hooks/useVocList.ts
@@ -11,6 +11,13 @@ export interface UseVocListParams {
   cursor?: string;
   limit?: number;
   /**
+   * #383: carries the re-triage deep link's target into the triage queue.
+   * The queue predicate excludes already-triaged VOCs, so without this the
+   * "트리아지에서 변경" link lands on a queue that cannot show what it points at.
+   * view='triage' only — the backend rejects it on other views.
+   */
+  pinVocId?: string;
+  /**
    * REV-2 #9: when false the query stays in 'pending' status and does not
    * fire its queryFn. Used by TriageRoute to avoid fetching the queue
    * before the capability gate decides.
@@ -28,10 +35,12 @@ export interface VocListPage {
 }
 
 export function useVocList(params: UseVocListParams): UseQueryResult<VocListPage> {
-  const { view, managedSystemId, tab, filters, sort, cursor, limit, enabled } = params;
+  const { view, managedSystemId, tab, filters, sort, cursor, limit, pinVocId, enabled } = params;
 
   return useQuery({
-    queryKey: ['vocs', view, managedSystemId, tab, filters, sort, cursor] as const,
+    // pinVocId belongs in the key: two deep links differing only by target must
+    // not share a cached queue (#383).
+    queryKey: ['vocs', view, managedSystemId, tab, filters, sort, cursor, pinVocId] as const,
     enabled: enabled !== false,
     queryFn: async ({ signal }) => {
       const qs = new URLSearchParams();
@@ -53,6 +62,7 @@ export function useVocList(params: UseVocListParams): UseQueryResult<VocListPage
           }
         }
       }
+      if (pinVocId) qs.set('pin_voc_id', pinVocId);
       if (sort) qs.set('sort', sort);
       if (cursor) qs.set('cursor', cursor);
       if (limit !== undefined) qs.set('limit', String(limit));

--- a/apps/frontend/src/features/voc/routes/TriageRoute.tsx
+++ b/apps/frontend/src/features/voc/routes/TriageRoute.tsx
@@ -57,10 +57,15 @@ export function TriageRoute(): React.ReactElement {
   // Fetch triage queue — server-pinned sort, no sort param sent (D-1.2).
   // REV-2 #9: gate BEFORE fetch via enabled:false so a blocked actor doesn't
   // trigger a queue query (and doesn't see a flash of queue chrome).
+  // #383: a deep link from the VOC detail panel ("트리아지에서 변경") carries its
+  // target as `selected`. Already-triaged VOCs are excluded by the queue
+  // predicate, so the target must be pinned explicitly or the queue cannot show
+  // it. Out-of-scope / unknown ids are dropped server-side.
   const { data, isLoading } = useVocList({
     view: 'triage',
     ...(search.managedSystem !== undefined ? { managedSystemId: search.managedSystem } : {}),
     tab: activeTab,
+    ...(search.selected !== undefined ? { pinVocId: search.selected } : {}),
     enabled: isApproved,
   });
 

--- a/apps/frontend/src/features/voc/routes/__tests__/TriageRoute.pinDeepLink.test.tsx
+++ b/apps/frontend/src/features/voc/routes/__tests__/TriageRoute.pinDeepLink.test.tsx
@@ -1,0 +1,110 @@
+// TriageRoute.pinDeepLink.test.tsx — #383
+//
+// The VOC detail panel's "트리아지에서 변경" button deep-links to
+// /vocs?view=triage&selected=<id>. Already-triaged VOCs are excluded by the
+// queue predicate, so the route must forward that target as `pinVocId` or the
+// console cannot show what the link points at.
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render } from '@testing-library/react';
+import type * as React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const navigateMock = vi.fn();
+let searchState: Record<string, unknown> = {};
+
+vi.mock('@tanstack/react-router', () => ({
+  useSearch: () => searchState,
+  useNavigate: () => navigateMock,
+  Link: ({ children, to }: { children: React.ReactNode; to: string }) => (
+    <a href={to}>{children}</a>
+  ),
+}));
+
+// Capture the exact params TriageRoute hands the list hook.
+const useVocListSpy = vi.fn((_params: Record<string, unknown>) => ({
+  data: { items: [], next_cursor: undefined },
+  isLoading: false,
+  error: null,
+  refetch: vi.fn(),
+}));
+
+vi.mock('../../hooks/useVocList', () => ({
+  useVocList: (params: unknown) => useVocListSpy(params as Record<string, unknown>),
+}));
+
+vi.mock('../../hooks/useWorkspaceActors', () => ({
+  useWorkspaceActors: () => ({ actors: [], isSuccess: true, isLoading: false, error: null }),
+}));
+
+vi.mock('@/lib/auth/useMe', () => ({ useMe: vi.fn() }));
+vi.mock('@/features/admin/permissions/use-permission-check', () => ({
+  usePermissionCheck: vi.fn(),
+  permissionCheckQueryKey: () => ['permission-check', 'voc.triage', null],
+  permissionRequestsMineKey: ['permission-requests-mine'],
+}));
+
+import { usePermissionCheck } from '@/features/admin/permissions/use-permission-check';
+import { useMe } from '@/lib/auth/useMe';
+import { TriageRoute } from '../TriageRoute';
+
+const ADMIN_ME = {
+  data: {
+    actor: {
+      id: 'admin-uuid-1',
+      external_id: 'admin-1',
+      email: 'admin@test.local',
+      display_name: '관리자',
+      role_level: 'admin',
+    },
+    workspace_id: 'ws-1',
+  },
+  isLoading: false,
+  isError: false,
+  isPending: false,
+  isSuccess: true,
+  error: null,
+};
+
+function renderRoute() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={qc}>
+      <TriageRoute />
+    </QueryClientProvider>,
+  );
+}
+
+describe('TriageRoute — re-triage deep link (#383)', () => {
+  beforeEach(() => {
+    vi.mocked(useMe).mockReturnValue(ADMIN_ME as unknown as ReturnType<typeof useMe>);
+    vi.mocked(usePermissionCheck).mockReturnValue({
+      data: { state: 'approved' },
+      isPending: false,
+      isError: false,
+    } as unknown as ReturnType<typeof usePermissionCheck>);
+    useVocListSpy.mockClear();
+    searchState = {};
+  });
+
+  it('forwards ?selected as pinVocId so the queue can carry the target', () => {
+    searchState = { selected: 'voc-deep-link-target' };
+
+    renderRoute();
+
+    const params = useVocListSpy.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(params.view).toBe('triage');
+    expect(params.pinVocId).toBe('voc-deep-link-target');
+  });
+
+  it('omits pinVocId when the URL carries no selection', () => {
+    searchState = {};
+
+    renderRoute();
+
+    const params = useVocListSpy.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(params).not.toHaveProperty('pinVocId');
+  });
+});

--- a/docs/frontend/specs/voc.md
+++ b/docs/frontend/specs/voc.md
@@ -608,11 +608,12 @@ All paths relative to the VOC service base (`/api` per `apps/backend/AGENTS.md` 
 | Property | Value |
 |---|---|
 | Method / Path | `GET /vocs` |
-| Query params | `view=inbox\|my\|triage`, `managed_system_id=:id\|all`, `tab=untriaged\|high\|unassigned\|similar\|no-link\|waiting`, `filter.severity=`, `filter.reporter_facing_status=`, `filter.owner=assigned\|unassigned`, `sort=created_at:desc\|severity:asc\|reporter_facing_status:asc`, `cursor=`, `limit=` |
+| Query params | `view=inbox\|my\|triage`, `managed_system_id=:id\|all`, `tab=untriaged\|high\|unassigned\|similar\|no-link\|waiting`, `pin_voc_id=:vocId` (view=triage only), `filter.severity=`, `filter.reporter_facing_status=`, `filter.owner=assigned\|unassigned`, `sort=created_at:desc\|severity:asc\|reporter_facing_status:asc`, `cursor=`, `limit=` |
+| `pin_voc_id` (#383) | Unions ONE VOC into a `view=triage` result even though the triage predicate (`triage_state IN ('untriaged','needs_more_information')`) excludes it, and returns it first. Exists so the detail panel's `트리아지에서 변경` deep link can re-triage an already-triaged VOC. Honoured **only inside the caller's existing triage scope** — an id outside scope, archived, in another workspace, or unknown is dropped **silently with 200** (a 403/404 here would be an existence probe). A VOC the tab already returns is not duplicated. The pinned row does **not** affect `page.has_more` / `page.cursor`, which stay computed from the tab query alone. `pin_voc_id` on any other `view` → `validation.failed`. |
 | Response | `{ items: VocListItem[], page: { cursor?, has_more: bool }, out_of_scope_summary?: { count, severity_distribution } }` |
 | `out_of_scope_summary` | Present when actor's effective scope union contains VOCs the actor cannot see; powers the Triage `<PermissionBlockedPanel state="summary_visible">` peek banner |
 | Errors | `permission.denied` (403 if actor lacks any VOC read scope) · `validation.failed` (bad cursor) |
-| Caching | Stale-while-revalidate on TanStack Query, key `[ 'vocs', view, managedSystem, tab, filters, sort ]` |
+| Caching | Stale-while-revalidate on TanStack Query, key `[ 'vocs', view, managedSystem, tab, filters, sort, cursor, pinVocId ]` — `pinVocId` is part of the key so two deep links differing only by target cannot share a cached queue |
 
 ### 8.3 `GET /vocs/:id` — Detail
 

--- a/packages/shared/src/vocs/list-query.ts
+++ b/packages/shared/src/vocs/list-query.ts
@@ -45,6 +45,12 @@ export const listVocsQuerySchema = z.object({
     .union([z.string().uuid(), z.literal('all')])
     .optional(),
   tab: vocTabEnumSchema.optional(),
+  // Re-triage deep link (#383). view=triage only — the triage queue predicate
+  // excludes already-triaged VOCs, so the VOC detail panel's "트리아지에서 변경"
+  // link needs an explicit way to carry its target into the queue. Honoured
+  // only inside the caller's existing triage scope; out-of-scope or unknown
+  // ids are dropped silently (never 403/404 — that would be an existence probe).
+  pin_voc_id: z.string().uuid().optional(),
   // Dot-key filter fields — Fastify query params are flat strings.
   'filter.severity': commaListOf(severityEnumSchema).optional(),
   'filter.reporter_facing_status': commaListOf(reporterFacingStatusEnumSchema).optional(),

--- a/scripts/gates/frontend-biome-allowlist.txt
+++ b/scripts/gates/frontend-biome-allowlist.txt
@@ -141,3 +141,17 @@ packages/shared/src/vocs/__tests__/edit-description-request.test.ts format -- pr
 apps/backend/src/modules/findings/__tests__/authorization-boundary.contract.test.ts lint/style/noNonNullAssertion -- pre-existing on develop; the suite reads seeded ids out of a Record<string, string> and asserts non-null at 13 call sites, none of which this branch added
 apps/backend/src/modules/findings/__tests__/authorization-boundary.contract.test.ts format -- pre-existing on develop; the file predates biome formatting and reformatting it would rewrite lines this branch never touched
 apps/backend/src/modules/findings/__tests__/authorization-boundary.contract.test.ts organizeImports -- pre-existing on develop; import order predates biome
+# Added for the re-triage deep-link branch (#383). Both files were already in
+# this state on develop; this branch adds a comment block plus one hook call to
+# TriageRoute.tsx and one new exported function to repo-read.ts, and touching a
+# file pulls its whole pre-existing diagnostic set into the gate's scope. Counts
+# were measured on develop 24c49c8 per file and reproduce exactly:
+# TriageRoute.tsx 6 = 6, repo-read.ts 17 = 17. This branch's own diagnostic
+# count on every file it touches is 0.
+apps/frontend/src/features/voc/routes/TriageRoute.tsx lint/suspicious/noExplicitAny -- pre-existing on develop (4x, unchanged); the two navigate() search reducers are typed `any` with inline eslint-disable comments that predate biome
+apps/frontend/src/features/voc/routes/TriageRoute.tsx lint/style/useImportType -- pre-existing on develop; `import * as React` predates biome
+apps/frontend/src/features/voc/routes/TriageRoute.tsx organizeImports -- pre-existing on develop; import order predates biome
+apps/backend/src/modules/voc/repo-read.ts lint/style/noNonNullAssertion -- pre-existing on develop (3x, unchanged); the triage scope path asserts non-null on scopes the caller already resolved
+apps/backend/src/modules/voc/repo-read.ts lint/correctness/noUnusedVariables -- pre-existing on develop (8x, unchanged); destructured repo args kept for call-site symmetry
+apps/backend/src/modules/voc/repo-read.ts lint/style/useNumberNamespace -- pre-existing on develop (5x, unchanged); cursor decoding uses bare Number/parseInt globals
+apps/backend/src/modules/voc/repo-read.ts format -- pre-existing on develop; long sql`` template lines predate biome formatting and reformatting them would rewrite lines this branch never touched


### PR DESCRIPTION
Closes #383.

## 무엇이 깨져 있었나

VOC 상세 패널의 `트리아지에서 변경` 버튼(PR #370, #363을 닫으려고 출하)이
`/vocs?view=triage&selected=<id>` 로 보내는데, **그 목적지는 자기가 가리키는 VOC를 표시할 수 없었다.**

1. `repo-read.ts` `buildVocListPredicate` — `view=triage` 는 `triage_state IN ('untriaged','needs_more_information')` 를 강제한다. 이미 확정된 VOC(= 이 버튼이 붙는 바로 그 대상)는 **네 탭 어디에도 없다.**
2. `TriageRoute.tsx:46` — 딥링크에 `tab` 이 없으므로 큐는 항상 `unassigned` 로 좁혀진다.
3. `VocTriageScreen.tsx:62` — `?? liveQueue[0]` 폴백이 **다른 VOC를 조용히 선택**한다.

컨덕터 실측(Mock Admin, `VOC-1712`): 좌측 큐에 대상 없음, 우측에는 **`VOC-SEED-09` 의 편집 폼**이
살아있는 `Triage 확정 & 다음 VOC` 버튼과 함께. 대상이 바뀌었다는 표시 없음.
**죽은 링크가 아니라 잘못된 레코드에 쓰기가 일어날 수 있는 오유도다.**

## 수정

**백엔드** — `GET /vocs` 에 `pin_voc_id`(view=triage 전용). VOC 하나를 결과에 union하고 맨 앞에 둔다.
- **권한 벽 무변경**: 이미 해결된 `scopeFilter` 를 그대로 통과시킨다. 스코프 밖·보관됨·타 워크스페이스·미존재는 **200으로 조용히 무시**(403/404는 존재 프로브가 된다).
- 탭이 이미 반환하는 VOC면 중복되지 않는다.
- pin된 행은 `has_more`/`cursor` 계산에서 제외 — 페이지네이션이 흔들리지 않는다.

**프론트** — `TriageRoute` 가 `selected` 를 `pinVocId` 로 전달, `useVocList` 가 쿼리키에 포함해 전송.
`VocTriageScreen` 은 뭉뚱그려져 있던 두 경우를 분리한다:
- 세션 중 큐에 있었다가 빠진 선택(확정 후) → **자동 다음 이동, 기존 동작 유지**
- 애초에 큐에 없던 선택(딥링크) → **대체품을 띄우지 말고 이유를 표시**

## 검증 (실측)

```
pnpm typecheck (전체)   6/6 successful
backend integration     1246 passed / 138 files   (기준선 1238/137)
frontend vitest          867 passed / 154 files   (기준선 862/152)
@fops/ui vitest          505 passed               (무변)
frontend visual           61 passed               (베이스라인 변경 0장)
frontend typecheck         0 errors
frontend biome             0 unexpected, 138 allowlisted   (기준선 131)
check-boundaries          OK
```

### 뮤테이션 매트릭스 — 3/3 사망

| 뮤턴트 | 발화한 단언 |
|---|---|
| `pinnedRows = rows` (union 제거) | BE 3건: `pins a triaged+assigned VOC…`(집합 차이), `places the pinned VOC first`, `leaves has_more and cursor…` |
| `selectedVoc = selectedInQueue ?? liveQueue[0]` (옛 폴백 복원) | FE `does not swap in another VOC…` — 안내가 뜬 **뒤** `Triage 확정` 버튼 부재를 단언하므로 공허하지 않다 |
| `pinVocId` 배선 제거 | FE `forwards ?selected as pinVocId…` |

### 새 테스트 13건

BE 8건(라우트 레벨, `app.inject`): pin 등장(집합 차이) / 첫 번째 위치 / 중복 없음 / **스코프 밖 200+누락**(Mock Developer 대조군) / 미존재 id 무시 / 보관 행 무시 / `view=inbox` 는 422 / 페이지네이션 불변.
FE 5건: 딥링크 대상 부재 시 대체 금지, 확정 후 자동 다음 이동 회귀 방지, 선택 없을 때 기존 폴백, 라우트 배선 2건.

`TriageRoute` 는 기존 테스트가 `useVocList` 를 인자 무시 팩토리로 모킹하고 있어 **기존 파일을 고치지 않고** 스파이를 쓰는 별도 파일을 추가했다.

## 문서

`docs/frontend/specs/voc.md` §8.2 에 `pin_voc_id` 의미론과 갱신된 캐시 키를 기록했다.
`docs/USER-MANUAL.md:124` 는 **이미 이 동작을 정확히 기술하고 있었다** — 드리프트한 쪽은 구현이었으므로 손대지 않았다.

## allowlist +7

파일 스코프 게이트가 선재 진단을 NEW로 올린 건. develop `24c49c8` 에서 파일별로 실측해 개수가 정확히 일치함을 확인했다(`TriageRoute.tsx` 6=6, `repo-read.ts` 17=17). **이 브랜치가 만든 진단은 0건이다.**

## 남는 것

이 수정으로 블랙박스 M05(두 운영자 동시 stale 판정)가 재실행 가능해진다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5bvJ64nqUZWP8bDkpqJGk