### PR TITLE
fix(tasks): add Managed System scope to Task and Task Request list seams

### DIFF
--- a/apps/backend/src/modules/task-requests/__tests__/list-task-requests.integration.test.ts
+++ b/apps/backend/src/modules/task-requests/__tests__/list-task-requests.integration.test.ts
@@ -1,0 +1,185 @@
+// Task Request list managed_system_id filter (#395).
+//
+// Gate: DATABASE_URL + DATABASE_URL_MIGRATE + WORKSPACE_ID. The conductor runs
+// this outside the sandbox.
+
+import type { FastifyInstance } from 'fastify';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import { loadConfig } from '../../../config.js';
+import { type DbHandle, createDb } from '../../../db/client.js';
+import { buildServer } from '../../../server.js';
+import {
+  SESSION_COOKIE_NAME,
+  cleanupReadTestTables,
+  insertMsDirectly,
+  insertVocDirectly,
+  loginAs,
+  uid,
+} from '../../voc/__tests__/_seed-helpers.js';
+import { insertTaskRequestRow } from './_seed-helpers.js';
+
+const APP_URL = process.env.DATABASE_URL ?? '';
+const MIGRATE_URL = process.env.DATABASE_URL_MIGRATE ?? '';
+const WORKSPACE_ID = process.env.WORKSPACE_ID ?? '';
+const runIntegration = Boolean(APP_URL && MIGRATE_URL && WORKSPACE_ID);
+
+const SLUG_PREFIX = 'it-task-req-list';
+
+describe.skipIf(!runIntegration)('task-request list managed_system_id filter (#395)', () => {
+  let dbHandle: DbHandle;
+  let migrateHandle: DbHandle;
+  let app: FastifyInstance;
+  let adminCookie: string;
+  let adminActorId: string;
+  let userActorId: string;
+  let vocId: string;
+  let msAId: string;
+  let msBId: string;
+  let requestAId: string;
+  let requestBId: string;
+
+  beforeAll(async () => {
+    process.env.NODE_ENV = 'test';
+    dbHandle = createDb(APP_URL);
+    migrateHandle = createDb(MIGRATE_URL);
+    app = await buildServer({ config: loadConfig(), dbHandle });
+    await app.ready();
+
+    adminCookie = await loginAs(app, 'mock-admin-1');
+
+    const actors = await dbHandle.pool.query<{ id: string; external_id: string }>(
+      `select id, external_id
+         from core.actors
+        where workspace_id = $1
+          and external_id = 'mock-admin-1'`,
+      [WORKSPACE_ID],
+    );
+    adminActorId = actors.rows.find((row) => row.external_id === 'mock-admin-1')?.id ?? '';
+    // A reporter actor for the seeded VOC; mock-user-1 exists in the seed set.
+    const reporters = await dbHandle.pool.query<{ id: string; external_id: string }>(
+      `select id, external_id
+         from core.actors
+        where workspace_id = $1
+          and external_id = 'mock-user-1'`,
+      [WORKSPACE_ID],
+    );
+    userActorId = reporters.rows.find((row) => row.external_id === 'mock-user-1')?.id ?? '';
+    if (!adminActorId || !userActorId) throw new Error('seed actors not found');
+  });
+
+  beforeEach(async () => {
+    await cleanupFixtures();
+    await seedFixtures();
+  });
+
+  afterAll(async () => {
+    await cleanupFixtures();
+    await app?.close();
+    await dbHandle?.close();
+    await migrateHandle?.close();
+  });
+
+  async function cleanupFixtures(): Promise<void> {
+    if (!migrateHandle) return;
+    await migrateHandle.pool.query(
+      `delete from task_request.task_requests
+        where workspace_id = $1
+          and primary_managed_system_id in (
+            select id from core.managed_systems where workspace_id = $1 and slug like $2
+          )`,
+      [WORKSPACE_ID, `${SLUG_PREFIX}%`],
+    );
+    await migrateHandle.pool.query(
+      `delete from voc.vocs
+        where workspace_id = $1
+          and primary_managed_system_id in (
+            select id from core.managed_systems where workspace_id = $1 and slug like $2
+          )`,
+      [WORKSPACE_ID, `${SLUG_PREFIX}%`],
+    );
+    await migrateHandle.pool.query(
+      `delete from core.rate_limits
+        where key like $1 || ':%'
+           or key like '127.0.0.%'`,
+      [WORKSPACE_ID],
+    );
+    await cleanupReadTestTables(dbHandle, WORKSPACE_ID, SLUG_PREFIX);
+  }
+
+  async function seedFixtures(): Promise<void> {
+    msAId = await insertMsDirectly(dbHandle, WORKSPACE_ID, uid(SLUG_PREFIX), 'MS A');
+    msBId = await insertMsDirectly(dbHandle, WORKSPACE_ID, uid(SLUG_PREFIX), 'MS B');
+    const voc = await insertVocDirectly(
+      dbHandle,
+      WORKSPACE_ID,
+      msAId,
+      userActorId,
+      'Task request filter seed VOC',
+    );
+    vocId = voc.id;
+    const requestA = await insertTaskRequestRow(migrateHandle, {
+      workspaceId: WORKSPACE_ID,
+      sourceType: 'voc',
+      sourceId: vocId,
+      primaryManagedSystemId: msAId,
+      evidenceSummary: 'MS A evidence',
+      requestedOutcome: 'MS A outcome',
+      requesterActorId: userActorId,
+      status: 'pending_review',
+    });
+    const requestB = await insertTaskRequestRow(migrateHandle, {
+      workspaceId: WORKSPACE_ID,
+      sourceType: 'voc',
+      sourceId: vocId,
+      primaryManagedSystemId: msBId,
+      evidenceSummary: 'MS B evidence',
+      requestedOutcome: 'MS B outcome',
+      requesterActorId: userActorId,
+      status: 'pending_review',
+    });
+    requestAId = requestA.id;
+    requestBId = requestB.id;
+  }
+
+  function listTaskRequests(managedSystemId?: string) {
+    const query = managedSystemId === undefined ? '' : `?managed_system_id=${managedSystemId}`;
+    return app.inject({
+      method: 'GET',
+      url: `/task-requests${query}`,
+      headers: { cookie: `${SESSION_COOKIE_NAME}=${adminCookie}` },
+    });
+  }
+
+  function ids(body: { items: Array<{ id: string }> }): string[] {
+    return body.items.map((item) => item.id);
+  }
+
+  it('AC-395-1: managed_system_id=<ms-a> returns only ms-a task requests', async () => {
+    const res = await listTaskRequests(msAId);
+    expect(res.statusCode).toBe(200);
+    const resIds = ids(res.json<{ items: Array<{ id: string }> }>());
+    expect(resIds).toContain(requestAId);
+    expect(resIds).not.toContain(requestBId);
+  });
+
+  it('AC-395-2: managed_system_id=all and omitted parameter both return all task requests', async () => {
+    const all = await listTaskRequests('all');
+    expect(all.statusCode).toBe(200);
+    const allIds = ids(all.json<{ items: Array<{ id: string }> }>());
+    expect(allIds).toContain(requestAId);
+    expect(allIds).toContain(requestBId);
+
+    const omitted = await listTaskRequests();
+    expect(omitted.statusCode).toBe(200);
+    const omittedIds = ids(omitted.json<{ items: Array<{ id: string }> }>());
+    expect(omittedIds).toContain(requestAId);
+    expect(omittedIds).toContain(requestBId);
+  });
+
+  it('AC-395-3: managed_system_id=not-a-uuid fails validation with 422', async () => {
+    const res = await listTaskRequests('not-a-uuid');
+    expect(res.statusCode).toBe(422);
+    expect(res.json<{ code: string }>().code).toBe('validation.failed');
+  });
+});

