### PR TITLE
fix(frontend): expose independent result/error on TaskRequestsRoute workflow hooks

### DIFF
--- a/apps/frontend/src/features/tasks/routes/task-requests/useTaskRequestConversion.ts
+++ b/apps/frontend/src/features/tasks/routes/task-requests/useTaskRequestConversion.ts
@@ -38,6 +38,10 @@ export interface UseTaskRequestConversionResult {
   setAnalyticsAreaId: (value: string) => void;
   analyticsAreas: Array<{ id: string; name: string }> | undefined;
   isPending: boolean;
+  /** Last conversion mutation's settled result, independent of toast state. */
+  result: TaskDto | null;
+  /** Last conversion mutation's settled error, independent of toast state. */
+  error: Error | null;
   canConvert: boolean;
   submit: (event: React.FormEvent<HTMLFormElement>) => void;
 }
@@ -155,6 +159,8 @@ export function useTaskRequestConversion({
     setAnalyticsAreaId: setConvertAnalyticsAreaId,
     analyticsAreas: analyticsAreasQuery.data?.items,
     isPending: convertMutation.isPending,
+    result: convertMutation.data ?? null,
+    error: convertMutation.error ?? null,
     canConvert: canConvertTaskRequest(item.status) && canManage,
     submit,
   };

--- a/apps/frontend/src/features/tasks/routes/task-requests/useTaskRequestDecision.ts
+++ b/apps/frontend/src/features/tasks/routes/task-requests/useTaskRequestDecision.ts
@@ -27,6 +27,10 @@ export interface UseTaskRequestDecisionResult {
   dialog: DecisionDialogState | null;
   isSubmitting: boolean;
   isPending: boolean;
+  /** Last decision mutation's settled result, independent of dialog/toast state. */
+  result: TaskRequestDto | null;
+  /** Last decision mutation's settled error, independent of dialog/toast state. */
+  error: ApiError | null;
   isSelfApproval: boolean;
   canApprove: boolean;
   canReject: boolean;
@@ -165,6 +169,8 @@ export function useTaskRequestDecision({
     dialog: decisionDialog,
     isSubmitting: isDecisionSubmitting,
     isPending: decisionMutation.isPending,
+    result: decisionMutation.data ?? null,
+    error: decisionMutation.error ?? null,
     isSelfApproval,
     canApprove,
     canReject,

--- a/apps/frontend/src/features/tasks/routes/task-requests/useTaskRequestLink.ts
+++ b/apps/frontend/src/features/tasks/routes/task-requests/useTaskRequestLink.ts
@@ -18,6 +18,10 @@ export interface UseTaskRequestLinkResult {
   isTasksLoading: boolean;
   inScopeTasks: TaskDto[] | undefined;
   isPending: boolean;
+  /** Last link mutation's settled result, independent of toast state. */
+  result: TaskDto | null;
+  /** Last link mutation's settled error, independent of toast state. */
+  error: ApiError | null;
   canLinkExisting: boolean;
   link: (taskId: string) => void;
 }
@@ -83,6 +87,8 @@ export function useTaskRequestLink({
     isTasksLoading: tasksQuery.isLoading,
     inScopeTasks,
     isPending: linkMutation.isPending,
+    result: linkMutation.data ?? null,
+    error: linkMutation.error ?? null,
     canLinkExisting: canLinkExistingTaskRequest(item.status) && canManage,
     link: (taskId) => {
       if (!linkMutation.isPending) linkMutation.mutate(taskId);


### PR DESCRIPTION
## Summary
Addresses the post-merge review comment on #418: `useTaskRequestDecision`/`Conversion`/`Link` each exposed `isPending` but routed their mutation outcome only through `toast`, so a consumer couldn't independently observe or compose each workflow's result/error — weaker than #407 AC-3 ("Decision, conversion, and link workflows have independent observable result/error interfaces").

- Added `result`/`error` fields to all three hooks, read directly from each hook's own `useMutation` state (`.data ?? null` / `.error ?? null`).
- No behavior change: toast side effects and all existing UI wiring untouched, these are pure additive read fields.

## Test plan
- [x] `pnpm typecheck` — 7/7
- [x] `pnpm --filter @fops/frontend test -- --run TaskRequestsRoute` — 24/24 unchanged
- [x] biome check on the 3 touched files — clean
- [x] `pnpm check:boundaries` — OK