### PR TITLE
chore(frontend): make route generation deterministic before typecheck/test

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Run both apps:
 pnpm dev            # frontend on :3010, backend on :3011
 ```
 
+`routeTree.gen.ts` is gitignored and generated deterministically by `pnpm gen:routes`; frontend typecheck and test scripts run it first.
+
 Sign in from `/login`. Authentication is mock in local development; pick a persona by its external id (`mock-admin-1`, `mock-developer-1`, `mock-user-1`, …).
 
 > **Serving to other machines on your network?** The dev server binds `0.0.0.0`, so a colleague can reach it by IP — but that origin is not a *secure context*, and browsers withhold `crypto.randomUUID` and `navigator.clipboard` there. Both are handled, but any new browser API you reach for should be checked against that constraint, because it will never reproduce on `localhost`.

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -7,11 +7,11 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest run",
+    "test": "pnpm --workspace-root run gen:routes && vitest run",
     "test:watch": "vitest",
     "test:visual": "playwright test -c playwright.config.ts",
     "test:visual:update": "playwright test -c playwright.config.ts --update-snapshots",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "pnpm --workspace-root run gen:routes && tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "build": "turbo run build",
     "dev": "turbo run dev",
+    "gen:routes": "node scripts/generate-routes.mjs",
     "test": "turbo run test",
     "lint": "biome check .",
     "format": "biome format --write .",

--- a/scripts/generate-routes.mjs
+++ b/scripts/generate-routes.mjs
@@ -1,0 +1,17 @@
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const frontendRoot = path.join(repositoryRoot, 'apps/frontend');
+const requireFromFrontend = createRequire(path.join(frontendRoot, 'package.json'));
+const routerPluginEntry = requireFromFrontend.resolve('@tanstack/router-plugin/vite');
+const requireFromRouterPlugin = createRequire(
+  path.resolve(routerPluginEntry, '../../..', 'package.json'),
+);
+const { Generator, getConfig } = requireFromRouterPlugin('@tanstack/router-generator');
+
+const config = getConfig({}, frontendRoot);
+const generator = new Generator({ config, root: frontendRoot });
+
+await generator.run();

--- a/turbo.json
+++ b/turbo.json
@@ -9,12 +9,23 @@
       "cache": false,
       "persistent": true
     },
+    "//#gen:routes": {
+      "inputs": [
+        "apps/frontend/package.json",
+        "apps/frontend/src/routes/**",
+        "apps/frontend/vite.config.ts",
+        "package.json",
+        "pnpm-lock.yaml",
+        "scripts/generate-routes.mjs"
+      ],
+      "outputs": ["apps/frontend/src/routeTree.gen.ts"]
+    },
     "test": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["^build", "//#gen:routes"],
       "outputs": ["coverage/**"]
     },
     "typecheck": {
-      "dependsOn": ["^build"]
+      "dependsOn": ["^build", "//#gen:routes"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- Fresh checkouts lack `routeTree.gen.ts` (it's only produced as a Vite-plugin side effect of `dev`/`build`), so `tsc --noEmit` alone throws a wall of ghost errors — a missing-module error plus cascading implicit-any on every route using the generated `useSearch`/`Link` generics — indistinguishable from real diagnostics. Confirmed 20+ ghost errors in this worktree before the fix.
- `scripts/generate-routes.mjs` drives `@tanstack/router-generator` directly (no Vite boot) via the same config resolution the Vite plugin uses.
- Wired as a cached root `//#gen:routes` turbo task feeding `typecheck`/`test`'s `dependsOn`, plus a `pnpm --workspace-root run gen:routes &&` prefix on the frontend package's own `typecheck`/`test` scripts so a package-filtered run (`turbo run typecheck --filter=@fops/frontend`) still generates first.
- `routeTree.gen.ts` stays gitignored (unchanged policy); turbo's declared `outputs` lets a cache hit restore it.

Closes #400

## Test plan
- [x] `rm routeTree.gen.ts && pnpm typecheck` (root, 7/7 tasks) — no ghost errors, all real
- [x] `rm routeTree.gen.ts && turbo run typecheck --filter=@fops/frontend` — generates first, no monorepo-wide build needed
- [x] Determinism: two consecutive `pnpm gen:routes` runs produce byte-identical output (sha256 match)
- [x] Mutation check: reverting the `dependsOn`/pretypecheck wiring reproduces the ghost-error wall (5+ `TS2345` on every route file)
- [x] No real implicit-any/type errors were exposed once generation is wired in — nothing to fix, nothing baselined
- [x] biome (file-scope, vs develop): new script formatted, 0 unexpected on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)