--- a/apps/backend/src/modules/task-requests/repo.ts
+++ b/apps/backend/src/modules/task-requests/repo.ts
@@ -133,9 +133,14 @@ export async function listTaskRequestsByWorkspace(
   input: {
     workspaceId: string;
     status?: TaskRequestRow['status'];
+    managedSystemId?: string;
   },
 ): Promise<TaskRequestRow[]> {
-  const statusPredicate = input.status === undefined ? sql`TRUE` : sql`status = ${input.status}`;
+  const predicates = [sql`workspace_id = ${input.workspaceId}`];
+  if (input.status !== undefined) predicates.push(sql`status = ${input.status}`);
+  if (input.managedSystemId !== undefined) {
+    predicates.push(sql`primary_managed_system_id = ${input.managedSystemId}`);
+  }
   const result = await (db as Db).execute<Record<string, unknown>>(sql`
     SELECT
       id, workspace_id, display_id, source_type, source_id, primary_managed_system_id,
@@ -143,8 +148,7 @@ export async function listTaskRequestsByWorkspace(
       reviewer_actor_id, decision_reason, decided_at,
       created_at, updated_at
     FROM task_request.task_requests
-    WHERE workspace_id = ${input.workspaceId}
-      AND ${statusPredicate}
+    WHERE ${sql.join(predicates, sql` AND `)}
     ORDER BY created_at DESC, id DESC
   `);
   return result.rows.map(mapTaskRequestRow);

--- a/apps/backend/src/modules/task-requests/routes.ts
+++ b/apps/backend/src/modules/task-requests/routes.ts
@@ -70,6 +70,9 @@ export const taskRequestsRoutes: FastifyPluginAsync<TaskRequestsRoutesOptions> =
           role_level: sess.role_level,
         },
         ...(parsed.data.status !== undefined ? { status: parsed.data.status } : {}),
