### PR TITLE
fix(frontend): make error catalog exhaustive against shared ERROR_CODES

### DIFF
--- a/apps/frontend/src/lib/api/__tests__/errorMapper.test.ts
+++ b/apps/frontend/src/lib/api/__tests__/errorMapper.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { ERROR_CODES, type ErrorCode } from '@fops/shared';
-import { errorMapper, GENERIC_ERROR_MESSAGE } from '../errorMapper';
+import {
+  CATALOG,
+  errorMapper,
+  GENERIC_ERROR_MESSAGE,
+  RETIRED_OR_SERVER_ONLY_CODES,
+} from '../errorMapper';
 
 const VALID_TONES = new Set(['error', 'warning', 'info']);
 
@@ -22,6 +27,12 @@ const SLICE_3_OWNER_CODES_EXACT: ReadonlyArray<ErrorCode> = [
 // now empty — no FE-mapping-suppression special-case is needed.
 const RETIRING_CODES: ReadonlyArray<ErrorCode> = [];
 
+function findUnclassifiedCodes(codes: readonly ErrorCode[]): ErrorCode[] {
+  return codes.filter(
+    (code) => !(code in CATALOG) && !RETIRED_OR_SERVER_ONLY_CODES.has(code),
+  );
+}
+
 function isSlice3OwnerCode(code: ErrorCode): boolean {
   if (RETIRING_CODES.includes(code)) return false;
   return (
@@ -31,8 +42,22 @@ function isSlice3OwnerCode(code: ErrorCode): boolean {
 }
 
 describe('errorMapper — ERROR_CODES coverage', () => {
-  it('every ERROR_CODES code maps to a non-empty Korean message', () => {
+  it('AC-2 classifies every shared code in the catalog or explicit server-only exclusions', () => {
+    expect(findUnclassifiedCodes(ERROR_CODES)).toEqual([]);
+  });
+
+  it('AC-2 detects a newly introduced shared code with no classification', () => {
+    const unclassified = findUnclassifiedCodes([
+      ...ERROR_CODES,
+      'test.new_shared_code' as ErrorCode,
+    ]);
+
+    expect(unclassified).toEqual(['test.new_shared_code']);
+  });
+
+  it('every mapped ERROR_CODES code maps to a non-empty Korean message', () => {
     for (const code of ERROR_CODES) {
+      if (RETIRED_OR_SERVER_ONLY_CODES.has(code)) continue;
       const mapped = errorMapper({ code, message: '' });
       expect(mapped.message, `code ${code}`).toBeTruthy();
       expect(mapped.message.length, `code ${code}`).toBeGreaterThan(0);
@@ -41,6 +66,7 @@ describe('errorMapper — ERROR_CODES coverage', () => {
 
   it('every code has tone in {error, warning, info}', () => {
     for (const code of ERROR_CODES) {
+      if (RETIRED_OR_SERVER_ONLY_CODES.has(code)) continue;
       const mapped = errorMapper({ code, message: '' });
       expect(VALID_TONES.has(mapped.tone), `code ${code} tone=${mapped.tone}`).toBe(true);
     }
@@ -55,6 +81,23 @@ describe('errorMapper — ERROR_CODES coverage', () => {
         `Slice 3 owner code ${code} must not fall back to generic`,
       ).not.toBe(GENERIC_ERROR_MESSAGE);
     }
+  });
+
+  it.each([
+    ['conflict.capability_already_denied', 'info'],
+    ['conflict.saved_view_name_taken', 'error'],
+    ['conflict.survey_not_open', 'error'],
+    ['conflict.survey_response_already_submitted', 'info'],
+    ['conflict.survey_results_unavailable', 'error'],
+  ] as const)('AC-1 maps %s to non-generic %s copy', (code, tone) => {
+    const mapped = errorMapper({ code, message: '' });
+
+    expect(mapped).toMatchObject({ tone });
+    expect(mapped.message).not.toBe(GENERIC_ERROR_MESSAGE);
+  });
+
+  it('AC-1 explicitly excludes the server-only not_implemented tombstone', () => {
+    expect(RETIRED_OR_SERVER_ONLY_CODES.has('not_implemented.todo')).toBe(true);
   });
 
   it('conflict.stale_write maps to warning + retry action when onRetry provided', () => {
@@ -111,7 +154,7 @@ describe('errorMapper — ERROR_CODES coverage', () => {
     expect(mapped.message).not.toBe(GENERIC_ERROR_MESSAGE);
   });
 
-  it('unknown code falls back to generic error', () => {
+  it('AC-3 unknown external code falls back to generic error', () => {
     const mapped = errorMapper({ code: 'made.up.code' as ErrorCode, message: '' });
     expect(mapped.message).toBe(GENERIC_ERROR_MESSAGE);
     expect(mapped.tone).toBe('error');

--- a/apps/frontend/src/lib/api/errorMapper.ts
+++ b/apps/frontend/src/lib/api/errorMapper.ts
@@ -1,4 +1,4 @@
-import { ERROR_CODES, type ErrorCode } from '@fops/shared';
+import type { ErrorCode } from '@fops/shared';
 import type { ApiErrorEnvelope, MappedError, Tone } from './types';
 
 export const GENERIC_ERROR_MESSAGE = '일시적 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.';
@@ -8,7 +8,7 @@ interface CatalogEntry {
   message: string | ((detail?: Record<string, unknown>) => string);
 }
 
-const CATALOG: Partial<Record<ErrorCode, CatalogEntry>> = {
+export const CATALOG: Partial<Record<ErrorCode, CatalogEntry>> = {
   // auth.*
   'auth.session_invalid':  { tone: 'error', message: '세션이 유효하지 않습니다. 다시 로그인해 주세요.' },
   'auth.session_required': { tone: 'error', message: '로그인이 필요합니다.' },
@@ -51,12 +51,17 @@ const CATALOG: Partial<Record<ErrorCode, CatalogEntry>> = {
   // conflict.*
   'conflict.idempotency_key_reuse':        { tone: 'error', message: '같은 요청 키로 다른 작업을 시도했습니다. 새로고침 후 다시 시도해 주세요.' },
   'conflict.capability_already_granted':   { tone: 'info',  message: '이미 권한이 부여되어 있습니다.' },
+  'conflict.capability_already_denied':    { tone: 'info',  message: '이미 권한이 거부되어 있습니다.' },
   'conflict.permission_request_duplicate': { tone: 'info',  message: '동일한 권한 요청이 이미 진행 중입니다.' },
   'conflict.duplicate_slug':               { tone: 'error', message: '이미 사용 중인 식별자입니다.' },
   'conflict.parent_archived':              { tone: 'error', message: '상위 항목이 보관되어 더 이상 변경할 수 없습니다.' },
   'conflict.record_archived':              { tone: 'error', message: '이 항목은 보관되어 더 이상 변경할 수 없습니다.' },
+  'conflict.saved_view_name_taken':        { tone: 'error', message: '이미 사용 중인 저장된 뷰 이름입니다.' },
   'conflict.stale_write':                  { tone: 'warning', message: '다른 사용자가 먼저 변경했습니다. 최신 내용을 불러올까요?' },
   'conflict.triage_already_committed':     { tone: 'error', message: '이미 트리아지가 완료되어 본인이 직접 수정할 수 없습니다.' },
+  'conflict.survey_not_open':              { tone: 'error', message: '이 설문은 현재 응답을 받을 수 없습니다.' },
+  'conflict.survey_response_already_submitted': { tone: 'info', message: '이 설문에는 이미 응답을 제출했습니다.' },
+  'conflict.survey_results_unavailable':   { tone: 'error', message: '이 설문은 아직 결과를 볼 수 없습니다.' },
 
   // not_found.*
   'not_found.record': { tone: 'error', message: '존재하지 않거나 접근할 수 없는 항목입니다.' },
@@ -117,5 +122,7 @@ export function errorMapper(envelope: ApiErrorEnvelope, opts?: { onRetry?: () =>
   return { tone, message, action };
 }
 
-// Sanity invariant — fail at module load if catalog drifts from ERROR_CODES.
-export const __codeCount = ERROR_CODES.length;
+// 501 tombstone for a server-internal unimplemented endpoint; no user copy by design.
+export const RETIRED_OR_SERVER_ONLY_CODES: ReadonlySet<ErrorCode> = new Set([
+  'not_implemented.todo',
+]);


### PR DESCRIPTION
## Summary
- Added the 5 missing user-facing shared error-code mappings (`conflict.capability_already_denied`, `conflict.saved_view_name_taken`, `conflict.survey_not_open`, `conflict.survey_response_already_submitted`, `conflict.survey_results_unavailable`), tones matched to existing symmetric copy.
- `not_implemented.todo` (a backend 501 tombstone for unimplemented endpoints, never a normal user-flow error) is explicitly excluded via a new `RETIRED_OR_SERVER_ONLY_CODES` set rather than given fake user copy.
- Replaced the dead `__codeCount` "sanity invariant" (read-only, compared nothing) with a real completeness test against `ERROR_CODES`.

Closes #405

## Test plan
- [x] Completeness test: every `ERROR_CODES` member is either mapped or in the explicit exclusion set; fails on an injected unclassified code
- [x] 5 new codes each map to non-generic message + correct tone
- [x] `not_implemented.todo` explicitly asserted as excluded
- [x] Unknown external codes still fall back to generic (regression)
- [x] Mutation check: removing one new catalog entry fails 3 tests
- [x] biome (file-scope, vs develop): both files match baseline error count after an import-type fixup
- [x] FE typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)