### PR TITLE
fix(permissions): wire the sensitive rate tier and normalize validation errors

### DIFF
--- a/apps/backend/src/modules/permissions/__tests__/decision.integration.test.ts
+++ b/apps/backend/src/modules/permissions/__tests__/decision.integration.test.ts
@@ -554,6 +554,101 @@ describe.skipIf(!runIntegration)('permission request decisions', () => {
     expect(await isPendingInMine(request, requesterCookie)).toBe(true);
   });
 
+  // ── Issue #404: validation 422 normalization + sensitive rate tier ──────
+
+  it.each([
+    ['AC-1 returns 422 with field detail for a bogus status filter (legacy list)', '/permission-requests'],
+    ['AC-1 returns 422 with field detail for a bogus status filter (console list)', '/permissions/requests'],
+  ] as const)('%s', async (_title, url) => {
+    const response = await app.inject({
+      method: 'GET',
+      url: `${url}?status=bogus`,
+      headers: { cookie: `${SESSION_COOKIE_NAME}=${adminCookie}` },
+    });
+    expect(response.statusCode).toBe(422);
+    expect(response.json()).toMatchObject({
+      code: 'validation.failed',
+      message: 'invalid query parameters',
+    });
+    const fields = response.json<{ detail: { fields: Array<{ path: unknown[] }> } }>().detail
+      .fields;
+    expect(fields.length).toBeGreaterThan(0);
+    expect(fields.some((field) => field.path.includes('status'))).toBe(true);
+  });
+
+  it('AC-2 returns 422 with field detail for a schema-violating decision body', async () => {
+    const id = await seedRequest();
+    const response = await decide(id, 'approve', { self_approval: 'not-an-object' });
+    expect(response.statusCode).toBe(422);
+    expect(response.json()).toMatchObject({ code: 'validation.failed' });
+    const fields = response.json<{ detail: { fields: Array<{ path: unknown[] }> } }>().detail
+      .fields;
+    expect(fields.length).toBeGreaterThan(0);
+    expect(fields.some((field) => field.path.includes('self_approval'))).toBe(true);
+  });
+
+  it('AC-3 rate-limits decision routes on the sensitive tier (5/min)', async () => {
+    const approver = await insertAdmin(`perm-self-rate404-${randomUUID()}`);
+    const requester = await insertDevActor(db, WORKSPACE_ID, `perm-decision-${randomUUID()}`);
+    const capabilities = [
+      'workspace.read',
+      'voc.read',
+      'finding.read',
+      'finding.manage',
+      'survey.read',
+      'survey.manage',
+    ] as const;
+    const ids = await Promise.all(
+      capabilities.map((capability) => seedRequest({ capability, requesterActorId: requester.id })),
+    );
+    for (const id of ids.slice(0, 5)) {
+      expect((await decide(id, 'approve', {}, approver.cookie)).statusCode).toBe(200);
+    }
+    const sixth = await decide(ids[5] ?? '', 'approve', {}, approver.cookie);
+    expect(sixth.statusCode).toBe(429);
+    const rateRow = await db.pool.query<{ counter: string }>(
+      `select counter from core.rate_limits where route_group = 'sensitive' and key = $1`,
+      [`${WORKSPACE_ID}:${approver.id}`],
+    );
+    expect(rateRow.rows).toHaveLength(1);
+    expect(Number(rateRow.rows[0]?.counter)).toBe(6);
+  });
+
+  it('AC-4 keeps the mutation tier (10/min) on permission request creation', async () => {
+    const requesterCookie = await loginAs(app, requesterExternalId);
+    const capabilities = [
+      'workspace.read',
+      'voc.read',
+      'finding.read',
+      'finding.manage',
+      'survey.read',
+      'survey.manage',
+      'survey.export',
+      'voc.triage',
+      'workspace.admin',
+      'task_request.self_approve',
+      'survey.read_personal_responses',
+    ] as const;
+    let sixthStatus = -1;
+    for (const [index, capability] of capabilities.entries()) {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/permission-requests',
+        headers: {
+          cookie: `${SESSION_COOKIE_NAME}=${requesterCookie}`,
+          'content-type': 'application/json',
+        },
+        payload: {
+          requested_capability: capability,
+          reason: `AC-4 ${capability}`,
+        },
+      });
+      if (index === 5) sixthStatus = response.statusCode;
+      if (index === 10) expect(response.statusCode).toBe(429);
+    }
+    expect(sixthStatus).not.toBe(429);
+  });
+
   it('returns not-found for an unknown request', async () => {
     const response = await decide(randomUUID(), 'approve', {});
     expect(response.statusCode).toBe(404);

--- a/apps/backend/src/modules/permissions/routes.ts
+++ b/apps/backend/src/modules/permissions/routes.ts
@@ -14,7 +14,7 @@ import {
   needMoreInfoPermissionRequestSchema,
   rejectPermissionRequestSchema,
 } from '@fops/shared';
-import { HttpError, sendError } from '../../lib/errors.js';
+import { HttpError, fieldsFromZodIssues, sendError } from '../../lib/errors.js';
 import { requireSession } from '../../middleware/require-session.js';
 import { requireWorkspace } from '../../middleware/require-workspace.js';
 import type { SessionService } from '../auth/session-service.js';
@@ -36,6 +36,7 @@ export interface PermissionsRoutesOptions {
   workspaceId: string;
   rateLimitConfig?: {
     mutation: Record<string, unknown>;
+    sensitive: Record<string, unknown>;
   };
 }
 
@@ -262,9 +263,8 @@ export const permissionsRoutes: FastifyPluginAsync<PermissionsRoutesOptions> = a
         })
         .safeParse(req.query);
       if (!parsed.success) {
-        return reply.code(400).send({
-          code: 'validation.failed',
-          message: 'invalid query parameters',
+        return sendError(reply, 'validation.failed', 'invalid query parameters', {
+          fields: fieldsFromZodIssues(parsed.error.issues),
         });
       }
       return await requestService.listAllActive(actor, parsed.data.status);
@@ -287,9 +287,8 @@ export const permissionsRoutes: FastifyPluginAsync<PermissionsRoutesOptions> = a
         })
         .safeParse(req.query);
       if (!parsed.success) {
-        return reply.code(400).send({
-          code: 'validation.failed',
-          message: 'invalid query parameters',
+        return sendError(reply, 'validation.failed', 'invalid query parameters', {
+          fields: fieldsFromZodIssues(parsed.error.issues),
         });
       }
       return await requestService.listAllActive(
@@ -363,7 +362,7 @@ export const permissionsRoutes: FastifyPluginAsync<PermissionsRoutesOptions> = a
       method: 'POST',
       url: `/permissions/requests/:id/${route.suffix}`,
       preHandler: [requireSession(sessionService), requireWorkspace(workspaceId)],
-      ...(rateLimitConfig ? { config: { rateLimit: rateLimitConfig.mutation as never } } : {}),
+      ...(rateLimitConfig ? { config: { rateLimit: rateLimitConfig.sensitive as never } } : {}),
       handler: async (req, reply) => {
         const sess = req.session;
         if (!sess) throw new HttpError('internal.unexpected', 'session missing after middleware');
@@ -382,9 +381,8 @@ export const permissionsRoutes: FastifyPluginAsync<PermissionsRoutesOptions> = a
         }
         const parsed = route.schema.safeParse(req.body ?? {});
         if (!parsed.success) {
-          return reply.code(400).send({
-            code: 'validation.failed',
-            message: 'invalid request body',
+          return sendError(reply, 'validation.failed', 'invalid request body', {
+            fields: fieldsFromZodIssues(parsed.error.issues),
           });
         }
         const actor: ActorContext = {

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -419,6 +419,7 @@ export async function buildServer(opts: BuildServerOptions): Promise<FastifyInst
     workspaceId,
     rateLimitConfig: {
       mutation: app.rateLimitConfig.mutation,
+      sensitive: app.rateLimitConfig.sensitive,
     },
   });
 


### PR DESCRIPTION
## Summary
- Permission Request decision routes (approve/reject/need-more-info/deny) now use the ADR-0015 sensitive tier (5/min) instead of mutation (10/min).
- Three hand-rolled `400 validation.failed` responses now go through the canonical `sendError`/`statusForCode` mapper → `422` with zod field detail.
- `POST /permission-requests` (creation) intentionally kept on the mutation tier.

## Test plan
- [x] `pnpm typecheck` (7/7)
- [x] `pnpm --filter @fops/backend test:integration` — 1259 passed / 1 pre-existing unrelated failure (`list-vocs.integration.test.ts` AC11, baseline drift from #413, reproduces identically on develop)
- [x] biome error count unchanged vs develop for all 3 touched files
- [x] `pnpm check:boundaries`

Closes #404