+        ...(parsed.data.managed_system_id !== undefined
+          ? { managed_system_id: parsed.data.managed_system_id }
+          : {}),
       });
       return reply.header('cache-control', 'private, no-cache').code(200).send(result);
     },

--- a/apps/backend/src/modules/task-requests/service.ts
+++ b/apps/backend/src/modules/task-requests/service.ts
@@ -453,14 +453,20 @@ export function createTaskRequestsService(deps: TaskRequestsServiceDeps) {
   async function listTaskRequests(args: {
     actor: TaskRequestsActor;
     status?: TaskRequestStatus;
+    managed_system_id?: string;
   }): Promise<{ items: TaskRequestDto[] }> {
     if (!hasElevatedFindingRole(args.actor)) {
       throw new HttpError('permission.denied', 'finding.manage capability required');
     }
 
+    const managedSystemId =
+      args.managed_system_id && args.managed_system_id !== 'all'
+        ? args.managed_system_id
+        : undefined;
     const rows = await listTaskRequestsByWorkspace(deps.db, {
       workspaceId: args.actor.workspace_id,
       ...(args.status !== undefined ? { status: args.status } : {}),
+      ...(managedSystemId !== undefined ? { managedSystemId } : {}),
     });
     const items: TaskRequestDto[] = [];
     for (const row of rows) {

--- a/apps/backend/src/modules/tasks/__tests__/list-tasks.integration.test.ts
+++ b/apps/backend/src/modules/tasks/__tests__/list-tasks.integration.test.ts
@@ -1,0 +1,145 @@
+// Task list managed_system_id filter (#395).
+//
+// Gate: DATABASE_URL + DATABASE_URL_MIGRATE + WORKSPACE_ID. The conductor runs
+// this outside the sandbox.
+
+import type { FastifyInstance } from 'fastify';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import { loadConfig } from '../../../config.js';
+import { type DbHandle, createDb } from '../../../db/client.js';
+import { buildServer } from '../../../server.js';
+import {
+  SESSION_COOKIE_NAME,
+  cleanupReadTestTables,
+  insertMsDirectly,
+  loginAs,
+  uid,
+} from '../../voc/__tests__/_seed-helpers.js';
+import { insertTaskRow } from './_seed-helpers.js';
+
+const APP_URL = process.env.DATABASE_URL ?? '';
+const MIGRATE_URL = process.env.DATABASE_URL_MIGRATE ?? '';
+const WORKSPACE_ID = process.env.WORKSPACE_ID ?? '';
+const runIntegration = Boolean(APP_URL && MIGRATE_URL && WORKSPACE_ID);
+
+const SLUG_PREFIX = 'it-task-list';
+
+describe.skipIf(!runIntegration)('task list managed_system_id filter (#395)', () => {
+  let dbHandle: DbHandle;
+  let migrateHandle: DbHandle;
+  let app: FastifyInstance;
+  let adminCookie: string;
+  let adminActorId: string;
+  let msAId: string;
+  let msBId: string;
+  let taskAId: string;
+  let taskBId: string;
+
+  beforeAll(async () => {
+    process.env.NODE_ENV = 'test';
+    dbHandle = createDb(APP_URL);
+    migrateHandle = createDb(MIGRATE_URL);
+    app = await buildServer({ config: loadConfig(), dbHandle });
+    await app.ready();
+
+    adminCookie = await loginAs(app, 'mock-admin-1');
+
+    const actors = await dbHandle.pool.query<{ id: string; external_id: string }>(
+      `select id, external_id
+         from core.actors
+        where workspace_id = $1
+          and external_id = 'mock-admin-1'`,
+      [WORKSPACE_ID],
+    );
+    adminActorId = actors.rows.find((row) => row.external_id === 'mock-admin-1')?.id ?? '';
+    if (!adminActorId) throw new Error('seed actors not found');
+  });
+
+  beforeEach(async () => {
+    await cleanupFixtures();
+    await seedFixtures();
+  });
+
+  afterAll(async () => {
+    await cleanupFixtures();
+    await app?.close();
+    await dbHandle?.close();
+    await migrateHandle?.close();
+  });
+
+  async function cleanupFixtures(): Promise<void> {
+    if (!migrateHandle) return;
+    await migrateHandle.pool.query(
+      `delete from task.tasks
+        where workspace_id = $1
+          and primary_managed_system_id in (
+            select id from core.managed_systems where workspace_id = $1 and slug like $2
+          )`,
+      [WORKSPACE_ID, `${SLUG_PREFIX}%`],
+    );
+    await migrateHandle.pool.query(
+      `delete from core.rate_limits
+        where key like $1 || ':%'
+           or key like '127.0.0.%'`,
+      [WORKSPACE_ID],
+    );
+    await cleanupReadTestTables(dbHandle, WORKSPACE_ID, SLUG_PREFIX);
+  }
+
+  async function seedFixtures(): Promise<void> {
+    msAId = await insertMsDirectly(dbHandle, WORKSPACE_ID, uid(SLUG_PREFIX), 'MS A');
+    msBId = await insertMsDirectly(dbHandle, WORKSPACE_ID, uid(SLUG_PREFIX), 'MS B');
+    const taskA = await insertTaskRow(migrateHandle, {
+      workspaceId: WORKSPACE_ID,
+      primaryManagedSystemId: msAId,
+      title: 'Task on MS A',
+      createdBy: adminActorId,
+    });
+    const taskB = await insertTaskRow(migrateHandle, {
+      workspaceId: WORKSPACE_ID,
+      primaryManagedSystemId: msBId,
+      title: 'Task on MS B',
+      createdBy: adminActorId,
+    });
+    taskAId = taskA.id;
+    taskBId = taskB.id;
+  }
+
+  function listTasks(managedSystemId?: string) {
+    const query = managedSystemId === undefined ? '' : `?managed_system_id=${managedSystemId}`;
+    return app.inject({
+      method: 'GET',
+      url: `/tasks${query}`,
+      headers: { cookie: `${SESSION_COOKIE_NAME}=${adminCookie}` },
+    });
+  }
+
+  it('AC-395-1: managed_system_id=<ms-a> returns only ms-a tasks', async () => {
+    const res = await listTasks(msAId);
+    expect(res.statusCode).toBe(200);
+    const resIds = res.json<{ items: Array<{ id: string }> }>().items.map((i) => i.id);
+    expect(resIds).toContain(taskAId);
+    expect(resIds).not.toContain(taskBId);
+  });
+
+  it('AC-395-2: managed_system_id=all and omitted parameter both return all tasks', async () => {
+    const all = await listTasks('all');
+    expect(all.statusCode).toBe(200);
+    const allIds = all.json<{ items: Array<{ id: string }> }>().items.map((i) => i.id);
+    expect(allIds).toContain(taskAId);
+    expect(allIds).toContain(taskBId);
+
+    const omitted = await listTasks();
+    expect(omitted.statusCode).toBe(200);
+    const omittedIds = omitted.json<{ items: Array<{ id: string }> }>().items.map((i) => i.id);
+    expect(omittedIds).toContain(taskAId);
+    expect(omittedIds).toContain(taskBId);
+  });
+
+  it('AC-395-3: managed_system_id=not-a-uuid fails validation with 422', async () => {
+    const res = await listTasks('not-a-uuid');
+    expect(res.statusCode).toBe(422);
+    expect(res.json<{ code: string }>().code).toBe('validation.failed');
+  });
+});

--- a/apps/backend/src/modules/tasks/repo.ts
+++ b/apps/backend/src/modules/tasks/repo.ts
@@ -149,12 +149,16 @@ export async function listTasksByWorkspace(
     workspaceId: string;
     status?: TaskStatus;
     assigneeActorId?: string;
+    managedSystemId?: string;
   },
 ): Promise<TaskRow[]> {
   const predicates = [sql`workspace_id = ${input.workspaceId}`];
   if (input.status !== undefined) predicates.push(sql`status = ${input.status}`);
   if (input.assigneeActorId !== undefined) {
     predicates.push(sql`assignee_actor_id = ${input.assigneeActorId}`);
+  }
+  if (input.managedSystemId !== undefined) {
+    predicates.push(sql`primary_managed_system_id = ${input.managedSystemId}`);
   }
   const result = await (db as Db).execute<Record<string, unknown>>(sql`
     SELECT ${TASK_SELECT}

--- a/apps/backend/src/modules/tasks/service.ts
+++ b/apps/backend/src/modules/tasks/service.ts
@@ -513,10 +513,15 @@ export function createTasksService(deps: TasksServiceDeps) {
     }
     const assigneeActorId =
       args.query.assignee === 'me' ? args.actor.actor_id : args.query.assignee;
+    const managedSystemId =
+      args.query.managed_system_id && args.query.managed_system_id !== 'all'
+        ? args.query.managed_system_id
+        : undefined;
     const rows = await listTasksByWorkspace(deps.db, {
       workspaceId: args.actor.workspace_id,
       ...(args.query.status !== undefined ? { status: args.query.status } : {}),
       ...(assigneeActorId !== undefined ? { assigneeActorId } : {}),
+      ...(managedSystemId !== undefined ? { managedSystemId } : {}),
     });
     const items: TaskDto[] = [];
     for (const row of rows) {

--- a/apps/frontend/src/features/tasks/routes/TaskBoardRoute.tsx
+++ b/apps/frontend/src/features/tasks/routes/TaskBoardRoute.tsx
@@ -94,14 +94,15 @@ function GroupByButton({ value, onChange }: { value: GroupBy; onChange: (value: 
   </div>;
 }
 
-export function TaskBoardRoute({ selectedParam }: { selectedParam?: string }) {
+export function TaskBoardRoute({ selectedParam, managedSystem }: { selectedParam?: string; managedSystem?: string }) {
   const navigate = useNavigate();
   const client = useQueryClient();
   const [groupBy, setGroupBy] = React.useState<GroupBy>('status');
   const [filters, setFilters] = React.useState<Filters>({});
   const [selectedId, setSelectedId] = React.useState<string | null>(selectedParam ?? null);
   const mutationTokens = React.useRef(new Map<string, number>());
-  const tasksQuery = useQuery({ queryKey: ['tasks'] as const, queryFn: ({ signal }) => listTasks({ signal }), staleTime: 30_000 });
+  const tasksKey = ['tasks', managedSystem] as const;
+  const tasksQuery = useQuery({ queryKey: tasksKey, queryFn: ({ signal }) => listTasks({ signal, ...(managedSystem !== undefined ? { managed_system_id: managedSystem } : {}) }), staleTime: 30_000 });
   const { actors } = useWorkspaceActors();
   const systemsQuery = useQuery({ queryKey: ['managed-systems', 'all'] as const, queryFn: ({ signal }) => fetchManagedSystems({ includeArchived: true, signal }), staleTime: 600_000 });
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }), useSensor(KeyboardSensor));
@@ -130,13 +131,13 @@ export function TaskBoardRoute({ selectedParam }: { selectedParam?: string }) {
       const token = (mutationTokens.current.get(task.id) ?? 0) + 1;
       mutationTokens.current.set(task.id, token);
       await client.cancelQueries({ queryKey: ['tasks'] });
-      const previousStatus = client.getQueryData<{ items: TaskDto[] }>(['tasks'])?.items.find((item) => item.id === task.id)?.status ?? task.status;
-      client.setQueryData<{ items: TaskDto[] }>(['tasks'], (old) => old ? { ...old, items: old.items.map((item) => item.id === task.id ? { ...item, status } : item) } : old);
+      const previousStatus = client.getQueryData<{ items: TaskDto[] }>(tasksKey)?.items.find((item) => item.id === task.id)?.status ?? task.status;
+      client.setQueryData<{ items: TaskDto[] }>(tasksKey, (old) => old ? { ...old, items: old.items.map((item) => item.id === task.id ? { ...item, status } : item) } : old);
       return { taskId: task.id, previousStatus, token };
     },
     onError: (error, _variables, context) => {
       if (context && mutationTokens.current.get(context.taskId) === context.token) {
-        client.setQueryData<{ items: TaskDto[] }>(['tasks'], (old) => old ? { ...old, items: old.items.map((item) => item.id === context.taskId ? { ...item, status: context.previousStatus } : item) } : old);
+        client.setQueryData<{ items: TaskDto[] }>(tasksKey, (old) => old ? { ...old, items: old.items.map((item) => item.id === context.taskId ? { ...item, status: context.previousStatus } : item) } : old);
       }
       if (error instanceof ApiError && error.code === 'conflict.stale_write' && context && mutationTokens.current.get(context.taskId) === context.token) { void client.invalidateQueries({ queryKey: ['tasks'] }); toast.error('Task changed elsewhere. Board refreshed.'); return; }
       toast.error('Task status could not be updated.');

--- a/apps/frontend/src/features/tasks/routes/TaskListRoute.test.tsx
+++ b/apps/frontend/src/features/tasks/routes/TaskListRoute.test.tsx
@@ -101,6 +101,18 @@ describe('TaskListRoute display ids', () => {
     expect(screen.queryByText(/10000000/)).not.toBeInTheDocument();
   });
 
+  it('AC-395-5: passes managed_system_id to listTasks when managedSystem prop is set', async () => {
+    vi.mocked(listTasks).mockClear();
+    renderWithClient(<TaskListRoute managedSystem="30000000-0000-0000-0000-000000000003" />);
+
+    await screen.findByText('TASK-1000');
+    expect(vi.mocked(listTasks)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        managed_system_id: '30000000-0000-0000-0000-000000000003',
+      }),
+    );
+  });
+
   it('opens the source Finding from the linked-context trail', async () => {
     navigateMock.mockClear();
     renderWithClient(<TaskListRoute />);

--- a/apps/frontend/src/features/tasks/routes/TaskListRoute.tsx
+++ b/apps/frontend/src/features/tasks/routes/TaskListRoute.tsx
@@ -239,12 +239,22 @@ export function TaskDetailPanel({
   );
 }
 
-export function TaskListRoute({ selectedParam }: { selectedParam?: string | undefined }) {
+export function TaskListRoute({
+  selectedParam,
+  managedSystem,
+}: {
+  selectedParam?: string | undefined;
+  managedSystem?: string;
+}) {
   const navigate = useNavigate();
   const [selectedId, setSelectedId] = React.useState<string | null>(selectedParam ?? null);
   const tasksQuery = useQuery({
-    queryKey: ['tasks'] as const,
-    queryFn: ({ signal }) => listTasks({ signal }),
+    queryKey: ['tasks', managedSystem] as const,
+    queryFn: ({ signal }) =>
+      listTasks({
+        signal,
+        ...(managedSystem !== undefined ? { managed_system_id: managedSystem } : {}),
+      }),
     staleTime: 30 * 1000,
   });
   const { actors } = useWorkspaceActors();

--- a/apps/frontend/src/features/tasks/routes/TaskRequestsRoute.tsx
+++ b/apps/frontend/src/features/tasks/routes/TaskRequestsRoute.tsx
@@ -907,13 +907,23 @@ function TaskRequestPanel({
   );
 }
 
-export function TaskRequestsRoute({ selectedParam }: { selectedParam?: string | undefined }) {
+export function TaskRequestsRoute({
+  selectedParam,
+  managedSystem,
+}: {
+  selectedParam?: string | undefined;
+  managedSystem?: string;
+}) {
   const [activeTab, setActiveTab] = React.useState<TaskRequestTab>('pending_review');
   const [selectedId, setSelectedId] = React.useState<string | null>(null);
 
   const taskRequestsQuery = useQuery({
-    queryKey: ['task-requests'] as const,
-    queryFn: ({ signal }) => fetchTaskRequests({ signal }),
+    queryKey: ['task-requests', managedSystem] as const,
+    queryFn: ({ signal }) =>
+      fetchTaskRequests({
+        signal,
+        ...(managedSystem !== undefined ? { managed_system_id: managedSystem } : {}),
+      }),
   });
   const meQuery = useQuery({
     queryKey: ['me'] as const,

--- a/apps/frontend/src/lib/api/task-requests.ts
+++ b/apps/frontend/src/lib/api/task-requests.ts
@@ -13,10 +13,17 @@ export interface ListTaskRequestsResponse {
 }
 
 export async function fetchTaskRequests(
-  options: { status?: TaskRequestStatus; signal?: AbortSignal } = {},
+  options: {
+    status?: TaskRequestStatus;
+    managed_system_id?: string;
+    signal?: AbortSignal;
+  } = {},
 ): Promise<ListTaskRequestsResponse> {
   const qs = new URLSearchParams();
   if (options.status !== undefined) qs.set('status', options.status);
+  if (options.managed_system_id !== undefined) {
+    qs.set('managed_system_id', options.managed_system_id);
+  }
   const path = qs.size > 0 ? `/task-requests?${qs.toString()}` : '/task-requests';
   const res = await apiClient<ListTaskRequestsResponse>('GET', path, {
     ...(options.signal !== undefined ? { signal: options.signal } : {}),

--- a/apps/frontend/src/lib/api/tasks.ts
+++ b/apps/frontend/src/lib/api/tasks.ts
@@ -15,11 +15,19 @@ export interface ListTasksResponse {
 }
 
 export async function listTasks(
-  options: { status?: TaskStatus; assignee?: string; signal?: AbortSignal } = {},
+  options: {
+    status?: TaskStatus;
+    assignee?: string;
+    managed_system_id?: string;
+    signal?: AbortSignal;
+  } = {},
 ): Promise<ListTasksResponse> {
   const qs = new URLSearchParams();
   if (options.status !== undefined) qs.set('status', options.status);
   if (options.assignee !== undefined) qs.set('assignee', options.assignee);
+  if (options.managed_system_id !== undefined) {
+    qs.set('managed_system_id', options.managed_system_id);
+  }
   const path = qs.size > 0 ? `/tasks?${qs.toString()}` : '/tasks';
   const res = await apiClient<ListTasksResponse>('GET', path, {
     ...(options.signal !== undefined ? { signal: options.signal } : {}),

--- a/apps/frontend/src/routes/_authed/tasks.tsx
+++ b/apps/frontend/src/routes/_authed/tasks.tsx
@@ -8,6 +8,7 @@ const tasksSearchSchema = z
   .object({
     view: z.enum(['requests', 'backlog', 'board', 'my', 'inbox']).optional(),
     param: z.string().optional(),
+    managedSystem: z.union([z.string().uuid(), z.literal('all')]).optional(),
   })
   .strict();
 
@@ -16,14 +17,16 @@ export const Route = createFileRoute('/_authed/tasks')({
   component: TasksRouteShell,
 });
 
-export function TasksRouteView({ search }: { search: { view?: 'requests' | 'backlog' | 'board' | 'my' | 'inbox'; param?: string } }) {
+export function TasksRouteView({ search }: { search: { view?: 'requests' | 'backlog' | 'board' | 'my' | 'inbox'; param?: string; managedSystem?: string } }) {
+  const managedSystemProps = search.managedSystem !== undefined ? { managedSystem: search.managedSystem } : {};
+  const selectedParamProps = search.param !== undefined ? { selectedParam: search.param } : {};
   if (search.view === 'requests') {
-    return <TaskRequestsRoute {...(search.param !== undefined ? { selectedParam: search.param } : {})} />;
+    return <TaskRequestsRoute {...managedSystemProps} {...selectedParamProps} />;
   }
   if (search.view === 'board') {
-    return <TaskBoardRoute {...(search.param !== undefined ? { selectedParam: search.param } : {})} />;
+    return <TaskBoardRoute {...managedSystemProps} {...selectedParamProps} />;
   }
-  return <TaskListRoute {...(search.param !== undefined ? { selectedParam: search.param } : {})} />;
+  return <TaskListRoute {...managedSystemProps} {...selectedParamProps} />;
 }
 
 function TasksRouteShell() {

--- a/packages/shared/src/task-requests/index.ts
+++ b/packages/shared/src/task-requests/index.ts
@@ -31,6 +31,7 @@ export type CreateTaskRequestFromVocClusterRequest = CreateTaskRequestRequest;
 export const listTaskRequestsQuerySchema = z
   .object({
     status: taskRequestStatusSchema.optional(),
+    managed_system_id: z.union([z.string().uuid(), z.literal('all')]).optional(),
   })
   .strict();
 export type ListTaskRequestsQuery = z.infer<typeof listTaskRequestsQuerySchema>;

--- a/packages/shared/src/tasks/index.ts
+++ b/packages/shared/src/tasks/index.ts
@@ -102,6 +102,7 @@ export const listTasksQuerySchema = z
   .object({
     status: taskStatusSchema.optional(),
     assignee: z.union([z.string().uuid(), z.literal('me')]).optional(),
+    managed_system_id: z.union([z.string().uuid(), z.literal('all')]).optional(),
   })
   .strict();
 export type ListTasksQuery = z.infer<typeof listTasksQuerySchema>;


### PR DESCRIPTION
## Summary
- `managed_system_id: uuid | 'all'` wired through shared schemas, backend SQL predicates, API client options, and `/tasks` route URL search state for all three task views (backlog/board/requests).
- Existing per-row `finding.manage` authorization loop (both modules) is unchanged — the SQL filter is a pre-filter on top of the query param, not a new authorization boundary; an out-of-scope managed_system_id fails closed to an empty list via the existing loop.
- Fixed a worker regression in review: the route search schema had dropped `param` entirely instead of adding `managedSystem` alongside it, and `TaskBoardRoute`'s optimistic-update cache writes referenced a nonexistent `tasksQuery.queryKey` — both fixed before verification.

## Test plan
- [x] `pnpm typecheck` (7/7, after fixing the `queryKey` type error)
- [x] `pnpm --filter @fops/backend test:integration` — 1265 passed / 1 pre-existing unrelated failure (baseline drift from #413, reproduces on develop)
- [x] `pnpm --filter @fops/frontend test` (tasks routes) — 48/48
- [x] biome error count unchanged vs develop for all touched files
- [x] `pnpm check:boundaries`

Closes #395